### PR TITLE
Issue # 437 CloneVisitor has many unused variables

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -186,7 +186,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(ClassOrInterfaceDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
 		List<ClassOrInterfaceType> extendsList = visit(_n.getExtends(), _arg);
@@ -204,7 +203,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(EnumDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
 		List<EnumConstantDeclaration> entries = visit(_n.getEntries(), _arg);
@@ -221,7 +219,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(EmptyTypeDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 
 		EmptyTypeDeclaration r = new EmptyTypeDeclaration(
@@ -233,7 +230,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(EnumConstantDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		List<Expression> args = visit(_n.getArgs(), _arg);
         List<BodyDeclaration<?>> classBody = visit(_n.getClassBody(), _arg);
@@ -249,7 +245,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(AnnotationDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
         List<BodyDeclaration<?>> members = visit(_n.getMembers(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
@@ -264,7 +259,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(AnnotationMemberDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		Type type_ = cloneNodes(_n.getType(), _arg);
 		Expression defaultValue = cloneNodes(_n.getDefaultValue(), _arg);
@@ -280,7 +274,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(FieldDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		Type type_ = cloneNodes(_n.getType(), _arg);
 		List<VariableDeclarator> variables = visit(_n.getVariables(), _arg);
@@ -322,7 +315,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(ConstructorDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
 		List<Parameter> parameters = visit(_n.getParameters(), _arg);
@@ -340,7 +332,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(MethodDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
 		Type type_ = cloneNodes(_n.getType(), _arg);
@@ -374,7 +365,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(EmptyMemberDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 
 		EmptyMemberDeclaration r = new EmptyMemberDeclaration(
@@ -386,7 +376,6 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
 	@Override
 	public Node visit(InitializerDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
 		BlockStmt block = cloneNodes(_n.getBlock(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 
@@ -1173,7 +1162,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	@Override
 	public Node visit(SynchronizedStmt _n, Object _arg) {
 		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		BlockStmt block = cloneNodes(_n.getBlock(), _arg);
+		BlockStmt block = cloneNodes(_n.getBody(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 
 		SynchronizedStmt r = new SynchronizedStmt(
@@ -1203,7 +1192,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	@Override
 	public Node visit(CatchClause _n, Object _arg) {
 		Parameter param = cloneNodes(_n.getParam(), _arg);
-		BlockStmt catchBlock = cloneNodes(_n.getCatchBlock(), _arg);
+		BlockStmt catchBlock = cloneNodes(_n.getBody(), _arg);
 		Comment comment = cloneNodes(_n.getComment(), _arg);
 
 		CatchClause r = new CatchClause(

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/visitor/CloneVisitorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/visitor/CloneVisitorTest.java
@@ -1,0 +1,95 @@
+package com.github.javaparser.junit.visitor;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.visitor.CloneVisitor;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.ast.body.EmptyTypeDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EmptyMemberDeclaration;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.InitializerDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class CloneVisitorTest{
+	CompilationUnit cu;
+	
+	@Before
+	public void setUp(){
+		cu = new CompilationUnit();
+	}
+	
+	@After
+	public void teardown() {
+		cu = null;
+	}
+	
+	@Test
+	public void cloneJavaDocTest(){
+
+		List<BodyDeclaration<?>> bodyDeclarationList = new ArrayList<BodyDeclaration<?>>();
+		bodyDeclarationList.add(new AnnotationMemberDeclaration().setJavaDocComment("javadoc"));
+		bodyDeclarationList.add(new ConstructorDeclaration().setJavaDocComment("javadoc"));
+		bodyDeclarationList.add(new EmptyMemberDeclaration().setJavaDocComment("javadoc"));
+		bodyDeclarationList.add(new EnumConstantDeclaration().setJavaDocComment("javadoc"));
+		bodyDeclarationList.add(new FieldDeclaration().setJavaDocComment("javadoc"));
+		bodyDeclarationList.add(new InitializerDeclaration().setJavaDocComment("javadoc"));
+		bodyDeclarationList.add(new MethodDeclaration().setJavaDocComment("javadoc"));
+		
+		List<TypeDeclaration<?>> typeDeclarationList = new ArrayList<TypeDeclaration<?>>();
+		AnnotationDeclaration annotationDeclaration = new AnnotationDeclaration();
+		annotationDeclaration.setName("nnotationDeclarationTest");
+		typeDeclarationList.add(annotationDeclaration.setJavaDocComment("javadoc"));
+		
+		EmptyTypeDeclaration emptyTypeDeclaration = new EmptyTypeDeclaration();
+		emptyTypeDeclaration.setName("emptyTypeDeclarationTest");
+		typeDeclarationList.add(emptyTypeDeclaration.setJavaDocComment("javadoc"));
+		
+		EnumDeclaration enumDeclaration = new EnumDeclaration();
+		enumDeclaration.setName("enumDeclarationTest");
+		typeDeclarationList.add(enumDeclaration.setJavaDocComment("javadoc"));
+		
+		ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration();
+		classOrInterfaceDeclaration.setName("classOrInterfaceDeclarationTest");
+		typeDeclarationList.add(classOrInterfaceDeclaration.setJavaDocComment("javadoc"));
+		
+		EmptyTypeDeclaration emptyTypeDeclaration1 = new EmptyTypeDeclaration();
+		emptyTypeDeclaration1.setName("emptyTypeDeclarationTest1");
+		typeDeclarationList.add(emptyTypeDeclaration.setMembers(bodyDeclarationList));
+		
+		cu.setTypes(typeDeclarationList);
+		CompilationUnit cuClone=(CompilationUnit) new CloneVisitor().visit(cu, null);
+		
+		List<TypeDeclaration<?>> typeDeclarationListClone = cuClone.getTypes();
+		Iterator<TypeDeclaration<?>> typeItr = typeDeclarationListClone.iterator();
+		TypeDeclaration<?>  typeDeclaration;
+		while(typeItr.hasNext()){
+			typeDeclaration = (TypeDeclaration<?>) typeItr.next();
+			if(typeDeclaration.getMembers()==null){
+				assertEquals(typeDeclaration.getComment().getContent(),"javadoc");
+			}else{
+				Iterator<BodyDeclaration<?>> bodyItr = typeDeclaration.getMembers().iterator();
+				while(bodyItr.hasNext()){
+					BodyDeclaration<?> bodyDeclaration = bodyItr.next();
+					assertEquals(bodyDeclaration.getComment().getContent(),"javadoc");
+				}
+			}
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
I removed the getJavaDoc statements in the CloneVisitor which were not used. I also replaced two deprecated methods.  Added one new test for CloneVisitor class to test clone javadoc.
