### PR TITLE
walkmod: remove unused imports

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ASTHelper.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ASTHelper.java
@@ -22,6 +22,7 @@
 package com.github.javaparser;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -280,6 +281,17 @@ public final class ASTHelper {
             type.setMembers(members);
         }
         members.add(decl);
+    }
+
+    public static <N extends Node> List<N> getNodesByType(Node container, Class<N> clazz) {
+        List<N> nodes = new ArrayList<N>();
+        for (Node child : container.getChildrenNodes()) {
+            if (clazz.isInstance(child)) {
+                nodes.add(clazz.cast(child));
+            }
+            nodes.addAll(getNodesByType(child, clazz));
+        }
+        return nodes;
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -18,11 +18,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
- 
+
 package com.github.javaparser.ast;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -41,195 +39,196 @@ import com.github.javaparser.ast.visitor.*;
  */
 public abstract class Node implements Cloneable {
 
-	private int beginLine;
+    private int beginLine;
 
-	private int beginColumn;
+    private int beginColumn;
 
-	private int endLine;
+    private int endLine;
 
-	private int endColumn;
-	
-	private Node parentNode;
+    private int endColumn;
 
-    private List<Node> childrenNodes =  new LinkedList<Node>();
+    private Node parentNode;
+
+    private List<Node> childrenNodes = new LinkedList<Node>();
     private List<Comment> orphanComments = new LinkedList<Comment>();
 
-	/**
-	 * This attribute can store additional information from semantic analysis.
-	 */
-	private Object data;
+    /**
+     * This attribute can store additional information from semantic analysis.
+     */
+    private Object data;
 
-	private Comment comment;
+    private Comment comment;
 
-	public Node() {
-	}
+    public Node() {
+    }
 
-	public Node(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		this.beginLine = beginLine;
-		this.beginColumn = beginColumn;
-		this.endLine = endLine;
-		this.endColumn = endColumn;
-	}
+    public Node(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        this.beginLine = beginLine;
+        this.beginColumn = beginColumn;
+        this.endLine = endLine;
+        this.endColumn = endColumn;
+    }
 
-	/**
-	 * Accept method for visitor support.
-	 * 
-	 * @param <R>
-	 *            the type the return value of the visitor
-	 * @param <A>
-	 *            the type the argument passed to the visitor
-	 * @param v
-	 *            the visitor implementation
-	 * @param arg
-	 *            the argument passed to the visitor
-	 * @return the result of the visit
-	 */
-	public abstract <R, A> R accept(GenericVisitor<R, A> v, A arg);
+    /**
+     * Accept method for visitor support.
+     * 
+     * @param <R>
+     *            the type the return value of the visitor
+     * @param <A>
+     *            the type the argument passed to the visitor
+     * @param v
+     *            the visitor implementation
+     * @param arg
+     *            the argument passed to the visitor
+     * @return the result of the visit
+     */
+    public abstract <R, A> R accept(GenericVisitor<R, A> v, A arg);
 
-	/**
-	 * Accept method for visitor support.
-	 * 
-	 * @param <A>
-	 *            the type the argument passed for the visitor
-	 * @param v
-	 *            the visitor implementation
-	 * @param arg
-	 *            any value relevant for the visitor
-	 */
-	public abstract <A> void accept(VoidVisitor<A> v, A arg);
+    /**
+     * Accept method for visitor support.
+     * 
+     * @param <A>
+     *            the type the argument passed for the visitor
+     * @param v
+     *            the visitor implementation
+     * @param arg
+     *            any value relevant for the visitor
+     */
+    public abstract <A> void accept(VoidVisitor<A> v, A arg);
 
-	/**
-	 * Return the begin column of this node.
-	 * 
-	 * @return the begin column of this node
-	 */
-	public final int getBeginColumn() {
-		return beginColumn;
-	}
+    /**
+     * Return the begin column of this node.
+     * 
+     * @return the begin column of this node
+     */
+    public final int getBeginColumn() {
+        return beginColumn;
+    }
 
-	/**
-	 * Return the begin line of this node.
-	 * 
-	 * @return the begin line of this node
-	 */
-	public final int getBeginLine() {
-		return beginLine;
-	}
+    /**
+     * Return the begin line of this node.
+     * 
+     * @return the begin line of this node
+     */
+    public final int getBeginLine() {
+        return beginLine;
+    }
 
-	/**
-	 * This is a comment associated with this node.
-	 *
-	 * @return comment property
-	 */
-	public final Comment getComment() {
-		return comment;
-	}
+    /**
+     * This is a comment associated with this node.
+     *
+     * @return comment property
+     */
+    public final Comment getComment() {
+        return comment;
+    }
 
-	/**
-	 * Use this to retrieve additional information associated to this node.
-	 *
-	 * @return data property
-	 */
-	public final Object getData() {
-		return data;
-	}
+    /**
+     * Use this to retrieve additional information associated to this node.
+     *
+     * @return data property
+     */
+    public final Object getData() {
+        return data;
+    }
 
-	/**
-	 * Return the end column of this node.
-	 * 
-	 * @return the end column of this node
-	 */
-	public final int getEndColumn() {
-		return endColumn;
-	}
+    /**
+     * Return the end column of this node.
+     * 
+     * @return the end column of this node
+     */
+    public final int getEndColumn() {
+        return endColumn;
+    }
 
-	/**
-	 * Return the end line of this node.
-	 * 
-	 * @return the end line of this node
-	 */
-	public final int getEndLine() {
-		return endLine;
-	}
+    /**
+     * Return the end line of this node.
+     * 
+     * @return the end line of this node
+     */
+    public final int getEndLine() {
+        return endLine;
+    }
 
-	/**
-	 * Sets the begin column of this node.
-	 * 
-	 * @param beginColumn
-	 *            the begin column of this node
-	 */
-	public final void setBeginColumn(final int beginColumn) {
-		this.beginColumn = beginColumn;
-	}
+    /**
+     * Sets the begin column of this node.
+     * 
+     * @param beginColumn
+     *            the begin column of this node
+     */
+    public final void setBeginColumn(final int beginColumn) {
+        this.beginColumn = beginColumn;
+    }
 
-	/**
-	 * Sets the begin line of this node.
-	 * 
-	 * @param beginLine
-	 *            the begin line of this node
-	 */
-	public final void setBeginLine(final int beginLine) {
-		this.beginLine = beginLine;
-	}
+    /**
+     * Sets the begin line of this node.
+     * 
+     * @param beginLine
+     *            the begin line of this node
+     */
+    public final void setBeginLine(final int beginLine) {
+        this.beginLine = beginLine;
+    }
 
-	/**
-	 * Use this to store additional information to this node.
-	 *
-	 * @param comment to be set
-	 */
-	public final void setComment(final Comment comment) {
-        if (comment!=null && (this instanceof Comment)){
+    /**
+     * Use this to store additional information to this node.
+     *
+     * @param comment to be set
+     */
+    public final void setComment(final Comment comment) {
+        if (comment != null && (this instanceof Comment)) {
             throw new RuntimeException("A comment can not be commented");
         }
-        if (this.comment!=null)
+        if (this.comment != null)
         {
             this.comment.setCommentedNode(null);
         }
-		this.comment = comment;
-        if (comment!=null) {
+        this.comment = comment;
+        if (comment != null) {
             this.comment.setCommentedNode(this);
         }
-	}
+    }
 
-	/**
-	 * Use this to store additional information to this node.
-	 *
-	 * @param data to be set
-	 */
-	public final void setData(final Object data) {
-		this.data = data;
-	}
+    /**
+     * Use this to store additional information to this node.
+     *
+     * @param data to be set
+     */
+    public final void setData(final Object data) {
+        this.data = data;
+    }
 
-	/**
-	 * Sets the end column of this node.
-	 * 
-	 * @param endColumn
-	 *            the end column of this node
-	 */
-	public final void setEndColumn(final int endColumn) {
-		this.endColumn = endColumn;
-	}
+    /**
+     * Sets the end column of this node.
+     * 
+     * @param endColumn
+     *            the end column of this node
+     */
+    public final void setEndColumn(final int endColumn) {
+        this.endColumn = endColumn;
+    }
 
-	/**
-	 * Sets the end line of this node.
-	 * 
-	 * @param endLine
-	 *            the end line of this node
-	 */
-	public final void setEndLine(final int endLine) {
-		this.endLine = endLine;
-	}
+    /**
+     * Sets the end line of this node.
+     * 
+     * @param endLine
+     *            the end line of this node
+     */
+    public final void setEndLine(final int endLine) {
+        this.endLine = endLine;
+    }
 
-	/**
-	 * Return the String representation of this node.
-	 * 
-	 * @return the String representation of this node
-	 */
-	@Override public final String toString() {
-		final DumpVisitor visitor = new DumpVisitor();
-		accept(visitor, null);
-		return visitor.getSource();
-	}
+    /**
+     * Return the String representation of this node.
+     * 
+     * @return the String representation of this node
+     */
+    @Override
+    public final String toString() {
+        final DumpVisitor visitor = new DumpVisitor();
+        accept(visitor, null);
+        return visitor.getSource();
+    }
 
     public final String toStringWithoutComments() {
         final DumpVisitor visitor = new DumpVisitor(false);
@@ -237,16 +236,18 @@ public abstract class Node implements Cloneable {
         return visitor.getSource();
     }
 
-	@Override public final int hashCode() {
-		return toString().hashCode();
-	}
+    @Override
+    public final int hashCode() {
+        return toString().hashCode();
+    }
 
-	@Override public boolean equals(final Object obj) {
-        if (obj==null || !(obj instanceof Node)){
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null || !(obj instanceof Node)) {
             return false;
         }
         return EqualsVisitor.equals(this, (Node) obj);
-	}
+    }
 
     @Override
     public Node clone() {
@@ -254,22 +255,22 @@ public abstract class Node implements Cloneable {
     }
 
     public Node getParentNode() {
-		return parentNode;
-	}
+        return parentNode;
+    }
 
-    public List<Node> getChildrenNodes(){
+    public List<Node> getChildrenNodes() {
         return childrenNodes;
     }
 
-    public boolean contains(Node other){
-        if (getBeginLine()>other.getBeginLine()) return false;
-        if (getBeginLine()==other.getBeginLine() && getBeginColumn()>other.getBeginColumn()) return false;
-        if (getEndLine()<other.getEndLine()) return false;
-        if (getEndLine()==other.getEndLine() && getEndColumn()<other.getEndColumn()) return false;
+    public boolean contains(Node other) {
+        if (getBeginLine() > other.getBeginLine()) return false;
+        if (getBeginLine() == other.getBeginLine() && getBeginColumn() > other.getBeginColumn()) return false;
+        if (getEndLine() < other.getEndLine()) return false;
+        if (getEndLine() == other.getEndLine() && getEndColumn() < other.getEndColumn()) return false;
         return true;
     }
 
-    public void addOrphanComment(Comment comment){
+    public void addOrphanComment(Comment comment) {
         orphanComments.add(comment);
         comment.setParentNode(this);
     }
@@ -285,7 +286,7 @@ public abstract class Node implements Cloneable {
      * it is associated with the statements, while the others are "orphan".
      * @return all comments that cannot be attributed to a concept
      */
-    public List<Comment> getOrphanComments(){
+    public List<Comment> getOrphanComments() {
         return orphanComments;
     }
 
@@ -295,12 +296,12 @@ public abstract class Node implements Cloneable {
      * around inside the Node
      * @return all Comments within the node as a list
      */
-    public List<Comment> getAllContainedComments(){
+    public List<Comment> getAllContainedComments() {
         List<Comment> comments = new LinkedList<Comment>();
         comments.addAll(getOrphanComments());
 
-        for (Node child : getChildrenNodes()){
-            if (child.getComment()!=null){
+        for (Node child : getChildrenNodes()) {
+            if (child.getComment() != null) {
                 comments.add(child.getComment());
             }
             comments.addAll(child.getAllContainedComments());
@@ -312,57 +313,57 @@ public abstract class Node implements Cloneable {
     /**
      * Assign a new parent to this node, removing it
      * from the list of children of the previous parent, if any.
-	 *
-	 * @param parentNode node to be set as parent
+     *
+     * @param parentNode node to be set as parent
      */
-	public void setParentNode(Node parentNode) {
+    public void setParentNode(Node parentNode) {
         // remove from old parent, if any
-        if (this.parentNode!=null){
+        if (this.parentNode != null) {
             this.parentNode.childrenNodes.remove(this);
         }
-		this.parentNode = parentNode;
+        this.parentNode = parentNode;
         // add to new parent, if any
-        if (this.parentNode!=null){
+        if (this.parentNode != null) {
             this.parentNode.childrenNodes.add(this);
         }
-	}
+    }
 
-	protected void setAsParentNodeOf(List<? extends Node> childNodes) {
-		if(childNodes != null){
-			Iterator<? extends Node> it = childNodes.iterator();
-			while(it.hasNext()){
-				Node current = it.next();
-				current.setParentNode(this);
-			}
-		}
-	}
+    protected void setAsParentNodeOf(List<? extends Node> childNodes) {
+        if (childNodes != null) {
+            Iterator<? extends Node> it = childNodes.iterator();
+            while (it.hasNext()) {
+                Node current = it.next();
+                current.setParentNode(this);
+            }
+        }
+    }
 
-	protected void setAsParentNodeOf(Node childNode) {
-		if(childNode != null){
-			childNode.setParentNode(this);
-		}
-	}
+    protected void setAsParentNodeOf(Node childNode) {
+        if (childNode != null) {
+            childNode.setParentNode(this);
+        }
+    }
 
     public static final int ABSOLUTE_BEGIN_LINE = -1;
     public static final int ABSOLUTE_END_LINE = -2;
 
-    public boolean isPositionedAfter(int line, int column){
-        if (line==ABSOLUTE_BEGIN_LINE) return true;
-        if (getBeginLine()>line){
+    public boolean isPositionedAfter(int line, int column) {
+        if (line == ABSOLUTE_BEGIN_LINE) return true;
+        if (getBeginLine() > line) {
             return true;
-        } else if (getBeginLine()==line){
-            return getBeginColumn()>column;
+        } else if (getBeginLine() == line) {
+            return getBeginColumn() > column;
         } else {
             return false;
         }
     }
 
-    public boolean isPositionedBefore(int line, int column){
-        if (line==ABSOLUTE_END_LINE) return true;
-        if (getEndLine()<line){
+    public boolean isPositionedBefore(int line, int column) {
+        if (line == ABSOLUTE_END_LINE) return true;
+        if (getEndLine() < line) {
             return true;
-        } else if (getEndLine()==line){
-            return getEndColumn()<column;
+        } else if (getEndLine() == line) {
+            return getEndColumn() < column;
         } else {
             return false;
         }
@@ -370,6 +371,6 @@ public abstract class Node implements Cloneable {
 
     public boolean hasComment()
     {
-        return comment!=null;
+        return comment != null;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -18,7 +18,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
- 
+
 package com.github.javaparser.ast.body;
 
 import java.util.List;
@@ -34,12 +34,12 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-import com.github.javaparser.ast.type.Type;
 
 /**
  * @author Julio Vilmar Gesser
  */
-public final class ConstructorDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration, NamedNode {
+public final class ConstructorDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration,
+        NamedNode {
 
     private int modifiers;
 
@@ -61,7 +61,8 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
         setName(name);
     }
 
-    public ConstructorDeclaration(int modifiers, List<AnnotationExpr> annotations, List<TypeParameter> typeParameters, String name, List<Parameter> parameters, List<NameExpr> throws_, BlockStmt block) {
+    public ConstructorDeclaration(int modifiers, List<AnnotationExpr> annotations, List<TypeParameter> typeParameters,
+                                  String name, List<Parameter> parameters, List<NameExpr> throws_, BlockStmt block) {
         super(annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
@@ -71,7 +72,9 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
         setBlock(block);
     }
 
-    public ConstructorDeclaration(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, List<TypeParameter> typeParameters, String name, List<Parameter> parameters, List<NameExpr> throws_, BlockStmt block) {
+    public ConstructorDeclaration(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers,
+                                  List<AnnotationExpr> annotations, List<TypeParameter> typeParameters, String name,
+                                  List<Parameter> parameters, List<NameExpr> throws_, BlockStmt block) {
         super(beginLine, beginColumn, endLine, endColumn, annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
@@ -110,7 +113,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
     }
 
     public NameExpr getNameExpr() {
-      return name;
+        return name;
     }
 
     public List<Parameter> getParameters() {
@@ -133,7 +136,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
 
     public void setBlock(BlockStmt block) {
         this.block = block;
-		setAsParentNodeOf(this.block);
+        setAsParentNodeOf(this.block);
     }
 
     public void setModifiers(int modifiers) {
@@ -150,17 +153,17 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
 
     public void setParameters(List<Parameter> parameters) {
         this.parameters = parameters;
-		setAsParentNodeOf(this.parameters);
+        setAsParentNodeOf(this.parameters);
     }
 
     public void setThrows(List<NameExpr> throws_) {
         this.throws_ = throws_;
-		setAsParentNodeOf(this.throws_);
+        setAsParentNodeOf(this.throws_);
     }
 
     public void setTypeParameters(List<TypeParameter> typeParameters) {
         this.typeParameters = typeParameters;
-		setAsParentNodeOf(this.typeParameters);
+        setAsParentNodeOf(this.typeParameters);
     }
 
     /**
@@ -170,7 +173,8 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
      * [throws exceptionsList]
      */
     @Override
-    public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows, boolean includingParameterName) {
+    public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows,
+                                         boolean includingParameterName) {
         StringBuffer sb = new StringBuffer();
         if (includingModifiers) {
             AccessSpecifier accessSpecifier = ModifierSet.getAccessSpecifier(getModifiers());

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -18,16 +18,12 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
- 
+
 package com.github.javaparser.ast.type;
 
-import com.github.javaparser.ast.NamedNode;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -35,73 +31,74 @@ import java.util.List;
  */
 public final class ClassOrInterfaceType extends Type {
 
-	private ClassOrInterfaceType scope;
+    private ClassOrInterfaceType scope;
 
-	private String name;
+    private String name;
 
-	private List<Type> typeArgs;
+    private List<Type> typeArgs;
 
-	public ClassOrInterfaceType() {
-	}
+    public ClassOrInterfaceType() {
+    }
 
-	public ClassOrInterfaceType(final String name) {
-		setName(name);
-	}
+    public ClassOrInterfaceType(final String name) {
+        setName(name);
+    }
 
-	public ClassOrInterfaceType(final ClassOrInterfaceType scope, final String name) {
-		setScope(scope);
-		setName(name);
-	}
+    public ClassOrInterfaceType(final ClassOrInterfaceType scope, final String name) {
+        setScope(scope);
+        setName(name);
+    }
 
-	public ClassOrInterfaceType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final ClassOrInterfaceType scope, final String name, final List<Type> typeArgs) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setScope(scope);
-		setName(name);
-		setTypeArgs(typeArgs);
-	}
+    public ClassOrInterfaceType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+                                final ClassOrInterfaceType scope, final String name, final List<Type> typeArgs) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setScope(scope);
+        setName(name);
+        setTypeArgs(typeArgs);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public ClassOrInterfaceType getScope() {
-		return scope;
-	}
+    public ClassOrInterfaceType getScope() {
+        return scope;
+    }
 
-	public List<Type> getTypeArgs() {
-		return typeArgs;
-	}
+    public List<Type> getTypeArgs() {
+        return typeArgs;
+    }
 
-	public boolean isBoxedType() {
-		return PrimitiveType.unboxMap.containsKey(name);
-	}
+    public boolean isBoxedType() {
+        return PrimitiveType.unboxMap.containsKey(name);
+    }
 
-	public PrimitiveType toUnboxedType() throws UnsupportedOperationException {
-		if(!isBoxedType())
-			throw new UnsupportedOperationException(name + " isn't a boxed type.");
-		return new PrimitiveType(PrimitiveType.unboxMap.get(name));
-	}
+    public PrimitiveType toUnboxedType() throws UnsupportedOperationException {
+        if (!isBoxedType()) throw new UnsupportedOperationException(name + " isn't a boxed type.");
+        return new PrimitiveType(PrimitiveType.unboxMap.get(name));
+    }
 
-	public void setName(final String name) {
-		this.name = name;
-	}
+    public void setName(final String name) {
+        this.name = name;
+    }
 
-	public void setScope(final ClassOrInterfaceType scope) {
-		this.scope = scope;
-		setAsParentNodeOf(this.scope);
-	}
+    public void setScope(final ClassOrInterfaceType scope) {
+        this.scope = scope;
+        setAsParentNodeOf(this.scope);
+    }
 
-	public void setTypeArgs(final List<Type> typeArgs) {
-		this.typeArgs = typeArgs;
-		setAsParentNodeOf(this.typeArgs);
-	}
+    public void setTypeArgs(final List<Type> typeArgs) {
+        this.typeArgs = typeArgs;
+        setAsParentNodeOf(this.typeArgs);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1131,6 +1131,7 @@ public final class DumpVisitor implements VoidVisitor<Object> {
 			}
 			printer.unindent();
 		}
+		printOrphanCommentsEnding(n);
 		printer.print("}");
 
 	}

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -2540,9 +2540,10 @@ Expression AllocationExpression(Expression scope):
 
   (ann = Annotation()   { annotations = add(annotations, ann);})*
   (
-	  type = PrimitiveType() {type.setAnnotations(annotations); arrayExpr = new ArrayCreationExpr(line, column, token.endLine, token.endColumn, type, null, 0);	  }
+	  type = PrimitiveType() {type.setAnnotations(annotations); }
 	  arr = ArrayDimsAndInits()
 	  {
+	    arrayExpr = new ArrayCreationExpr(line, column, token.endLine, token.endColumn, type, null, 0);
 	    arrayExpr.setArraysAnnotations((List)arr[2]);
 	  	if (arr[0] instanceof Integer) {
 	  	    arrayExpr.setArrayCount(((Integer)arr[0]).intValue());

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -21,12 +21,15 @@
  
 package com.github.javaparser.bdd.steps;
 
+import com.github.javaparser.ASTHelper;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
 import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.github.javaparser.bdd.steps.SharedSteps.getMemberByTypeAndPosition;
@@ -34,6 +37,7 @@ import static com.github.javaparser.bdd.steps.SharedSteps.getMethodByPositionAnd
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class ParsingSteps {
@@ -218,4 +222,37 @@ public class ParsingSteps {
         assertThat(conditionalExpr.getElseExpr().getClass().getName(), is(LambdaExpr.class.getName()));
     }
 
+    @Then("the begin line is $line")
+    public void thenTheBeginLineIs(int line) {
+        Node node = (Node) state.get("selectedNode");
+        assertEquals(line, node.getBeginLine());
+    }
+
+    @Then("the begin column is $column")
+    public void thenTheBeginColumnIs(int column) {
+        Node node = (Node) state.get("selectedNode");
+        assertEquals(column, node.getBeginColumn());
+    }
+
+    @Then("the end line is $line")
+    public void thenTheEndLineIs(int line) {
+        Node node = (Node) state.get("selectedNode");
+        assertEquals(line, node.getEndLine());
+    }
+
+    @Then("the end column is $column")
+    public void thenTheEndColumnIs(int column) {
+        Node node = (Node) state.get("selectedNode");
+        assertEquals(column, node.getEndColumn());
+    }
+
+    @When("I take the ArrayCreationExpr")
+    public void iTakeTheArrayCreationExpr() {
+        CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
+        List<ArrayCreationExpr> arrayCreationExprs = ASTHelper.getNodesByType(compilationUnit, ArrayCreationExpr.class);
+        if (arrayCreationExprs.size() != 1) {
+            throw new RuntimeException("Exactly one ArrayCreationExpr expected");
+        }
+        state.put("selectedNode", arrayCreationExprs.get(0));
+    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -48,6 +48,24 @@ public class ParsingSteps {
         this.state = state;
     }
 
+    /*
+     * When steps
+     */
+
+    @When("I take the ArrayCreationExpr")
+    public void iTakeTheArrayCreationExpr() {
+        CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
+        List<ArrayCreationExpr> arrayCreationExprs = ASTHelper.getNodesByType(compilationUnit, ArrayCreationExpr.class);
+        if (arrayCreationExprs.size() != 1) {
+            throw new RuntimeException("Exactly one ArrayCreationExpr expected");
+        }
+        state.put("selectedNode", arrayCreationExprs.get(0));
+    }
+
+    /*
+     * Then steps
+     */
+
     @Then("constructor $constructorPosition in class $classPosition declaration as a String is \"$expectedString\"")
     public void thenTheConstructorDeclarationAsAStringIs(int constructorPosition, int classPosition, String expectedString) {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
@@ -246,13 +264,4 @@ public class ParsingSteps {
         assertEquals(column, node.getEndColumn());
     }
 
-    @When("I take the ArrayCreationExpr")
-    public void iTakeTheArrayCreationExpr() {
-        CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
-        List<ArrayCreationExpr> arrayCreationExprs = ASTHelper.getNodesByType(compilationUnit, ArrayCreationExpr.class);
-        if (arrayCreationExprs.size() != 1) {
-            throw new RuntimeException("Exactly one ArrayCreationExpr expected");
-        }
-        state.put("selectedNode", arrayCreationExprs.get(0));
-    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
@@ -79,7 +79,6 @@ public class SharedSteps {
         state.put("cu1", JavaParser.parse(new ByteArrayInputStream(classSrc.trim().getBytes())));
     }
 
-
     @When("the following sources is parsed by the second CompilationUnit:$classSrc")
     public void whenTheFollowingSourcesIsParsedBytTheSecondCompilationUnit(String classSrc) throws ParseException {
         state.put("cu2", JavaParser.parse(new ByteArrayInputStream(classSrc.getBytes())));
@@ -128,40 +127,6 @@ public class SharedSteps {
     public void thenTheExpectedSourcesShouldBe(String classSrc) {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
         assertThat(compilationUnit.toString(), CoreMatchers.is(equalToIgnoringWhiteSpace(classSrc)));
-    }
-
-    @Then("the begin line is $line")
-    public void thenTheBeginLineIs(int line) {
-        Node node = (Node) state.get("selectedNode");
-        assertEquals(line, node.getBeginLine());
-    }
-
-    @Then("the begin column is $line")
-    public void thenTheBeginColumnIs(int column) {
-        Node node = (Node) state.get("selectedNode");
-        assertEquals(column, node.getBeginColumn());
-    }
-
-    @Then("the end line is $line")
-    public void thenTheEndLineIs(int line) {
-        Node node = (Node) state.get("selectedNode");
-        assertEquals(line, node.getEndLine());
-    }
-
-    @Then("the end column is $line")
-    public void thenTheEndColumnIs(int column) {
-        Node node = (Node) state.get("selectedNode");
-        assertEquals(column, node.getEndColumn());
-    }
-
-    @When("I take the ArrayCreationExpr")
-    public void iTakeTheArrayCreationExpr() {
-        CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
-        List<ArrayCreationExpr> arrayCreationExprs = ASTHelper.getNodesByType(compilationUnit, ArrayCreationExpr.class);
-        if (arrayCreationExprs.size() != 1) {
-            throw new RuntimeException("Exactly one ArrayCreationExpr expected");
-        }
-        state.put("selectedNode", arrayCreationExprs.get(0));
     }
 
     public static BodyDeclaration getMemberByTypeAndPosition(TypeDeclaration typeDeclaration, int position,

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
@@ -59,6 +59,10 @@ public class SharedSteps {
         this.state = state;
     }
 
+    /*
+     * Given steps
+     */
+
     @Given("a CompilationUnit")
     public void givenACompilationUnit() {
         state.put("cu1", new CompilationUnit());
@@ -68,6 +72,10 @@ public class SharedSteps {
     public void givenASecondCompilationUnit() {
         state.put("cu2", new CompilationUnit());
     }
+
+    /*
+     * When steps
+     */
 
     @When("the following source is parsed:$classSrc")
     public void whenTheFollowingSourceIsParsed(String classSrc) throws ParseException {

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
@@ -21,15 +21,12 @@
  
 package com.github.javaparser.bdd.steps;
 
-import com.github.javaparser.ASTHelper;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
-import com.github.javaparser.ast.expr.ArrayCreationExpr;
 import org.hamcrest.CoreMatchers;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
@@ -40,14 +37,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class SharedSteps {

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -30,3 +30,28 @@ public class B {
         System.out.println(i);
     };
 }
+
+
+Scenario: Dumping orphan comments in empty method
+Given the class:
+class A {
+    public void helloWorld(String greeting, String name) {
+        //sdfsdfsdf
+            //sdfds
+        /*
+                            dgfdgfdgfdgfdgfd
+         */
+    }
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+class A {
+
+    public void helloWorld(String greeting, String name) {
+    //sdfsdfsdf
+    //sdfds
+    /*
+                            dgfdgfdgfdgfdgfd
+         */
+    }
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -267,3 +267,18 @@ public class A{
 	}
 }
 Then ThenExpr in the conditional expression of the statement 1 in method 1 in class 1 is LambdaExpr
+
+
+Scenario: Parsing array creation expressions the positions are correct
+
+Given a CompilationUnit
+When the following source is parsed (trimming space):
+public class A{
+    int[][] a = new int[][]{};
+}
+When I take the ArrayCreationExpr
+Then the begin line is 2
+Then the begin column is 17
+Then the end line is 2
+Then the end column is 29
+


### PR DESCRIPTION
I ran walkmod to remove unused imports. I used the formatter configuration provided with the project, so as a side effects the three files touched were also nicely formatted according to our standard.

If you prefer I can limit this PR to just the imports (undoing the formatting).

Anyway we could consider using walkmod to apply our formatting rules to the project.
