### PR TITLE
Issue 430 clean up annotation handling

### DIFF
--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -22,12 +22,6 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
-    <dependencies>
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-        </dependency>
-    </dependencies>
 
     <properties>
         <java.version>1.8</java.version>

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -22,6 +22,12 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+    </dependencies>
 
     <properties>
         <java.version>1.8</java.version>

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
@@ -24,6 +24,7 @@ package com.github.javaparser.ast;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.utils.Utils;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -43,7 +44,7 @@ import java.util.List;
  * </pre>
  * @author Julio Vilmar Gesser
  */
-public final class PackageDeclaration extends Node {
+public final class PackageDeclaration extends Node implements NodeWithAnnotations<PackageDeclaration> {
 
     private List<AnnotationExpr> annotations;
 
@@ -108,9 +109,10 @@ public final class PackageDeclaration extends Node {
      * @param annotations
      *            the annotations to set
      */
-    public void setAnnotations(List<AnnotationExpr> annotations) {
+    public PackageDeclaration setAnnotations(List<AnnotationExpr> annotations) {
         this.annotations = annotations;
         setAsParentNodeOf(this.annotations);
+        return this;
     }
 
     /**
@@ -119,9 +121,10 @@ public final class PackageDeclaration extends Node {
      * @param name
      *            the name to set
      */
-    public void setName(NameExpr name) {
+    public PackageDeclaration setName(NameExpr name) {
         this.name = name;
         setAsParentNodeOf(this.name);
+        return this;
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArrays.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArrays.java
@@ -12,7 +12,30 @@ public interface NodeWithArrays<T> {
 
 	T setArrayCount(int arrayCount);
 
+	/**
+	 * <p>Arrays annotations are annotations on the arrays modifiers of the type.
+	 * Consider this example:</p>
+	 *
+	 * <p><pre>
+	 * {@code
+	 * int @Ann1 [] @Ann2 [] array;
+	 * }</pre></p>
+	 *
+	 * <p>in this this method will return a list with the annotation expressions <pre>@Ann1</pre>
+	 * and <pre>@Ann2</pre></p>
+	 *
+	 * <p>Note that the first list element of arraysAnnotations will refer to the first array modifier encountered.
+	 * Considering the example the first element will be a list containing just @Ann1 while the second element will
+	 * be a list containing just @Ann2.
+	 * </p>
+	 *
+	 * <p>This property is guaranteed to hold: <pre>{@code getArraysAnnotations().size() == getArrayCount()}</pre>
+	 * If a certain array modifier has no annotation the corresponding entry of arraysAnnotations will be null</p>
+	 */
 	List<List<AnnotationExpr>> getArraysAnnotations();
 
+	/**
+	 * For a description of the arrayAnnotations field refer to {@link #getArraysAnnotations()}
+	 */
 	T setArraysAnnotations(List<List<AnnotationExpr>> arraysAnnotations);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.TypeArguments;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -32,7 +33,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class ClassOrInterfaceType extends Type implements NodeWithName<ClassOrInterfaceType> {
+public final class ClassOrInterfaceType extends Type<ClassOrInterfaceType> implements NodeWithName<ClassOrInterfaceType>, NodeWithAnnotations<ClassOrInterfaceType> {
 
     private ClassOrInterfaceType scope;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -1,6 +1,7 @@
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
@@ -18,7 +19,7 @@ import java.util.List;
  *
  * @since 3.0.0
  */
-public class IntersectionType extends Type {
+public class IntersectionType extends Type<IntersectionType> implements NodeWithAnnotations<IntersectionType> {
 
     private List<ReferenceType> elements;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -72,7 +72,7 @@ public final class PrimitiveType extends Type<PrimitiveType> implements NodeWith
 		}
 	}
 
-	static final HashMap<String, Primitive> unboxMap = new HashMap<String, Primitive>();
+	static final HashMap<String, Primitive> unboxMap = new HashMap<>();
 	static {
 		for(Primitive unboxedType : Primitive.values()) {
 			unboxMap.put(unboxedType.nameOfBoxedType, unboxedType);
@@ -88,10 +88,9 @@ public final class PrimitiveType extends Type<PrimitiveType> implements NodeWith
 		this.type = type;
 	}
 
-	public PrimitiveType(Range range, final Primitive type, final List<AnnotationExpr> annotations) {
+	public PrimitiveType(Range range, final Primitive type) {
 		super(range);
 		this.type = type;
-		setAnnotations(annotations);
 	}
 
 	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -22,16 +22,19 @@
 package com.github.javaparser.ast.type;
 
 import java.util.HashMap;
+import java.util.List;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
 /**
  * @author Julio Vilmar Gesser
  */
-public final class PrimitiveType extends Type {
-	
+public final class PrimitiveType extends Type<PrimitiveType> implements NodeWithAnnotations<PrimitiveType> {
+
 	public static final PrimitiveType BYTE_TYPE = new PrimitiveType(Primitive.Byte);
 
 	public static final PrimitiveType SHORT_TYPE = new PrimitiveType(Primitive.Short);
@@ -85,9 +88,10 @@ public final class PrimitiveType extends Type {
 		this.type = type;
 	}
 
-	public PrimitiveType(Range range, final Primitive type) {
+	public PrimitiveType(Range range, final Primitive type, final List<AnnotationExpr> annotations) {
 		super(range);
 		this.type = type;
+		setAnnotations(annotations);
 	}
 
 	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithArrays;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -36,6 +37,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 /**
  * @author Julio Vilmar Gesser
  */
+public final class ReferenceType extends Type<ReferenceType> implements NodeWithType<ReferenceType>, NodeWithAnnotations<ReferenceType> {
 public final class ReferenceType extends Type implements NodeWithType<ReferenceType>, NodeWithArrays<ReferenceType> {
 
 	private Type type;
@@ -103,7 +105,7 @@ public final class ReferenceType extends Type implements NodeWithType<ReferenceT
 	public static ReferenceType create(PrimitiveType type, int arrayCount) {
 		return new ReferenceType(type, arrayCount);
 	}
-	
+
 	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
 		return v.visit(this, arg);
 	}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -37,8 +37,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class ReferenceType extends Type<ReferenceType> implements NodeWithType<ReferenceType>, NodeWithAnnotations<ReferenceType> {
-public final class ReferenceType extends Type implements NodeWithType<ReferenceType>, NodeWithArrays<ReferenceType> {
+public final class ReferenceType extends Type<ReferenceType> implements NodeWithType<ReferenceType>, NodeWithAnnotations<ReferenceType>, NodeWithArrays<ReferenceType>  {
 
 	private Type type;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -136,35 +136,12 @@ public final class ReferenceType extends Type<ReferenceType> implements NodeWith
         return this;
 	}
 
-	/**
-	 * <p>Arrays annotations are annotations on the arrays modifiers of the type.
-	 * Consider this example:</p>
-	 * 
-	 * <p><pre>
-	 * {@code
-	 * int @Ann1 [] @Ann2 [] array;
-	 * }</pre></p>
-	 * 
-	 * <p>in this this method will return a list with the annotation expressions <pre>@Ann1</pre>
-	 * and <pre>@Ann2</pre></p>
-	 * 
-	 * <p>Note that the first list element of arraysAnnotations will refer to the first array modifier encountered.
-	 * Considering the example the first element will be a list containing just @Ann1 while the second element will
-	 * be a list containing just @Ann2.
-	 * </p>
-	 *
-	 * <p>This property is guaranteed to hold: <pre>{@code getArraysAnnotations().size() == getArrayCount()}</pre>
-	 * If a certain array modifier has no annotation the corresponding entry of arraysAnnotations will be null</p>
-	 */
 	@Override
     public List<List<AnnotationExpr>> getArraysAnnotations() {
         arraysAnnotations = ensureNotNull(arraysAnnotations);
         return arraysAnnotations;
     }
 
-	/**
-	 * For a description of the arrayAnnotations field refer to {@link #getArraysAnnotations()}
-	 */
 	@Override
     public ReferenceType setArraysAnnotations(List<List<AnnotationExpr>> arraysAnnotations) {
         this.arraysAnnotations = arraysAnnotations;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -24,6 +24,7 @@ package com.github.javaparser.ast.type;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 
 import java.util.List;
 
@@ -32,7 +33,7 @@ import static com.github.javaparser.utils.Utils.*;
 /**
  * @author Julio Vilmar Gesser
  */
-public abstract class Type extends Node {
+public abstract class Type<T extends Type> extends Node {
 
     private List<AnnotationExpr> annotations;
 
@@ -49,16 +50,18 @@ public abstract class Type extends Node {
     
     public Type(Range range, List<AnnotationExpr> annotations) {
         super(range);
-        this.annotations = annotations;
+        setAnnotations(annotations);
     }
-    
+
     public List<AnnotationExpr> getAnnotations() {
         annotations = ensureNotNull(annotations);
         return annotations;
     }
 
-    public void setAnnotations(List<AnnotationExpr> annotations) {
+    public T setAnnotations(List<AnnotationExpr> annotations) {
+        setAsParentNodeOf(annotations);
         this.annotations = annotations;
+        return (T) this;
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -1,6 +1,7 @@
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
@@ -10,7 +11,7 @@ import java.util.List;
  * Represents a set of types. A given value of this type has to be assignable to at least one of the element types.
  * As of Java 8 it is only used in catch clauses.
  */
-public class UnionType extends Type {
+public class UnionType extends Type<UnionType> implements NodeWithAnnotations<UnionType> {
 
     private List<ReferenceType> elements;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -21,8 +21,14 @@
  
 package com.github.javaparser.ast.type;
 
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
+import java.util.List;
+
+import static com.github.javaparser.ast.internal.Utils.ensureNotNull;
 
 /**
  * An unknown parameter type object. It plays the role of a null object for
@@ -31,7 +37,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  *
  * @author Didier Villevalois
  */
-public final class UnknownType extends Type {
+public final class UnknownType extends Type<UnknownType> {
 
     public UnknownType() {
     }
@@ -45,4 +51,15 @@ public final class UnknownType extends Type {
     public <A> void accept(final VoidVisitor<A> v, final A arg) {
         v.visit(this, arg);
     }
+
+    @Override
+    public List<AnnotationExpr> getAnnotations() {
+        throw new IllegalStateException("Inferred lambda types cannot be annotated.");
+    }
+
+    @Override
+    public UnknownType setAnnotations(List<AnnotationExpr> annotations) {
+        throw new IllegalStateException("Inferred lambda types cannot be annotated.");
+    }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -22,13 +22,10 @@
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
 import java.util.List;
-
-import static com.github.javaparser.ast.internal.Utils.ensureNotNull;
 
 /**
  * An unknown parameter type object. It plays the role of a null object for

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -22,16 +22,17 @@
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
 /**
  * @author Julio Vilmar Gesser
  */
-public final class VoidType extends Type {
-	
+public final class VoidType extends Type<VoidType> implements NodeWithAnnotations<VoidType> {
+
 	public static final VoidType VOID_TYPE = new VoidType();
-	
+
 	public VoidType() {
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -22,13 +22,14 @@
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
 /**
  * @author Julio Vilmar Gesser
  */
-public final class WildcardType extends Type {
+public final class WildcardType extends Type<WildcardType> implements NodeWithAnnotations<WildcardType> {
 
 	private ReferenceType ext;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -441,13 +441,14 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	@Override
 	public Node visit(PrimitiveType _n, Object _arg) {
 		Comment comment = cloneNodes(_n.getComment(), _arg);
+		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 
 		PrimitiveType r = new PrimitiveType(
 				_n.getRange(),
-				_n.getType(),
-				_n.getAnnotations()
+				_n.getType()
 		);
 		r.setComment(comment);
+		r.setAnnotations(annotations);
 		return r;
 	}
 
@@ -474,12 +475,13 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
     @Override
     public Node visit(IntersectionType _n, Object _arg) {
+		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
         List<ReferenceType> elements = visit(_n.getElements(), _arg);
 
-        IntersectionType r = new IntersectionType(_n.getRange(),
-                elements);
+        IntersectionType r = new IntersectionType(_n.getRange(), elements);
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
+		r.setAnnotations(annotations);
         return r;
     }
 
@@ -496,15 +498,18 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(VoidType _n, Object _arg) {
+		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 
 		VoidType r = new VoidType(_n.getRange());
+		r.setAnnotations(annotations);
 		r.setComment(comment);
 		return r;
 	}
 
 	@Override
 	public Node visit(WildcardType _n, Object _arg) {
+		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		ReferenceType ext = cloneNodes(_n.getExtends(), _arg);
 		ReferenceType sup = cloneNodes(_n.getSuper(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
@@ -514,6 +519,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 				ext, sup
 		);
 		r.setComment(comment);
+		r.setAnnotations(annotations);
 		return r;
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -88,6 +88,7 @@ import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithArrays;
 import com.github.javaparser.ast.stmt.AssertStmt;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.BreakStmt;
@@ -456,14 +457,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	public Node visit(ReferenceType _n, Object _arg) {
 		List<AnnotationExpr> ann = visit(_n.getAnnotations(), _arg);
 		Type type_ = cloneNodes(_n.getType(), _arg);
-		List<List<AnnotationExpr>> arraysAnnotations = _n.getArraysAnnotations();
-		List<List<AnnotationExpr>> _arraysAnnotations = null;
-		if(arraysAnnotations != null){
-			_arraysAnnotations = new LinkedList<>();
-			for(List<AnnotationExpr> aux: arraysAnnotations){
-				_arraysAnnotations.add(visit(aux, _arg));
-			}
-		}
+		List<List<AnnotationExpr>> _arraysAnnotations = cloneArraysAnnotations(_n, _arg);
 
         ReferenceType r = new ReferenceType(_n.getBegin().line,
                 _n.getBegin().column, _n.getEnd().line, _n.getEnd().column, type_,
@@ -558,16 +552,8 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 			// exclusive constructors
 			r.setInitializer(cloneNodes(_n.getInitializer(), _arg));
 		}
-		List<List<AnnotationExpr>> arraysAnnotations = _n.getArraysAnnotations();
-		List<List<AnnotationExpr>> _arraysAnnotations = null;
-		if(arraysAnnotations != null){
-			_arraysAnnotations = new LinkedList<>();
-			for(List<AnnotationExpr> aux: arraysAnnotations){
-				_arraysAnnotations.add(visit(aux, _arg));
-			}
-		}
-		r.setArraysAnnotations(_arraysAnnotations);
-        Comment comment = cloneNodes(_n.getComment(), _arg);
+		r.setArraysAnnotations(cloneArraysAnnotations(_n, _arg));
+		Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
 		return r;
 	}
@@ -1294,4 +1280,16 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
         return (T) r;
     }
 
+
+	private List<List<AnnotationExpr>> cloneArraysAnnotations(NodeWithArrays<?> _n, Object _arg) {
+		List<List<AnnotationExpr>> arraysAnnotations = _n.getArraysAnnotations();
+		List<List<AnnotationExpr>> _arraysAnnotations = null;
+		if(arraysAnnotations != null){
+			_arraysAnnotations = new LinkedList<>();
+			for(List<AnnotationExpr> aux: arraysAnnotations){
+				_arraysAnnotations.add(visit(aux, _arg));
+			}
+		}
+		return _arraysAnnotations;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -444,7 +444,8 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 		PrimitiveType r = new PrimitiveType(
 				_n.getRange(),
-				_n.getType()
+				_n.getType(),
+				_n.getAnnotations()
 		);
 		r.setComment(comment);
 		return r;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -487,12 +487,14 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
     @Override
     public Node visit(UnionType _n, Object _arg) {
+		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
         List<ReferenceType> elements = visit(_n.getElements(), _arg);
 
         UnionType r = new UnionType(_n.getRange(),
                 elements);
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
+		r.setAnnotations(annotations);
         return r;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -537,6 +537,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
 	@Override
 	public void visit(final IntersectionType n, final Object arg) {
 		printJavaComment(n.getComment(), arg);
+		printAnnotations(n.getAnnotations(), false, arg);
 		boolean isFirst = true;
 		for (ReferenceType element : n.getElements()) {
 			element.accept(this, arg);
@@ -644,6 +645,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
 	@Override
 	public void visit(final VoidType n, final Object arg) {
 		printJavaComment(n.getComment(), arg);
+		printAnnotations(n.getAnnotations(), false, arg);
 		printer.print("void");
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -492,12 +492,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
 	@Override
 	public void visit(final PrimitiveType n, final Object arg) {
 		printJavaComment(n.getComment(), arg);
-		if (!isNullOrEmpty(n.getAnnotations())) {
-			for (AnnotationExpr ae : n.getAnnotations()) {
-				ae.accept(this, arg);
-				printer.print(" ");
-			}
-		}
+		printAnnotations(n.getAnnotations(), arg);
 		switch (n.getType()) {
 			case Boolean:
 				printer.print("boolean");
@@ -553,30 +548,25 @@ public class DumpVisitor implements VoidVisitor<Object> {
 		}
 	}
 
-	@Override
-	public void visit(final UnionType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		boolean isFirst = true;
-		for (ReferenceType element : n.getElements()) {
-			if (isFirst) {
-				isFirst = false;
-			} else {
-				printer.print(" | ");
-			}
-			element.accept(this, arg);
-		}
-	}
+    @Override public void visit(final UnionType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+		printAnnotations(n.getAnnotations(), arg);
+        boolean isFirst = true;
+        for (ReferenceType element : n.getElements()) {
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                printer.print(" | ");
+            }
+	        element.accept(this, arg);
+        }
+    }
 
 
 	@Override
 	public void visit(final WildcardType n, final Object arg) {
 		printJavaComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (AnnotationExpr ae : n.getAnnotations()) {
-				printer.print(" ");
-				ae.accept(this, arg);
-			}
-		}
+		printAnnotations(n.getAnnotations(), arg);
 		printer.print("?");
 		if (n.getExtends() != null) {
 			printer.print(" extends ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -492,7 +492,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
 	@Override
 	public void visit(final PrimitiveType n, final Object arg) {
 		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), arg);
+		printAnnotations(n.getAnnotations(), true, arg);
 		switch (n.getType()) {
 			case Boolean:
 				printer.print("boolean");
@@ -550,7 +550,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
 
     @Override public void visit(final UnionType n, final Object arg) {
         printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), arg);
+		printAnnotations(n.getAnnotations(), true, arg);
         boolean isFirst = true;
         for (ReferenceType element : n.getElements()) {
             if (isFirst) {
@@ -566,7 +566,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
 	@Override
 	public void visit(final WildcardType n, final Object arg) {
 		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), arg);
+		printAnnotations(n.getAnnotations(), false, arg);
 		printer.print("?");
 		if (n.getExtends() != null) {
 			printer.print(" extends ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -83,6 +83,7 @@ import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithArrays;
 import com.github.javaparser.ast.stmt.AssertStmt;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.BreakStmt;
@@ -664,24 +665,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
 			return false;
 		}
-		List<List<AnnotationExpr>> n1a = n1.getArraysAnnotations();
-		List<List<AnnotationExpr>> n2a = n2.getArraysAnnotations();
-
-		if (n1a !=null && n2a!= null) {
-			if(n1a.size() != n2a.size()){
-				return false;
-			}
-			else{
-				int i = 0;
-				for(List<AnnotationExpr> aux: n1a){
-					if(!nodesEquals(aux, n2a.get(i))){
-						return false;
-					}
-					i++;
-				}
-			}
-		}
-		else if (n1a != n2a){
+		if (!arraysAnnotationsEquals(n1, n2)) {
 			return false;
 		}
 		return true;
@@ -806,26 +790,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		if (!nodesEquals(n1.getDimensions(), n2.getDimensions())) {
 			return false;
 		}
-		List<List<AnnotationExpr>> n1a = n1.getArraysAnnotations();
-		List<List<AnnotationExpr>> n2a = n2.getArraysAnnotations();
 
-		if (n1a !=null && n2a!= null) {
-			if(n1a.size() != n2a.size()){
-				return false;
-			}
-			else{
-				int i = 0;
-				for(List<AnnotationExpr> aux: n1a){
-					if(!nodesEquals(aux, n2a.get(i))){
-						return false;
-					}
-					i++;
-				}
-			}
-		}
-		else if (n1a != n2a){
+		if (!arraysAnnotationsEquals(n1, n2)) {
 			return false;
 		}
+
 		return true;
 	}
 
@@ -1537,4 +1506,27 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
         }
         return true;
     }
+
+	private boolean arraysAnnotationsEquals(NodeWithArrays<?> n1, NodeWithArrays<?> n2) {
+		List<List<AnnotationExpr>> n1a = n1.getArraysAnnotations();
+		List<List<AnnotationExpr>> n2a = n2.getArraysAnnotations();
+
+		if (n1a != null && n2a != null) {
+			if (n1a.size() != n2a.size()) {
+				return false;
+			} else {
+				int i = 0;
+				for (List<AnnotationExpr> aux : n1a) {
+					if (!nodesEquals(aux, n2a.get(i))) {
+						return false;
+					}
+					i++;
+				}
+			}
+		} else if (n1a != n2a) {
+			return false;
+		}
+		return true;
+	}
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -690,6 +690,10 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     @Override public Boolean visit(final IntersectionType n1, final Node arg) {
         final IntersectionType n2 = (IntersectionType) arg;
 
+		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+			return false;
+		}
+
         List<ReferenceType> n1Elements = n1.getElements();
         List<ReferenceType> n2Elements = n2.getElements();
 
@@ -714,6 +718,10 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 
     @Override public Boolean visit(final UnionType n1, final Node arg) {
         final UnionType n2 = (UnionType) arg;
+
+		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+			return false;
+		}
 
         List<ReferenceType> n1Elements = n1.getElements();
         List<ReferenceType> n2Elements = n2.getElements();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -763,11 +763,6 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 	}
 
 	@Override public Boolean visit(final UnknownType n1, final Node arg) {
-		final UnknownType n2 = (UnknownType) arg;
-
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
 		return true;
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -1304,6 +1304,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final ReferenceType n, final A arg) {
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
 		{
 			R result = n.getType().accept(this, arg);
 			if (result != null) {
@@ -1558,14 +1564,10 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final VariableDeclarationExpr n, final A arg) {
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
 			}
 		}
 		{

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -444,6 +444,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final ClassOrInterfaceType n, final A arg) {
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
 		if (n.getScope() != null) {
 			{
 				R result = n.getScope().accept(this, arg);
@@ -1288,6 +1294,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final PrimitiveType n, final A arg) {
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
 		return null;
 	}
 
@@ -1321,6 +1333,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
     @Override
     public R visit(final IntersectionType n, final A arg) {
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
         {
             for (ReferenceType element : n.getElements()) {
                 R result = element.accept(this, arg);
@@ -1334,6 +1352,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
     @Override
     public R visit(final UnionType n, final A arg) {
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
         {
             for (ReferenceType element : n.getElements()) {
                 R result = element.accept(this, arg);
@@ -1613,6 +1637,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final VoidType n, final A arg) {
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
 		return null;
 	}
 
@@ -1635,6 +1665,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final WildcardType n, final A arg) {
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			R result = a.accept(this, arg);
+			if (result != null) {
+				return result;
+			}
+		}
 		if (n.getExtends() != null) {
 			{
 				R result = n.getExtends().accept(this, arg);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -82,6 +82,7 @@ import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithArrays;
 import com.github.javaparser.ast.stmt.AssertStmt;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.BreakStmt;
@@ -114,10 +115,26 @@ import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.ast.type.WildcardType;
 
+import java.util.List;
+
 /**
  * @author Julio Vilmar Gesser
  */
 public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A> {
+
+	private R visitArraysAnnotations(NodeWithArrays<?> n, A arg) {
+		for(List<AnnotationExpr> aux: n.getArraysAnnotations()) {
+			if (aux != null) {
+				for (AnnotationExpr annotation : aux) {
+					R result = annotation.accept(this, arg);
+					if (result != null) {
+						return result;
+					}
+				}
+			}
+		}
+		return null;
+	}
 
 	@Override
 	public R visit(final AnnotationDeclaration n, final A arg) {
@@ -208,6 +225,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final ArrayCreationExpr n, final A arg) {
+		{
+			R result = visitArraysAnnotations(n, arg);
+			if (result != null) {
+				return result;
+			}
+		}
 		{
 			R result = n.getType().accept(this, arg);
 			if (result != null) {
@@ -1316,6 +1339,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
 	@Override
 	public R visit(final ReferenceType n, final A arg) {
+		{
+			R result = visitArraysAnnotations(n, arg);
+			if (result != null) {
+				return result;
+			}
+		}
 		for (final AnnotationExpr a : n.getAnnotations()) {
 			R result = a.accept(this, arg);
 			if (result != null) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -330,6 +330,7 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 
 	@Override public Node visit(final ClassOrInterfaceType n, final A arg) {
+		visitAnnotations(n, arg);
 		if (n.getScope() != null) {
 			n.setScope((ClassOrInterfaceType) n.getScope().accept(this, arg));
 		}
@@ -827,7 +828,8 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 
     @Override
     public Node visit(final UnionType n, final A arg) {
-        final List<ReferenceType> elements = n.getElements();
+		visitAnnotations(n, arg);
+		final List<ReferenceType> elements = n.getElements();
         if (elements != null) {
             for (int i = 0; i < elements.size(); i++) {
                 elements.set(i, (ReferenceType) elements.get(i).accept(this, arg));

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -86,6 +86,7 @@ import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.stmt.AssertStmt;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.BreakStmt;
@@ -136,13 +137,7 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 
 	@Override public Node visit(final AnnotationDeclaration n, final A arg) {
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
+		visitAnnotations(n, arg);
         final List<BodyDeclaration<?>> members = n.getMembers();
 		if (members != null) {
 			for (int i = 0; i < members.size(); i++) {
@@ -151,6 +146,16 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 			removeNulls(members);
 		}
 		return n;
+	}
+
+	private void visitAnnotations(NodeWithAnnotations<?> n, A arg) {
+		final List<AnnotationExpr> annotations = n.getAnnotations();
+		if (annotations != null) {
+			for (int i = 0; i < annotations.size(); i++) {
+				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+			}
+			removeNulls(annotations);
+		}
 	}
 
 	@Override public Node visit(final AnnotationMemberDeclaration n, final A arg) {
@@ -292,13 +297,7 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 
 	@Override public Node visit(final ClassOrInterfaceDeclaration n, final A arg) {
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
+		visitAnnotations(n, arg);
 		final List<TypeParameter> typeParameters = n.getTypeParameters();
 		if (typeParameters != null) {
 			for (int i = 0; i < typeParameters.size(); i++) {
@@ -785,25 +784,20 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 	
 	@Override public Node visit(MultiTypeParameter n, A arg) {
+		visitAnnotations(n, arg);
         visit((BaseParameter<?>) n, arg);
         n.setType((UnionType)n.getType().accept(this, arg));
         return n;
     }
 
     protected Node visit(final BaseParameter<?> n, final A arg) {
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		
+		visitAnnotations(n, arg);
 		n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
 		return n;
 	}
 
 	@Override public Node visit(final PrimitiveType n, final A arg) {
+		visitAnnotations(n, arg);
 		return n;
 	}
 
@@ -813,12 +807,14 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 
 	@Override public Node visit(final ReferenceType n, final A arg) {
+		visitAnnotations(n, arg);
 		n.setType((Type) n.getType().accept(this, arg));
 		return n;
 	}
 
     @Override
     public Node visit(final IntersectionType n, final A arg) {
+		visitAnnotations(n, arg);
         final List<ReferenceType> elements = n.getElements();
         if (elements != null) {
             for (int i = 0; i < elements.size(); i++) {
@@ -1000,6 +996,7 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 
 	@Override public Node visit(final VoidType n, final A arg) {
+		visitAnnotations(n, arg);
 		return n;
 	}
 
@@ -1010,6 +1007,7 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
 	}
 
 	@Override public Node visit(final WildcardType n, final A arg) {
+		visitAnnotations(n, arg);
 		if (n.getExtends() != null) {
 			n.setExtends((ReferenceType) n.getExtends().accept(this, arg));
 		}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -86,6 +86,7 @@ import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.nodeTypes.NodeWithArrays;
 import com.github.javaparser.ast.stmt.AssertStmt;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.BreakStmt;
@@ -117,6 +118,8 @@ import com.github.javaparser.ast.type.UnionType;
 import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.ast.type.WildcardType;
+
+import java.util.List;
 
 /**
  * @author Julio Vilmar Gesser
@@ -157,6 +160,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final ArrayCreationExpr n, final A arg) {
 		visitComment(n.getComment(), arg);
+		visitArraysAnnotations(n, arg);
 		n.getType().accept(this, arg);
 		if (!isNullOrEmpty(n.getDimensions())) {
 			for (final Expression dim : n.getDimensions()) {
@@ -654,8 +658,9 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 	}
 
 	@Override public void visit(final ReferenceType n, final A arg) {
-		visitAnnotations(n, arg);
 		visitComment(n.getComment(), arg);
+		visitAnnotations(n, arg);
+		visitArraysAnnotations(n, arg);
 		n.getType().accept(this, arg);
 	}
 
@@ -864,6 +869,16 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 	private void visitAnnotations(NodeWithAnnotations<?> n, A arg) {
 		for (AnnotationExpr annotation : n.getAnnotations()) {
 			annotation.accept(this, arg);
+		}
+	}
+
+	private void visitArraysAnnotations(NodeWithArrays<?> n, A arg) {
+		for (List<AnnotationExpr> aux : n.getArraysAnnotations()) {
+			if (aux != null) {
+				for (AnnotationExpr annotation : aux) {
+					annotation.accept(this, arg);
+				}
+			}
 		}
 	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -127,10 +127,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			a.accept(this, arg);
 		}
 		n.getNameExpr().accept(this, arg);
 		if (n.getMembers() != null) {
@@ -145,10 +143,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			a.accept(this, arg);
 		}
 		n.getType().accept(this, arg);
 		if (n.getDefaultValue() != null) {
@@ -310,10 +306,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			a.accept(this, arg);
 		}
 		if (n.getTypeParameters() != null) {
 			for (final TypeParameter t : n.getTypeParameters()) {
@@ -651,20 +645,16 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final PackageDeclaration n, final A arg) {
 		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			a.accept(this, arg);
 		}
 		n.getName().accept(this, arg);
 	}
 
 	@Override public void visit(final Parameter n, final A arg) {
 		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			a.accept(this, arg);
 		}
 		n.getType().accept(this, arg);
 		n.getId().accept(this, arg);
@@ -672,10 +662,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 	
 	@Override public void visit(final MultiTypeParameter n, final A arg) {
 		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
+		for (final AnnotationExpr a : n.getAnnotations()) {
+			a.accept(this, arg);
 		}
         if (n.getType() != null) {
 			n.getType().accept(this, arg);
@@ -693,6 +681,9 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 	}
 
 	@Override public void visit(final ReferenceType n, final A arg) {
+		for (AnnotationExpr annotation : n.getAnnotations()) {
+			annotation.accept(this, arg);
+		}
 		visitComment(n.getComment(), arg);
 		n.getType().accept(this, arg);
 	}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -85,6 +85,7 @@ import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.stmt.AssertStmt;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.BreakStmt;
@@ -127,9 +128,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			a.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
 		n.getNameExpr().accept(this, arg);
 		if (n.getMembers() != null) {
             for (final BodyDeclaration<?> member : n.getMembers()) {
@@ -143,9 +142,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			a.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
 		n.getType().accept(this, arg);
 		if (n.getDefaultValue() != null) {
 			n.getDefaultValue().accept(this, arg);
@@ -247,9 +244,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			a.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
 		n.getNameExpr().accept(this, arg);
 		for (final TypeParameter t : n.getTypeParameters()) {
 			t.accept(this, arg);
@@ -267,6 +262,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final ClassOrInterfaceType n, final A arg) {
 		visitComment(n.getComment(), arg);
+		visitAnnotations(n, arg);
 		if (n.getScope() != null) {
 			n.getScope().accept(this, arg);
 		}
@@ -306,9 +302,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			a.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
 		if (n.getTypeParameters() != null) {
 			for (final TypeParameter t : n.getTypeParameters()) {
 				t.accept(this, arg);
@@ -371,11 +365,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
+		visitAnnotations(n, arg);
 		if (n.getArgs() != null) {
 			for (final Expression e : n.getArgs()) {
 				e.accept(this, arg);
@@ -393,11 +383,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
+		visitAnnotations(n, arg);
 		n.getNameExpr().accept(this, arg);
 		if (n.getImplements() != null) {
 			for (final ClassOrInterfaceType c : n.getImplements()) {
@@ -449,11 +435,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
+		visitAnnotations(n, arg);
 		n.getType().accept(this, arg);
 		for (final VariableDeclarator var : n.getVariables()) {
 			var.accept(this, arg);
@@ -575,11 +557,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 		if (n.getJavaDoc() != null) {
 			n.getJavaDoc().accept(this, arg);
 		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
+		visitAnnotations(n, arg);
 		if (n.getTypeParameters() != null) {
 			for (final TypeParameter t : n.getTypeParameters()) {
 				t.accept(this, arg);
@@ -645,26 +623,20 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final PackageDeclaration n, final A arg) {
 		visitComment(n.getComment(), arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			a.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
 		n.getName().accept(this, arg);
 	}
 
 	@Override public void visit(final Parameter n, final A arg) {
 		visitComment(n.getComment(), arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			a.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
 		n.getType().accept(this, arg);
 		n.getId().accept(this, arg);
 	}
 	
 	@Override public void visit(final MultiTypeParameter n, final A arg) {
 		visitComment(n.getComment(), arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			a.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
         if (n.getType() != null) {
 			n.getType().accept(this, arg);
 		}
@@ -673,6 +645,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final PrimitiveType n, final A arg) {
 		visitComment(n.getComment(), arg);
+		visitAnnotations(n, arg);
 	}
 
 	@Override public void visit(final QualifiedNameExpr n, final A arg) {
@@ -681,23 +654,23 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 	}
 
 	@Override public void visit(final ReferenceType n, final A arg) {
-		for (AnnotationExpr annotation : n.getAnnotations()) {
-			annotation.accept(this, arg);
-		}
+		visitAnnotations(n, arg);
 		visitComment(n.getComment(), arg);
 		n.getType().accept(this, arg);
 	}
 
     @Override public void visit(final IntersectionType n, final A arg) {
         visitComment(n.getComment(), arg);
-        for (ReferenceType element : n.getElements()) {
+		visitAnnotations(n, arg);
+		for (ReferenceType element : n.getElements()) {
             element.accept(this, arg);
         }
     }
 
     @Override public void visit(final UnionType n, final A arg) {
         visitComment(n.getComment(), arg);
-        for (ReferenceType element : n.getElements()) {
+		visitAnnotations(n, arg);
+		for (ReferenceType element : n.getElements()) {
             element.accept(this, arg);
         }
     }
@@ -809,11 +782,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final VariableDeclarationExpr n, final A arg) {
 		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
+		visitAnnotations(n, arg);
 		n.getType().accept(this, arg);
 		for (final VariableDeclarator v : n.getVars()) {
 			v.accept(this, arg);
@@ -834,6 +803,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final VoidType n, final A arg) {
 		visitComment(n.getComment(), arg);
+		visitAnnotations(n, arg);
+
 	}
 
 	@Override public void visit(final WhileStmt n, final A arg) {
@@ -844,6 +815,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
 	@Override public void visit(final WildcardType n, final A arg) {
 		visitComment(n.getComment(), arg);
+		visitAnnotations(n, arg);
 		if (n.getExtends() != null) {
 			n.getExtends().accept(this, arg);
 		}
@@ -886,6 +858,12 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     private void visitComment(final Comment n, final A arg) {
 		if (n != null) {
 			n.accept(this, arg);
+		}
+	}
+
+	private void visitAnnotations(NodeWithAnnotations<?> n, A arg) {
+		for (AnnotationExpr annotation : n.getAnnotations()) {
+			annotation.accept(this, arg);
 		}
 	}
 }

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1984,25 +1984,24 @@ WildcardType Wildcard():
 PrimitiveType PrimitiveType():
 {
 	PrimitiveType ret;
-	List<AnnotationExpr> annotations = new ArrayList<AnnotationExpr>();
 }
 {
 (
-  "boolean" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Boolean, annotations); }
+  "boolean" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Boolean); }
 |
-  "char" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Char, annotations); }
+  "char" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Char); }
 |
-  "byte" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Byte, annotations); }
+  "byte" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Byte); }
 |
-  "short" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Short, annotations); }
+  "short" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Short); }
 |
-  "int" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Int, annotations); }
+  "int" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Int); }
 |
-  "long" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Long, annotations); }
+  "long" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Long); }
 |
-  "float" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Float, annotations); }
+  "float" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Float); }
 |
-  "double" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Double, annotations); }
+  "double" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Double); }
 )
 { return ret; }
 }

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1984,24 +1984,25 @@ WildcardType Wildcard():
 PrimitiveType PrimitiveType():
 {
 	PrimitiveType ret;
+	List<AnnotationExpr> annotations = new ArrayList<AnnotationExpr>();
 }
 {
 (
-  "boolean" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Boolean); }
+  "boolean" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Boolean, annotations); }
 |
-  "char" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Char); }
+  "char" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Char, annotations); }
 |
-  "byte" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Byte); }
+  "byte" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Byte, annotations); }
 |
-  "short" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Short); }
+  "short" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Short, annotations); }
 |
-  "int" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Int); }
+  "int" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Int, annotations); }
 |
-  "long" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Long); }
+  "long" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Long, annotations); }
 |
-  "float" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Float); }
+  "float" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Float, annotations); }
 |
-  "double" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Double); }
+  "double" { ret = new PrimitiveType(tokenRange(), PrimitiveType.Primitive.Double, annotations); }
 )
 { return ret; }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ChangingMethodsFromAClassWithAVisitorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ChangingMethodsFromAClassWithAVisitorTest.java
@@ -1,13 +1,12 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import org.junit.Test;
 
-public class PrintingTheCompilationUnitToSystemOutputTest {
+public class ChangingMethodsFromAClassWithAVisitorTest {
     @Test
     public void printingTheCompilationUnitToSystemOutput() throws Exception {
         try (TestFileToken f = new TestFileToken("test.java")) {
-            CuPrinter.main(new String[]{});
+            MethodChanger_1.main(new String[]{});
         }
     }
-
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ChangingMethodsFromAClassWithoutAVisitorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ChangingMethodsFromAClassWithoutAVisitorTest.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import org.junit.Test;
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ClassCreator.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ClassCreator.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import java.util.EnumSet;
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/CreatingACompilationUnitFromScratch.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/CreatingACompilationUnitFromScratch.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import org.junit.Test;
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/CuPrinter.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/CuPrinter.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/MethodChanger_1.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/MethodChanger_1.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/MethodChanger_2.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/MethodChanger_2.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import java.io.FileInputStream;
 import java.util.List;

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/MethodPrinter.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/MethodPrinter.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/PrintingTheCompilationUnitToSystemOutputTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/PrintingTheCompilationUnitToSystemOutputTest.java
@@ -1,12 +1,13 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import org.junit.Test;
 
-public class ChangingMethodsFromAClassWithAVisitorTest {
+public class PrintingTheCompilationUnitToSystemOutputTest {
     @Test
     public void printingTheCompilationUnitToSystemOutput() throws Exception {
         try (TestFileToken f = new TestFileToken("test.java")) {
-            MethodChanger_1.main(new String[]{});
+            CuPrinter.main(new String[]{});
         }
     }
+
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/TestFileToken.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/TestFileToken.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import org.apache.commons.io.IOUtils;
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/VisitingClassMethodsTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/VisitingClassMethodsTest.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 import org.junit.Test;
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/D.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/D.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit.removenode;
+package com.github.javaparser.junit.wiki_samples.removenode;
 
 public class D {
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/GitHubTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/GitHubTest.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit.removenode;
+package com.github.javaparser.junit.wiki_samples.removenode;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/GitHubTest_2.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/GitHubTest_2.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit.removenode;
+package com.github.javaparser.junit.wiki_samples.removenode;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/RemoveDeleteNodeFromAst.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/removenode/RemoveDeleteNodeFromAst.java
@@ -1,6 +1,6 @@
-package com.github.javaparser.junit.removenode;
+package com.github.javaparser.junit.wiki_samples.removenode;
 
-import com.github.javaparser.junit.TestFileToken;
+import com.github.javaparser.junit.wiki_samples.TestFileToken;
 import org.junit.Test;
 
 public class RemoveDeleteNodeFromAst {

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -445,6 +445,8 @@ public class Abc<@C A, @C X extends @C String & @C Serializable> {
 */
     }
 }
+
+Scenario: we can parse a package-info file.
 Given the class in the file "package-info.java"
 When the class is parsed by the Java parser
 Then it is dumped to:

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -373,3 +373,82 @@ class Foo {
     void m1(@Boo boolean @Index1 [] @Index2 [] boolArray) {
     }
 }
+
+Scenario: Annotations are supported on annotations
+Given the class:
+@C @interface D {
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+@C
+@interface D {
+}
+
+Scenario: Annotations are supported on interfaces
+Given the class:
+@C interface Abc {
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+@C
+interface Abc {
+}
+
+Scenario: Annotations are supported on enums
+Given the class:
+@C enum Abc {
+}
+When the class is parsed by the Java parser
+Then it is dumped to:
+@C
+enum Abc {
+
+}
+
+Scenario: Annotations are supported on classes (issue 436 is the commented part)
+Given the compilation unit:
+@C
+public class Abc<@C A, @C X extends @C String & @C Serializable> {
+
+	@C int @C[] @C []f;
+
+	@C
+	public Abc(@C int p, List<@C ? extends Object> aa){
+		@C int b;
+	}
+	public @C void a(@C int o) {
+/*		try {
+			throw new IOException();
+		} catch (@C NullPointerException | @C IOException e) {
+		}
+*/	}
+}
+When the compilation unit is parsed by the Java parser
+Then it is dumped to:
+@C
+public class Abc<@C A, @C X extends @C String & @C Serializable> {
+
+    @C
+    int @C[] @C[] f;
+
+    @C
+    public Abc(@C int p, List<@C ? extends Object> aa) {
+        @C int b;
+    }
+
+    @C
+    public void a(@C int o) {
+    /*		try {
+			throw new IOException();
+		} catch (@C NullPointerException | @C IOException e) {
+		}
+*/
+    }
+}
+Given the class in the file "package-info.java"
+When the class is parsed by the Java parser
+Then it is dumped to:
+/**
+ * This package contains class for doing some stuff.
+ */
+@C package com.company.stuff;

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -429,7 +429,7 @@ Then it is dumped to:
 public class Abc<@C A, @C X extends @C String & @C Serializable> {
 
     @C
-    int @C[] @C[] f;
+    int @C [] @C [] f;
 
     @C
     public Abc(@C int p, List<@C ? extends Object> aa) {

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/samples/package-info.java
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/samples/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains class for doing some stuff.
+ */
+@C
+package com.company.stuff;

--- a/javaparser-testing/src/test/resources/com/github/javaparser/junit/wiki_samples/TestFile.java
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/junit/wiki_samples/TestFile.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.junit;
+package com.github.javaparser.junit.wiki_samples;
 
 public class TestFile {
     public int foo(int e) {


### PR DESCRIPTION
Fixes #430

I've double checked the visiting of annotations for all Types. Type has eight subclasses: ReferenceType, ClassOrInterfaceType, UnionType, UnknownType, PrimitiveType, WildcardType, VoidType and IntersectionType. With some research I came to the conclusion that all of these types except UnknownType can be annotated, so I made sure their annotations were visited in all visitors.

I did not look at other nodes with annotations, and I think I should continue work on #353 to make sure there are no errors in these visitors.
