### PR TITLE
Issue 302: Change ConstructorDeclarations throws clause to have Refer…

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
@@ -47,7 +48,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
 
     private List<Parameter> parameters;
 
-    private List<NameExpr> throws_;
+    private List<ReferenceType> throws_;
 
     private BlockStmt block;
 
@@ -60,7 +61,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
     }
 
     public ConstructorDeclaration(int modifiers, List<AnnotationExpr> annotations, List<TypeParameter> typeParameters,
-                                  String name, List<Parameter> parameters, List<NameExpr> throws_, BlockStmt block) {
+                                  String name, List<Parameter> parameters, List<ReferenceType> throws_, BlockStmt block) {
         super(annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
@@ -72,7 +73,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
 
     public ConstructorDeclaration(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers,
                                   List<AnnotationExpr> annotations, List<TypeParameter> typeParameters, String name,
-                                  List<Parameter> parameters, List<NameExpr> throws_, BlockStmt block) {
+                                  List<Parameter> parameters, List<ReferenceType> throws_, BlockStmt block) {
         super(beginLine, beginColumn, endLine, endColumn, annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
@@ -121,7 +122,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
         return parameters;
     }
 
-    public List<NameExpr> getThrows() {
+    public List<ReferenceType> getThrows() {
         throws_ = ensureNotNull(throws_);
         return throws_;
     }
@@ -154,7 +155,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
         setAsParentNodeOf(this.parameters);
     }
 
-    public void setThrows(List<NameExpr> throws_) {
+    public void setThrows(List<ReferenceType> throws_) {
         this.throws_ = throws_;
         setAsParentNodeOf(this.throws_);
     }
@@ -198,7 +199,7 @@ public final class ConstructorDeclaration extends BodyDeclaration implements Doc
         sb.append(")");
         if (includingThrows) {
             boolean firstThrow = true;
-            for (NameExpr thr : getThrows()) {
+            for (ReferenceType thr : getThrows()) {
                 if (firstThrow) {
                     firstThrow = false;
                     sb.append(" throws ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -262,7 +262,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
 		List<Parameter> parameters = visit(_n.getParameters(), _arg);
-		List<NameExpr> throws_ = visit(_n.getThrows(), _arg);
+		List<ReferenceType> throws_ = visit(_n.getThrows(), _arg);
 		BlockStmt block = cloneNodes(_n.getBlock(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1018,8 +1018,8 @@ public class DumpVisitor implements VoidVisitor<Object> {
 
 		if (!isNullOrEmpty(n.getThrows())) {
 			printer.print(" throws ");
-			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
-				final NameExpr name = i.next();
+			for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext();) {
+				final ReferenceType name = i.next();
 				name.accept(this, arg);
 				if (i.hasNext()) {
 					printer.print(", ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -518,7 +518,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 			}
 		}
 		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
+			for (final ReferenceType name : n.getThrows()) {
 				{
 					R result = name.accept(this, arg);
 					if (result != null) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -394,10 +394,10 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 			}
 			removeNulls(parameters);
 		}
-		final List<NameExpr> throwz = n.getThrows();
+		final List<ReferenceType> throwz = n.getThrows();
 		if (throwz != null) {
 			for (int i = 0; i < throwz.size(); i++) {
-				throwz.set(i, (NameExpr) throwz.get(i).accept(this, arg));
+				throwz.set(i, (ReferenceType) throwz.get(i).accept(this, arg));
 			}
 			removeNulls(throwz);
 		}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -283,7 +283,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 			}
 		}
 		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
+			for (final ReferenceType name : n.getThrows()) {
 				name.accept(this, arg);
 			}
 		}

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1711,11 +1711,13 @@ ConstructorDeclaration ConstructorDeclaration(Modifier modifier):
 	int bbColumn = 0;
 	int beLine = 0;
 	int beColumn = 0;
+	Type throwType;
 }
 {
   [ typeParameters = TypeParameters() { int[] lineCol=(int[])typeParameters.remove(0); if(line==-1){ line=lineCol[0]; column=lineCol[1];} } ]
   // Modifiers matched in the caller
-  name = SimpleName() { if(line==-1){line=token.beginLine; column=token.beginColumn;}} parameters = FormalParameters() [ "throws" throws_ = NameList() ]
+  name = SimpleName() { if(line==-1){line=token.beginLine; column=token.beginColumn;}} parameters = FormalParameters() [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
+  ("," throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); })* ]
   "{" { bbLine=token.beginLine; bbColumn=token.beginColumn; }
     [ LOOKAHEAD(ExplicitConstructorInvocation()) exConsInv = ExplicitConstructorInvocation() ]
     stmts = Statements()

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -326,6 +326,26 @@ class A {
 }
 Then no errors are reported
 
+Scenario: Classes that are thrown from a method can be annotated
+
+Given a CompilationUnit
+When the following source is parsed:
+class A {
+    void a() throws @Abc X {
+    }
+}
+Then no errors are reported
+
+Scenario: Classes that are thrown from a constructor can be annotated
+
+Given a CompilationUnit
+When the following source is parsed:
+class A {
+    A() throws @Abc X {
+    }
+}
+Then no errors are reported
+
 
 Scenario: Parsing trailing semicolons inside the imports area should work
 

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/visitor_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/visitor_scenarios.story
@@ -73,4 +73,4 @@ Given a CompilationUnit
 Given a VoidVisitorAdapter with a visit method that asserts sensible line positions
 When the "JavaConcepts.java" is parsed
 When the CompilationUnit is visited by the PositionTestVisitor
-Then the total number of nodes visited is 1425
+Then the total number of nodes visited is 1427


### PR DESCRIPTION
…enceTypes instead of NameExprs.

@ftomassetti - I need you to check this carefully, since I simply copied your change here: https://github.com/javaparser/javaparser/commit/13ce95600c7c6badc1a65962ad21bc34152b7318
