### PR TITLE
Report whole package name

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
@@ -90,12 +90,19 @@ public final class PackageDeclaration extends Node {
     }
 
     /**
-     * Return the name of the package.
-     * 
+     * Return the name expression of the package.
+     *
      * @return the name of the package
      */
     public NameExpr getName() {
         return name;
+    }
+
+    /**
+     * Get full package name.
+     */
+    public String getPackageName() {
+        return name.toString();
     }
 
     /**

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -283,6 +283,6 @@ public class ParsingSteps {
     @Then("the package name is $package")
     public void thenThePackageNameIs(String expected) {
         PackageDeclaration node = (PackageDeclaration) state.get("selectedNode");
-        assertEquals(expected, node.getName().getName());
+        assertEquals(expected, node.getName().toString());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -3,12 +3,12 @@
  * Copyright (C) 2011, 2013-2015 The JavaParser Team.
  *
  * This file is part of JavaParser.
- * 
+ *
  * JavaParser can be used either under the terms of
  * a) the GNU Lesser General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * b) the terms of the Apache License 
+ * b) the terms of the Apache License
  *
  * You should have received a copy of both licenses in LICENCE.LGPL and
  * LICENCE.APACHE. Please refer to those files for details.
@@ -18,7 +18,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
- 
+
 package com.github.javaparser.bdd.steps;
 
 import com.github.javaparser.ASTHelper;
@@ -60,6 +60,16 @@ public class ParsingSteps {
             throw new RuntimeException("Exactly one ArrayCreationExpr expected");
         }
         state.put("selectedNode", arrayCreationExprs.get(0));
+    }
+
+    @When("I take the PackageDeclaration")
+    public void iTakeThePackageDeclaration() {
+        CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
+        List<PackageDeclaration> packages = ASTHelper.getNodesByType(compilationUnit, PackageDeclaration.class);
+        if (packages.size() != 1) {
+            throw new RuntimeException("Exactly one ArrayCreationExpr expected");
+        }
+        state.put("selectedNode", packages.get(0));
     }
 
     /*
@@ -231,7 +241,7 @@ public class ParsingSteps {
         ExistenceOfParentNodeVerifier parentVerifier = new ExistenceOfParentNodeVerifier();
         parentVerifier.verify(compilationUnit);
     }
-    
+
     @Then("ThenExpr in the conditional expression of the statement $statementPosition in method $methodPosition in class $classPosition is LambdaExpr")
     public void thenLambdaInConditionalExpressionInMethodInClassIsParentOfContainedParameter(int statementPosition, int methodPosition, int classPosition) {
     	Statement statement = getStatementInMethodInClass(statementPosition, methodPosition, classPosition);
@@ -270,4 +280,9 @@ public class ParsingSteps {
         // if the code is not parsed then exceptions are thrown before reaching this step
     }
 
+    @Then("the package name is $package")
+    public void thenThePackageNameIs(String expected) {
+        PackageDeclaration node = (PackageDeclaration) state.get("selectedNode");
+        assertEquals(expected, node.getName().getName());
+    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -283,6 +283,7 @@ public class ParsingSteps {
     @Then("the package name is $package")
     public void thenThePackageNameIs(String expected) {
         PackageDeclaration node = (PackageDeclaration) state.get("selectedNode");
+        assertEquals(expected, node.getPackageName());
         assertEquals(expected, node.getName().toString());
     }
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -280,7 +280,6 @@ Then the begin column is 17
 Then the end line is 2
 Then the end column is 29
 
-
 Scenario: simple cast on lambda expression can be parsed
 
 Given a CompilationUnit
@@ -338,3 +337,13 @@ import foo.b;
 class A {
 }
 Then no errors are reported
+
+
+Scenario: Full package name should be parsed
+
+Given a CompilationUnit
+When the following source is parsed:
+package com.github.javaparser.bdd;
+class C {}
+When I take the PackageDeclaration
+Then the package name is com.github.javaparser.bdd


### PR DESCRIPTION
It seems that the parser reports only the last package component. Attaching reproducing test, I would welcome some guidance on where to fix this.

`Then the package name is com.github.javaparser.bdd(com.github.javaparser.bdd.steps.ParsingSteps): expected:<[com.github.javaparser.]bdd> but was:<[]bdd>`
