### PR TITLE
Add TypedNode interface

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/PositionUtils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/PositionUtils.java
@@ -22,6 +22,7 @@
 package com.github.javaparser;
 
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.body.AnnotableNode;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -105,11 +106,8 @@ public final class PositionUtils {
     }
 
     private static Node beginNodeWithoutConsideringAnnotations(Node node) {
-        if (node instanceof MethodDeclaration) {
-            MethodDeclaration casted = (MethodDeclaration) node;
-            return casted.getType();
-        } else if (node instanceof FieldDeclaration) {
-            FieldDeclaration casted = (FieldDeclaration) node;
+        if (node instanceof MethodDeclaration || node instanceof FieldDeclaration) {
+            TypedNode casted = (TypedNode) node;
             return casted.getType();
         } else if (node instanceof ClassOrInterfaceDeclaration) {
             ClassOrInterfaceDeclaration casted = (ClassOrInterfaceDeclaration) node;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/TypedNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/TypedNode.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2015 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast;
+
+import com.github.javaparser.ast.type.Type;
+
+/**
+ * A node having a type.
+ *
+ * The main reason for this interface is to permit users to manipulate homogeneously all nodes with getType/setType
+ * methods
+ *
+ * @since 2.3.1
+ */
+public interface TypedNode {
+    Type getType();
+
+    void setType(Type type);
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.body;
 
 import com.github.javaparser.ast.DocumentableNode;
 import com.github.javaparser.ast.NamedNode;
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.Expression;
@@ -35,7 +36,7 @@ import java.util.List;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class AnnotationMemberDeclaration extends BodyDeclaration implements DocumentableNode, NamedNode {
+public final class AnnotationMemberDeclaration extends BodyDeclaration implements DocumentableNode, NamedNode, TypedNode {
 
     private int modifiers;
 
@@ -100,6 +101,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration implement
         return name;
     }
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -117,6 +119,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration implement
         this.name = name;
     }
 
+    @Override
     public void setType(Type type) {
         this.type = type;
         setAsParentNodeOf(type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -22,6 +22,7 @@
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.ast.DocumentableNode;
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.type.Type;
@@ -36,7 +37,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class FieldDeclaration extends BodyDeclaration implements DocumentableNode {
+public final class FieldDeclaration extends BodyDeclaration implements DocumentableNode, TypedNode {
 
     private int modifiers;
 
@@ -95,6 +96,7 @@ public final class FieldDeclaration extends BodyDeclaration implements Documenta
         return modifiers;
     }
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -108,6 +110,7 @@ public final class FieldDeclaration extends BodyDeclaration implements Documenta
         this.modifiers = modifiers;
     }
 
+    @Override
     public void setType(Type type) {
         this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -21,10 +21,7 @@
  
 package com.github.javaparser.ast.body;
 
-import com.github.javaparser.ast.AccessSpecifier;
-import com.github.javaparser.ast.DocumentableNode;
-import com.github.javaparser.ast.NamedNode;
-import com.github.javaparser.ast.TypeParameter;
+import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -41,7 +38,7 @@ import static com.github.javaparser.ast.internal.Utils.ensureNotNull;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class MethodDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration, NamedNode {
+public final class MethodDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration, NamedNode, TypedNode {
 
 	private int modifiers;
 
@@ -152,6 +149,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
         return throws_;
 	}
 
+	@Override
 	public Type getType() {
 		return type;
 	}
@@ -192,6 +190,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
 		setAsParentNodeOf(this.throws_);
 	}
 
+	@Override
 	public void setType(final Type type) {
 		this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.body;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -31,7 +32,7 @@ import java.util.List;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class Parameter extends BaseParameter {
+public final class Parameter extends BaseParameter implements TypedNode {
     private Type type;
 
     private boolean isVarArgs;
@@ -65,6 +66,7 @@ public final class Parameter extends BaseParameter {
         v.visit(this, arg);
     }
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -73,6 +75,7 @@ public final class Parameter extends BaseParameter {
         return isVarArgs;
     }
 
+    @Override
     public void setType(Type type) {
         this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -32,7 +33,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class ArrayCreationExpr extends Expression {
+public final class ArrayCreationExpr extends Expression implements TypedNode {
 
     private Type type;
 
@@ -100,6 +101,7 @@ public final class ArrayCreationExpr extends Expression {
         return initializer;
     }
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -118,6 +120,7 @@ public final class ArrayCreationExpr extends Expression {
 		setAsParentNodeOf(this.initializer);
     }
 
+    @Override
     public void setType(Type type) {
         this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -28,7 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class CastExpr extends Expression {
+public final class CastExpr extends Expression implements TypedNode {
 
     private Type type;
 
@@ -62,6 +63,7 @@ public final class CastExpr extends Expression {
         return expr;
     }
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -71,6 +73,7 @@ public final class CastExpr extends Expression {
 		setAsParentNodeOf(this.expr);
     }
 
+    @Override
     public void setType(Type type) {
         this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -33,7 +34,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  * </code>
  * @author Julio Vilmar Gesser
  */
-public final class ClassExpr extends Expression {
+public final class ClassExpr extends Expression implements TypedNode {
 
     private Type type;
 
@@ -59,10 +60,12 @@ public final class ClassExpr extends Expression {
         v.visit(this, arg);
     }
 
+    @Override
     public Type getType() {
         return type;
     }
 
+    @Override
     public void setType(Type type) {
         this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -28,7 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class InstanceOfExpr extends Expression {
+public final class InstanceOfExpr extends Expression implements TypedNode {
 
 	private Expression expr;
 
@@ -61,6 +62,7 @@ public final class InstanceOfExpr extends Expression {
 		return expr;
 	}
 
+	@Override
 	public Type getType() {
 		return type;
 	}
@@ -70,6 +72,7 @@ public final class InstanceOfExpr extends Expression {
 		setAsParentNodeOf(this.expr);
 	}
 
+	@Override
 	public void setType(final Type type) {
 		this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -30,7 +31,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  * @author Raquel Pau
  *
  */
-public class TypeExpr extends Expression{
+public class TypeExpr extends Expression implements TypedNode {
 
     private Type type;
 
@@ -51,10 +52,12 @@ public class TypeExpr extends Expression{
         v.visit(this, arg);
     }
 
+    @Override
     public Type getType() {
         return type;
     }
 
+    @Override
     public void setType(Type type) {
         this.type = type;
         setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.body.ModifierSet;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.type.Type;
@@ -35,7 +36,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class VariableDeclarationExpr extends Expression {
+public final class VariableDeclarationExpr extends Expression implements TypedNode {
 
 	private int modifiers;
 
@@ -92,6 +93,7 @@ public final class VariableDeclarationExpr extends Expression {
 		return modifiers;
 	}
 
+	@Override
 	public Type getType() {
 		return type;
 	}
@@ -110,6 +112,7 @@ public final class VariableDeclarationExpr extends Expression {
 		this.modifiers = modifiers;
 	}
 
+	@Override
 	public void setType(final Type type) {
 		this.type = type;
 		setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.type;
 
+import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -32,7 +33,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class ReferenceType extends Type {
+public final class ReferenceType extends Type implements TypedNode {
 
 	private Type type;
 
@@ -81,6 +82,7 @@ public final class ReferenceType extends Type {
 		return arrayCount;
 	}
 
+	@Override
 	public Type getType() {
 		return type;
 	}
@@ -89,6 +91,7 @@ public final class ReferenceType extends Type {
 		this.arrayCount = arrayCount;
 	}
 
+	@Override
 	public void setType(final Type type) {
 		this.type = type;
 		setAsParentNodeOf(this.type);


### PR DESCRIPTION
Implements #271 by adding a TypedNode interface with the following methods:

```
void setType(Type t);
Type getType();
```

I'm seeing a single test failure in com.github.javaparser.bdd.DumpingTest: https://gist.github.com/nallar/8703500c7516f09cbd76

It's failing before this commit and looks like a line-endings issue, so may just be an issue with my local environment.

I haven't added any new tests for TypedNode as I'm not sure how to add/write tests with JBehave.
