### PR TITLE
Fix for #109

### DIFF
--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -2047,15 +2047,6 @@ NameExpr SimpleName():
  */
 
 Expression Expression():
-/*
- * This expansion has been written this way instead of:
- *   Assignment() | ConditionalExpression()
- * for performance reasons.
- * However, it is a weakening of the grammar for it allows the LHS of
- * assignments to be any conditional expression whereas it can only be
- * a primary expression.  Consider adding a semantic predicate to work
- * around this.
- */
 {
 	Expression ret;
 	AssignExpr.Operator op;
@@ -2064,37 +2055,41 @@ Expression Expression():
 	RangedList<Type> typeArgs = new RangedList<Type>(null);
 }
 {
-  ret = ConditionalExpression()
-  [
-    (
-       LOOKAHEAD(2)
-    op = AssignmentOperator() value = Expression() { ret = new AssignExpr(range(ret.getBegin(), pos(token.endLine, token.endColumn)), ret, value, op); }
-  |
-   "->" lambdaBody = LambdaBody()
-   {
-     if (ret instanceof CastExpr)
-     {
-       ret = generateLambda(ret, lambdaBody);
-     }
-     else if (ret instanceof ConditionalExpr){
-     	 ConditionalExpr ce = (ConditionalExpr) ret;
-         if(ce.getElseExpr() != null){
-            ce.setElseExpr(generateLambda(ce.getElseExpr(), lambdaBody));
-         }
-     }
-     else
-     {
-       ret = generateLambda(ret, lambdaBody);
-     }
-   }
- |  "::"  [typeArgs = TypeArguments() ] (<IDENTIFIER> | "new")
- {
-   ret = new MethodReferenceExpr(range(ret.getBegin(), pos(token.endLine, token.endColumn)), ret, createTypeArguments(typeArgs.list), token.image);
- }
-   )
-  ]
-
-  { return ret; }
+    ret = ConditionalExpression()
+    [
+        (
+                LOOKAHEAD(2)
+                op = AssignmentOperator() value = Expression()
+                {
+                    if(ret instanceof FieldAccessExpr || ret instanceof NameExpr || ret instanceof ArrayAccessExpr) {
+                        ret = new AssignExpr(range(ret.getBegin(), pos(token.endLine, token.endColumn)), ret, value, op);
+                    } else {
+                        throwParseException("Left hand side of an assignment can only be a primary expression");
+                    }
+                }
+            |
+                "->" lambdaBody = LambdaBody()
+                {
+                    if (ret instanceof CastExpr) {
+                        ret = generateLambda(ret, lambdaBody);
+                    }
+                    else if (ret instanceof ConditionalExpr){
+                        ConditionalExpr ce = (ConditionalExpr) ret;
+                        if(ce.getElseExpr() != null){
+                            ce.setElseExpr(generateLambda(ce.getElseExpr(), lambdaBody));
+                        }
+                    } else {
+                        ret = generateLambda(ret, lambdaBody);
+                    }
+                }
+            |
+                "::"  [typeArgs = TypeArguments() ] (<IDENTIFIER> | "new")
+                {
+                    ret = new MethodReferenceExpr(range(ret.getBegin(), pos(token.endLine, token.endColumn)), ret, createTypeArguments(typeArgs.list), token.image);
+                }
+        )
+    ]
+    { return ret; }
 }
 
 AssignExpr.Operator AssignmentOperator():

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -21,53 +21,32 @@
 
 package com.github.javaparser.bdd.steps;
 
-import static com.github.javaparser.bdd.steps.SharedSteps.getMemberByTypeAndPosition;
-import static com.github.javaparser.bdd.steps.SharedSteps.getMethodByPositionAndClassPosition;
-import static java.lang.String.format;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.io.StringReader;
-import java.util.List;
-import java.util.Map;
-
-import org.jbehave.core.annotations.Given;
-import org.jbehave.core.annotations.Then;
-import org.jbehave.core.annotations.When;
-
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
 import com.github.javaparser.TokenMgrException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.PackageDeclaration;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.ConstructorDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.body.TypeDeclaration;
