### PR TITLE
Issue 211: consider literals with newlines

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -32,9 +32,13 @@ public class StringLiteralExpr extends LiteralExpr {
 	protected String value;
 
 	public StringLiteralExpr() {
+        this.value = "";
 	}
 
 	public StringLiteralExpr(final String value) {
+        if (value.contains("\n") || value.contains("\t")) {
+            throw new IllegalArgumentException("Illegal literal expression: some characters have to be escaped");
+        }
 		this.value = value;
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -36,8 +36,8 @@ public class StringLiteralExpr extends LiteralExpr {
 	}
 
 	public StringLiteralExpr(final String value) {
-        if (value.contains("\n") || value.contains("\t")) {
-            throw new IllegalArgumentException("Illegal literal expression: some characters have to be escaped");
+        if (value.contains("\n") || value.contains("\r")) {
+            throw new IllegalArgumentException("Illegal literal expression: newlines (line feed or carriage return) have to be escaped");
         }
 		this.value = value;
 	}

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -22,13 +22,18 @@
 package com.github.javaparser.bdd.steps;
 
 import com.github.javaparser.ASTHelper;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseException;
+import com.github.javaparser.TokenMgrError;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
+import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
 
+import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +44,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class ParsingSteps {
 
@@ -47,6 +53,18 @@ public class ParsingSteps {
     public ParsingSteps(Map<String, Object> state){
         this.state = state;
     }
+
+    private String sourceUnderTest;
+
+    /*
+     * Given steps
+     */
+
+    @Given("the class:$classSrc")
+    public void givenTheClass(String classSrc) {
+        this.sourceUnderTest = classSrc.trim();
+    }
+
 
     /*
      * When steps
@@ -285,5 +303,15 @@ public class ParsingSteps {
         PackageDeclaration node = (PackageDeclaration) state.get("selectedNode");
         assertEquals(expected, node.getPackageName());
         assertEquals(expected, node.getName().toString());
+    }
+
+    @Then("the Java parser cannot parse it because of lexical errors")
+    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseException {
+        try {
+            JavaParser.parse(new ByteArrayInputStream(sourceUnderTest.getBytes()));
+            fail("Lexical error expected");
+        } catch (TokenMgrError e) {
+            // ok
+        }
     }
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -133,3 +133,20 @@ package test;
 enum XYZ {
 
 }
+
+
+Scenario: Strings with escaped newlines are parsed correctly
+Given the class:
+class A {
+    public void helloWorld(String greeting, String name) {
+        return "hello\nworld";
+    }
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+class A {
+
+    public void helloWorld(String greeting, String name) {
+        return "hello\nworld";
+    }
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -57,6 +57,7 @@ class A {
 }
 
 
+
 Scenario: Dumping orphan comments in empty method (issue 192)
 Given the class:
 public class StepImplementation {

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -347,3 +347,14 @@ package com.github.javaparser.bdd;
 class C {}
 When I take the PackageDeclaration
 Then the package name is com.github.javaparser.bdd
+
+
+Scenario: Strings with unescaped newlines are NOT parsed correctly
+Given the class:
+class A {
+    public void helloWorld(String greeting, String name) {
+        return "hello
+        world";
+    }
+}
+Then the Java parser cannot parse it because of lexical errors


### PR DESCRIPTION
- a test verifies that string literals with newlines are parsed and dumped correctly
- we prevent StringLiteralExpr with newlines or tabs from being instantiated
