### PR TITLE
Add other things to parse in the dump tests

### DIFF
--- a/javaparser-testing/pom.xml
+++ b/javaparser-testing/pom.xml
@@ -78,6 +78,7 @@
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -95,6 +96,7 @@
             <groupId>de.codecentric</groupId>
             <artifactId>jbehave-junit-runner</artifactId>
             <version>1.2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
@@ -23,8 +23,7 @@ package com.github.javaparser.bdd.steps;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.visitor.DumpVisitor;
+import com.github.javaparser.ast.Node;
 
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
@@ -37,29 +36,52 @@ import static org.junit.Assert.assertThat;
 
 public class DumpingSteps {
 
-    private CompilationUnit compilationUnit;
+    private Node resultNode;
     private String sourceUnderTest;
 
-    @Given("the class:$classSrc")
+    @Given("the {class|compilation unit|expression|block|expressions|statement|import|annotation|body declaration}:$classSrc")
     public void givenTheClass(String classSrc) {
         this.sourceUnderTest = classSrc.trim();
     }
 
-    @Given("the compilation unit:$classSrc")
-    public void givenTheCompilationUnit(String classSrc) {
-        this.sourceUnderTest = classSrc.trim();
+    @When("the {class|compilation unit} is parsed by the Java parser")
+    public void whenTheClassIsParsedByTheJavaParser() throws ParseException {
+        resultNode = JavaParser.parse(new StringReader(sourceUnderTest), true);
     }
 
-    @When("the class is parsed by the Java parser")
-    public void whenTheClassIsParsedByTheJavaParser() throws ParseException {
-        compilationUnit = JavaParser.parse(new StringReader(sourceUnderTest), true);
+    @When("the expression is parsed by the Java parser")
+    public void whenTheExpressionIsParsedByTheJavaParser() throws ParseException {
+        resultNode = JavaParser.parseExpression(sourceUnderTest);
+    }
+
+    @When("the block is parsed by the Java parser")
+    public void whenTheBlockIsParsedByTheJavaParser() throws ParseException {
+        resultNode = JavaParser.parseBlock(sourceUnderTest);
+    }
+
+    @When("the statement is parsed by the Java parser")
+    public void whenTheStatementIsParsedByTheJavaParser() throws ParseException {
+        resultNode = JavaParser.parseStatement(sourceUnderTest);
+    }
+
+    @When("the import is parsed by the Java parser")
+    public void whenTheImportIsParsedByTheJavaParser() throws ParseException {
+        resultNode = JavaParser.parseImport(sourceUnderTest);
+    }
+
+    @When("the annotation is parsed by the Java parser")
+    public void whenTheAnnotationIsParsedByTheJavaParser() throws ParseException {
+        resultNode = JavaParser.parseAnnotation(sourceUnderTest);
+    }
+
+    @When("the body declaration is parsed by the Java parser")
+    public void whenTheBodyDeclarationIsParsedByTheJavaParser() throws ParseException {
+        resultNode = JavaParser.parseBodyDeclaration(sourceUnderTest);
     }
 
     @Then("it is dumped to:$dumpSrc")
     public void isDumpedTo(String dumpSrc) {
-        DumpVisitor dumpVisitor = new DumpVisitor();
-        dumpVisitor.visit(compilationUnit, null);
-        assertThat(dumpVisitor.getSource().trim(), is(dumpSrc.trim()));
+        assertThat(resultNode.toString().trim(), is(dumpSrc.trim()));
     }
 
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -170,3 +170,47 @@ class A {
         }
     }
 }
+
+Scenario: we can parse blocks
+Given the block:
+{
+    a=2;
+    b=3;
+}
+When the block is parsed by the Java parser
+Then it is dumped to:
+{
+    a = 2;
+    b = 3;
+}
+
+Scenario: we can parse statements
+Given the statement:
+while (true) {
+}
+When the statement is parsed by the Java parser
+Then it is dumped to:
+while (true) {
+}
+
+Scenario: we can parse imports
+Given the import:
+import static a.b.c.Abc.*;
+When the import is parsed by the Java parser
+Then it is dumped to:
+import static a.b.c.Abc.*;
+
+Scenario: we can parse annotations
+Given the annotation:
+@Abc
+When the annotation is parsed by the Java parser
+Then it is dumped to:
+@Abc
+
+Scenario: we can parse body declarations
+Given the body declaration:
+private static final int x = 20;
+When the body declaration is parsed by the Java parser
+Then it is dumped to:
+private static final int x = 20;
+


### PR DESCRIPTION
JavaParser has parse methods for all kinds of structures, but the tests only use the one that parses compilation units. Now we can do everything that is available.
