### PR TITLE
Enabled access to the tokens after parsing

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -440,7 +440,17 @@ public final class JavaParser {
         return b.getBeginLine()>(a.getEndLine()+1);
     }
 
-    private static void insertComments(CompilationUnit cu, String code) throws IOException {
+    /**
+     * Parses the comments in the Java code contained in the String and attaches
+     * them to nodes of the CompilationUnit.
+     *
+     * @param cu
+     *            the CompilationUnit to attach the comments to
+     * @param code
+     *            Java source code
+     * @throws IOException
+     */
+    public static void insertComments(CompilationUnit cu, String code) throws IOException {
         CommentsParser commentsParser = new CommentsParser();
         CommentsCollection allComments = commentsParser.parse(code);
 

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -23,7 +23,7 @@ options {
   LOOKAHEAD=1;
   STATIC=false;
   JAVA_UNICODE_ESCAPE=true;
-  //COMMON_TOKEN_ACTION=true; // Will not use CommonTokenAction to handle JavaDoc and comments
+  COMMON_TOKEN_ACTION=true; // Using the CommonTokenAction callback to collect tokens for later usage
   //SUPPORT_CLASS_VISIBILITY_PUBLIC=false;
   JDK_VERSION = "1.6";
   TOKEN_FACTORY = "ASTParser.GTToken";
@@ -56,7 +56,7 @@ import com.github.javaparser.ast.type.*;
 /**
  * <p>This class was generated automatically by javacc, do not edit.</p>
  */
-final class ASTParser {
+public final class ASTParser {
 
     void reset(InputStream in, String encoding) {
         ReInit(in, encoding);
@@ -98,6 +98,16 @@ final class ASTParser {
             throwParseException(token, "Duplicated modifier");
         }
         return ModifierSet.addModifier(modifiers, mod);
+    }
+
+    /**
+     * Return the list of tokens that have been encountered while parsing code using
+     * this parser.
+     *
+     * @return a list of tokens
+     */
+    public List<Token> getTokens() {
+        return token_source.getTokens();
     }
 
     private void throwParseException(Token token, String message) throws ParseException {
@@ -167,6 +177,19 @@ SKIP :
 | "\n"
 | "\r"
 | "\f"
+}
+
+TOKEN_MGR_DECLS :
+{
+    private List<Token> tokens = new ArrayList<Token>();
+
+    List<Token> getTokens() {
+        return tokens;
+    }
+
+    private void CommonTokenAction(Token token) {
+        tokens.add(token);
+    }
 }
 
 /* COMMENTS */


### PR DESCRIPTION
Enabled the COMMON_TOKEN_ACTION=true option in the java_1_8.jj file.

Implemented a CommonTokenAction(Token token) method in the
TOKEN_MGR_DECLS that collects encountered tokens in a list.

Added a getter for this list of tokens in the ASTParser.

Made ASTParser public so that it may be used directly, not just using
the JavaParser wrapper class.

Made JavaParser.insertComments(...) public so that it may be used to
attach comments to a CompilationUnit that has been parsed using the
ASTParser directly.
