### PR TITLE
Java 7 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<name>javaparser</name>
 	<url>http://code.google.com/p/javaparser/</url>
 	<inceptionYear>2007</inceptionYear>
-	<description>This package contains a Java 1.5 Parser with AST generation and visitor support. 
+	<description>This package contains a Java 1.7 Parser with AST generation and visitor support. 
 		The AST records the source code structure, javadoc and comments. Soon will be 
 		possible change the AST nodes or create new ones to modify source code like refactoring.
 		This parser is based on Sreenivasa Viswanadha Java 1.5 parser.</description>

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 +-------------------------------------------------------------------------------+
-|  Java 1.5 parser and Abstract Syntax Tree.                                    |
+|  Java 1.7 parser and Abstract Syntax Tree.                                    |
 +-------------------------------------------------------------------------------+
 |  Copyright (C) 2007 Júlio Vilmar Gesser                                       |
 |  jgesser@gmail.com                                                            |
@@ -19,7 +19,7 @@
 |  along with this program.  If not, see <http://www.gnu.org/licenses/>.        |
 +-------------------------------------------------------------------------------+    
 
-This package contains a Java 1.5 Parser with AST generation and visitor support. 
+This package contains a Java 1.7 Parser with AST generation and visitor support. 
 The AST records the source code structure, javadoc and comments. Soon will be 
 possible change the AST nodes or create new ones to modify source code like refactoring.
 This parser is based on Sreenivasa Viswanadha Java 1.5 parser.

--- a/src/main/java/japa/parser/ast/body/BaseParameter.java
+++ b/src/main/java/japa/parser/ast/body/BaseParameter.java
@@ -1,0 +1,71 @@
+package japa.parser.ast.body;
+
+import japa.parser.ast.Node;
+import japa.parser.ast.expr.AnnotationExpr;
+
+import java.util.List;
+
+public abstract class BaseParameter extends Node {
+    private int modifiers;
+
+    private List<AnnotationExpr> annotations;
+    
+    private VariableDeclaratorId id;
+    
+    public BaseParameter() {
+    }
+    
+    public BaseParameter(VariableDeclaratorId id) {
+        setId(id);
+	}
+
+	public BaseParameter(int modifiers, VariableDeclaratorId id) {
+        setModifiers(modifiers);
+        setId(id);
+	}
+	
+	public BaseParameter(int modifiers, List<AnnotationExpr> annotations, VariableDeclaratorId id) {
+        setModifiers(modifiers);
+        setAnnotations(annotations);
+        setId(id);
+	}
+
+	public BaseParameter(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, VariableDeclaratorId id) {
+	    super(beginLine, beginColumn, endLine, endColumn);
+        setModifiers(modifiers);
+        setAnnotations(annotations);
+        setId(id);
+	}
+
+    public List<AnnotationExpr> getAnnotations() {
+        return annotations;
+    }
+
+    public VariableDeclaratorId getId() {
+        return id;
+    }
+
+    /**
+     * Return the modifiers of this parameter declaration.
+     * 
+     * @see ModifierSet
+     * @return modifiers
+     */
+    public int getModifiers() {
+        return modifiers;
+    }
+
+    public void setAnnotations(List<AnnotationExpr> annotations) {
+        this.annotations = annotations;
+        setAsParentNodeOf(this.annotations);
+    }
+
+    public void setId(VariableDeclaratorId id) {
+        this.id = id;
+        setAsParentNodeOf(this.id);
+    }
+
+    public void setModifiers(int modifiers) {
+        this.modifiers = modifiers;
+    }
+}

