### PR TITLE
Bugs due to null lists

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/internal/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/internal/Utils.java
@@ -1,0 +1,20 @@
+package com.github.javaparser.ast.internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Federico Tomassetti
+ * @since 2.0.1
+ */
+public class Utils {
+
+    public static <T> List<T> ensureNotNull(List<T> list) {
+        return list == null ? Collections.<T>emptyList() : list;
+    }
+
+    public static <E> boolean isNullOrEmpty(Collection<E> collection) {
+        return collection == null || collection.isEmpty();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -82,6 +82,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.github.javaparser.ast.internal.Utils.isNullOrEmpty;
+
 /**
  * Dumps the AST to formatted Java source code.
  * 
@@ -199,7 +201,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 	}
 
 	private void printMemberAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
-		if (annotations != null) {
+		if (!isNullOrEmpty(annotations)) {
 			for (final AnnotationExpr a : annotations) {
 				a.accept(this, arg);
 				printer.printLn();
@@ -208,7 +210,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 	}
 
 	private void printAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
-		if (annotations != null) {
+		if (!isNullOrEmpty(annotations)) {
 			for (final AnnotationExpr a : annotations) {
 				a.accept(this, arg);
 				printer.print(" ");
@@ -217,7 +219,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 	}
 
 	private void printTypeArgs(final List<Type> args, final Object arg) {
-		if (args != null) {
+        if (!isNullOrEmpty(args)) {
 			printer.print("<");
 			for (final Iterator<Type> i = args.iterator(); i.hasNext();) {
 				final Type t = i.next();
@@ -231,7 +233,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 	}
 
 	private void printTypeParameters(final List<TypeParameter> args, final Object arg) {
-		if (args != null) {
+        if (!isNullOrEmpty(args)) {
 			printer.print("<");
 			for (final Iterator<TypeParameter> i = args.iterator(); i.hasNext();) {
 				final TypeParameter t = i.next();
@@ -246,7 +248,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 
 	private void printArguments(final List<Expression> args, final Object arg) {
 		printer.print("(");
-		if (args != null) {
+        if (!isNullOrEmpty(args)) {
 			for (final Iterator<Expression> i = args.iterator(); i.hasNext();) {
 				final Expression e = i.next();
 				e.accept(this, arg);
@@ -355,7 +357,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 
 		printTypeParameters(n.getTypeParameters(), arg);
 
-		if (n.getExtends() != null) {
+		if (!isNullOrEmpty(n.getExtends())) {
 			printer.print(" extends ");
 			for (final Iterator<ClassOrInterfaceType> i = n.getExtends().iterator(); i.hasNext();) {
 				final ClassOrInterfaceType c = i.next();
@@ -366,7 +368,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 			}
 		}
 
-		if (n.getImplements() != null) {
+		if (!isNullOrEmpty(n.getImplements())) {
 			printer.print(" implements ");
 			for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext();) {
 				final ClassOrInterfaceType c = i.next();
@@ -379,7 +381,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 
 		printer.printLn(" {");
 		printer.indent();
-		if (n.getMembers() != null) {
+		if (!isNullOrEmpty(n.getMembers())) {
 			printMembers(n.getMembers(), arg);
 		}
 
@@ -969,7 +971,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 		}
 		printer.print(")");
 
-		if (n.getThrows() != null && !n.getThrows().isEmpty()) {
+		if (!isNullOrEmpty(n.getThrows())) {
 			printer.print(" throws ");
 			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
 				final NameExpr name = i.next();
@@ -1018,7 +1020,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 			printer.print("[]");
 		}
 
-		if (n.getThrows() != null && !n.getThrows().isEmpty()) {
+		if (!isNullOrEmpty(n.getThrows())) {
 			printer.print(" throws ");
 			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
 				final NameExpr name = i.next();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -74,6 +74,7 @@ import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.ast.type.WildcardType;
+import static com.github.javaparser.ast.internal.Utils.isNullOrEmpty;
 
 /**
  * @author Julio Vilmar Gesser
@@ -122,7 +123,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 	@Override public void visit(final ArrayCreationExpr n, final A arg) {
 		visitComment(n.getComment(), arg);
 		n.getType().accept(this, arg);
-		if (n.getDimensions() != null) {
+		if (!isNullOrEmpty(n.getDimensions())) {
 			for (final Expression dim : n.getDimensions()) {
 				dim.accept(this, arg);
 			}


### PR DESCRIPTION
In some situations we do not handle correctly empty lists. In visitors we just check for null lists but empty lists have the same meaning so they should be treated in the same way (derived from #54 )
