### PR TITLE
Support for comments inside different parts of 'if' statement

### DIFF
--- a/src/main/javacc/java_1_5.jj
+++ b/src/main/javacc/java_1_5.jj
@@ -2912,12 +2912,17 @@ IfStmt IfStatement():
 	int line;
 	int column;
        Comment cmmt = getComment();
+       Comment thenCmmt = null;
+       Comment elseCmmt = null;
 }
 {
-  "if" {line=token.beginLine; column=token.beginColumn;} "(" condition = Expression() ")" thenStmt = Statement() [ LOOKAHEAD(1) "else" elseStmt = Statement() ]
+  "if" {line=token.beginLine; column=token.beginColumn;} "(" condition = Expression() ")" {thenCmmt = getComment();} thenStmt = Statement() [ LOOKAHEAD(1) "else" {elseCmmt = getComment();} elseStmt = Statement() ]
   { 
       IfStmt tmp = new IfStmt(line, column, token.endLine, token.endColumn,condition, thenStmt, elseStmt);
-      tmp.setComment(cmmt); 
+      tmp.setComment(cmmt);
+      thenStmt.setComment(thenCmmt);
+      if (elseStmt != null)
+          elseStmt.setComment(elseCmmt);
       return tmp;
   }
 }


### PR DESCRIPTION
Currently comment support is somewhat incomplete.

For example, if a comment is placed somewhere between 'if' and 'else' statement it simply gets lost during the parse phase (before the comments patch such a comment went to the compilation unit 'comments' field). So this patch is a quick hack to support such comments for the particular case.

Probably we should decide how to _properly_ choose a "parent" node for a given comment and re-check the whole comments processing during parsing.

Signed-off-by: Alexey Morozov morozov@ac-sw.com
