### PR TITLE
Issue 157 enhance parser frontend

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
@@ -41,10 +41,10 @@ import java.util.List;
  * @author Júlio Vilmar Gesser
  */
 class CommentsInserter {
-    private boolean doNotAssignCommentsPreceedingEmptyLines = true;
-    private boolean doNotConsiderAnnotationsAsNodeStartForCodeAttribution = false;
-    
-    CommentsInserter() {
+    private final ParserConfiguration configuration;
+
+    CommentsInserter(ParserConfiguration configuration) {
+        this.configuration = configuration;
     }
 
     /**
@@ -57,22 +57,6 @@ class CommentsInserter {
         CommentsCollection allComments = commentsParser.parse(cuSourceCode);
 
         insertCommentsInCu(cu, allComments);
-    }
-
-    public boolean getDoNotConsiderAnnotationsAsNodeStartForCodeAttribution() {
-        return doNotConsiderAnnotationsAsNodeStartForCodeAttribution;
-    }
-
-    public void setDoNotConsiderAnnotationsAsNodeStartForCodeAttribution(boolean newValue) {
-        this.doNotConsiderAnnotationsAsNodeStartForCodeAttribution = newValue;
-    }
-
-    public boolean getDoNotAssignCommentsPreceedingEmptyLines() {
-        return doNotAssignCommentsPreceedingEmptyLines;
-    }
-
-    public void setDoNotAssignCommentsPreceedingEmptyLines(boolean newValue) {
-        this.doNotAssignCommentsPreceedingEmptyLines = newValue;
     }
 
     /**
@@ -131,7 +115,7 @@ class CommentsInserter {
             List<Comment> commentsInsideChild = new LinkedList<Comment>();
             for (Comment c : commentsToAttribute) {
                 if (PositionUtils.nodeContains(child, c,
-                        doNotConsiderAnnotationsAsNodeStartForCodeAttribution)) {
+                        configuration.doNotConsiderAnnotationsAsNodeStartForCodeAttribution)) {
                     commentsInsideChild.add(c);
                 }
             }
@@ -163,7 +147,7 @@ class CommentsInserter {
         childrenAndComments.addAll(children);
         childrenAndComments.addAll(commentsToAttribute);
         PositionUtils.sortByBeginPosition(childrenAndComments,
-                doNotConsiderAnnotationsAsNodeStartForCodeAttribution);
+                configuration.doNotConsiderAnnotationsAsNodeStartForCodeAttribution);
 
         for (Node thing : childrenAndComments) {
             if (thing instanceof Comment) {
@@ -173,7 +157,7 @@ class CommentsInserter {
                 }
             } else {
                 if (previousComment != null && !thing.hasComment()) {
-                    if (!doNotAssignCommentsPreceedingEmptyLines
+                    if (!configuration.doNotAssignCommentsPrecedingEmptyLines
                             || !thereAreLinesBetween(previousComment, thing)) {
                         thing.setComment(previousComment);
                         attributedComments.add(previousComment);

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.stmt.Statement;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -186,6 +187,39 @@ public final class JavaParser {
 	 */
 	public static CompilationUnit parse(final File file) throws FileNotFoundException, ParseProblemException {
 		return simplifiedParse(provider(file), true);
+	}
+
+
+	public static CompilationUnit parse(final Path path, final Charset encoding) throws ParseProblemException, IOException {
+		return simplifiedParse(provider(path, encoding), true);
+	}
+
+	/**
+	 * Parses the Java code contained in a file and returns a
+	 * {@link CompilationUnit} that represents it.
+	 *
+	 * @param path     path to a file containing Java source code
+	 * @param encoding encoding of the source code
+	 * @return CompilationUnit representing the Java source code
+	 * @throws IOException the path could not be accessed
+	 * @throws ParseProblemException if the source code has parser errors
+	 */
+	public static CompilationUnit parse(final Path path, final Charset encoding, boolean considerComments) throws ParseProblemException, IOException {
+		return simplifiedParse(provider(path, encoding), considerComments);
+	}
+
+	/**
+	 * Parses the Java code contained in a file and returns a
+	 * {@link CompilationUnit} that represents it.<br>
+	 * Note: Uses UTF-8 encoding
+	 *
+	 * @param path     path to a file containing Java source code
+	 * @return CompilationUnit representing the Java source code
+	 * @throws ParseProblemException if the source code has parser errors
+	 * @throws IOException the path could not be accessed
+	 */
+	public static CompilationUnit parse(final Path path) throws IOException, ParseProblemException {
+		return simplifiedParse(provider(path), true);
 	}
 
 	public static CompilationUnit parse(final Reader reader) throws ParseProblemException {

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.stmt.Statement;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -68,19 +69,6 @@ public final class JavaParser {
 	}
 
 	/**
-	 * Return the list of tokens that have been encountered while parsing code
-	 * using this parser.
-	 *
-	 * @return a list of tokens
-	 */
-	public List<Token> getTokens() {
-		if (astParser == null) {
-			throw new IllegalStateException("Don't ask for tokens before anything has been parsed.");
-		}
-		return astParser.getTokens();
-	}
-
-	/**
 	 * Parses source code without comments.
 	 * It takes the source code from a Provider.
 	 * The context indicates what can be found in the source code (compilation unit, block, import...)
@@ -94,11 +82,11 @@ public final class JavaParser {
 		final ASTParser parser = getParserForProvider(provider);
 		try {
 			N resultNode = context.parse(parser);
-			return new ParseResult<>(Optional.of(resultNode), parser.problems);
+			return new ParseResult<>(Optional.of(resultNode), parser.problems, astParser.getTokens());
 		} catch (ParseException e) {
-			return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), tokenRange(e.currentToken))));
+			return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), tokenRange(e.currentToken))), new LinkedList<>());
         } catch (TokenMgrException e) {
-            return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), Range.UNKNOWN)));
+            return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), Range.UNKNOWN)), new LinkedList<>());
 		} finally {
 			try {
 				provider.close();
@@ -122,11 +110,11 @@ public final class JavaParser {
 			final CompilationUnit resultNode = ParseContext.COMPILATION_UNIT.parse(parser);
 			commentsInserter.insertComments(resultNode, sourceCode);
 
-			return new ParseResult<>(Optional.of(resultNode), parser.problems);
+			return new ParseResult<>(Optional.of(resultNode), parser.problems, astParser.getTokens());
 		} catch (ParseException e) {
-            return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), tokenRange(e.currentToken))));
+            return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), tokenRange(e.currentToken))), new LinkedList<>());
         } catch (TokenMgrException e) {
-            return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), Range.UNKNOWN)));
+            return new ParseResult<>(Optional.empty(), singletonList(new Problem(e.getMessage(), Range.UNKNOWN)), new LinkedList<>());
         } catch (IOException e) {
             // The commentsInserter won't throw an IOException since it's reading from a String.
 			throw new AssertionError("Unreachable code");

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.github.javaparser.ASTParser.tokenRange;
+import static com.github.javaparser.ParseContext.*;
 import static com.github.javaparser.Providers.UTF8;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.Utils.providerToString;
@@ -108,7 +109,7 @@ public final class JavaParser {
 		try {
 			final String sourceCode = providerToString(provider);
             final ASTParser parser = getParserForProvider(provider(sourceCode));
-			final CompilationUnit resultNode = ParseContext.COMPILATION_UNIT.parse(parser);
+			final CompilationUnit resultNode = COMPILATION_UNIT.parse(parser);
 			commentsInserter.insertComments(resultNode, sourceCode);
 
 			return new ParseResult<>(Optional.of(resultNode), parser.problems, astParser.getTokens());
@@ -128,7 +129,7 @@ public final class JavaParser {
 		}
 	}
 
-	public static CompilationUnit parse(final InputStream in, final Charset encoding) throws ParseProblemException {
+	public static CompilationUnit parse(final InputStream in, final Charset encoding) {
 		return parse(in, encoding, true);
 	}
 
@@ -141,7 +142,7 @@ public final class JavaParser {
 	 * @return CompilationUnit representing the Java source code
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static CompilationUnit parse(final InputStream in, Charset encoding, boolean considerComments) throws ParseProblemException {
+	public static CompilationUnit parse(final InputStream in, Charset encoding, boolean considerComments) {
 		return simplifiedParse(provider(in, encoding), considerComments);
 	}
 
@@ -154,11 +155,11 @@ public final class JavaParser {
 	 * @return CompilationUnit representing the Java source code
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static CompilationUnit parse(final InputStream in) throws ParseProblemException {
+	public static CompilationUnit parse(final InputStream in) {
 		return parse(in, UTF8, true);
 	}
 
-	public static CompilationUnit parse(final File file, final Charset encoding) throws ParseProblemException, FileNotFoundException {
+	public static CompilationUnit parse(final File file, final Charset encoding) throws FileNotFoundException {
 		return simplifiedParse(provider(file, encoding), true);
 	}
 
@@ -171,7 +172,7 @@ public final class JavaParser {
 	 * @return CompilationUnit representing the Java source code
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static CompilationUnit parse(final File file, final Charset encoding, boolean considerComments) throws ParseProblemException, FileNotFoundException {
+	public static CompilationUnit parse(final File file, final Charset encoding, boolean considerComments) throws FileNotFoundException {
 		return simplifiedParse(provider(file, encoding), considerComments);
 	}
 
@@ -185,12 +186,12 @@ public final class JavaParser {
 	 * @throws ParseProblemException if the source code has parser errors
 	 * @throws FileNotFoundException the file was not found
 	 */
-	public static CompilationUnit parse(final File file) throws FileNotFoundException, ParseProblemException {
+	public static CompilationUnit parse(final File file) throws FileNotFoundException {
 		return simplifiedParse(provider(file), true);
 	}
 
 
-	public static CompilationUnit parse(final Path path, final Charset encoding) throws ParseProblemException, IOException {
+	public static CompilationUnit parse(final Path path, final Charset encoding) throws IOException {
 		return simplifiedParse(provider(path, encoding), true);
 	}
 
@@ -204,7 +205,7 @@ public final class JavaParser {
 	 * @throws IOException the path could not be accessed
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static CompilationUnit parse(final Path path, final Charset encoding, boolean considerComments) throws ParseProblemException, IOException {
+	public static CompilationUnit parse(final Path path, final Charset encoding, boolean considerComments) throws IOException {
 		return simplifiedParse(provider(path, encoding), considerComments);
 	}
 
@@ -218,15 +219,15 @@ public final class JavaParser {
 	 * @throws ParseProblemException if the source code has parser errors
 	 * @throws IOException the path could not be accessed
 	 */
-	public static CompilationUnit parse(final Path path) throws IOException, ParseProblemException {
+	public static CompilationUnit parse(final Path path) throws IOException {
 		return simplifiedParse(provider(path), true);
 	}
 
-	public static CompilationUnit parse(final Reader reader) throws ParseProblemException {
+	public static CompilationUnit parse(final Reader reader) {
 		return parse(reader, true);
 	}
 
-	public static CompilationUnit parse(final Reader reader, boolean considerComments) throws ParseProblemException {
+	public static CompilationUnit parse(final Reader reader, boolean considerComments) {
 		return simplifiedParse(provider(reader), considerComments);
 	}
 
@@ -239,7 +240,7 @@ public final class JavaParser {
 	 * @return CompilationUnit representing the Java source code
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static CompilationUnit parse(String code, boolean considerComments) throws ParseProblemException {
+	public static CompilationUnit parse(String code, boolean considerComments) {
 		return simplifiedParse(provider(code), considerComments);
 	}
 
@@ -251,7 +252,7 @@ public final class JavaParser {
 	 * @return CompilationUnit representing the Java source code
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static CompilationUnit parse(String code) throws ParseProblemException {
+	public static CompilationUnit parse(String code) {
 		return parse(code, true);
 	}
 
@@ -263,8 +264,8 @@ public final class JavaParser {
 	 * @return BlockStmt representing the Java block
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static BlockStmt parseBlock(final String blockStatement) throws ParseProblemException {
-		return simplifiedParse(ParseContext.BLOCK, provider(blockStatement));
+	public static BlockStmt parseBlock(final String blockStatement) {
+		return simplifiedParse(BLOCK, provider(blockStatement));
 	}
 
 	/**
@@ -275,11 +276,11 @@ public final class JavaParser {
 	 * @return Statement representing the Java statement
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static Statement parseStatement(final String statement) throws ParseProblemException {
-		return simplifiedParse(ParseContext.STATEMENT, provider(statement));
+	public static Statement parseStatement(final String statement) {
+		return simplifiedParse(STATEMENT, provider(statement));
 	}
 
-	private static <T> T simplifiedParse(ParseContext<T> context, Provider provider) throws ParseProblemException {
+	private static <T> T simplifiedParse(ParseContext<T> context, Provider provider) {
 		ParseResult<T> result = new JavaParser(new ParserConfiguration()).parseStructure(context, provider);
 		if (result.isSuccessful()) {
 			return result.result.get();
@@ -287,12 +288,12 @@ public final class JavaParser {
 		throw new ParseProblemException(result.problems);
 	}
 
-    private static CompilationUnit simplifiedParse(Provider provider, boolean considerComments) throws ParseProblemException {
+    private static CompilationUnit simplifiedParse(Provider provider, boolean considerComments) {
         final ParseResult<CompilationUnit> result;
         if (considerComments) {
             result = new JavaParser(new ParserConfiguration()).parseFull(provider);
         } else {
-            result = new JavaParser(new ParserConfiguration()).parseStructure(ParseContext.COMPILATION_UNIT, provider);
+            result = new JavaParser(new ParserConfiguration()).parseStructure(COMPILATION_UNIT, provider);
         }
         if (result.isSuccessful()) {
             return result.result.get();
@@ -308,8 +309,8 @@ public final class JavaParser {
 	 * @return list of Statement representing the Java statement
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static List<Statement> parseStatements(final String statements) throws ParseProblemException {
-		return simplifiedParse(ParseContext.STATEMENTS, provider(statements));
+	public static List<Statement> parseStatements(final String statements) {
+		return simplifiedParse(STATEMENTS, provider(statements));
 	}
 
 	/**
@@ -320,8 +321,8 @@ public final class JavaParser {
 	 * @return ImportDeclaration representing the Java import declaration
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static ImportDeclaration parseImport(final String importDeclaration) throws ParseProblemException {
-		return simplifiedParse(ParseContext.IMPORT_DECLARATION, provider(importDeclaration));
+	public static ImportDeclaration parseImport(final String importDeclaration) {
+		return simplifiedParse(IMPORT_DECLARATION, provider(importDeclaration));
 	}
 
 	/**
@@ -332,8 +333,8 @@ public final class JavaParser {
 	 * @return Expression representing the Java expression
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static Expression parseExpression(final String expression) throws ParseProblemException {
-		return simplifiedParse(ParseContext.EXPRESSION, provider(expression));
+	public static Expression parseExpression(final String expression) {
+		return simplifiedParse(EXPRESSION, provider(expression));
 	}
 
 	/**
@@ -344,8 +345,8 @@ public final class JavaParser {
 	 * @return AnnotationExpr representing the Java annotation
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static AnnotationExpr parseAnnotation(final String annotation) throws ParseProblemException {
-		return simplifiedParse(ParseContext.ANNOTATION, provider(annotation));
+	public static AnnotationExpr parseAnnotation(final String annotation) {
+		return simplifiedParse(ANNOTATION, provider(annotation));
 	}
 
 	/**
@@ -356,8 +357,8 @@ public final class JavaParser {
 	 * @return BodyDeclaration representing the Java annotation
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static BodyDeclaration<?> parseAnnotationBodyDeclaration(final String body) throws ParseProblemException {
-		return simplifiedParse(ParseContext.ANNOTATION_BODY, provider(body));
+	public static BodyDeclaration<?> parseAnnotationBodyDeclaration(final String body) {
+		return simplifiedParse(ANNOTATION_BODY, provider(body));
 	}
 
 	/**
@@ -368,8 +369,8 @@ public final class JavaParser {
 	 * @return BodyDeclaration representing the Java class body
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static BodyDeclaration<?> parseClassBodyDeclaration(String body) throws ParseProblemException {
-		return simplifiedParse(ParseContext.CLASS_BODY, provider(body));
+	public static BodyDeclaration<?> parseClassBodyDeclaration(String body) {
+		return simplifiedParse(CLASS_BODY, provider(body));
 	}
 
 	/**
@@ -380,7 +381,7 @@ public final class JavaParser {
 	 * @return BodyDeclaration representing the Java interface body
 	 * @throws ParseProblemException if the source code has parser errors
 	 */
-	public static BodyDeclaration parseInterfaceBodyDeclaration(String body) throws ParseProblemException {
-		return simplifiedParse(ParseContext.INTERFACE_BODY, provider(body));
+	public static BodyDeclaration parseInterfaceBodyDeclaration(String body) {
+		return simplifiedParse(INTERFACE_BODY, provider(body));
 	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseContext.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseContext.java
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.stmt.Statement;
 import java.util.List;
 
 @FunctionalInterface
+// TODO this needs a better name. "StartProduction"?
 public interface ParseContext<R> {
 	ParseContext<CompilationUnit> COMPILATION_UNIT = ASTParser::CompilationUnit;
 	ParseContext<BlockStmt> BLOCK = ASTParser::Block;

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseContext.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseContext.java
@@ -1,0 +1,27 @@
+package com.github.javaparser;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface ParseContext<R> {
+	ParseContext<CompilationUnit> COMPILATION_UNIT = ASTParser::CompilationUnit;
+	ParseContext<BlockStmt> BLOCK = ASTParser::Block;
+	ParseContext<List<Statement>> STATEMENTS = ASTParser::Statements;
+	ParseContext<Statement> STATEMENT = ASTParser::Statement;
+	ParseContext<ImportDeclaration> IMPORT_DECLARATION= ASTParser::ImportDeclaration;
+	ParseContext<Expression> EXPRESSION = ASTParser::Expression;
+	ParseContext<AnnotationExpr> ANNOTATION = ASTParser::Annotation;
+	ParseContext<BodyDeclaration<?>> ANNOTATION_BODY = ASTParser::AnnotationBodyDeclaration;
+	ParseContext<BodyDeclaration<?>> CLASS_BODY = p -> p.ClassOrInterfaceBodyDeclaration(false);
+	ParseContext<BodyDeclaration<?>> INTERFACE_BODY = p -> p.ClassOrInterfaceBodyDeclaration(true);
+
+	R parse(ASTParser parser) throws ParseException;
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Thrown when parsing problems occur during parsing with the static methods on JavaParser.
  */
-public class ParseProblemException extends Exception {
+public class ParseProblemException extends RuntimeException {
     /** The problems that were encountered during parsing */
     public final List<Problem> problems;
     

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
@@ -2,10 +2,23 @@ package com.github.javaparser;
 
 import java.util.List;
 
+/**
+ * Thrown when parsing problems occur during parsing with the static methods on JavaParser.
+ */
 public class ParseProblemException extends Exception {
-  public final List<Problem> problems;
-
-  public ParseProblemException(List<Problem> problems) {
-    this.problems = problems;
-  }
+    /** The problems that were encountered during parsing */
+    public final List<Problem> problems;
+    
+    ParseProblemException(List<Problem> problems) {
+        super(createMessage(problems));
+        this.problems = problems;
+    }
+    
+    private static String createMessage(List<Problem> problems){
+        StringBuilder message = new StringBuilder();
+        for(Problem problem: problems){
+            message.append(problem.toString()).append("\n");
+        }
+        return message.toString();
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
@@ -1,0 +1,11 @@
+package com.github.javaparser;
+
+import java.util.List;
+
+public class ParseProblemException extends Exception {
+  public final List<Problem> problems;
+
+  public ParseProblemException(List<Problem> problems) {
+    this.problems = problems;
+  }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
@@ -1,0 +1,19 @@
+package com.github.javaparser;
+
+import java.util.List;
+import java.util.Optional;
+
+public class ParseResult<T> {
+	public ParseResult(Optional<T> result, List<Problem> problems) {
+		this.result = result;
+		this.problems = problems;
+	}
+
+	public final List<Problem> problems;
+
+	public final Optional<T> result;
+
+	public boolean isSuccessful() {
+		return problems.isEmpty();
+	}
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
@@ -7,12 +7,14 @@ import java.util.Optional;
  * The results given when parsing with an instance of JavaParser.
  */
 public class ParseResult<T> {
-    public final List<Problem> problems;
     public final Optional<T> result;
+    public final List<Problem> problems;
+    public final List<Token> tokens;
 
-    public ParseResult(Optional<T> result, List<Problem> problems) {
+    public ParseResult(Optional<T> result, List<Problem> problems, List<Token> tokens) {
         this.result = result;
         this.problems = problems;
+        this.tokens = tokens;
     }
     
     public boolean isSuccessful() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
@@ -3,17 +3,31 @@ package com.github.javaparser;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * The results given when parsing with an instance of JavaParser.
+ */
 public class ParseResult<T> {
-	public ParseResult(Optional<T> result, List<Problem> problems) {
-		this.result = result;
-		this.problems = problems;
-	}
+    public final List<Problem> problems;
+    public final Optional<T> result;
 
-	public final List<Problem> problems;
+    public ParseResult(Optional<T> result, List<Problem> problems) {
+        this.result = result;
+        this.problems = problems;
+    }
+    
+    public boolean isSuccessful() {
+        return problems.isEmpty();
+    }
 
-	public final Optional<T> result;
-
-	public boolean isSuccessful() {
-		return problems.isEmpty();
-	}
+    @Override
+    public String toString() {
+        if (isSuccessful()) {
+            return "Parsing successful";
+        }
+        StringBuilder message = new StringBuilder("Parsing failed:\n");
+        for (Problem problem : problems) {
+            message.append(problem.toString()).append("\n");
+        }
+        return message.toString();
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -1,5 +1,6 @@
 package com.github.javaparser;
 
 public class ParserConfiguration {
-
+    public boolean doNotAssignCommentsPrecedingEmptyLines = true;
+    public boolean doNotConsiderAnnotationsAsNodeStartForCodeAttribution = false;
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -1,0 +1,5 @@
+package com.github.javaparser;
+
+public class ParserConfiguration {
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/Problem.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Problem.java
@@ -1,16 +1,19 @@
 package com.github.javaparser;
 
+/**
+ * A problem that was encountered during parsing.
+ */
 public class Problem {
-	public final String message;
-	public final Range range;
+    public final String message;
+    public final Range range;
 
-	public Problem(String message, Range range) {
-		this.message = message;
-		this.range = range;
-	}
+    Problem(String message, Range range) {
+        this.message = message;
+        this.range = range;
+    }
 
-	@Override
-	public String toString() {
-		return message + " " + range;
-	}
+    @Override
+    public String toString() {
+        return message + " " + range;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/Problem.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Problem.java
@@ -1,0 +1,16 @@
+package com.github.javaparser;
+
+public class Problem {
+	public final String message;
+	public final Range range;
+
+	public Problem(String message, Range range) {
+		this.message = message;
+		this.range = range;
+	}
+
+	@Override
+	public String toString() {
+		return message + " " + range;
+	}
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/Providers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Providers.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
  * Factory for providers of source code for JavaParser.
  * Providers that have no parameter for encoding but need it will use UTF-8.
  */
-public abstract class Providers {
+public final class Providers {
 	public static final Charset UTF8 = Charset.forName("utf-8");
 
 	private Providers() {

--- a/javaparser-core/src/main/java/com/github/javaparser/Providers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Providers.java
@@ -2,6 +2,9 @@ package com.github.javaparser;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
 
 /**
  * Factory for providers of source code for JavaParser.
@@ -37,6 +40,14 @@ public abstract class Providers {
 
 	public static Provider provider(File file) throws FileNotFoundException {
 		return provider(file, UTF8);
+	}
+
+	public static Provider provider(Path path, Charset encoding) throws IOException {
+		return provider(Files.newInputStream(path), encoding);
+	}
+
+	public static Provider provider(Path path) throws IOException {
+		return provider(path, UTF8);
 	}
 
 	public static Provider provider(String source) {

--- a/javaparser-core/src/main/java/com/github/javaparser/Providers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Providers.java
@@ -1,0 +1,46 @@
+package com.github.javaparser;
+
+import java.io.*;
+import java.nio.charset.Charset;
+
+/**
+ * Factory for providers of source code for JavaParser.
+ * Providers that have no parameter for encoding but need it will use UTF-8.
+ */
+public abstract class Providers {
+	public static final Charset UTF8 = Charset.forName("utf-8");
+
+	private Providers() {
+	}
+
+	public static Provider provider(Reader reader) {
+		return new StreamProvider(reader);
+	}
+
+	public static Provider provider(InputStream input, Charset encoding) {
+		try {
+			return new StreamProvider(input, encoding.name());
+		} catch (IOException e) {
+			// The only one that is thrown is UnsupportedCharacterEncodingException,
+			// and that's a fundamental problem, so runtime exception.
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static Provider provider(InputStream input) {
+		return provider(input, UTF8);
+	}
+
+	public static Provider provider(File file, Charset encoding) throws FileNotFoundException {
+		return provider(new FileInputStream(file), encoding);
+	}
+
+	public static Provider provider(File file) throws FileNotFoundException {
+		return provider(file, UTF8);
+	}
+
+	public static Provider provider(String source) {
+		return new StringProvider(source);
+	}
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -21,6 +21,9 @@
 
 package com.github.javaparser.utils;
 
+import com.github.javaparser.Provider;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
@@ -62,15 +65,26 @@ public class Utils {
 	}
 
 	public static String readerToString(Reader reader) throws IOException {
-		char[] arr = new char[8*1024]; // 8K at a time
-		StringBuilder buf = new StringBuilder();
+		final StringBuilder result = new StringBuilder();
+		final char[] buffer = new char[8 * 1024];
 		int numChars;
 
-		while ((numChars = reader.read(arr, 0, arr.length)) > 0) {
-			buf.append(arr, 0, numChars);
+		while ((numChars = reader.read(buffer, 0, buffer.length)) > 0) {
+			result.append(buffer, 0, numChars);
 		}
 
-		return buf.toString();
+		return result.toString();
 	}
 
+	public static String providerToString(Provider provider) throws IOException {
+		final StringBuilder result = new StringBuilder();
+		final char[] buffer = new char[8 * 1024];
+		int numChars;
+
+		while ((numChars = provider.read(buffer, 0, buffer.length)) != -1) {
+			result.append(buffer, 0, numChars);
+		}
+
+		return result.toString();
+	}
 }

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -61,8 +61,9 @@ import static com.github.javaparser.Position.*;
 final class ASTParser {
 
     private final Position INVALID = pos(-1, 0);
-   
-	void reset(InputStream in, String encoding) throws IOException {
+    List<Problem> problems = new ArrayList<Problem>();
+
+    void reset(InputStream in, String encoding) throws IOException {
         ReInit(new StreamProvider(in, encoding));
     }
 
@@ -94,19 +95,19 @@ final class ASTParser {
 		}
 	}
 
-    public void addModifier(EnumSet<Modifier> modifiers, Modifier mod, Token token) throws ParseException {
+    public void addModifier(EnumSet<Modifier> modifiers, Modifier mod) {
         if (modifiers.contains(mod)) {
-            throwParseException("Duplicated modifier");
+            addProblem("Duplicated modifier");
         }
         modifiers.add(mod);
     }
     
-    public void addMultipleModifier(EnumSet<Modifier> modifiers, EnumSet<Modifier> mods, Token token) throws ParseException {
+    public void addMultipleModifier(EnumSet<Modifier> modifiers, EnumSet<Modifier> mods) {
         if(mods == null)
             return;
         for(Modifier m : mods)
             if (modifiers.contains(m)) 
-                throwParseException("Duplicated modifier");
+                addProblem("Duplicated modifier");
         for(Modifier m : mods)
             modifiers.add(m);
     }
@@ -121,21 +122,11 @@ final class ASTParser {
         return token_source.getTokens();
     }
 
-    private void throwParseException(String message) throws ParseException {
-        StringBuilder buf = new StringBuilder();
-        buf.append(message);
-        buf.append(": \"");
-        buf.append(token.image);
-        buf.append("\" at line ");
-        buf.append(token.beginLine);
-        buf.append(", column ");
-        buf.append(token.beginColumn);
-        ParseException e = new ParseException(buf.toString());
-        e.currentToken = token;
-        throw e;
+    private void addProblem(String message) {
+        problems.add(new Problem(message + ": \"" + token.image, tokenRange()));
     }
 
-    private Expression generateLambda(Expression ret, Statement lambdaBody) throws ParseException {
+    private Expression generateLambda(Expression ret, Statement lambdaBody) {
 	    if (ret instanceof EnclosedExpr) {
 	        Expression inner = ((EnclosedExpr) ret).getInner();
 	        if (inner != null && inner instanceof NameExpr) {
@@ -157,7 +148,7 @@ final class ASTParser {
             Expression inner = generateLambda(castExpr.getExpr(), lambdaBody);
             castExpr.setExpr(inner);
 	    } else {
-	        throw new ParseException("Failed to parse lambda expression! Please create an issue at https://github.com/javaparser/javaparser/issues");
+	        addProblem("Failed to parse lambda expression! Please create an issue at https://github.com/javaparser/javaparser/issues");
 	    }
 	    return ret;
     }
@@ -209,6 +200,10 @@ final class ASTParser {
     }
     
     private Range tokenRange() {
+        return tokenRange(token);
+    }
+
+    public static Range tokenRange(Token token) {
         return range(token.beginLine, token.beginColumn, token.endLine, token.endColumn);
     }
 }
@@ -1302,27 +1297,27 @@ ModifierHolder Modifiers():
  (
   LOOKAHEAD(2)
   (
-   "public" { addModifier(modifiers, Modifier.PUBLIC, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "public" { addModifier(modifiers, Modifier.PUBLIC); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "static" { addModifier(modifiers, Modifier.STATIC, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "static" { addModifier(modifiers, Modifier.STATIC); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "protected" {  addModifier(modifiers, Modifier.PROTECTED, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "protected" {  addModifier(modifiers, Modifier.PROTECTED); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "private" { addModifier(modifiers, Modifier.PRIVATE, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "private" { addModifier(modifiers, Modifier.PRIVATE); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "final" { addModifier(modifiers, Modifier.FINAL, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "final" { addModifier(modifiers, Modifier.FINAL); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "abstract" { addModifier(modifiers, Modifier.ABSTRACT, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "abstract" { addModifier(modifiers, Modifier.ABSTRACT); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "synchronized" { addModifier(modifiers, Modifier.SYNCHRONIZED, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "synchronized" { addModifier(modifiers, Modifier.SYNCHRONIZED); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "native" { addModifier(modifiers, Modifier.NATIVE, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "native" { addModifier(modifiers, Modifier.NATIVE); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "transient" { addModifier(modifiers, Modifier.TRANSIENT, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "transient" { addModifier(modifiers, Modifier.TRANSIENT); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "volatile" { addModifier(modifiers, Modifier.VOLATILE, token); begin = begin.orIfInvalid(tokenBegin()); }
+   "volatile" { addModifier(modifiers, Modifier.VOLATILE); begin = begin.orIfInvalid(tokenBegin()); }
   |
-   "strictfp" { addModifier(modifiers, Modifier.STRICTFP, token);  begin = begin.orIfInvalid(tokenBegin()); }
+   "strictfp" { addModifier(modifiers, Modifier.STRICTFP);  begin = begin.orIfInvalid(tokenBegin()); }
   |
    ann = Annotation() { annotations = add(annotations, ann); begin = begin.orIfInvalid(ann.getBegin()); }
   )
@@ -1396,7 +1391,7 @@ List<ClassOrInterfaceType> ExtendsList(boolean isInterface):
    ( "," cit = ClassOrInterfaceType() { ret.add(cit); extendsMoreThanOne = true; } )*
    {
       if (extendsMoreThanOne && !isInterface)
-         throwParseException("A class cannot extend more than one other class");
+         addProblem("A class cannot extend more than one other class");
    }
    { return ret; }
 }
@@ -1411,7 +1406,7 @@ List<ClassOrInterfaceType> ImplementsList(boolean isInterface):
    ( "," cit = ClassOrInterfaceTypeWithAnnotations() { ret.add(cit); } )*
    {
       if (isInterface)
-         throwParseException("An interface cannot implement other interfaces");
+         addProblem("An interface cannot implement other interfaces");
    }
    { return ret; }
 }
@@ -1539,14 +1534,14 @@ BodyDeclaration<?> ClassOrInterfaceBodyDeclaration(boolean isInterface):
 	  ret = InitializerDeclaration()
 	  {
 	     if (isInterface)
-	        throwParseException("An interface cannot have initializers");
+	        addProblem("An interface cannot have initializers");
 	  }
 	|
 	  modifier = Modifiers() [ "default" modifier2= Modifiers()
 	  {
 	    if(!isInterface)
 	    {
-	      throwParseException("A class cannot have default members");
+	      addProblem("A class cannot have default members");
 	    }
 	    isDefault = true;
 	  }]
@@ -1570,21 +1565,21 @@ BodyDeclaration<?> ClassOrInterfaceBodyDeclaration(boolean isInterface):
 	      {
 	        if(isDefault && ret!= null && ((MethodDeclaration)ret).getBody() == null)
 	        {
-	          throwParseException("\"default\" methods must have a body");
+	          addProblem("\"default\" methods must have a body");
 	        }
 	        ((MethodDeclaration)ret).setDefault(isDefault);
 	        if(modifier2!= null)
 	        {
 	          aux = modifier2.modifiers;
 	        }
-	        addMultipleModifier(modifier.modifiers, aux, token);
+	        addMultipleModifier(modifier.modifiers, aux);
 	        ((MethodDeclaration)ret).setModifiers(modifier.modifiers);
 	      }
 	  )
 	  {
 	    if(isDefault && ! (ret instanceof MethodDeclaration))
 	    {
-	      throwParseException("Only methods can have the keyword \"default\".");
+	      addProblem("Only methods can have the keyword \"default\".");
 	    }
 	  }
 	|

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -3140,7 +3140,7 @@ TryStmt TryStatement():
   )
   {
     if (finallyBlock==null && catchs==null && resources==null) {
-      throwParseException("Try has no finally, no catch, and no resources");
+      addProblem("Try has no finally, no catch, and no resources");
     }
     return new TryStmt(range(begin, tokenEnd()), resources, tryBlock, catchs, finallyBlock);
   }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/CommentParsingSteps.java
@@ -31,8 +31,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.io.StringReader;
 
+import com.github.javaparser.ParseProblemException;
 import org.jbehave.core.annotations.Alias;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
@@ -41,7 +41,6 @@ import org.jbehave.core.model.ExamplesTable;
 import org.jbehave.core.steps.Parameters;
 
 import com.github.javaparser.JavaParser;
-import com.github.javaparser.ParseException;
 import com.github.javaparser.TokenMgrException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -91,12 +90,12 @@ public class CommentParsingSteps {
     }
 
     @When("the class is parsed by the Java parser")
-    public void whenTheClassIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheClassIsParsedByTheJavaParser() throws ParseProblemException {
         compilationUnit = JavaParser.parse(sourceUnderTest);
     }
 
     @Then("the Java parser cannot parse it because of lexical errors")
-    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseException {
+    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseProblemException {
         try {
             compilationUnit = JavaParser.parse(sourceUnderTest);
             fail("Lexical error expected");

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ComparingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ComparingSteps.java
@@ -42,12 +42,12 @@ public class ComparingSteps {
      */
 
     @Given("the first class:$classSrc")
-    public void givenTheFirstClass(String classSrc) throws ParseProblemException {
+    public void givenTheFirstClass(String classSrc) {
         this.first = JavaParser.parse(classSrc.trim());
     }
 
     @Given("the second class:$classSrc")
-    public void givenTheSecondClass(String classSrc) throws ParseProblemException {
+    public void givenTheSecondClass(String classSrc) {
         this.second = JavaParser.parse(classSrc.trim());
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ComparingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ComparingSteps.java
@@ -22,7 +22,7 @@
 package com.github.javaparser.bdd.steps;
 
 import com.github.javaparser.JavaParser;
-import com.github.javaparser.ParseException;
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
 import static org.hamcrest.CoreMatchers.*;
 import org.jbehave.core.annotations.Given;
@@ -42,12 +42,12 @@ public class ComparingSteps {
      */
 
     @Given("the first class:$classSrc")
-    public void givenTheFirstClass(String classSrc) throws ParseException {
+    public void givenTheFirstClass(String classSrc) throws ParseProblemException {
         this.first = JavaParser.parse(classSrc.trim());
     }
 
     @Given("the second class:$classSrc")
-    public void givenTheSecondClass(String classSrc) throws ParseException {
+    public void givenTheSecondClass(String classSrc) throws ParseProblemException {
         this.second = JavaParser.parse(classSrc.trim());
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
@@ -59,52 +59,52 @@ public class DumpingSteps {
     }
 
     @When("the {class|compilation unit} is parsed by the Java parser")
-    public void whenTheClassIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheClassIsParsedByTheJavaParser() {
         resultNode = JavaParser.parse(sourceUnderTest, true);
     }
 
     @When("the expression is parsed by the Java parser")
-    public void whenTheExpressionIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheExpressionIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseExpression(sourceUnderTest);
     }
 
     @When("the block is parsed by the Java parser")
-    public void whenTheBlockIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheBlockIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseBlock(sourceUnderTest);
     }
 
     @When("the statement is parsed by the Java parser")
-    public void whenTheStatementIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheStatementIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseStatement(sourceUnderTest);
     }
 
     @When("the import is parsed by the Java parser")
-    public void whenTheImportIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheImportIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseImport(sourceUnderTest);
     }
 
     @When("the annotation is parsed by the Java parser")
-    public void whenTheAnnotationIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheAnnotationIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseAnnotation(sourceUnderTest);
     }
 
     @When("the annotation body declaration is parsed by the Java parser")
-    public void whenTheBodyDeclarationIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheBodyDeclarationIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseAnnotationBodyDeclaration(sourceUnderTest);
     }
 
     @When("the class body declaration is parsed by the Java parser")
-    public void whenTheClassBodyDeclarationIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheClassBodyDeclarationIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseClassBodyDeclaration(sourceUnderTest);
     }
 
     @When("the interface body declaration is parsed by the Java parser")
-    public void whenTheInterfaceBodyDeclarationIsParsedByTheJavaParser() throws ParseProblemException {
+    public void whenTheInterfaceBodyDeclarationIsParsedByTheJavaParser() {
         resultNode = JavaParser.parseInterfaceBodyDeclaration(sourceUnderTest);
     }
 
     @When("the class is visited by an empty ModifierVisitorAdapter")
-    public void whenTheClassIsVisitedByAnEmptyModifierVisitorAdapter() throws ParseProblemException {
+    public void whenTheClassIsVisitedByAnEmptyModifierVisitorAdapter() {
         (new ModifierVisitorAdapter() {
         }).visit((CompilationUnit) resultNode, null);
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/DumpingSteps.java
@@ -31,6 +31,7 @@ import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import com.github.javaparser.ParseProblemException;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
@@ -58,52 +59,52 @@ public class DumpingSteps {
     }
 
     @When("the {class|compilation unit} is parsed by the Java parser")
-    public void whenTheClassIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheClassIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parse(sourceUnderTest, true);
     }
 
     @When("the expression is parsed by the Java parser")
-    public void whenTheExpressionIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheExpressionIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parseExpression(sourceUnderTest);
     }
 
     @When("the block is parsed by the Java parser")
-    public void whenTheBlockIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheBlockIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parseBlock(sourceUnderTest);
     }
 
     @When("the statement is parsed by the Java parser")
-    public void whenTheStatementIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheStatementIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parseStatement(sourceUnderTest);
     }
 
     @When("the import is parsed by the Java parser")
-    public void whenTheImportIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheImportIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parseImport(sourceUnderTest);
     }
 
     @When("the annotation is parsed by the Java parser")
-    public void whenTheAnnotationIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheAnnotationIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parseAnnotation(sourceUnderTest);
     }
 
-    @When("the body declaration is parsed by the Java parser")
-    public void whenTheBodyDeclarationIsParsedByTheJavaParser() throws ParseException {
-        resultNode = JavaParser.parseBodyDeclaration(sourceUnderTest);
+    @When("the annotation body declaration is parsed by the Java parser")
+    public void whenTheBodyDeclarationIsParsedByTheJavaParser() throws ParseProblemException {
+        resultNode = JavaParser.parseAnnotationBodyDeclaration(sourceUnderTest);
     }
 
     @When("the class body declaration is parsed by the Java parser")
-    public void whenTheClassBodyDeclarationIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheClassBodyDeclarationIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parseClassBodyDeclaration(sourceUnderTest);
     }
 
     @When("the interface body declaration is parsed by the Java parser")
-    public void whenTheInterfaceBodyDeclarationIsParsedByTheJavaParser() throws ParseException {
+    public void whenTheInterfaceBodyDeclarationIsParsedByTheJavaParser() throws ParseProblemException {
         resultNode = JavaParser.parseInterfaceBodyDeclaration(sourceUnderTest);
     }
 
     @When("the class is visited by an empty ModifierVisitorAdapter")
-    public void whenTheClassIsVisitedByAnEmptyModifierVisitorAdapter() throws ParseException {
+    public void whenTheClassIsVisitedByAnEmptyModifierVisitorAdapter() throws ParseProblemException {
         (new ModifierVisitorAdapter() {
         }).visit((CompilationUnit) resultNode, null);
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
@@ -33,6 +33,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.type.ReferenceType;
 import org.jbehave.core.annotations.Alias;
 import org.jbehave.core.annotations.Given;
@@ -110,12 +111,12 @@ public class ManipulationSteps {
     }
 
     @When("is the String \"$value\" is parsed by the JavaParser using parseBlock")
-    public void whenIsTheStringIsParsedByTheJavaParser(String value) throws ParseException {
+    public void whenIsTheStringIsParsedByTheJavaParser(String value) throws ParseProblemException {
         blockStmt = JavaParser.parseBlock(value);
     }
 
     @When("is the String \"$value\" is parsed by the JavaParser using parseStatement")
-    public void whenIsTheStringIsParsedByTheJavaParserUsingParseStatement(String value) throws ParseException {
+    public void whenIsTheStringIsParsedByTheJavaParserUsingParseStatement(String value) throws ParseProblemException {
         statement= JavaParser.parseStatement(value);
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
@@ -111,12 +111,12 @@ public class ManipulationSteps {
     }
 
     @When("is the String \"$value\" is parsed by the JavaParser using parseBlock")
-    public void whenIsTheStringIsParsedByTheJavaParser(String value) throws ParseProblemException {
+    public void whenIsTheStringIsParsedByTheJavaParser(String value) {
         blockStmt = JavaParser.parseBlock(value);
     }
 
     @When("is the String \"$value\" is parsed by the JavaParser using parseStatement")
-    public void whenIsTheStringIsParsedByTheJavaParserUsingParseStatement(String value) throws ParseProblemException {
+    public void whenIsTheStringIsParsedByTheJavaParserUsingParseStatement(String value) {
         statement= JavaParser.parseStatement(value);
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -334,11 +334,11 @@ public class ParsingSteps {
     }
 
     @Then("the Java parser cannot parse it because of lexical errors")
-    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseProblemException {
+    public void javaParserCannotParseBecauseOfLexicalErrors() {
         try {
             JavaParser.parse(sourceUnderTest);
             fail("Lexical error expected");
-        } catch (TokenMgrException e) {
+        } catch (ParseProblemException e) {
             // ok
         }
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -348,7 +348,7 @@ public class ParsingSteps {
         try {
             JavaParser.parse(sourceUnderTest);
             fail("Parse error expected");
-        } catch (ParseException e) {
+        } catch (ParseProblemException e) {
             // ok
         }
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -36,6 +36,7 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 
+import com.github.javaparser.ParseProblemException;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
@@ -333,7 +334,7 @@ public class ParsingSteps {
     }
 
     @Then("the Java parser cannot parse it because of lexical errors")
-    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseException {
+    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseProblemException {
         try {
             JavaParser.parse(sourceUnderTest);
             fail("Lexical error expected");

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
@@ -34,6 +34,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
 
+import com.github.javaparser.ParseProblemException;
 import org.hamcrest.CoreMatchers;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
@@ -74,22 +75,22 @@ public class SharedSteps {
      */
 
     @When("the following source is parsed:$classSrc")
-    public void whenTheFollowingSourceIsParsed(String classSrc) throws ParseException {
+    public void whenTheFollowingSourceIsParsed(String classSrc) throws ParseProblemException {
         state.put("cu1", JavaParser.parse(classSrc.trim()));
     }
 
     @When("the following source is parsed (trimming space):$classSrc")
-    public void whenTheFollowingSourceIsParsedTrimmingSpace(String classSrc) throws ParseException {
+    public void whenTheFollowingSourceIsParsedTrimmingSpace(String classSrc) throws ParseProblemException {
         state.put("cu1", JavaParser.parse(classSrc.trim()));
     }
 
     @When("the following sources is parsed by the second CompilationUnit:$classSrc")
-    public void whenTheFollowingSourcesIsParsedBytTheSecondCompilationUnit(String classSrc) throws ParseException {
+    public void whenTheFollowingSourcesIsParsedBytTheSecondCompilationUnit(String classSrc) throws ParseProblemException {
         state.put("cu2", JavaParser.parse(classSrc.trim()));
     }
 
     @When("file \"$fileName\" is parsed")
-    public void whenTheJavaFileIsParsed(String fileName) throws IOException, ParseException, URISyntaxException {
+    public void whenTheJavaFileIsParsed(String fileName) throws IOException, URISyntaxException, ParseProblemException {
         URL url = getClass().getResource("../samples/" + fileName);
         CompilationUnit compilationUnit = JavaParser.parse(new File(url.toURI()));
         state.put("cu1", compilationUnit);

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
@@ -75,22 +75,22 @@ public class SharedSteps {
      */
 
     @When("the following source is parsed:$classSrc")
-    public void whenTheFollowingSourceIsParsed(String classSrc) throws ParseProblemException {
+    public void whenTheFollowingSourceIsParsed(String classSrc) {
         state.put("cu1", JavaParser.parse(classSrc.trim()));
     }
 
     @When("the following source is parsed (trimming space):$classSrc")
-    public void whenTheFollowingSourceIsParsedTrimmingSpace(String classSrc) throws ParseProblemException {
+    public void whenTheFollowingSourceIsParsedTrimmingSpace(String classSrc) {
         state.put("cu1", JavaParser.parse(classSrc.trim()));
     }
 
     @When("the following sources is parsed by the second CompilationUnit:$classSrc")
-    public void whenTheFollowingSourcesIsParsedBytTheSecondCompilationUnit(String classSrc) throws ParseProblemException {
+    public void whenTheFollowingSourcesIsParsedBytTheSecondCompilationUnit(String classSrc) {
         state.put("cu2", JavaParser.parse(classSrc.trim()));
     }
 
     @When("file \"$fileName\" is parsed")
-    public void whenTheJavaFileIsParsed(String fileName) throws IOException, URISyntaxException, ParseProblemException {
+    public void whenTheJavaFileIsParsed(String fileName) throws IOException, URISyntaxException {
         URL url = getClass().getResource("../samples/" + fileName);
         CompilationUnit compilationUnit = JavaParser.parse(new File(url.toURI()));
         state.put("cu1", compilationUnit);

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/dumping_scenarios.story
@@ -231,10 +231,10 @@ Then it is dumped to:
 
 Scenario: we can parse body declarations
 Given the body:
-private static final int x = 20;
-When the body declaration is parsed by the Java parser
+String author();
+When the annotation body declaration is parsed by the Java parser
 Then it is dumped to:
-private static final int x = 20;
+String author();
 
 Scenario: we can parse class body declarations
 Given the body:


### PR DESCRIPTION
#157 suggests a new interface for JavaParser. This PR contains a reduced version of the suggestion.

There are two interfaces:
1. the static methods on JavaParser form the "quick & dirty" interface
2. the methods on an instance of JavaParser are the "power user" interface.

Interface 1 has not been changed much. There is a different exception, and that exception can hold multiple parsing problems.

For interface 2:
- what we're parsing (compilation unit, expression, block...) is now specified as a parameter instead of using a different parameter. This happens to be a single-method interface, so now any production of ASTParser can be used.
- where the source code is coming from is now determined by JavaCC's Provider interface. The Providers factory class has several methods for creating Providers.
- parsing doesn't always fail on the first parsing problem anymore. It still does in many cases, but this can be improved. This way we can collect the problems and return them, instead of returning only one. Additionally the parse result, the node, is returned if parsing was completed. Both can be returned from a single parse call: a list of problems and a result node, which lays the ground work for continuous parsing (#136)

Things that are significantly different from #157:
- There is no reference to the origin of the source code (the path() suggestion.) This can be done, but I don't know how useful it is (we can indicate a file, but how do we say that the source code came from a string or an input stream?) It can always be added on later.
- Problems don't have a severity. I can't imagine needing it right now since everything seems to be an error. Maybe when this feature is used extensively there will be a need.

Things to do:
- Use error recovery to turn more fatal problems into recoverable errors, see #136 
- Write tests...

Thanks to @ptitjes for thinking this up!
