### PR TITLE
Fix for issue #52

### DIFF
--- a/src/main/java/japa/parser/ast/Node.java
+++ b/src/main/java/japa/parser/ast/Node.java
@@ -222,7 +222,10 @@ public abstract class Node {
 	}
 
 	@Override public boolean equals(final Object obj) {
-		return EqualsVisitor.equals(this, (Node) obj);
+        if (obj==null || !(obj instanceof Node)){
+            return false;
+        }
+        return EqualsVisitor.equals(this, (Node) obj);
 	}
 
 	public Node getParentNode() {

--- a/src/test/java/japa/parser/ast/test/TestNode.java
+++ b/src/test/java/japa/parser/ast/test/TestNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2014, The GitHub project https://github.com/matozoid/javaparser.
+ * 
+ * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package japa.parser.ast.test;
+
+import japa.parser.ast.CompilationUnit;
+import japa.parser.ast.Node;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Federico Tomassetti
+ * @since July 2014
+ */
+public class TestNode {
+
+    @Test public void testIssue52NodeEqualsWorkWithNull() throws Exception {
+        Node n = new CompilationUnit();
+        assertFalse(n.equals(null));
+    }
+
+    @Test public void testIssue52NodeEqualsWorkWithArbitraryObjects() throws Exception {
+        Node n = new CompilationUnit();
+        assertFalse(n.equals("anObjectWhichIsNotANode, it is a String"));
+    }
+
+}


### PR DESCRIPTION
From Issue 52:

See Node.java, line 225:

``` java
@Override public boolean equals(final Object obj) {
    return EqualsVisitor.equals(this, (Node) obj);
}
```

This is a violation of the expected behavior of Equals, going to fix it and write a test for it.

Example of code causing the exception:

``` java
        Node n = new CompilationUnit();
        assertFalse(n.equals("anObjectWhichIsNotANode, it is a String"));
```
