### PR TITLE
Fix #114

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1144,6 +1144,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 	}
 
 	@Override public void visit(final ExpressionStmt n, final Object arg) {
+		printOrphanCommentsBeforeThisChildNode(n);
 		printJavaComment(n.getComment(), arg);
 		n.getExpression().accept(this, arg);
 		printer.print(";");

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.visitor.DumpVisitor;
 import org.jbehave.core.annotations.*;
 import org.jbehave.core.model.ExamplesTable;
 import org.jbehave.core.steps.Parameters;
@@ -42,6 +43,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class CommentParsingSteps {
@@ -139,6 +141,13 @@ public class CommentParsingSteps {
             assertThat(lineCommentUnderTest.getEndColumn(), is(expectedLineComment.getEndColumn()));
             index ++;
         }
+    }
+
+    @Then("it is dumped to:$dumpSrc")
+    public void isDumpedTo(String dumpSrc) {
+        DumpVisitor dumpVisitor = new DumpVisitor();
+        dumpVisitor.visit(compilationUnit, null);
+        assertThat(dumpVisitor.getSource().trim(), is(dumpSrc.trim()));
     }
 
     @Then("the compilation unit is not commented")

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
@@ -424,7 +424,7 @@ When the class is parsed by the Java parser
 Then the compilation unit has 1 contained comments
 Then comment 1 in compilation unit commented node is PrimitiveType
 
-Scenario: We dump correctly two consecutive line-comments
+Scenario: We dump correctly two consecutive line-comments in a class
  
 Given the class:
 class A {
@@ -443,3 +443,26 @@ class A {
 
     ;
 }
+
+Scenario: We dump correctly two consecutive line-comments in a method
+
+Given the class:
+class A {
+  void aMethod(){
+     // foo
+     // bar
+     int a;
+  };
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+class A {
+    
+    void aMethod() {
+        // bar
+        int a;
+    }
+                            
+    ;
+}
+

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
@@ -457,12 +457,13 @@ class A {
 When the class is parsed by the Java parser
 Then it is dumped to:
 class A {
-    
+
     void aMethod() {
+        // foo
         // bar
         int a;
     }
-                            
+
     ;
 }
 

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
@@ -423,3 +423,23 @@ class A {
 When the class is parsed by the Java parser
 Then the compilation unit has 1 contained comments
 Then comment 1 in compilation unit commented node is PrimitiveType
+
+Scenario: We dump correctly two consecutive line-comments
+ 
+Given the class:
+class A {
+  // foo
+  // bar
+  void aMethod(){};
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+class A {
+
+    // foo
+    // bar
+    void aMethod() {
+    }
+
+    ;
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
@@ -430,7 +430,7 @@ Given the class:
 class A {
   // foo
   // bar
-  void aMethod(){};
+  void aMethod(){}
 }
 When the class is parsed by the Java parser
 Then it is dumped to:
@@ -440,8 +440,6 @@ class A {
     // bar
     void aMethod() {
     }
-
-    ;
 }
 
 Scenario: We dump correctly two consecutive line-comments in a method
@@ -452,7 +450,7 @@ class A {
      // foo
      // bar
      int a;
-  };
+  }
 }
 When the class is parsed by the Java parser
 Then it is dumped to:
@@ -463,7 +461,5 @@ class A {
         // bar
         int a;
     }
-
-    ;
 }
 

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
@@ -150,3 +150,18 @@ Then the block comments have the following positions:
 Then the Javadoc comments have the following positions:
 |beginLine|beginColumn|endLine|endColumn|
 |15|5|17|8|
+
+Scenario: A method containing two consecutive line comments is parsed correctly
+
+Given the class:
+class A {
+  void aMethod(){
+     // foo
+     // bar
+     int a;
+  };
+}
+When the class is parsed by the comment parser
+Then the total number of comments is 2
+Then line comment 1 is " foo"
+Then line comment 2 is " bar"

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
@@ -159,7 +159,7 @@ class A {
      // foo
      // bar
      int a;
-  };
+  }
 }
 When the class is parsed by the comment parser
 Then the total number of comments is 2


### PR DESCRIPTION
Orphan comments preceding ExpressionStatemens were not dumped.

I added a few tests (3) to cover this case.