--- a/src/main/java/japa/parser/ast/body/ConstructorDeclaration.java
+++ b/src/main/java/japa/parser/ast/body/ConstructorDeclaration.java
@@ -100,7 +100,7 @@ public final class ConstructorDeclaration extends BodyDeclaration {
     }
 
     public String getName() {
-        return name.getName();
+        return name == null ? null : name.getName();
     }
 
     public NameExpr getNameExpr() {

--- a/src/main/java/japa/parser/ast/body/MultiTypeParameter.java
+++ b/src/main/java/japa/parser/ast/body/MultiTypeParameter.java
@@ -1,0 +1,42 @@
+package japa.parser.ast.body;
+
+import japa.parser.ast.expr.AnnotationExpr;
+import japa.parser.ast.type.Type;
+import japa.parser.ast.visitor.GenericVisitor;
+import japa.parser.ast.visitor.VoidVisitor;
+
+import java.util.List;
+
+public class MultiTypeParameter extends BaseParameter {
+    private List<Type> types;
+	
+    public MultiTypeParameter() {}
+
+    public MultiTypeParameter(int modifiers, List<AnnotationExpr> annotations, List<Type> types, VariableDeclaratorId id) {
+        super(modifiers, annotations, id);
+        this.types = types;
+    }
+
+    public MultiTypeParameter(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, List<Type> types, VariableDeclaratorId id) {
+        super(beginLine, beginColumn, endLine, endColumn, modifiers, annotations, id);
+        this.types = types;
+	}
+
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
+    
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
+
+    public List<Type> getTypes() {
+        return types;
+    }
+
+    public void setTypes(List<Type> types) {
+        this.types = types;
+    }
+}

--- a/src/main/java/japa/parser/ast/body/Parameter.java
+++ b/src/main/java/japa/parser/ast/body/Parameter.java
@@ -21,7 +21,6 @@
  */
 package japa.parser.ast.body;
 
-import japa.parser.ast.Node;
 import japa.parser.ast.expr.AnnotationExpr;
 import japa.parser.ast.type.Type;
 import japa.parser.ast.visitor.GenericVisitor;
@@ -32,39 +31,28 @@ import java.util.List;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class Parameter extends Node {
-
-    private int modifiers;
-
-    private List<AnnotationExpr> annotations;
-
+public final class Parameter extends BaseParameter {
     private Type type;
 
     private boolean isVarArgs;
-
-    private VariableDeclaratorId id;
 
     public Parameter() {
     }
 
     public Parameter(Type type, VariableDeclaratorId id) {
+    	super(id);
         setType(type);
-        setId(id);
     }
 
     public Parameter(int modifiers, Type type, VariableDeclaratorId id) {
-        setModifiers(modifiers);
+    	super(modifiers, id);
         setType(type);
-        setId(id);
     }
 
     public Parameter(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, Type type, boolean isVarArgs, VariableDeclaratorId id) {
-        super(beginLine, beginColumn, endLine, endColumn);
-        setModifiers(modifiers);
-        setAnnotations(annotations);
+        super(beginLine, beginColumn, endLine, endColumn, modifiers, annotations, id);
         setType(type);
         setVarArgs(isVarArgs);
-        setId(id);
     }
 
     @Override
@@ -77,44 +65,12 @@ public final class Parameter extends Node {
         v.visit(this, arg);
     }
 
-    public List<AnnotationExpr> getAnnotations() {
-        return annotations;
-    }
-
-    public VariableDeclaratorId getId() {
-        return id;
-    }
-
-    /**
-     * Return the modifiers of this parameter declaration.
-     * 
-     * @see ModifierSet
-     * @return modifiers
-     */
-    public int getModifiers() {
-        return modifiers;
-    }
-
     public Type getType() {
         return type;
     }
 
     public boolean isVarArgs() {
         return isVarArgs;
-    }
-
-    public void setAnnotations(List<AnnotationExpr> annotations) {
-        this.annotations = annotations;
-		setAsParentNodeOf(this.annotations);
-    }
-
-    public void setId(VariableDeclaratorId id) {
-        this.id = id;
-		setAsParentNodeOf(this.id);
-    }
-
-    public void setModifiers(int modifiers) {
-        this.modifiers = modifiers;
     }
 
     public void setType(Type type) {

--- a/src/main/java/japa/parser/ast/stmt/CatchClause.java
+++ b/src/main/java/japa/parser/ast/stmt/CatchClause.java
@@ -21,8 +21,14 @@
  */
 package japa.parser.ast.stmt;
 
+import java.util.List;
+
 import japa.parser.ast.Node;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
+import japa.parser.ast.body.VariableDeclaratorId;
+import japa.parser.ast.expr.AnnotationExpr;
+import japa.parser.ast.type.Type;
 import japa.parser.ast.visitor.GenericVisitor;
 import japa.parser.ast.visitor.VoidVisitor;
 
@@ -31,24 +37,29 @@ import japa.parser.ast.visitor.VoidVisitor;
  */
 public final class CatchClause extends Node {
 
-	private Parameter except;
+    private MultiTypeParameter except;
 
-	private BlockStmt catchBlock;
+    private BlockStmt catchBlock;
 
-	public CatchClause() {
-	}
+    public CatchClause() {
+    }
 
-	public CatchClause(final Parameter except, final BlockStmt catchBlock) {
-		setExcept(except);
-		setCatchBlock(catchBlock);
-	}
+    public CatchClause(final MultiTypeParameter except, final BlockStmt catchBlock) {
+        setExcept(except);
+        setCatchBlock(catchBlock);
+    }
+	
+    public CatchClause(int exceptModifier, List<AnnotationExpr> exceptAnnotations, List<Type> exceptTypes, VariableDeclaratorId exceptId, BlockStmt catchBlock) {
+        this(new MultiTypeParameter(exceptModifier, exceptAnnotations, exceptTypes, exceptId), catchBlock);
+    }
 
-	public CatchClause(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Parameter except, final BlockStmt catchBlock) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExcept(except);
-		setCatchBlock(catchBlock);
-	}
+    public CatchClause(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+    	    final int exceptModifier, final List<AnnotationExpr> exceptAnnotations, final List<Type> exceptTypes, 
+    	    final VariableDeclaratorId exceptId, final BlockStmt catchBlock) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExcept(new MultiTypeParameter(beginLine, beginColumn, endLine, endColumn, exceptModifier, exceptAnnotations, exceptTypes, exceptId));
+        setCatchBlock(catchBlock);
+    }
 
 	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
 		return v.visit(this, arg);
@@ -62,7 +73,7 @@ public final class CatchClause extends Node {
 		return catchBlock;
 	}
 
-	public Parameter getExcept() {
+	public MultiTypeParameter getExcept() {
 		return except;
 	}
 
@@ -71,7 +82,7 @@ public final class CatchClause extends Node {
 		setAsParentNodeOf(this.catchBlock);
 	}
 
-	public void setExcept(final Parameter except) {
+	public void setExcept(final MultiTypeParameter except) {
 		this.except = except;
 		setAsParentNodeOf(this.except);
 	}

--- a/src/main/java/japa/parser/ast/stmt/TryStmt.java
+++ b/src/main/java/japa/parser/ast/stmt/TryStmt.java
@@ -23,6 +23,7 @@ package japa.parser.ast.stmt;
 
 import japa.parser.ast.visitor.GenericVisitor;
 import japa.parser.ast.visitor.VoidVisitor;
+import japa.parser.ast.expr.VariableDeclarationExpr;
 
 import java.util.List;
 
@@ -30,6 +31,8 @@ import java.util.List;
  * @author Julio Vilmar Gesser
  */
 public final class TryStmt extends Statement {
+	
+	private List<VariableDeclarationExpr> resources;
 
 	private BlockStmt tryBlock;
 
@@ -48,9 +51,10 @@ public final class TryStmt extends Statement {
 	}
 
 	public TryStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn, final BlockStmt tryBlock,
-			final List<CatchClause> catchs, final BlockStmt finallyBlock) {
+			final int endLine, final int endColumn, List<VariableDeclarationExpr> resources,
+			final BlockStmt tryBlock, final List<CatchClause> catchs, final BlockStmt finallyBlock) {
 		super(beginLine, beginColumn, endLine, endColumn);
+		this.resources = resources;
 		setTryBlock(tryBlock);
 		setCatchs(catchs);
 		setFinallyBlock(finallyBlock);
@@ -77,6 +81,10 @@ public final class TryStmt extends Statement {
 	public BlockStmt getTryBlock() {
 		return tryBlock;
 	}
+	
+	public List<VariableDeclarationExpr> getResources() {
+		return resources;
+	}
 
 	public void setCatchs(final List<CatchClause> catchs) {
 		this.catchs = catchs;
@@ -91,5 +99,9 @@ public final class TryStmt extends Statement {
 	public void setTryBlock(final BlockStmt tryBlock) {
 		this.tryBlock = tryBlock;
 		setAsParentNodeOf(this.tryBlock);
+	}
+	
+	public void setResources(List<VariableDeclarationExpr> resources) {
+		this.resources = resources;
 	}
 }

--- a/src/main/java/japa/parser/ast/visitor/CloneVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/CloneVisitor.java
@@ -24,6 +24,7 @@ import japa.parser.ast.body.FieldDeclaration;
 import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.TypeDeclaration;
 import japa.parser.ast.body.VariableDeclarator;
@@ -340,6 +341,21 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 		Parameter r = new Parameter(
 				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
 				_n.getModifiers(), annotations, type_, _n.isVarArgs(), id
+		);
+		r.setComment(comment);
+		return r;
+	}
+	
+	@Override
+	public Node visit(MultiTypeParameter _n, Object _arg) {
+		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+		List<Type> types = visit(_n.getTypes(), _arg);
+		VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
+		Comment comment = cloneNodes(_n.getComment(), _arg);
+
+		MultiTypeParameter r = new MultiTypeParameter(
+				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+				_n.getModifiers(), annotations, types, id
 		);
 		r.setComment(comment);
 		return r;
@@ -1135,13 +1151,13 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(CatchClause _n, Object _arg) {
-		Parameter except = cloneNodes(_n.getExcept(), _arg);
+		MultiTypeParameter except = cloneNodes(_n.getExcept(), _arg);
 		BlockStmt catchBlock = cloneNodes(_n.getCatchBlock(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 
 		CatchClause r = new CatchClause(
 				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				except, catchBlock
+				except.getModifiers(), except.getAnnotations(), except.getTypes(), except.getId(), catchBlock
 		);
 		r.setComment(comment);
 		return r;

--- a/src/main/java/japa/parser/ast/visitor/CloneVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/CloneVisitor.java
@@ -1119,6 +1119,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(TryStmt _n, Object _arg) {
+		List<VariableDeclarationExpr> resources = visit(_n.getResources(),_arg);
 		BlockStmt tryBlock = cloneNodes(_n.getTryBlock(), _arg);
 		List<CatchClause> catchs = visit(_n.getCatchs(), _arg);
 		BlockStmt finallyBlock = cloneNodes(_n.getFinallyBlock(), _arg);
@@ -1126,7 +1127,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 		TryStmt r = new TryStmt(
 				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				tryBlock, catchs, finallyBlock
+				resources, tryBlock, catchs, finallyBlock
 		);
 		r.setComment(comment);
 		return r;

--- a/src/main/java/japa/parser/ast/visitor/DumpVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/DumpVisitor.java
@@ -42,6 +42,7 @@ import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
 import japa.parser.ast.body.ModifierSet;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.TypeDeclaration;
 import japa.parser.ast.body.VariableDeclarator;
@@ -963,6 +964,21 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 		printer.print(" ");
 		n.getId().accept(this, arg);
 	}
+	
+    public void visit(MultiTypeParameter n, Object arg) {
+        printAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+
+        Iterator<Type> types = n.getTypes().iterator();
+        types.next().accept(this, arg);
+        while (types.hasNext()) {
+        	printer.print(" | ");
+        	types.next().accept(this, arg);
+        }
+        
+        printer.print(" ");
+        n.getId().accept(this, arg);
+    }
 
 	@Override public void visit(final ExplicitConstructorInvocationStmt n, final Object arg) {
 		printJavaComment(n.getComment(), arg);

--- a/src/main/java/japa/parser/ast/visitor/DumpVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/DumpVisitor.java
@@ -1299,6 +1299,26 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 	@Override public void visit(final TryStmt n, final Object arg) {
 		printJavaComment(n.getComment(), arg);
 		printer.print("try ");
+		if (!n.getResources().isEmpty()) {
+			printer.print("(");
+			Iterator<VariableDeclarationExpr> resources = n.getResources().iterator();
+			boolean first = true;
+			while (resources.hasNext()) {
+				visit(resources.next(), arg);
+				if (resources.hasNext()) {
+					printer.print(";");
+					printer.printLn();
+					if (first) {
+						printer.indent();
+					}
+				}
+				first = false;
+			}
+			if (n.getResources().size() > 1) {
+				printer.unindent();
+			}
+			printer.print(") ");
+		}
 		n.getTryBlock().accept(this, arg);
 		if (n.getCatchs() != null) {
 			for (final CatchClause c : n.getCatchs()) {

--- a/src/main/java/japa/parser/ast/visitor/EqualsVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/EqualsVisitor.java
@@ -30,6 +30,7 @@ import japa.parser.ast.PackageDeclaration;
 import japa.parser.ast.TypeParameter;
 import japa.parser.ast.body.AnnotationDeclaration;
 import japa.parser.ast.body.AnnotationMemberDeclaration;
+import japa.parser.ast.body.BaseParameter;
 import japa.parser.ast.body.ClassOrInterfaceDeclaration;
 import japa.parser.ast.body.ConstructorDeclaration;
 import japa.parser.ast.body.EmptyMemberDeclaration;
@@ -40,6 +41,7 @@ import japa.parser.ast.body.FieldDeclaration;
 import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.VariableDeclarator;
 import japa.parser.ast.body.VariableDeclaratorId;
@@ -99,9 +101,11 @@ import japa.parser.ast.stmt.WhileStmt;
 import japa.parser.ast.type.ClassOrInterfaceType;
 import japa.parser.ast.type.PrimitiveType;
 import japa.parser.ast.type.ReferenceType;
+import japa.parser.ast.type.Type;
 import japa.parser.ast.type.VoidType;
 import japa.parser.ast.type.WildcardType;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -535,9 +539,32 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 
 		return Boolean.TRUE;
 	}
-
+	
 	@Override public Boolean visit(final Parameter n1, final Node arg) {
 		final Parameter n2 = (Parameter) arg;
+		if (!nodeEquals(n1.getType(), n2.getType())) {
+			return Boolean.FALSE;
+		}
+		return visit((BaseParameter) n1, arg);
+	}
+	
+	@Override public Boolean visit(MultiTypeParameter n1, Node arg) {
+		MultiTypeParameter n2 = (MultiTypeParameter) arg;
+		if (n1.getTypes().size() != n2.getTypes().size()) {
+			return Boolean.FALSE;
+		}
+		Iterator<Type> n1types = n1.getTypes().iterator();
+		Iterator<Type> n2types = n2.getTypes().iterator();
+		while (n1types.hasNext() && n2types.hasNext()) {
+			if (!nodeEquals(n1types.next(), n2types.next())) {
+				return Boolean.FALSE;
+			}
+		}
+		return visit((BaseParameter) n1, arg);
+	}
+
+	protected Boolean visit(final BaseParameter n1, final Node arg) {
+		final BaseParameter n2 = (BaseParameter) arg;
 
 		if (n1.getModifiers() != n2.getModifiers()) {
 			return Boolean.FALSE;
@@ -547,17 +574,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 			return Boolean.FALSE;
 		}
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-
 		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
 			return Boolean.FALSE;
 		}
 
 		return Boolean.TRUE;
 	}
-
+	
 	@Override public Boolean visit(final EmptyMemberDeclaration n1, final Node arg) {
 		return Boolean.TRUE;
 	}

--- a/src/main/java/japa/parser/ast/visitor/GenericVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/GenericVisitor.java
@@ -39,6 +39,7 @@ import japa.parser.ast.body.FieldDeclaration;
 import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.VariableDeclarator;
 import japa.parser.ast.body.VariableDeclaratorId;
@@ -147,6 +148,8 @@ public interface GenericVisitor<R, A> {
 	public R visit(MethodDeclaration n, A arg);
 
 	public R visit(Parameter n, A arg);
+	
+	public R visit(MultiTypeParameter n, A arg);
 
 	public R visit(EmptyMemberDeclaration n, A arg);
 

--- a/src/main/java/japa/parser/ast/visitor/GenericVisitorAdapter.java
+++ b/src/main/java/japa/parser/ast/visitor/GenericVisitorAdapter.java
@@ -1407,9 +1407,11 @@ public abstract class GenericVisitorAdapter<R, A> implements
 	@Override
 	public R visit(final SynchronizedStmt n, final A arg) {
 		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
+			if (n.getExpr() != null) {
+			    R result = n.getExpr().accept(this, arg);
+			    if (result != null) {
+				    return result;
+			    }
 			}
 		}
 		{

--- a/src/main/java/japa/parser/ast/visitor/GenericVisitorAdapter.java
+++ b/src/main/java/japa/parser/ast/visitor/GenericVisitorAdapter.java
@@ -40,6 +40,7 @@ import japa.parser.ast.body.FieldDeclaration;
 import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.TypeDeclaration;
 import japa.parser.ast.body.VariableDeclarator;
@@ -1243,6 +1244,35 @@ public abstract class GenericVisitorAdapter<R, A> implements
 			R result = n.getType().accept(this, arg);
 			if (result != null) {
 				return result;
+			}
+		}
+		{
+			R result = n.getId().accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
+		return null;
+	}
+	
+	@Override
+	public R visit(final MultiTypeParameter n, final A arg) {
+		if (n.getAnnotations() != null) {
+			for (final AnnotationExpr a : n.getAnnotations()) {
+				{
+					R result = a.accept(this, arg);
+					if (result != null) {
+						return result;
+					}
+				}
+			}
+		}
+		{
+			for (final Type type : n.getTypes()) {
+				R result = type.accept(this, arg);
+				if (result != null) {
+					return result;
+				}
 			}
 		}
 		{

--- a/src/main/java/japa/parser/ast/visitor/ModifierVisitorAdapter.java
+++ b/src/main/java/japa/parser/ast/visitor/ModifierVisitorAdapter.java
@@ -30,6 +30,7 @@ import japa.parser.ast.PackageDeclaration;
 import japa.parser.ast.TypeParameter;
 import japa.parser.ast.body.AnnotationDeclaration;
 import japa.parser.ast.body.AnnotationMemberDeclaration;
+import japa.parser.ast.body.BaseParameter;
 import japa.parser.ast.body.BodyDeclaration;
 import japa.parser.ast.body.ClassOrInterfaceDeclaration;
 import japa.parser.ast.body.ConstructorDeclaration;
@@ -41,6 +42,7 @@ import japa.parser.ast.body.FieldDeclaration;
 import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.TypeDeclaration;
 import japa.parser.ast.body.VariableDeclarator;
@@ -108,6 +110,7 @@ import japa.parser.ast.type.Type;
 import japa.parser.ast.type.VoidType;
 import japa.parser.ast.type.WildcardType;
 
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -247,7 +250,7 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 
 	@Override public Node visit(final CatchClause n, final A arg) {
-		n.setExcept((Parameter) n.getExcept().accept(this, arg));
+		n.setExcept((MultiTypeParameter) n.getExcept().accept(this, arg));
 		n.setCatchBlock((BlockStmt) n.getCatchBlock().accept(this, arg));
 		return n;
 
@@ -747,8 +750,24 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 		n.setName((NameExpr) n.getName().accept(this, arg));
 		return n;
 	}
-
+	
 	@Override public Node visit(final Parameter n, final A arg) {
+		visit((BaseParameter) n, arg);
+		n.setType((Type) n.getType().accept(this, arg));
+		return n;
+	}
+	
+	public Node visit(MultiTypeParameter n, A arg) {
+    	visit((BaseParameter) n, arg);
+    	List<Type> types = new LinkedList<Type>();
+    	for (Type type : n.getTypes()) {
+    		types.add((Type) type.accept(this, arg));
+    	}
+        n.setTypes(types);
+        return n;
+    }
+
+	protected Node visit(final BaseParameter n, final A arg) {
 		final List<AnnotationExpr> annotations = n.getAnnotations();
 		if (annotations != null) {
 			for (int i = 0; i < annotations.size(); i++) {
@@ -756,7 +775,7 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 			}
 			removeNulls(annotations);
 		}
-		n.setType((Type) n.getType().accept(this, arg));
+		
 		n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
 		return n;
 	}

--- a/src/main/java/japa/parser/ast/visitor/VoidVisitor.java
+++ b/src/main/java/japa/parser/ast/visitor/VoidVisitor.java
@@ -39,6 +39,7 @@ import japa.parser.ast.body.FieldDeclaration;
 import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.VariableDeclarator;
 import japa.parser.ast.body.VariableDeclaratorId;
@@ -147,6 +148,8 @@ public interface VoidVisitor<A> {
 	void visit(MethodDeclaration n, A arg);
 
 	void visit(Parameter n, A arg);
+	
+	void visit(MultiTypeParameter n, A arg);
 
 	void visit(EmptyMemberDeclaration n, A arg);
 

--- a/src/main/java/japa/parser/ast/visitor/VoidVisitorAdapter.java
+++ b/src/main/java/japa/parser/ast/visitor/VoidVisitorAdapter.java
@@ -41,6 +41,7 @@ import japa.parser.ast.body.FieldDeclaration;
 import japa.parser.ast.body.InitializerDeclaration;
 import japa.parser.ast.body.JavadocComment;
 import japa.parser.ast.body.MethodDeclaration;
+import japa.parser.ast.body.MultiTypeParameter;
 import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.TypeDeclaration;
 import japa.parser.ast.body.VariableDeclarator;
@@ -662,6 +663,19 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 			}
 		}
 		n.getType().accept(this, arg);
+		n.getId().accept(this, arg);
+	}
+	
+	@Override public void visit(final MultiTypeParameter n, final A arg) {
+		visitComment(n.getComment(), arg);
+		if (n.getAnnotations() != null) {
+			for (final AnnotationExpr a : n.getAnnotations()) {
+				a.accept(this, arg);
+			}
+		}
+		for (final Type type : n.getTypes()) {
+			type.accept(this, arg);
+		}
 		n.getId().accept(this, arg);
 	}
 

--- a/src/main/javacc/java_1_5.jj
+++ b/src/main/javacc/java_1_5.jj
@@ -325,19 +325,23 @@ TOKEN :
         <DECIMAL_LITERAL> (["l","L"])
       | <HEX_LITERAL> (["l","L"])
       | <OCTAL_LITERAL> (["l","L"])
+      | <BINARY_LITERAL> (["l","L"])
   >
 |
   < INTEGER_LITERAL:
         <DECIMAL_LITERAL>
       | <HEX_LITERAL>
       | <OCTAL_LITERAL>
+      | <BINARY_LITERAL>
   >
 |
-  < #DECIMAL_LITERAL: ["1"-"9"] (["0"-"9"])* >
+  < #DECIMAL_LITERAL: (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) >
 |
-  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"])+ >
+  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"]((["0"-"9","a"-"f","A"-"F","_"])*["0"-"9","a"-"f","A"-"F"])?) >
 |
-  < #OCTAL_LITERAL: "0" (["0"-"7"])* >
+  < #OCTAL_LITERAL: "0" (["0"-"7"]((["0"-"7","_"])*["0"-"7"])?) >
+|
+  < #BINARY_LITERAL: "0" ["b","B"] (["0","1"]((["0","1","_"])*["0","1"])?) >
 |
   < FLOATING_POINT_LITERAL:
         <DECIMAL_FLOATING_POINT_LITERAL>

--- a/src/main/javacc/java_1_5.jj
+++ b/src/main/javacc/java_1_5.jj
@@ -3155,6 +3155,7 @@ TryStmt TryStatement():
  * finally/catch is present.
  */
 {
+    List resources = new LinkedList();
 	BlockStmt tryBlock;
 	BlockStmt finallyBlock = null;
 	List catchs = null;
@@ -3167,24 +3168,51 @@ TryStmt TryStatement():
        Comment cmmt = getComment();
 }
 {
-  "try" {line=token.beginLine; column=token.beginColumn;} tryBlock = Block()
+  "try" {line=token.beginLine; column=token.beginColumn;}
+  (resources = ResourceSpecification())?
+  tryBlock = Block()
   (
+        LOOKAHEAD(2)
   		(
   			"catch" {cLine=token.beginLine; cColumn=token.beginColumn;}
   			"(" except = FormalParameter() ")" catchBlock = Block()
   			{ catchs = add(catchs, new CatchClause(cLine, cColumn, token.endLine, token.endColumn, except, catchBlock)); }
-  		)+
+  		)*
   		[ "finally" finallyBlock = Block() ]
   	|
   		"finally" finallyBlock = Block()
   )
   { 
-      TryStmt tmp = new TryStmt(line, column, token.endLine, token.endColumn,tryBlock, catchs, finallyBlock); 
+      TryStmt tmp = new TryStmt(line, column, token.endLine, token.endColumn, resources, tryBlock, catchs, finallyBlock); 
       tmp.setComment(cmmt); 
       return tmp;
   }
 }
 
+
+List ResourceSpecification() :
+{
+List vars;
+}
+{
+  "("
+  vars = Resources()
+  (LOOKAHEAD(2) ";")?
+  ")"
+  { return vars; }
+}
+
+
+List Resources() :
+{
+	List vars = new LinkedList();
+	VariableDeclarationExpr var;
+}
+ {
+  /*this is a bit more lenient than we need to be, eg allowing access modifiers like private*/
+  var = VariableDeclarationExpression() {vars.add(var);} (LOOKAHEAD(2) ";" var = VariableDeclarationExpression() {vars.add(var);})*
+  { return vars; }
+}
 
 
 /* We use productions to match >>>, >> and > so that we can keep the

--- a/src/main/javacc/java_1_5.jj
+++ b/src/main/javacc/java_1_5.jj
@@ -3161,6 +3161,10 @@ TryStmt TryStatement():
 	List catchs = null;
 	Parameter except;
 	BlockStmt catchBlock;
+	Modifier exceptModifier;
+	Type exceptType;
+	List exceptTypes = new LinkedList();
+	VariableDeclaratorId exceptId;
 	int line;
 	int column;
 	int cLine;
@@ -3175,8 +3179,14 @@ TryStmt TryStatement():
         LOOKAHEAD(2)
   		(
   			"catch" {cLine=token.beginLine; cColumn=token.beginColumn;}
-  			"(" except = FormalParameter() ")" catchBlock = Block()
-  			{ catchs = add(catchs, new CatchClause(cLine, cColumn, token.endLine, token.endColumn, except, catchBlock)); }
+  			"(" 
+  			exceptModifier = Modifiers() exceptType = Type() { exceptTypes.add(exceptType); }
+  			( "|" exceptType = Type() { exceptTypes.add(exceptType); } )*
+  			exceptId = VariableDeclaratorId()
+  			")"
+  			 
+  			catchBlock = Block()
+  			{ catchs = add(catchs, new CatchClause(cLine, cColumn, token.endLine, token.endColumn, exceptModifier.modifiers, exceptModifier.annotations, exceptTypes, exceptId, catchBlock)); exceptTypes = new LinkedList(); }
   		)*
   		[ "finally" finallyBlock = Block() ]
   	|

--- a/src/main/javacc/java_1_5.jj
+++ b/src/main/javacc/java_1_5.jj
@@ -1855,9 +1855,14 @@ List TypeArguments():
 	Type type;
 }
 {
-   "<" { ret.add(new int[]{token.beginLine, token.beginColumn}); }
-   type = TypeArgument() { ret.add(type); } ( "," type = TypeArgument() { ret.add(type); } )*
-   ">"
+   (
+     "<" { ret.add(new int[]{token.beginLine, token.beginColumn}); }
+     type = TypeArgument() { ret.add(type); } ( "," type = TypeArgument() { ret.add(type); } )*
+     ">"
+   )
+   { return ret; }
+ |
+   "<>" { ret.add(null); } /*dummy add null since it is always removed*/
    { return ret; }
 }
 

--- a/src/main/javacc/java_1_7.jj
+++ b/src/main/javacc/java_1_7.jj
@@ -1,20 +1,20 @@
 /*
  * Copyright (C) 2008 Julio Vilmar Gesser.
  *
- * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ * This file is part of Java 1.7 parser and Abstract Syntax Tree.
  *
- * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * Java 1.7 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * Java 1.7 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Java 1.7 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 options {
@@ -31,20 +31,20 @@ PARSER_BEGIN(ASTParser)
 /*
  * Copyright (C) 2008 Julio Vilmar Gesser.
  * 
- * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ * This file is part of Java 1.7 parser and Abstract Syntax Tree.
  *
- * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * Java 1.7 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * Java 1.7 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Java 1.7 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
  */
 package japa.parser;
 

--- a/src/test/resources/japa/parser/ast/test/DumperTestClass.java
+++ b/src/test/resources/japa/parser/ast/test/DumperTestClass.java
@@ -350,6 +350,13 @@ public class DumperTestClass<T extends List<int[]>, X> extends Base implements S
         try (InputStream in = createInputStream()) {
             System.out.println(in);
         }
+        try {
+            System.out.println("whatever");
+        } catch (IOException | RuntimeException e) {
+            System.out.println(e);
+        } catch (@something @something2 final Exception | Error e) {
+            System.out.println(e);
+        }
         return JavaParser.parse(file);
     }
 

--- a/src/test/resources/japa/parser/ast/test/DumperTestClass.java
+++ b/src/test/resources/japa/parser/ast/test/DumperTestClass.java
@@ -336,6 +336,20 @@ public class DumperTestClass<T extends List<int[]>, X> extends Base implements S
         } catch (RuntimeException e) {
             System.out.println("catch");
         }
+        try (InputSteam in = createInputStream()) {
+            System.out.println(in);
+        } catch (IOException e) {
+            System.out.println("catch");
+        }
+        try (InputSteam in = createInputStream();
+            InputSteam in2 = createInputStream()) {
+            System.out.println(in);
+        } catch (IOException e) {
+            System.out.println("catch");
+        }
+        try (InputStream in = createInputStream()) {
+            System.out.println(in);
+        }
         return JavaParser.parse(file);
     }
 

--- a/src/test/resources/japa/parser/ast/test/DumperTestClass.java
+++ b/src/test/resources/japa/parser/ast/test/DumperTestClass.java
@@ -35,6 +35,12 @@ public class DumperTestClass<T extends List<int[]>, X> extends Base implements S
 
     short sh1, sh2 = 1;
 
+    int intWithUnderscore = 1234_5678;
+
+    long longWithUnderscore = 1234_5678L;
+
+    int binaryLiteral = 0b101101;
+
     List<String>[][] arrLS = (List<String>[][]) new List<?>[10][];
 
     ;

--- a/src/test/resources/japa/parser/ast/test/DumperTestClass.java
+++ b/src/test/resources/japa/parser/ast/test/DumperTestClass.java
@@ -52,6 +52,10 @@ public class DumperTestClass<T extends List<int[]>, X> extends Base implements S
         byte b = (byte) +y;
     }
 
+    List<String> diamond1 = new List<>();
+
+    List<> diamond2 = new List<String>();
+
     @Deprecated()
     static class Ugly {
 


### PR DESCRIPTION
I've added the ability to parse Java 7 source, which includes: binary literals, underscores in numeric literals, the "diamond operator", try-with-resource blocks, and multi-catch clauses. The last one is the biggest change, because it involves adding a new method to the visitors.
