### PR TITLE
[squid:S2786] Nested "enum"s should not be declared static

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
@@ -29,7 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class AssignExpr extends Expression {
 
-    public static enum Operator {
+    public enum Operator {
         assign, // =
         plus, // +=
         minus, // -=

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -29,7 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class BinaryExpr extends Expression {
 
-    public static enum Operator {
+    public enum Operator {
         or, // ||
         and, // &&
         binOr, // |

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
@@ -29,7 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class UnaryExpr extends Expression {
 
-	public static enum Operator {
+	public enum Operator {
 		positive, // +
 		negative, // -
 		preIncrement, // ++

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/samples/JavaConcepts.java
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/samples/JavaConcepts.java
@@ -123,12 +123,12 @@ public class JavaConcepts<T extends List<int[]>, X> extends Base implements Seri
         asc, def
     }
 
-    public static enum Sexo {
+    public enum Sexo {
 
         m, @Deprecated
         f;
 
-        public static enum Sexo_ implements Serializable, Cloneable {
+        public enum Sexo_ implements Serializable, Cloneable {
         }
 
         private Sexo() {
@@ -136,7 +136,7 @@ public class JavaConcepts<T extends List<int[]>, X> extends Base implements Seri
     }
 
     @Deprecated
-    public static enum Enum {
+    public enum Enum {
 
         m(1) {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2786 - “Nested "enum"s should not be declared static”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2786

Please let me know if you have any questions.
Ayman Abdelghany.
