### PR TITLE
Upgrade to JavaCC 6.1.3 and use new TokenMgrException.

### DIFF
--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -44,6 +44,13 @@
                         </configuration>
                     </execution>
                 </executions>
+				<dependencies>
+					<dependency>
+						<groupId>net.java.dev.javacc</groupId>
+						<artifactId>javacc</artifactId>
+						<version>6.1.2</version>
+					</dependency>
+				</dependencies>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -108,7 +108,13 @@ public final class JavaParser {
         try {
             String code = SourcesHelper.streamToString(in, encoding);
             InputStream in1 = SourcesHelper.stringToStream(code, encoding);
-            CompilationUnit cu = new ASTParser(in1, encoding).CompilationUnit();
+            Provider p;
+            if (encoding == null){
+            	p = new StreamProvider(in1);
+            } else {
+            	p = new StreamProvider(in1, encoding);
+            }
+            CompilationUnit cu = new ASTParser(p).CompilationUnit();
             if (considerComments){
                 insertComments(cu,code);
             }
@@ -182,7 +188,7 @@ public final class JavaParser {
         try {
             String code = SourcesHelper.readerToString(reader);
             Reader reader1 = SourcesHelper.stringToReader(code);
-            CompilationUnit cu = new ASTParser(reader1).CompilationUnit();
+            CompilationUnit cu = new ASTParser(new StreamProvider(reader1)).CompilationUnit();
             if (considerComments){
                 insertComments(cu,code);
             }
@@ -204,9 +210,7 @@ public final class JavaParser {
      */
     public static BlockStmt parseBlock(final String blockStatement)
             throws ParseException {
-        StringReader sr = new StringReader(blockStatement);
-        BlockStmt result = new ASTParser(sr).Block();
-        sr.close();
+        BlockStmt result = new ASTParser(blockStatement).Block();
         return result;
     }
 
@@ -221,9 +225,7 @@ public final class JavaParser {
      *             if the source code has parser errors
      */
     public static Statement parseStatement(final String statement) throws ParseException {
-        StringReader sr = new StringReader(statement);
-        Statement stmt = new ASTParser(sr).Statement();
-        sr.close();
+        Statement stmt = new ASTParser(statement).Statement();
         return stmt;
     }
 
@@ -239,7 +241,7 @@ public final class JavaParser {
      */
     public static ImportDeclaration parseImport(final String importDeclaration) throws ParseException {
         StringReader sr = new StringReader(importDeclaration);
-        ImportDeclaration id = new ASTParser(sr).ImportDeclaration();
+        ImportDeclaration id = new ASTParser(new StreamProvider(sr)).ImportDeclaration();
         sr.close();
         return id;
     }
@@ -256,7 +258,7 @@ public final class JavaParser {
      */
     public static Expression parseExpression(final String expression) throws ParseException {
         StringReader sr = new StringReader(expression);
-        Expression e = new ASTParser(sr).Expression();
+        Expression e = new ASTParser(new StreamProvider(sr)).Expression();
         sr.close();
         return e;
     }
@@ -273,7 +275,7 @@ public final class JavaParser {
      */
     public static AnnotationExpr parseAnnotation(final String annotation) throws ParseException {
         StringReader sr = new StringReader(annotation);
-        AnnotationExpr ae = new ASTParser(sr).Annotation();
+        AnnotationExpr ae = new ASTParser(new StreamProvider(sr)).Annotation();
         sr.close();
         return ae;
     }
@@ -290,7 +292,7 @@ public final class JavaParser {
      */
     public static BodyDeclaration parseBodyDeclaration(final String body) throws ParseException {
         StringReader sr = new StringReader(body);
-        BodyDeclaration bd = new ASTParser(sr).AnnotationBodyDeclaration();
+        BodyDeclaration bd = new ASTParser(new StreamProvider(sr)).AnnotationBodyDeclaration();
         sr.close();
         return bd;
     }

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -27,6 +27,7 @@ options {
   //SUPPORT_CLASS_VISIBILITY_PUBLIC=false;
   JDK_VERSION = "1.6";
   TOKEN_FACTORY = "ASTParser.GTToken";
+  JAVA_TEMPLATE_TYPE = "modern";
 }
 
 PARSER_BEGIN(ASTParser)
@@ -58,8 +59,8 @@ import com.github.javaparser.ast.type.*;
  */
 final class ASTParser {
 
-    void reset(InputStream in, String encoding) {
-        ReInit(in, encoding);
+    void reset(InputStream in, String encoding) throws IOException {
+        ReInit(new StreamProvider(in, encoding));
     }
 
     private List add(List list, Object obj) {

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
@@ -23,7 +23,7 @@ package com.github.javaparser.bdd.steps;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
-import com.github.javaparser.TokenMgrError;
+import com.github.javaparser.TokenMgrException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.*;
@@ -87,7 +87,7 @@ public class CommentParsingSteps {
         try {
             compilationUnit = JavaParser.parse(new ByteArrayInputStream(sourceUnderTest.getBytes()));
             fail("Lexical error expected");
-        } catch (TokenMgrError e) {
+        } catch (TokenMgrException e) {
             // ok
         }
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -24,7 +24,7 @@ package com.github.javaparser.bdd.steps;
 import com.github.javaparser.ASTHelper;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
-import com.github.javaparser.TokenMgrError;
+import com.github.javaparser.TokenMgrException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.PackageDeclaration;
@@ -327,7 +327,7 @@ public class ParsingSteps {
         try {
             JavaParser.parse(new ByteArrayInputStream(sourceUnderTest.getBytes()));
             fail("Lexical error expected");
-        } catch (TokenMgrError e) {
+        } catch (TokenMgrException e) {
             // ok
         }
     }


### PR DESCRIPTION
Solves #270 

JavaCC has new option `JAVA_TEMPLATE_TYPE = "modern"`. This option also changes TokenMgrError to TokenMgrException, a RuntimeException.
