### PR TITLE
make PositionUtils final and adding a private constructor

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/PositionUtils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/PositionUtils.java
@@ -35,7 +35,11 @@ import java.util.List;
 
 import static java.lang.Integer.signum;
 
-public class PositionUtils {
+public final class PositionUtils {
+
+    private PositionUtils() {
+        // prevent instantiation
+    }
 
     public static <T extends Node> void sortByBeginPosition(List<T> nodes){
         sortByBeginPosition(nodes, false);


### PR DESCRIPTION
PositionUtils is a utils class (all methods static), however it does not have a private constructor. Adding it and making the class final to prevent extension.

P.S. I am working on a Java linter from time to time and I use JavaParser to test it. And the Java linter is based on JavaParser, so if you wonder where such nitpick pull requests are coming from... well... take a look at [effectivejava](https://github.com/ftomassetti/effectivejava)
