### PR TITLE
Testing comments parser support for specifying encodings

### DIFF
--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/TestUtils.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/TestUtils.java
@@ -1,0 +1,16 @@
+package com.github.javaparser.bdd;
+
+import java.io.InputStream;
+
+public class TestUtils {
+
+    public static InputStream getSampleStream(String sampleName) {
+        InputStream is = TestUtils.class.getClassLoader().getResourceAsStream("com/github/javaparser/bdd/samples/"
+                + sampleName + ".java");
+        if (is == null) {
+            throw new RuntimeException("Example not found, check your test. Sample name: " + sampleName);
+        }
+        return is;
+    }
+
+}

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.visitor.DumpVisitor;
+import com.github.javaparser.bdd.TestUtils;
 import org.jbehave.core.annotations.*;
 import org.jbehave.core.model.ExamplesTable;
 import org.jbehave.core.steps.Parameters;
@@ -55,6 +56,12 @@ public class CommentParsingSteps {
     @Given("the class:$classSrc")
     public void givenTheClass(String classSrc) {
         this.sourceUnderTest = classSrc.trim();
+    }
+
+    @When("read sample \"$sampleName\" using encoding \"$encoding\"")
+    public void givenTheClassWithEncoding(String sampleName, String encoding) throws IOException {
+        sourceUnderTest = null;
+        commentsCollection = new CommentsParser().parse(TestUtils.getSampleStream(sampleName), encoding);
     }
 
     @When("the class is parsed by the comment parser")

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
@@ -165,3 +165,9 @@ When the class is parsed by the comment parser
 Then the total number of comments is 2
 Then line comment 1 is " foo"
 Then line comment 2 is " bar"
+
+Scenario: Comments from a file with an non-UTF-8 encoding are parsed correctly
+
+When read sample "ClassInLatin1" using encoding "ISO-8859-1"
+Then the total number of comments is 3
+Then line comment 2 is " A l'émej in piasì che sent dësgust."

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/samples/ClassInLatin1.java
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/samples/ClassInLatin1.java
@@ -1,0 +1,6 @@
+// Comment in Latin1:
+// A l'émej in piasì che sent dësgust.
+// For the curios reader, this is Piedmontese dialect
+class A {
+
+}


### PR DESCRIPTION
We add a test reading a file saved with an encoding different from the default one (ISO-8859-1 instead of UTF-8).

We want to be able to read the comments correctly.

This test has been discussed in #41. The functionality has been introduced in #50.
