### PR TITLE
Can not get some same comments in different locations associated with…

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -370,7 +370,7 @@ public final class JavaParser {
                     commentsInsideChild.add(c);
                 }
             }
-            commentsToAttribute.removeAll(commentsInsideChild);
+            
             insertCommentsInNode(child,commentsInsideChild);
         }
 


### PR DESCRIPTION
… a class or interface

Line no 373
commentsToAttribute.removeAll(commentsInsideChild); 
 in JavaParser.java should not be written as this line is present at
Line no 423
if call that line earlier this will remove those comments which should be added.
