### PR TITLE
fix #89: removing unused fields from CommentsParser.State

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
@@ -11,11 +11,8 @@ public class CommentsParser {
 
     private enum State {
         CODE,
-        WAITING_FOR_LINE_COMMENT,
         IN_LINE_COMMENT,
-        WAITING_FOR_BLOCK_COMMENT,
         IN_BLOCK_COMMENT,
-        WAITING_TO_LEAVE_BLOCK_COMMENT,
         IN_STRING;
     }
 


### PR DESCRIPTION
See issue #89 
