### PR TITLE
Add escape methods for Char and String Literal Expr

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
@@ -22,10 +22,12 @@
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.internal.Utils;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
 import static com.github.javaparser.Position.pos;
+import static com.github.javaparser.Range.*;
 
 /**
  * @author Julio Vilmar Gesser
@@ -44,11 +46,18 @@ public final class CharLiteralExpr extends StringLiteralExpr {
      */
     @Deprecated
     public CharLiteralExpr(int beginLine, int beginColumn, int endLine, int endColumn, String value) {
-        this(new Range(pos(beginLine, beginColumn), pos(endLine, endColumn)), value);
+        this(range(pos(beginLine, beginColumn), pos(endLine, endColumn)), value);
     }
     
     public CharLiteralExpr(Range range, String value) {
         super(range, value);
+    }
+
+    /**
+     * Utility method that creates a new StringLiteralExpr. Escapes EOL characters.
+     */
+    public static CharLiteralExpr escape(String string) {
+        return new CharLiteralExpr(Utils.escapeEndOfLines(string));
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -22,12 +22,14 @@
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.internal.Utils;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
 import static com.github.javaparser.Position.pos;
 
 /**
+ * Java® Language Specification 3.10.5 String Literals
  * @author Julio Vilmar Gesser
  */
 public class StringLiteralExpr extends LiteralExpr {
@@ -43,6 +45,13 @@ public class StringLiteralExpr extends LiteralExpr {
             throw new IllegalArgumentException("Illegal literal expression: newlines (line feed or carriage return) have to be escaped");
         }
 		this.value = value;
+	}
+
+	/**
+	 * Utility method that creates a new StringLiteralExpr. Escapes EOL characters.
+	 */
+	public static StringLiteralExpr escape(String string) {
+		return new StringLiteralExpr(Utils.escapeEndOfLines(string));
 	}
 
 	/**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/internal/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/internal/Utils.java
@@ -26,14 +26,36 @@ import java.util.Collection;
 import java.util.List;
 
 /**
+ * Any kind of utility.
+ *
  * @author Federico Tomassetti
  */
 public class Utils {
-    public static <T> List<T> ensureNotNull(List<T> list) {
-        return list == null ? new ArrayList<T>() : list;
-    }
+	public static <T> List<T> ensureNotNull(List<T> list) {
+		return list == null ? new ArrayList<T>() : list;
+	}
 
-    public static <E> boolean isNullOrEmpty(Collection<E> collection) {
-        return collection == null || collection.isEmpty();
-    }
+	public static <E> boolean isNullOrEmpty(Collection<E> collection) {
+		return collection == null || collection.isEmpty();
+	}
+
+	/**
+	 * @return string with ASCII characters 10 and 13 replaced by the text "\n" and "\r".
+	 */
+	public static String escapeEndOfLines(String string) {
+		StringBuilder escapedString = new StringBuilder();
+		for (char c : string.toCharArray()) {
+			switch (c) {
+				case '\n':
+					escapedString.append("\\n");
+					break;
+				case '\r':
+					escapedString.append("\\r");
+					break;
+				default:
+					escapedString.append(c);
+			}
+		}
+		return escapedString.toString();
+	}
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -369,12 +369,22 @@ When I take the PackageDeclaration
 Then the package name is com.github.javaparser.bdd
 
 
-Scenario: Strings with unescaped newlines are NOT parsed correctly
+Scenario: Strings with unescaped newlines are illegal (issue 211)
 Given the class:
 class A {
     public void helloWorld(String greeting, String name) {
         return "hello
         world";
+    }
+}
+Then the Java parser cannot parse it because of lexical errors
+
+Scenario: Chars with unescaped newlines are illegal (issue 211)
+Given the class:
+class A {
+    public void helloWorld(String greeting, String name) {
+        return '
+';
     }
 }
 Then the Java parser cannot parse it because of lexical errors


### PR DESCRIPTION
As requested in #211 

I'm not certain I should call this method "escape". There will probably be a factory method coming soon, and this should be the escaped alternative, so if the factory method is "create" then this could be "createEscaped" or "createEscapeEOL". Maybe escape itself should be the factory method, and be named "create", although it may hide a user error where he/she is passing in EOL characters inadvertently.

Thoughts?
