### PR TITLE
Performance improvement

### DIFF
--- a/src/main/java/japa/parser/PositionUtils.java
+++ b/src/main/java/japa/parser/PositionUtils.java
@@ -17,17 +17,24 @@ public class PositionUtils {
         sortByBeginPosition(nodes, false);
     }
 
+    
     public static <T extends Node> void sortByBeginPosition(List<T> nodes, boolean ignoringAnnotations){
-        for (int i=0;i<nodes.size();i++){
-            for (int j=i+1;j<nodes.size();j++){
-                T nodeI = nodes.get(i);
-                T nodeJ = nodes.get(j);
+        T[] arrayNodos=(T[])new Node[0];
+        arrayNodos = (T[])nodes.toArray(arrayNodos);
+        for (int i=0;i<arrayNodos.length;i++){
+            for (int j=i+1;j<arrayNodos.length;j++){
+                T nodeI = arrayNodos[i];
+                T nodeJ = arrayNodos[j];
                 if (!areInOrder(nodeI, nodeJ, ignoringAnnotations)){
-                    nodes.set(i,nodeJ);
-                    nodes.set(j,nodeI);
+                    arrayNodos[i]=nodeJ;
+                    arrayNodos[j]=nodeI;
                 }
             }
         }
+        for (int i=0;i<arrayNodos.length;i++){
+            nodes.set(i,arrayNodos[i]);
+        }
+
     }
 
     public static boolean areInOrder(Node a, Node b){


### PR DESCRIPTION
Bubble sort algorithm over a double linked list has poor performance,
making the javaparser unusable in large projects.

This ugly refactor avoid the issue, reducing the complexity to O(n^2)