-import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.ast.expr.ArrayCreationExpr;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.CastExpr;
-import com.github.javaparser.ast.expr.ConditionalExpr;
-import com.github.javaparser.ast.expr.LambdaExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.MethodReferenceExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.Statement;
+import org.jbehave.core.annotations.Given;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.javaparser.bdd.steps.SharedSteps.getMemberByTypeAndPosition;
+import static com.github.javaparser.bdd.steps.SharedSteps.getMethodByPositionAndClassPosition;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.*;
 
 public class ParsingSteps {
 
@@ -77,13 +56,13 @@ public class ParsingSteps {
         this.state = state;
     }
 
-    private String sourceUnderTest;
+    private String sourceUnderTest=null;
 
     /*
      * Given steps
      */
 
-    @Given("the class:$classSrc")
+    @Given("the {class|statement}:$classSrc")
     public void givenTheClass(String classSrc) {
         this.sourceUnderTest = classSrc.trim();
     }
@@ -332,12 +311,22 @@ public class ParsingSteps {
         assertEquals(expectedValue, expr.getType().isUsingDiamondOperator());
     }
 
-    @Then("the Java parser cannot parse it because of lexical errors")
-    public void javaParserCannotParseBecauseOfLexicalErrors() throws ParseException {
+    @Then("the Java parser cannot parse the compilation unit")
+    public void javaParserCannotParseCompilationUnit() {
         try {
             JavaParser.parse(sourceUnderTest);
-            fail("Lexical error expected");
-        } catch (TokenMgrException e) {
+            fail("Error expected");
+        } catch (TokenMgrException | ParseException e) {
+            // ok
+        }
+    }
+
+    @Then("the Java parser cannot parse the statement")
+    public void javaParserCannotParseExpression() {
+        try {
+            Statement statement = JavaParser.parseStatement(sourceUnderTest);
+            fail("Error expected");
+        } catch (TokenMgrException | ParseException e) {
             // ok
         }
     }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/parsing_scenarios.story
@@ -377,7 +377,7 @@ class A {
         world";
     }
 }
-Then the Java parser cannot parse it because of lexical errors
+Then the Java parser cannot parse the compilation unit
 
 Scenario: Chars with unescaped newlines are illegal (issue 211)
 Given the class:
@@ -387,7 +387,7 @@ class A {
 ';
     }
 }
-Then the Java parser cannot parse it because of lexical errors
+Then the Java parser cannot parse the compilation unit
 
 Scenario: Diamond Operator information is exposed
 
@@ -460,4 +460,86 @@ public class Example {
         true /*primaryConnection*/); // comment
   }
 }
+Then no errors are reported
+
+Scenario: We can not have a conditional expression on the left of an assignment statement (issue 109)
+Given the statement:
+a?b:c = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have an or expression on the left of an assignment statement (issue 109)
+Given the statement:
+a||b = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have an instanceof expression on the left of an assignment statement (issue 109)
+Given the statement:
+a instanceof C = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have a less than expression on the left of an assignment statement (issue 109)
+Given the statement:
+a < 3 = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have an unary minus expression on the left of an assignment statement (issue 109)
+Given the statement:
+-a = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have a postfix increment expression on the left of an assignment statement (issue 109)
+Given the statement:
+a++ = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have a cast on the left of an assignment statement (issue 109)
+Given the statement:
+(double)a = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can have a primary expression on the left of an assignment statement (issue 109)
+Given a CompilationUnit
+When the following source is parsed:
+class X { void a() {a = 1;} }
+Then no errors are reported
+
+Scenario: We can not have a conditional expression on the left of an assignment expression (issue 109)
+Given the statement:
+a = a?b:c = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have an or expression on the left of an assignment expression (issue 109)
+Given the statement:
+a = a||b = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have an instanceof expression on the left of an assignment expression (issue 109)
+Given the statement:
+a = a instanceof C = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have a less than expression on the left of an assignment expression (issue 109)
+Given the statement:
+a = a < 3 = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have an unary minus expression on the left of an assignment expression (issue 109)
+Given the statement:
+a = -a = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have a postfix increment expression on the left of an assignment expression (issue 109)
+Given the statement:
+a = a++ = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can not have a cast on the left of an assignment expression (issue 109)
+Given the statement:
+a = (double)a = 1;
+Then the Java parser cannot parse the statement
+
+Scenario: We can have a primary expression on the left of an assignment expression (issue 109)
+Given a CompilationUnit
+When the following source is parsed:
+class X { void a() {a = b = 1;} }
 Then no errors are reported


### PR DESCRIPTION
#109 do not accept non-primary expressions on the left hand side of assignments.

The fix is to check the type of the expression going in.

I'm thinking that this could be caught in the AST instead.

Sorry for the unclear commits thanks to reformatting: what is added is a type check in the grammar.
