### PR TITLE
Issue 147: add clone method to Node

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -20,15 +20,14 @@
 
 package com.github.javaparser.ast;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.visitor.DumpVisitor;
-import com.github.javaparser.ast.visitor.EqualsVisitor;
-import com.github.javaparser.ast.visitor.GenericVisitor;
-import com.github.javaparser.ast.visitor.VoidVisitor;
+import com.github.javaparser.ast.visitor.*;
 
 /**
  * Abstract class for all nodes of the AST.
@@ -39,7 +38,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  * 
  * @author Julio Vilmar Gesser
  */
-public abstract class Node {
+public abstract class Node implements Cloneable {
 
 	private int beginLine;
 
@@ -248,7 +247,12 @@ public abstract class Node {
         return EqualsVisitor.equals(this, (Node) obj);
 	}
 
-	public Node getParentNode() {
+    @Override
+    public Node clone() {
+        return this.accept(new CloneVisitor(), null);
+    }
+
+    public Node getParentNode() {
 		return parentNode;
 	}
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
@@ -186,6 +186,12 @@ public class ManipulationSteps {
         ASTHelper.addParameter(method, ASTHelper.createParameter(ASTHelper.INT_TYPE, paramName));
     }
 
+    @When("the compilation unit is cloned")
+    public void whenTheCompilationUnitIsCloned() throws CloneNotSupportedException {
+        CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
+        state.put("cu1", compilationUnit.clone());
+    }
+
     @When("the ChangeNameToUpperCaseVisitor visits to compilation unit")
     public void whenTheVisitorVisitsToCompilationUnit() {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/manipulation_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/manipulation_scenarios.story
@@ -124,3 +124,21 @@ Then method 1 in class 1 has 2 parameters
 Then method 2 in class 1 has 1 parameter
 Then method 1 in class 1 parameter 2 is type int called "value"
 Then method 2 in class 1 parameter 1 is type int called "value"
+
+
+Scenario: Clone a compilation unit
+
+Given a CompilationUnit
+When the following source is parsed:
+package japa.parser.ast.manipulation;
+
+public class UpdateMethod {
+
+    public void changeToUpperCase(String param){}
+
+    public void anotherMethodToChange(){}
+}
+When the compilation unit is cloned
+Then method 1 in class 1 has the name "changeToUpperCase"
+Then method 1 in class 1 has 1 parameters
+Then method 2 in class 1 has 0 parameter


### PR DESCRIPTION
This is a proposal: let me know if it makes sense to you. The rationale is to make cloning easier to use. ~~While this solution means few lines of code it uses reflection.~~

~~\* We could pre-calculate the method of CloneVisitor to call at construction time~~
~~\* We could change approach and have different implementations of the clone method (each one calling a different method of CloneVisitor)~~

Reference: #147 
