### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
@@ -92,7 +92,7 @@ public class CommentsInserter
         PositionUtils.sortByBeginPosition(children);
 
         if (cu.getPackage() != null
-                && (children.size() == 0 || PositionUtils.areInOrder(
+                && (children.isEmpty() || PositionUtils.areInOrder(
                         comments.get(0), children.get(0)))) {
             cu.setComment(comments.get(0));
             comments.remove(0);
@@ -107,7 +107,7 @@ public class CommentsInserter
      */
     private void insertCommentsInNode(Node node,
             List<Comment> commentsToAttribute) {
-        if (commentsToAttribute.size() == 0)
+        if (commentsToAttribute.isEmpty())
             return;
 
         // the comments can:

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
@@ -55,14 +55,14 @@ public class CommentsParser {
          * Is the last character the one expected?
          */
         boolean isLastChar(char expectedChar) {
-            return prevTwoChars.size() >= 1 && prevTwoChars.peekLast().equals(expectedChar);
+            return !prevTwoChars.isEmpty() && prevTwoChars.peekLast().equals(expectedChar);
         }
 
         /**
          * Is the character before the last one the same as expectedChar?
          */
         public boolean isSecondToLastChar(char expectedChar) {
-            return prevTwoChars.size() >= 1 && prevTwoChars.peekFirst().equals(expectedChar);
+            return !prevTwoChars.isEmpty() && prevTwoChars.peekFirst().equals(expectedChar);
         }
 
         /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.
