### PR TITLE
Fixed: CommentsParser

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
@@ -33,7 +33,8 @@ public class CommentsParser {
         CODE,
         IN_LINE_COMMENT,
         IN_BLOCK_COMMENT,
-        IN_STRING;
+        IN_STRING,
+        IN_CHAR;
     }
 
     private static final int COLUMNS_PER_TAB = 4;
@@ -85,6 +86,8 @@ public class CommentsParser {
                         currentContent = new StringBuffer();
                     } else if (c == '"') {
                         state = State.IN_STRING;
+                    } else if (c == '\'') {
+                        state = State.IN_CHAR;
                     } else {
                         // nothing to do
                     }
@@ -127,6 +130,11 @@ public class CommentsParser {
                     break;
                 case IN_STRING:
                     if (!prevTwoChars.peekLast().equals('\\') && c == '"') {
+                        state = State.CODE;
+                    }
+                    break;
+                case IN_CHAR:
+                    if (!prevTwoChars.peekLast().equals('\\') && c == '\'') {
                         state = State.CODE;
                     }
                     break;

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
@@ -184,3 +184,16 @@ Given the class:
 /*/
 class Foo {}
 Then the Java parser cannot parse it because of lexical errors
+
+Scenario: A Class With Character Literal is processed by the Comments Parser
+Given the class:
+class A {
+    /** comment1 */
+    private char c = '"';
+    /** comment2 */
+    private String d;
+}
+When the class is parsed by the comment parser
+Then the total number of comments is 2
+Then Javadoc comment 1 is "comment1"
+Then Javadoc comment 2 is "comment2"


### PR DESCRIPTION
Fixed: a class with character literal cannot be parsed correctly by the Comments Parser
