### PR TITLE
Expose position information of type/method names

### DIFF
--- a/src/main/java/japa/parser/ast/body/MethodDeclaration.java
+++ b/src/main/java/japa/parser/ast/body/MethodDeclaration.java
@@ -42,7 +42,7 @@ public final class MethodDeclaration extends BodyDeclaration {
 
 	private Type type;
 
-	private String name;
+	private NameExpr name;
 
 	private List<Parameter> parameters;
 
@@ -125,8 +125,12 @@ public final class MethodDeclaration extends BodyDeclaration {
 	}
 
 	public String getName() {
-		return name;
+		return name.getName();
 	}
+
+    public NameExpr getNameExpr() {
+        return name;
+    }
 
 	public List<Parameter> getParameters() {
 		return parameters;
@@ -158,8 +162,12 @@ public final class MethodDeclaration extends BodyDeclaration {
 	}
 
 	public void setName(final String name) {
-		this.name = name;
+		this.name = new NameExpr(name);
 	}
+
+    public void setNameExpr(final NameExpr name) {
+        this.name = name;
+    }
 
 	public void setParameters(final List<Parameter> parameters) {
 		this.parameters = parameters;

--- a/src/main/java/japa/parser/ast/body/TypeDeclaration.java
+++ b/src/main/java/japa/parser/ast/body/TypeDeclaration.java
@@ -22,6 +22,7 @@
 package japa.parser.ast.body;
 
 import japa.parser.ast.expr.AnnotationExpr;
+import japa.parser.ast.expr.NameExpr;
 
 import java.util.List;
 
@@ -30,7 +31,7 @@ import java.util.List;
  */
 public abstract class TypeDeclaration extends BodyDeclaration {
 
-	private String name;
+	private NameExpr name;
 
 	private int modifiers;
 
@@ -78,7 +79,7 @@ public abstract class TypeDeclaration extends BodyDeclaration {
 	}
 
 	public final String getName() {
-		return name;
+		return name.getName();
 	}
 
 	public void setMembers(List<BodyDeclaration> members) {
@@ -91,6 +92,14 @@ public abstract class TypeDeclaration extends BodyDeclaration {
 	}
 
 	public final void setName(String name) {
-		this.name = name;
+		this.name = new NameExpr(name);
 	}
+
+  public final void setNameExpr(NameExpr nameExpr) {
+    this.name = nameExpr;
+  }
+
+  public final NameExpr getNameExpr() {
+    return name;
+  }
 }

--- a/src/main/javacc/java_1_5.jj
+++ b/src/main/javacc/java_1_5.jj
@@ -1332,7 +1332,7 @@ TypeDeclaration TypeDeclaration():
 ClassOrInterfaceDeclaration ClassOrInterfaceDeclaration(Modifier modifier):
 {
    boolean isInterface = false;
-   String name;
+   NameExpr name;
    List typePar = null;
    List extList = null;
    List impList = null;
@@ -1343,14 +1343,15 @@ ClassOrInterfaceDeclaration ClassOrInterfaceDeclaration(Modifier modifier):
 }
 {
   ( "class" | "interface" { isInterface = true; } ) { if (line == -1) {line=token.beginLine; column=token.beginColumn;} }
-  <IDENTIFIER> { name = token.image; }
+  name = Name()
   [ typePar = TypeParameters() {typePar.remove(0);} ]
   [ extList = ExtendsList(isInterface) ]
   [ impList = ImplementsList(isInterface) ]
   members = ClassOrInterfaceBody(isInterface)
 
-  { ClassOrInterfaceDeclaration tmp = new ClassOrInterfaceDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, isInterface, name, typePar, extList, impList, members); 
-    tmp.setComment(cmmt); 
+  { ClassOrInterfaceDeclaration tmp = new ClassOrInterfaceDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, isInterface, null, typePar, extList, impList, members);
+    tmp.setNameExpr(name);
+    tmp.setComment(cmmt);
     return tmp;
   }
 }
@@ -1388,7 +1389,7 @@ List ImplementsList(boolean isInterface):
 
 EnumDeclaration EnumDeclaration(Modifier modifier):
 {
-	String name;
+	NameExpr name;
 	List impList = null;
 	EnumConstantDeclaration entry;
 	List entries = null;
@@ -1400,7 +1401,7 @@ EnumDeclaration EnumDeclaration(Modifier modifier):
 }
 {
   "enum" { if (line == -1) {line=token.beginLine; column=token.beginColumn;} }
-  <IDENTIFIER> { name = token.image; }
+  name = Name()
   [ impList = ImplementsList(false) ]
   "{"
   	[
@@ -1414,8 +1415,9 @@ EnumDeclaration EnumDeclaration(Modifier modifier):
   "}"
 
   { 
-      EnumDeclaration tmp = new EnumDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, name, impList, entries, members);
-      tmp.setComment(cmmt); 
+      EnumDeclaration tmp = new EnumDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, null, impList, entries, members);
+      tmp.setNameExpr(name);
+      tmp.setComment(cmmt);
       return tmp;
   }
 }
@@ -1631,7 +1633,7 @@ MethodDeclaration MethodDeclaration(Modifier modifier):
 {
 	List typeParameters = null;
 	Type type;
-	String name;
+	NameExpr name;
 	List parameters;
 	int arrayCount = 0;
 	List throws_ = null;
@@ -1644,13 +1646,14 @@ MethodDeclaration MethodDeclaration(Modifier modifier):
   // Modifiers already matched in the caller!
   [ typeParameters = TypeParameters() { int[] lineCol=(int[])typeParameters.remove(0); if(line==-1){ line=lineCol[0]; column=lineCol[1];} } ]
   type = ResultType() { if(line==-1){line=type.getBeginLine(); column=type.getBeginColumn();}}
-  <IDENTIFIER> { name = token.image; } parameters = FormalParameters() ( "[" "]" { arrayCount++; } )*
+  name = Name() parameters = FormalParameters() ( "[" "]" { arrayCount++; } )*
   [ "throws" throws_ = NameList() ]
   ( block = Block() | ";" )
 
   { 
-      MethodDeclaration tmp = new MethodDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, typeParameters, type, name, parameters, arrayCount, throws_, block); 
-      tmp.setComment(cmmt); 
+      MethodDeclaration tmp = new MethodDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, typeParameters, type, null, parameters, arrayCount, throws_, block);
+      tmp.setNameExpr(name);
+      tmp.setComment(cmmt);
       return tmp;
   }
 }
