### PR TITLE
Code Quality Improvement - @FunctionalInterface annotation should be used to flag Single Abstract Method interfaces

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/NamedNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/NamedNode.java
@@ -28,6 +28,7 @@ package com.github.javaparser.ast;
  * 
  * @since 2.0.1 
  */
+@FunctionalInterface
 public interface NamedNode {
     String getName();
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotableNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotableNode.java
@@ -31,6 +31,7 @@ import java.util.List;
  * @author Federico Tomassetti
  * @since July 2014
  */
+@FunctionalInterface
 public interface AnnotableNode {
     public List<AnnotationExpr> getAnnotations();
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1609 - “@FunctionalInterface annotation should be used to flag Single Abstract Method interfaces”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1609.

Please let me know if you have any questions.

Christian
