### PR TITLE
Better formatting for if statements

### DIFF
--- a/src/main/java/japa/parser/ast/visitor/DumpVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/DumpVisitor.java
@@ -1185,11 +1185,32 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 		printJavaComment(n.getComment(), arg);
 		printer.print("if (");
 		n.getCondition().accept(this, arg);
-		printer.print(") ");
+		final boolean thenBlock = n.getThenStmt() instanceof BlockStmt;
+		if (thenBlock) // block statement should start on the same line
+			printer.print(") ");
+		else {
+			printer.printLn(")");
+			printer.indent();
+		}
 		n.getThenStmt().accept(this, arg);
+		if (!thenBlock)
+			printer.unindent();
 		if (n.getElseStmt() != null) {
-			printer.print(" else ");
+			if (thenBlock)
+				printer.print(" ");
+			else
+				printer.printLn();
+			final boolean elseIf = n.getElseStmt() instanceof IfStmt;
+			final boolean elseBlock = n.getElseStmt() instanceof BlockStmt;
+			if (elseIf || elseBlock) // put chained if and start of block statement on a same level
+				printer.print("else ");
+			else {
+				printer.printLn("else");
+				printer.indent();
+			}
 			n.getElseStmt().accept(this, arg);
+			if (!(elseIf || elseBlock))
+				printer.unindent();
 		}
 	}
 

--- a/src/test/resources/japa/parser/ast/test/DumperTestClass.java
+++ b/src/test/resources/japa/parser/ast/test/DumperTestClass.java
@@ -263,7 +263,16 @@ public class DumperTestClass<T extends List<int[]>, X> extends Base implements S
             teste = new DumperTestClass(1);
             x = x == 0 ? 2 : 4;
         }
-        if (true) x = 1; else x = 3;
+        if (true)
+            x = 1;
+        else
+            x = 3;
+        if (true)
+            x = 1;
+        else if (false)
+            x = 3;
+        else
+            x = 2;
         while (true) {
             xxx: while (x == 3) continue xxx;
             break;


### PR DESCRIPTION
The former formatting was

if (cond) <then-statement>[ else <else-statement>]

in case of chained ifs it became like this

if (cond1) <then-statement> else if (cond2) <then-statement>[ else <else-statement> ]

now it should be like this:

if (cond)
    <then-statement>
else if (cond2)
    <then-statement>
else
    <else-statement>

Signed-off-by: Alexey Morozov morozov@ac-sw.com
