### PR TITLE
JavaDoc Comment Begin Line Equality Checking is missing

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -591,6 +591,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		if (!objEquals(n1.getContent(), n2.getContent())) {
 			return Boolean.FALSE;
 		}
+		if (!objEquals(n1.getBeginLine(), n2.getBeginLine())) {
+            		return Boolean.FALSE;
+        	}
 
 		return Boolean.TRUE;
 	}


### PR DESCRIPTION
JavaDoc Comment Begin Line Equality Checking is missing that is why if same java doc comments are added at different lines. JavaParser.java only adds a single javadoc comment in the whole compilation unit
