### PR TITLE
issue #152: Parse Failed due to ConditionalExpr in lambda

### DIFF
--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1962,6 +1962,12 @@ Expression Expression():
        inner = generateLambda(((CastExpr)ret).getExpr(), lambdaBody);
        ((CastExpr)ret).setExpr(inner);
      }
+     else if (ret instanceof ConditionalExpr){
+     	 ConditionalExpr ce = (ConditionalExpr) ret;
+         if(ce.getElseExpr() != null){
+            ce.setElseExpr(generateLambda(ce.getElseExpr(), lambdaBody));
+         }
+     }
      else
      {
        ret = generateLambda(ret, lambdaBody);

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -208,5 +208,13 @@ public class ParsingSteps {
         ExistenceOfParentNodeVerifier parentVerifier = new ExistenceOfParentNodeVerifier();
         parentVerifier.verify(compilationUnit);
     }
+    
+    @Then("ThenExpr in the conditional expression of the statement $statementPosition in method $methodPosition in class $classPosition is LambdaExpr")
+    public void thenLambdaInConditionalExpressionInMethodInClassIsParentOfContainedParameter(int statementPosition, int methodPosition, int classPosition) {
+    	Statement statement = getStatementInMethodInClass(statementPosition, methodPosition, classPosition);
+    	ReturnStmt returnStmt = (ReturnStmt) statement;
+    	ConditionalExpr conditionalExpr = (ConditionalExpr)returnStmt.getExpr();
+        assertThat(conditionalExpr.getElseExpr().getClass().getName(), is(LambdaExpr.class.getName()));
+    }
 
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -255,3 +255,15 @@ interface MyInterface {
 Then method 1 class 1 is a default method
 Then method 2 class 1 is not a default method
 Then all nodes refer to their parent
+
+
+Scenario: A lambda expression inside a conditional expression is parsed by the Java Parser
+
+Given a CompilationUnit
+When the following source is parsed:
+public class A{
+	static <T> Predicate<T> isEqual(Object targetRef) {
+	    return (null == targetRef)? Objects::isNull : object -> targetRef.equals(object);
+	}
+}
+Then ThenExpr in the conditional expression of the statement 1 in method 1 in class 1 is LambdaExpr


### PR DESCRIPTION
Solved. It was a bug in the Expression() rule
