### PR TITLE
Prepare next release (2.3.0? 3.0.0?)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,7 @@
+Version 2.3.0
+-------------
+
+* ClassOrInterfaceType implements NamedNode
+* DumpVisitor can now be extended
+* Improved documentation
+* AST: lists are now lazy initialized

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>2.2.3-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-testing/pom.xml
+++ b/javaparser-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>2.2.3-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-testing/pom.xml
+++ b/javaparser-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-testing/pom.xml
+++ b/javaparser-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,17 @@
 		<url>https://github.com/javaparser/javaparser/issues</url>
 	</issueManagement>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshot</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<groupId>com.github.javaparser</groupId>
 	<artifactId>javaparser-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0</version>
 
 	<name>javaparser-parent</name>
 	<url>https://github.com/javaparser</url>
@@ -133,7 +133,7 @@
 		<connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
 		<developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
 		<url>https://github.com/javaparser/javaparser.git</url>
-		<tag>HEAD</tag>
+		<tag>javaparser-parent-2.3.0</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<groupId>com.github.javaparser</groupId>
 	<artifactId>javaparser-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>2.2.3-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 
 	<name>javaparser-parent</name>
 	<url>https://github.com/javaparser</url>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<groupId>com.github.javaparser</groupId>
 	<artifactId>javaparser-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 
 	<name>javaparser-parent</name>
 	<url>https://github.com/javaparser</url>
@@ -133,7 +133,7 @@
 		<connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
 		<developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
 		<url>https://github.com/javaparser/javaparser.git</url>
-		<tag>javaparser-parent-2.3.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>


### PR DESCRIPTION
- updated version number
- added a changelog

About the version number:
I would go for 2.3.0: I think we introduce compatibility breaking changes but we do not have enough change to move to 3.0.0 in my opinion. What do you think?
