### PR TITLE
Adding test to verify that /*/ is not recognized as a comment

### DIFF
--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
@@ -22,6 +22,7 @@ package com.github.javaparser.bdd.steps;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
+import com.github.javaparser.TokenMgrError;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.*;
@@ -45,6 +46,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class CommentParsingSteps {
 
@@ -70,6 +72,16 @@ public class CommentParsingSteps {
     @When("the class is parsed by the Java parser")
     public void whenTheClassIsParsedByTheJavaParser() throws ParseException {
         compilationUnit = JavaParser.parse(new ByteArrayInputStream(sourceUnderTest.getBytes()));
+    }
+
+    @Then("the Java parser cannot parse it because of lexical errors")
+    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseException {
+        try {
+            compilationUnit = JavaParser.parse(new ByteArrayInputStream(sourceUnderTest.getBytes()));
+            fail("Lexical error expected");
+        } catch (TokenMgrError e) {
+            // ok
+        }
     }
 
     @Then("the total number of comments is $expectedCount")

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
@@ -165,3 +165,16 @@ When the class is parsed by the comment parser
 Then the total number of comments is 2
 Then line comment 1 is " foo"
 Then line comment 2 is " bar"
+
+Scenario: Should not recognize /*/ as a comment
+
+Given the class:
+/*/
+class Foo {}
+When the class is parsed by the comment parser
+Then the total number of comments is 0
+
+Given the class:
+/*/
+class Foo {}
+Then the Java parser cannot parse it because of lexical errors


### PR DESCRIPTION
Following #95 we add a test to prevent possible future regressions.
