### PR TITLE
Implement AnnotableNode interface in BaseParameter

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/BaseParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/BaseParameter.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import static com.github.javaparser.ast.internal.Utils.*;
 
-public abstract class BaseParameter extends Node {
+public abstract class BaseParameter extends Node implements AnnotableNode {
     private int modifiers;
 
     private List<AnnotationExpr> annotations;


### PR DESCRIPTION
I use a method in a project of mine to extract a specific annotation from an _AnnotableNode_. When I passed a _Parameter_, I've noticed that its superclass _BaseParameter_ doesn't implement the _AnnotableNode_ interface even though it provides a _getAnnotations()_ method.
