### PR TITLE
Issue 326: use correct EOL character in multiline comments

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsParser.java
@@ -172,7 +172,7 @@ public class CommentsParser {
                         }
                         state = State.CODE;
                     } else {
-                        currentContent.append(c=='\r'?'\n':c);
+                        currentContent.append(c == '\r' ? System.getProperty("line.separator") : c);
                     }
                     break;
                 case IN_STRING:


### PR DESCRIPTION
https://github.com/javaparser/javaparser/issues/326
