### PR TITLE
issue247: parsing slash asterisk sequence in block comments

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
@@ -35,7 +35,7 @@ public class CommentsParser {
         IN_LINE_COMMENT,
         IN_BLOCK_COMMENT,
         IN_STRING,
-        IN_CHAR;
+        IN_CHAR
     }
 
     private static final int COLUMNS_PER_TAB = 4;
@@ -105,7 +105,12 @@ public class CommentsParser {
                     }
                     break;
                 case IN_BLOCK_COMMENT:
-                    if (prevTwoChars.peekLast().equals('*') && c=='/' && !prevTwoChars.peekFirst().equals('/')){
+                    // '/*/' is not a valid block comment: it starts the block comment but it does not close it
+                    // However this sequence can be contained inside a comment and in that case it close the comment
+                    // For example:
+                    // /* blah blah /*/
+                    // At the previous line we had a valid block comment
+                    if (prevTwoChars.peekLast().equals('*') && c=='/' && (!prevTwoChars.peekFirst().equals('/') || currentContent.length() > 0)){
 
                         // delete last character
                         String content = currentContent.deleteCharAt(currentContent.toString().length()-1).toString();

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/comment_parsing_scenarios.story
@@ -185,6 +185,14 @@ Given the class:
 class Foo {}
 Then the Java parser cannot parse it because of lexical errors
 
+Scenario: Should recognize /*/ inside a block comment
+
+Given the class:
+/* Foo /*/
+When the class is parsed by the comment parser
+Then the total number of comments is 1
+Then block comment 1 is " Foo /"
+
 Scenario: A Class With Character Literal is processed by the Comments Parser
 Given the class:
 class A {


### PR DESCRIPTION
The issue is that this is invalid:

```
/*/
```

But this is valid:

```
/*      /*/
```

A slash followed by an asterisk can be part of a block comment but a slash, an asterisk and a slash are not a valid block comment.

Fix #247 
