### PR TITLE
Issue 140: extra space in new object creation expression

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -894,7 +894,9 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 		printer.print("new ");
 
 		printTypeArgs(n.getTypeArgs(), arg);
+		if (!isNullOrEmpty(n.getTypeArgs())) {
 			printer.print(" ");
+		}
 
 		n.getType().accept(this, arg);
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/DumpingTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/DumpingTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2015 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with JavaParser.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.javaparser.bdd;
+
+import com.github.javaparser.bdd.steps.DumpingSteps;
+import de.codecentric.jbehave.junit.monitoring.JUnitReportingRunner;
+import org.jbehave.core.steps.InjectableStepsFactory;
+import org.jbehave.core.steps.InstanceStepsFactory;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitReportingRunner.class)
+public class DumpingTest extends BasicJBehaveTest {
+
+    @Override
+    public InjectableStepsFactory stepsFactory() {
+        return new InstanceStepsFactory(configuration(), new DumpingSteps());
+    }
+
+    public DumpingTest() {
+        super("**/bdd/dumping*.story");
+    }
+}
+

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2015 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with JavaParser.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.javaparser.bdd.steps;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseException;
+import com.github.javaparser.TokenMgrError;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.comments.*;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.visitor.DumpVisitor;
+import com.github.javaparser.bdd.TestUtils;
+import org.jbehave.core.annotations.Alias;
+import org.jbehave.core.annotations.Given;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+import org.jbehave.core.model.ExamplesTable;
+import org.jbehave.core.steps.Parameters;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static com.github.javaparser.bdd.steps.SharedSteps.getMemberByTypeAndPosition;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class DumpingSteps {
+
+    private CompilationUnit compilationUnit;
+    private CommentsCollection commentsCollection;
+    private String sourceUnderTest;
+
+    @Given("the class:$classSrc")
+    public void givenTheClass(String classSrc) {
+        this.sourceUnderTest = classSrc.trim();
+    }
+
+    @When("the class is parsed by the Java parser")
+    public void whenTheClassIsParsedByTheJavaParser() throws ParseException {
+        compilationUnit = JavaParser.parse(new ByteArrayInputStream(sourceUnderTest.getBytes()));
+    }
+
+    @Then("it is dumped to:$dumpSrc")
+    public void isDumpedTo(String dumpSrc) {
+        DumpVisitor dumpVisitor = new DumpVisitor();
+        dumpVisitor.visit(compilationUnit, null);
+        assertThat(dumpVisitor.getSource().trim(), is(dumpSrc.trim()));
+    }
+
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -1,0 +1,12 @@
+Scenario: When printing the instantiation we should use the right amount of spaces
+
+Given the class:
+public class A {
+    Object foo = new Object();
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+public class A {
+
+    Object foo = new Object();
+}


### PR DESCRIPTION
When dumping the expression:

``` java
new Foo()
```

two spaces are inserted between `new` and `Foo`.

In this patch we add:
- one test for prove the bug and protect against regressions
- the fix for the bug

See #140 for details.
