### PR TITLE
Fix for "When visit ArrayCreationExpression initializer is missed in some cases. #321".

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -672,7 +672,8 @@ public class DumpVisitor implements VoidVisitor<Object> {
 				printer.print("[]");
 			}
 
-		} else {
+		}
+		if (n.getInitializer() != null) {
 			for (int i = 0; i < n.getArrayCount(); i++) {
 				if (arraysAnnotations != null && i < arraysAnnotations.size()) {
 					List<AnnotationExpr> annotations = arraysAnnotations.get(i);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -179,12 +179,11 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 					}
 				}
 			}
-		} else {
-			{
-				R result = n.getInitializer().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
+		}
+		if (n.getInitializer() != null) {
+			R result = n.getInitializer().accept(this, arg);
+			if (result != null) {
+				return result;
 			}
 		}
 		return null;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -183,7 +183,8 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 				}
 				removeNulls(dimensions);
 			}
-		} else {
+		}
+		if (n.getInitializer() != null) {
 			n.setInitializer((ArrayInitializerExpr) n.getInitializer().accept(this, arg));
 		}
 		return n;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -125,7 +125,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 			for (final Expression dim : n.getDimensions()) {
 				dim.accept(this, arg);
 			}
-		} else {
+		}
+		if (n.getInitializer() != null) {
 			n.getInitializer().accept(this, arg);
 		}
 	}


### PR DESCRIPTION
Visit array initializer even if array creation expression had dimensions.
