### PR TITLE
Add minimal NodeWithModifiers

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/NodeWithModifiers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/NodeWithModifiers.java
@@ -1,0 +1,10 @@
+package com.github.javaparser.ast;
+
+import com.github.javaparser.ast.body.ModifierSet;
+
+/**
+ * A Node with Modifiers.
+ */
+public interface NodeWithModifiers {
+	int getModifiers();
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.body;
 
 import com.github.javaparser.ast.DocumentableNode;
 import com.github.javaparser.ast.NamedNode;
+import com.github.javaparser.ast.NodeWithModifiers;
 import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -36,7 +37,7 @@ import java.util.List;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class AnnotationMemberDeclaration extends BodyDeclaration implements DocumentableNode, NamedNode, TypedNode {
+public final class AnnotationMemberDeclaration extends BodyDeclaration implements DocumentableNode, NamedNode, TypedNode, NodeWithModifiers {
 
     private int modifiers;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/BaseParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/BaseParameter.java
@@ -22,13 +22,14 @@
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeWithModifiers;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 
 import java.util.List;
 
 import static com.github.javaparser.ast.internal.Utils.*;
 
-public abstract class BaseParameter extends Node implements AnnotableNode {
+public abstract class BaseParameter extends Node implements AnnotableNode, NodeWithModifiers {
     private int modifiers;
 
     private List<AnnotationExpr> annotations;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -23,10 +23,7 @@ package com.github.javaparser.ast.body;
 
 import java.util.List;
 
-import com.github.javaparser.ast.AccessSpecifier;
-import com.github.javaparser.ast.DocumentableNode;
-import com.github.javaparser.ast.NamedNode;
-import com.github.javaparser.ast.TypeParameter;
+import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -40,7 +37,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
  * @author Julio Vilmar Gesser
  */
 public final class ConstructorDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration,
-        NamedNode {
+        NamedNode, NodeWithModifiers {
 
     private int modifiers;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -22,6 +22,7 @@
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.ast.DocumentableNode;
+import com.github.javaparser.ast.NodeWithModifiers;
 import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -37,7 +38,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class FieldDeclaration extends BodyDeclaration implements DocumentableNode, TypedNode {
+public final class FieldDeclaration extends BodyDeclaration implements DocumentableNode, TypedNode, NodeWithModifiers {
 
     private int modifiers;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -38,7 +38,7 @@ import static com.github.javaparser.ast.internal.Utils.ensureNotNull;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class MethodDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration, NamedNode, TypedNode {
+public final class MethodDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration, NamedNode, TypedNode, NodeWithModifiers {
 
 	private int modifiers;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.body;
 
 import com.github.javaparser.ast.DocumentableNode;
 import com.github.javaparser.ast.NamedNode;
+import com.github.javaparser.ast.NodeWithModifiers;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 
@@ -34,7 +35,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public abstract class TypeDeclaration extends BodyDeclaration implements NamedNode, DocumentableNode {
+public abstract class TypeDeclaration extends BodyDeclaration implements NamedNode, DocumentableNode, NodeWithModifiers {
 
 	private NameExpr name;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.NodeWithModifiers;
 import com.github.javaparser.ast.TypedNode;
 import com.github.javaparser.ast.body.ModifierSet;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -36,7 +37,7 @@ import static com.github.javaparser.ast.internal.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class VariableDeclarationExpr extends Expression implements TypedNode {
+public final class VariableDeclarationExpr extends Expression implements TypedNode, NodeWithModifiers {
 
 	private int modifiers;
 


### PR DESCRIPTION
Minimal implementation: only added the interface without changing the contract. That can be done in a major release. The Java 8 suggestion is of course still far away for JavaParser :-)