@@ -3315,7 +3318,7 @@ Expression  MemberValueArrayInitializer():
 
 AnnotationDeclaration AnnotationTypeDeclaration(Modifier modifier):
 {
-	String name;
+	NameExpr name;
 	List members;
 	int line = modifier.beginLine;
 	int column = modifier.beginColumn;
@@ -3323,12 +3326,13 @@ AnnotationDeclaration AnnotationTypeDeclaration(Modifier modifier):
 }
 {
   "@" { if (line == -1) {line=token.beginLine; column=token.beginColumn;} }
-  "interface" <IDENTIFIER> { name = token.image; } members = AnnotationTypeBody()
+  "interface" name = Name() members = AnnotationTypeBody()
 
   { 
-      AnnotationDeclaration tmp = new AnnotationDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, name, members); 
-      tmp.setComment(cmmt); 
-      return tmp; 
+      AnnotationDeclaration tmp = new AnnotationDeclaration(line, column, token.endLine, token.endColumn,popJavadoc(), modifier.modifiers, modifier.annotations, null, members);
+      tmp.setNameExpr(name);
+      tmp.setComment(cmmt);
+      return tmp;
   }
 }
 

--- a/src/test/java/japa/parser/ast/test/TestNodePositions.java
+++ b/src/test/java/japa/parser/ast/test/TestNodePositions.java
@@ -165,6 +165,7 @@ public class TestNodePositions {
 
 		@Override public void visit(final AnnotationDeclaration n, final Object arg) {
 			doTest(source, n);
+			doTest(source, n.getNameExpr());
 			super.visit(n, arg);
 		}
 
@@ -245,6 +246,7 @@ public class TestNodePositions {
 
 		@Override public void visit(final ClassOrInterfaceDeclaration n, final Object arg) {
 			doTest(source, n);
+			doTest(source, n.getNameExpr());
 			super.visit(n, arg);
 		}
 
@@ -310,6 +312,7 @@ public class TestNodePositions {
 
 		@Override public void visit(final EnumDeclaration n, final Object arg) {
 			doTest(source, n);
+			doTest(source, n.getNameExpr());
 			super.visit(n, arg);
 		}
 
@@ -415,6 +418,7 @@ public class TestNodePositions {
 
 		@Override public void visit(final MethodDeclaration n, final Object arg) {
 			doTest(source, n);
+			doTest(source, n.getNameExpr());
 			super.visit(n, arg);
 		}
 


### PR DESCRIPTION
I added the following methods to retrieve the exact position of names:
- TypeDeclaration#{get,set}NameExpr()
- MethodDeclaration#{get,set}NameExpr()

No existing APIs are changed or removed, so it should be backward compatible.

This commit fixes #11.
