### PR TITLE
[squid:S1149] Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -174,7 +174,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
     @Override
     public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows,
                                          boolean includingParameterName) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (includingModifiers) {
             AccessSpecifier accessSpecifier = ModifierSet.getAccessSpecifier(getModifiers());
             sb.append(accessSpecifier.getCodeRepresenation());

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -230,7 +230,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
      */
     @Override
     public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows, boolean includingParameterName) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (includingModifiers) {
             AccessSpecifier accessSpecifier = ModifierSet.getAccessSpecifier(getModifiers());
             sb.append(accessSpecifier.getCodeRepresenation());

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
@@ -97,7 +97,7 @@ public class CommentsParser {
         State state = State.CODE;
         LineComment currentLineComment = null;
         BlockComment currentBlockComment = null;
-        StringBuffer currentContent = null;
+        StringBuilder currentContent = null;
 
         int currLine = 1;
         int currCol  = 1;
@@ -119,13 +119,13 @@ public class CommentsParser {
                         currentLineComment.setBeginLine(currLine);
                         currentLineComment.setBeginColumn(currCol - 1);
                         state = State.IN_LINE_COMMENT;
-                        currentContent = new StringBuffer();
+                        currentContent = new StringBuilder();
                     } else if (parserState.isLastChar('/') && c == '*') {
                         currentBlockComment = new BlockComment();
                         currentBlockComment.setBeginLine(currLine);
                         currentBlockComment.setBeginColumn(currCol - 1);
                         state = State.IN_BLOCK_COMMENT;
-                        currentContent = new StringBuffer();
+                        currentContent = new StringBuilder();
                     } else if (c == '"') {
                         state = State.IN_STRING;
                     } else if (c == '\'') {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.
Ayman Abdelghany.
