### PR TITLE
Document arraysAnnotations in ReferenceType

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -92,7 +92,7 @@ public final class ReferenceType extends Type {
 	}
 
 	/**
-	 * <p>Arrays annotations are annotations on the Arrays modifiers of the type.
+	 * <p>Arrays annotations are annotations on the arrays modifiers of the type.
 	 * Consider this example:</p>
 	 * 
 	 * <p><pre>
@@ -103,6 +103,11 @@ public final class ReferenceType extends Type {
 	 * <p>in this this method will return a list with the annotation expressions <pre>@Ann1</pre>
 	 * and <pre>@Ann2</pre></p>
 	 * 
+	 * <p>Note that the first list element of arraysAnnotations will refer to the first array modifier encountered.
+	 * Considering the example the first element will be a list containing just @Ann1 while the second element will
+	 * be a list containing just @Ann2.
+	 * </p>
+	 *
 	 * <p>This property is guaranteed to hold: <pre>{@code getArraysAnnotations().size() == getArrayCount()}</pre>
 	 * If a certain array modifier has no annotation the corresponding entry of arraysAnnotations will be null</p>
 	 */

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -91,10 +91,28 @@ public final class ReferenceType extends Type {
 		setAsParentNodeOf(this.type);
 	}
 
+	/**
+	 * <p>Arrays annotations are annotations on the Arrays modifiers of the type.
+	 * Consider this example:</p>
+	 * 
+	 * <p><pre>
+	 * {@code
+	 * int @Ann1 [] @Ann2 [] array;
+	 * }</pre></p>
+	 * 
+	 * <p>in this this method will return a list with the annotation expressions <pre>@Ann1</pre>
+	 * and <pre>@Ann2</pre></p>
+	 * 
+	 * <p>This property is guaranteed to hold: <pre>{@code getArraysAnnotations().size() == getArrayCount()}</pre>
+	 * If a certain array modifier has no annotation the corresponding entry of arraysAnnotations will be null</p>
+	 */
     public List<List<AnnotationExpr>> getArraysAnnotations() {
         return arraysAnnotations;
     }
 
+	/**
+	 * For a description of the arrayAnnotations field refer to {@link #getArraysAnnotations()}
+	 */
     public void setArraysAnnotations(List<List<AnnotationExpr>> arraysAnnotations) {
         this.arraysAnnotations = arraysAnnotations;
     }


### PR DESCRIPTION
The field `arraysAnnotations` of `ReferenceType` is not obvious and to understand its meaning it is necessary to dig into the grammar.

It is used to collect annotations on the array modifiers, like the annotations used in this example:

`Foo @Ann1 [] [] @Ann2 [] foo;`

This patch is just about adding a Javadoc for the getter of the field and a reference in the setter.

See issue #139  
