### PR TITLE
issue454: appveyor: setting M2_HOME

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
 build_script:
   - mvn clean package --batch-mode -DskipTest
 test_script:


### PR DESCRIPTION
See #454 

Fixing the path to M2_HOME.

Notes: we install our own maven and one test is still failing
