### PR TITLE
Fix hashCode to differentiate between Nodes that have the same toString

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -250,8 +250,14 @@ public abstract class Node {
     hash = addToHashCode(hash, hashMultiplier, this.getBeginColumn());
     hash = addToHashCode(hash, hashMultiplier, this.getEndLine());
     hash = addToHashCode(hash, hashMultiplier, this.getEndColumn());
-    //hash = addToHashCode(hash, hashMultiplier, this.getData().hashCode());
-    hash = addToHashCode(hash, hashMultiplier, this.getComment().hashCode());
+    Object data = this.getData();
+    if (null != data) {
+      hash = addToHashCode(hash, hashMultiplier, data.hashCode());
+    }
+    Comment comment = this.getComment();
+    if (null != comment) {
+      hash = addToHashCode(hash, hashMultiplier, comment.hashCode());
+    }
 		return hash;
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -237,21 +237,21 @@ public abstract class Node {
         return visitor.getSource();
     }
 
-  private final int addToHashCode(int currentHashCode, int hashToAdd) {
-    currentHashCode *= 67;
+  protected final int addToHashCode(int currentHashCode, int hashMultiplier, int hashToAdd) {
+    currentHashCode *= hashMultiplier;
     return currentHashCode + hashToAdd;
   }
 
-	@Override public final int hashCode() {
+	@Override public int hashCode() {
     final int hashMultiplier = 67;
     int hash = 461;
-    hash = addToHashCode(hash, this.toString().hashCode());
-    hash = addToHashCode(hash, this.getBeginLine());
-    hash = addToHashCode(hash, this.getBeginColumn());
-    hash = addToHashCode(hash, this.getEndLine());
-    hash = addToHashCode(hash, this.getEndColumn());
-    hash = addToHashCode(hash, this.getData().hashCode());
-    hash = addToHashCode(hash, this.getComment().hashCode());
+    hash = addToHashCode(hash, hashMultiplier, this.toString().hashCode());
+    hash = addToHashCode(hash, hashMultiplier, this.getBeginLine());
+    hash = addToHashCode(hash, hashMultiplier, this.getBeginColumn());
+    hash = addToHashCode(hash, hashMultiplier, this.getEndLine());
+    hash = addToHashCode(hash, hashMultiplier, this.getEndColumn());
+    //hash = addToHashCode(hash, hashMultiplier, this.getData().hashCode());
+    hash = addToHashCode(hash, hashMultiplier, this.getComment().hashCode());
 		return hash;
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -237,8 +237,22 @@ public abstract class Node {
         return visitor.getSource();
     }
 
+  private final int addToHashCode(int currentHashCode, int hashToAdd) {
+    currentHashCode *= 67;
+    return currentHashCode + hashToAdd;
+  }
+
 	@Override public final int hashCode() {
-		return toString().hashCode();
+    final int hashMultiplier = 67;
+    int hash = 461;
+    hash = addToHashCode(hash, this.toString().hashCode());
+    hash = addToHashCode(hash, this.getBeginLine());
+    hash = addToHashCode(hash, this.getBeginColumn());
+    hash = addToHashCode(hash, this.getEndLine());
+    hash = addToHashCode(hash, this.getEndColumn());
+    hash = addToHashCode(hash, this.getData().hashCode());
+    hash = addToHashCode(hash, this.getComment().hashCode());
+		return hash;
 	}
 
 	@Override public boolean equals(final Object obj) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -47,6 +47,18 @@ public abstract class Comment extends Node {
         this.content = content;
     }
 
+    @Override public final int hashCode() {
+      final int hashMultiplier = 71;
+      int hash = 463;
+      hash = addToHashCode(hash, hashMultiplier, this.toString().hashCode());
+      hash = addToHashCode(hash, hashMultiplier, this.getBeginLine());
+      hash = addToHashCode(hash, hashMultiplier, this.getBeginColumn());
+      hash = addToHashCode(hash, hashMultiplier, this.getEndLine());
+      hash = addToHashCode(hash, hashMultiplier, this.getEndColumn());
+      hash = addToHashCode(hash, hashMultiplier, this.getContent().hashCode());
+      return hash;
+    }
+
     /**
      * Return the text of the comment.
      * 


### PR DESCRIPTION
I don't think these Nodes compare as equal, and so they should not hash equally either.  I've added information such as line numbers to the hashCode method to fix this.

All the tests continue to pass.

If I'm wrong and they do compare as equal... maybe they shouldn't?  They're completely different Nodes in completely different places in the source...?
