### PR TITLE
Issue 252: VoidVisitorAdapter skips some NameExprs

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -143,11 +143,12 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
     }
 
     public void setName(String name) {
-        this.name = new NameExpr(name);
+        setNameExpr(new NameExpr(name));
     }
 
     public void setNameExpr(NameExpr name) {
         this.name = name;
+	setAsParentNodeOf(this.name);
     }
 
     public void setParameters(List<Parameter> parameters) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -175,11 +175,12 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
 	}
 
 	public void setName(final String name) {
-		this.name = new NameExpr(name);
+		setNameExpr(new NameExpr(name));
 	}
 
     public void setNameExpr(final NameExpr name) {
         this.name = name;
+	setAsParentNodeOf(this.name);
     }
 
     public void setParameters(final List<Parameter> parameters) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -70,8 +70,8 @@ public abstract class TypeDeclaration extends BodyDeclaration implements NamedNo
 	}
 
 	public final List<BodyDeclaration> getMembers() {
-        members = ensureNotNull(members);
-        return members;
+        	members = ensureNotNull(members);
+        	return members;
 	}
 
 	/**
@@ -99,14 +99,15 @@ public abstract class TypeDeclaration extends BodyDeclaration implements NamedNo
 	}
 
 	public final void setName(String name) {
-		this.name = new NameExpr(name);
+		setNameExpr(new NameExpr(name));
 	}
 
-    public final void setNameExpr(NameExpr nameExpr) {
-      this.name = nameExpr;
-    }
+	public final void setNameExpr(NameExpr nameExpr) {
+		this.name = nameExpr;
+		setAsParentNodeOf(this.name);
+	}
 
-    public final NameExpr getNameExpr() {
-      return name;
-    }
+	public final NameExpr getNameExpr() {
+		return name;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -82,11 +82,12 @@ public final class FieldAccessExpr extends Expression {
 	}
 
 	public void setField(final String field) {
-		this.field = new NameExpr(field);
+		setFieldExpr(new NameExpr(field));
 	}
 
 	public void setFieldExpr(NameExpr field) {
 		this.field = field;
+		setAsParentNodeOf(this.field);
 	}
 
 	public void setScope(final Expression scope) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -101,11 +101,12 @@ public final class MethodCallExpr extends Expression {
 	}
 
 	public void setName(final String name) {
-		this.name = new NameExpr(name);
+		setNameExpr(new NameExpr(name));
 	}
 
 	public void setNameExpr(NameExpr name) {
 		this.name = name;
+		setAsParentNodeOf(this.name);
 	}
 
 	public void setScope(final Expression scope) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -88,6 +88,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 				a.accept(this, arg);
 			}
 		}
+		n.getNameExpr().accept(this, arg);
 		if (n.getMembers() != null) {
 			for (final BodyDeclaration member : n.getMembers()) {
 				member.accept(this, arg);
@@ -210,6 +211,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 				a.accept(this, arg);
 			}
 		}
+		n.getNameExpr().accept(this, arg);
 		if (n.getTypeParameters() != null) {
 			for (final TypeParameter t : n.getTypeParameters()) {
 				t.accept(this, arg);
@@ -284,6 +286,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 				t.accept(this, arg);
 			}
 		}
+		n.getNameExpr().accept(this, arg);
 		if (n.getParameters() != null) {
 			for (final Parameter p : n.getParameters()) {
 				p.accept(this, arg);
@@ -327,6 +330,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
+		n.getNameExpr().accept(this, arg);
 	}
 
 	@Override public void visit(final EnclosedExpr n, final A arg) {
@@ -366,6 +370,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 				a.accept(this, arg);
 			}
 		}
+		n.getNameExpr().accept(this, arg);
 		if (n.getImplements() != null) {
 			for (final ClassOrInterfaceType c : n.getImplements()) {
 				c.accept(this, arg);
@@ -410,6 +415,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 	@Override public void visit(final FieldAccessExpr n, final A arg) {
 		visitComment(n.getComment(), arg);
 		n.getScope().accept(this, arg);
+		n.getFieldExpr().accept(this, arg);
 	}
 
 	@Override public void visit(final FieldDeclaration n, final A arg) {
@@ -530,6 +536,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 				t.accept(this, arg);
 			}
 		}
+		n.getNameExpr().accept(this, arg);
 		if (n.getArgs() != null) {
 			for (final Expression e : n.getArgs()) {
 				e.accept(this, arg);
@@ -553,6 +560,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 			}
 		}
 		n.getType().accept(this, arg);
+		n.getNameExpr().accept(this, arg);
 		if (n.getParameters() != null) {
 			for (final Parameter p : n.getParameters()) {
 				p.accept(this, arg);


### PR DESCRIPTION
VoidVisitorAdaper was updated to visit child NameExprs.

In the process of making this change, I found that in several cases nodes were not properly set as the parent of NameExprs thy contain.  This has also been addressed.

Changes have resulted in 4 tests failing.  However, I think that the tests are now incorrect and should be updated.  For example, because ClassOrInterfaceDeclaration now correctly contains it's name, orphan comments are no longer assigned to it.  Similarly, the total number of visited nodes has now increased.
