### PR TITLE
issue 148: add additional test to verify we dump correctly orphan com…

### DIFF
--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_attribution_scenarios.story
@@ -463,3 +463,36 @@ class A {
     }
 }
 
+Scenario: We dump correctly orphan comments in a for loop
+Given the class:
+class A {
+    public static List calcularResultadoFinal(List avaliacoes) throws SQLException, ClassNotFoundException{
+        for(Avaliacao avaliacao: avaliacoes){
+            // if(avaliacao.obterAprovacao()){
+            // avaliacao.setResultadoFinal("Aprovado");
+            // }else{
+            // avaliacao.setResultadoFinal("Reprovado");
+            // }
+            avaliacao.setEmAberto(false);
+            avaliacao.editar();
+        }
+        return avaliacoes;
+    }
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+class A {
+
+    public static List calcularResultadoFinal(List avaliacoes) throws SQLException, ClassNotFoundException {
+        for (Avaliacao avaliacao : avaliacoes) {
+            // if(avaliacao.obterAprovacao()){
+            // avaliacao.setResultadoFinal("Aprovado");
+            // }else{
+            // avaliacao.setResultadoFinal("Reprovado");
+            // }
+            avaliacao.setEmAberto(false);
+            avaliacao.editar();
+        }
+        return avaliacoes;
+    }
+}


### PR DESCRIPTION
…ments in a for loop

The issue reported a problem with has been solved with recent releases of JavaParser. This PR is just about adding an additional test case to assure we dump correctly orphan comments inside for statements.
