### PR TITLE
Issue 149: parsing combined casts

### DIFF
--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -2256,7 +2256,9 @@ Expression CastExpression():
 	int line;
 	int column;
 	AnnotationExpr ann;
+	Type st;
 	List annotations = null;
+	List secondaryTypes = null;
 }
 {
   "(" {line=token.beginLine; column=token.beginColumn;}
@@ -2265,7 +2267,7 @@ Expression CastExpression():
   	  LOOKAHEAD(2)
   	  type = PrimitiveType() ")" ret = UnaryExpression() { type.setAnnotations(annotations); ret = new CastExpr(line, column, token.endLine, token.endColumn,type, ret); }
   	|
-  	  type = ReferenceType() ")" ret = UnaryExpressionNotPlusMinus() { type.setAnnotations(annotations); ret = new CastExpr(line, column, token.endLine, token.endColumn,type, ret); }
+  	  type = ReferenceType() ("&" st = ReferenceType() { secondaryTypes = add(secondaryTypes, st);} )* ")" ret = UnaryExpressionNotPlusMinus() { type.setAnnotations(annotations); ret = new CastExpr(line, column, token.endLine, token.endColumn,type, ret); }
   )
   { return ret; }
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -255,3 +255,16 @@ interface MyInterface {
 Then method 1 class 1 is a default method
 Then method 2 class 1 is not a default method
 Then all nodes refer to their parent
+
+
+Scenario: simple cast on lambda expression can be parsed
+
+Given a CompilationUnit
+When the following source is parsed:
+class A {
+    static final Comparator<ChronoLocalDate> DATE_ORDER =
+        (Comparator<ChronoLocalDate>) (date1, date2) -> {
+            return Long.compare(date1.toEpochDay(), date2.toEpochDay());
+        };
+}
+Then all nodes refer to their parent

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -268,3 +268,15 @@ class A {
         };
 }
 Then all nodes refer to their parent
+
+Scenario: a combined cast on lambda expression can be parsed
+
+Given a CompilationUnit
+When the following source is parsed:
+class A {
+    static final Comparator<ChronoLocalDate> DATE_ORDER =
+        (Comparator<ChronoLocalDate> & Serializable) (date1, date2) -> {
+            return Long.compare(date1.toEpochDay(), date2.toEpochDay());
+        };
+}
+Then all nodes refer to their parent

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -280,3 +280,13 @@ class A {
         };
 }
 Then all nodes refer to their parent
+
+Scenario: a combined cast on a literal can be parsed
+
+Given a CompilationUnit
+When the following source is parsed:
+class A {
+    static int a = (Comparator<ChronoLocalDate> & Serializable) 1;
+}
+Then all nodes refer to their parent
+


### PR DESCRIPTION
In issue 149 has been reported one issue with a new form of casts (introduced in Java 8) that we were not supporting.

Example:

```
Object foo = (Cloneable & Serializable)bar;
```

I suggest one solution in which the existing node type `CastExpression` get an additional fields named `secondaryTypes` which collect all types but the first. We could of course add a method to get allTypes (so the first one and the secondary ones in one collection).

Otherwise we could add a new type of expression (CombinedCastExpression) and maybe rename the existing one to SimpleCastExpression. Maybe both types could inherited by an abstract type named CastExpression.

Suggestions?
