### PR TITLE
Code Quality Improvement - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -312,7 +312,7 @@ public final class JavaParser {
         List<Node> children = cu.getChildrenNodes();
         PositionUtils.sortByBeginPosition(children);
 
-        if (cu.getPackage()!=null && (children.size()==0 || PositionUtils.areInOrder(comments.get(0), children.get(0)))){
+        if (cu.getPackage()!=null && (children.isEmpty() || PositionUtils.areInOrder(comments.get(0), children.get(0)))){
             cu.setComment(comments.get(0));
             comments.remove(0);
         }
@@ -353,7 +353,7 @@ public final class JavaParser {
      * It returns the node that were not attributed.
      */
     private static void insertCommentsInNode(Node node, List<Comment> commentsToAttribute){
-        if (commentsToAttribute.size()==0) return;
+        if (commentsToAttribute.isEmpty()) return;
 
         // the comments can:
         // 1) Inside one of the child, then it is the child that have to associate them

--- a/javaparser-core/src/main/java/com/github/javaparser/PositionUtils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/PositionUtils.java
@@ -85,7 +85,7 @@ public final class PositionUtils {
         if (node instanceof AnnotableNode){
             List<AnnotationExpr> annotations = new LinkedList<AnnotationExpr>();
             annotations.addAll(((AnnotableNode) node).getAnnotations());
-            if (annotations.size()==0){
+            if (annotations.isEmpty()){
                 return null;
             }
             sortByBeginPosition(annotations);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1676,7 +1676,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
         List<Node> everything = new LinkedList<Node>();
         everything.addAll(node.getChildrenNodes());
         sortByBeginPosition(everything);
-        if (everything.size()==0) {
+        if (everything.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: dev.eclipse.org/sonar/rules/show/squid:S1155.

Please let me know if you have any questions.

Christian
