### PR TITLE
Parse annotations around reference types

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -54,7 +55,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
 
 	private int arrayCount;
 
-	private List<NameExpr> throws_;
+	private List<ReferenceType> throws_;
 
 	private BlockStmt body;
 
@@ -78,7 +79,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
 
 	public MethodDeclaration(final int modifiers, final List<AnnotationExpr> annotations,
 			final List<TypeParameter> typeParameters, final Type type, final String name,
-			final List<Parameter> parameters, final int arrayCount, final List<NameExpr> throws_, final BlockStmt block) {
+			final List<Parameter> parameters, final int arrayCount, final List<ReferenceType> throws_, final BlockStmt block) {
 		super(annotations);
 		setModifiers(modifiers);
 		setTypeParameters(typeParameters);
@@ -93,7 +94,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
 	public MethodDeclaration(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
 			final int modifiers, final List<AnnotationExpr> annotations,
 			final List<TypeParameter> typeParameters, final Type type, final String name,
-			final List<Parameter> parameters, final int arrayCount, final List<NameExpr> throws_, final BlockStmt block) {
+			final List<Parameter> parameters, final int arrayCount, final List<ReferenceType> throws_, final BlockStmt block) {
 		super(beginLine, beginColumn, endLine, endColumn, annotations);
 		setModifiers(modifiers);
 		setTypeParameters(typeParameters);
@@ -145,7 +146,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
         return parameters;
 	}
 
-	public List<NameExpr> getThrows() {
+	public List<ReferenceType> getThrows() {
         throws_ = ensureNotNull(throws_);
         return throws_;
 	}
@@ -185,7 +186,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
 		setAsParentNodeOf(this.parameters);
 	}
 
-	public void setThrows(final List<NameExpr> throws_) {
+	public void setThrows(final List<ReferenceType> throws_) {
 		this.throws_ = throws_;
 		setAsParentNodeOf(this.throws_);
 	}
@@ -276,7 +277,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
         sb.append(")");
         if (includingThrows) {
             boolean firstThrow = true;
-            for (NameExpr thr : getThrows()) {
+            for (ReferenceType thr : getThrows()) {
                 if (firstThrow) {
                     firstThrow = false;
                     sb.append(" throws ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -281,7 +281,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
 		Type type_ = cloneNodes(_n.getType(), _arg);
 		List<Parameter> parameters = visit(_n.getParameters(), _arg);
-		List<NameExpr> throws_ = visit(_n.getThrows(), _arg);
+		List<ReferenceType> throws_ = visit(_n.getThrows(), _arg);
 		BlockStmt block = cloneNodes(_n.getBody(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1012,8 +1012,8 @@ public class DumpVisitor implements VoidVisitor<Object> {
 
 		if (!isNullOrEmpty(n.getThrows())) {
 			printer.print(" throws ");
-			for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext();) {
-				final ReferenceType name = i.next();
+			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
+				final NameExpr name = i.next();
 				name.accept(this, arg);
 				if (i.hasNext()) {
 					printer.print(", ");
@@ -1061,8 +1061,8 @@ public class DumpVisitor implements VoidVisitor<Object> {
 
 		if (!isNullOrEmpty(n.getThrows())) {
 			printer.print(" throws ");
-			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
-				final NameExpr name = i.next();
+			for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext();) {
+				final ReferenceType name = i.next();
 				name.accept(this, arg);
 				if (i.hasNext()) {
 					printer.print(", ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1012,8 +1012,8 @@ public class DumpVisitor implements VoidVisitor<Object> {
 
 		if (!isNullOrEmpty(n.getThrows())) {
 			printer.print(" throws ");
-			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
-				final NameExpr name = i.next();
+			for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext();) {
+				final ReferenceType name = i.next();
 				name.accept(this, arg);
 				if (i.hasNext()) {
 					printer.print(", ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -1068,7 +1068,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 			}
 		}
 		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
+			for (final ReferenceType name : n.getThrows()) {
 				{
 					R result = name.accept(this, arg);
 					if (result != null) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -675,10 +675,10 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 			}
 			removeNulls(parameters);
 		}
-		final List<NameExpr> throwz = n.getThrows();
+		final List<ReferenceType> throwz = n.getThrows();
 		if (throwz != null) {
 			for (int i = 0; i < throwz.size(); i++) {
-				throwz.set(i, (NameExpr) throwz.get(i).accept(this, arg));
+				throwz.set(i, (ReferenceType) throwz.get(i).accept(this, arg));
 			}
 			removeNulls(throwz);
 		}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -559,7 +559,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 			}
 		}
 		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
+			for (final ReferenceType name : n.getThrows()) {
 				name.accept(this, arg);
 			}
 		}

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1571,20 +1571,38 @@ MethodDeclaration MethodDeclaration(Modifier modifier):
 	BlockStmt block = null;
 	int line = modifier.beginLine;
 	int column = modifier.beginColumn;
+	Type throwType;
 }
 {
   // Modifiers already matched in the caller!
   [ typeParameters = TypeParameters() { int[] lineCol=(int[])typeParameters.remove(0); if(line==-1){ line=lineCol[0]; column=lineCol[1];} } ]
   type = ResultType() { if(line==-1){line=type.getBeginLine(); column=type.getBeginColumn();}}
   name = Name() parameters = FormalParameters() ( "[" "]" { arrayCount++; } )*
-  [ "throws" throws_ = NameList() ]
+  [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
+    ("," throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); })* ]
   ( block = Block() | ";" )
-
   { 
       MethodDeclaration tmp = new MethodDeclaration(line, column, token.endLine, token.endColumn, modifier.modifiers, modifier.annotations, typeParameters, type, null, parameters, arrayCount, throws_, block);
       tmp.setNameExpr(name);
       return tmp;
   }
+}
+
+ReferenceType ReferenceTypeWithAnnotations():
+{
+	List annotations = new ArrayList();
+	AnnotationExpr annotation = null;
+	ReferenceType type;
+}
+{
+    (annotation = Annotation() { annotations = add(annotations, annotation); } )* type = ReferenceType() {
+        if (type.getAnnotations() != null) {
+            type.getAnnotations().addAll(annotations);
+        } else {
+            type.setAnnotations(annotations);
+        }
+        return type;
+    }
 }
 
 List FormalParameters():

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1302,12 +1302,10 @@ List ImplementsList(boolean isInterface):
 {
    List ret = new LinkedList();
    ClassOrInterfaceType cit;
-   AnnotationExpr ann;
-   List annotations = null;
 }
 {
-   "implements" (ann = Annotation()   { annotations = add(annotations, ann);})* cit = ClassOrInterfaceType() { cit.setAnnotations(annotations); ret.add(cit); }
-   ( "," cit = ClassOrInterfaceType() { ret.add(cit); } )*
+   "implements" cit = ClassOrInterfaceTypeWithAnnotations() { ret.add(cit); }
+   ( "," cit = ClassOrInterfaceTypeWithAnnotations() { ret.add(cit); } )*
    {
       if (isInterface)
          throwParseException(token, "An interface cannot implement other interfaces");
@@ -1813,6 +1811,24 @@ ClassOrInterfaceType ClassOrInterfaceType():
   )*
   { return ret; }
 }
+
+ClassOrInterfaceType ClassOrInterfaceTypeWithAnnotations():
+{
+	List annotations = new ArrayList();
+	AnnotationExpr annotation = null;
+	ClassOrInterfaceType type;
+}
+{
+    (annotation = Annotation() { annotations = add(annotations, annotation); } )* type = ClassOrInterfaceType() {
+        if (type.getAnnotations() != null) {
+            type.getAnnotations().addAll(annotations);
+        } else {
+            type.setAnnotations(annotations);
+        }
+        return type;
+    }
+}
+
 
 List TypeArguments():
 {

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/visitor_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/visitor_scenarios.story
@@ -73,5 +73,4 @@ Given a CompilationUnit
 Given a VoidVisitorAdapter with a visit method that asserts sensible line positions
 When the "JavaConcepts.java" is parsed
 When the CompilationUnit is visited by the PositionTestVisitor
-Then the total number of nodes visited is 1334
-
+Then the total number of nodes visited is 1338


### PR DESCRIPTION
In both throws and implements clause we should parse annotations preceding the elements.

Fixing this would permit to parse two files present in the OpenJDK which are currently not parsed.

If you agree with this approach I could just add a few extra tests to protect from regressions.
