### PR TITLE
Add getText Method to JavadocComment class

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -25,10 +25,16 @@ import com.github.javaparser.Range;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.HashMap;
+import java.util.LinkedList;
+
 /**
  * @author Julio Vilmar Gesser
  */
 public final class JavadocComment extends Comment {
+
+    LinkedList<AnnotationPairs> annotations = new LinkedList<>();
+    String text;
 
     public JavadocComment() {
     }
@@ -49,5 +55,28 @@ public final class JavadocComment extends Comment {
     @Override
     public <A> void accept(VoidVisitor<A> v, A arg) {
         v.visit(this, arg);
+    }
+
+    public String getText() {
+        String text = toString();
+        text = text.replaceFirst("/\\*\\*\n", "");
+        text = text.replaceAll("\n *\\*/.*\n", "");
+        text = text.replaceAll(" *\\* *", "");
+        this.text = text;
+        return text;
+    }
+
+    private class AnnotationPairs {
+        String annotation;
+        String text;
+
+        public AnnotationPairs(String annotation, String text) {
+            this.annotation = annotation;
+            this.text = text;
+        }
+
+        public String getAnnotation() {return annotation;}
+
+        public String getText() {return text;}
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/comments/JavadocCommentTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/comments/JavadocCommentTest.java
@@ -1,0 +1,47 @@
+package com.github.javaparser.ast.comments;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Kido on 9/24/16.
+ */
+public class JavadocCommentTest {
+
+    @Test
+    public void testGetText() throws Exception {
+        Visitor v = new Visitor();
+        try {
+            FileInputStream fis = new FileInputStream("temp/Test1.java");
+            CompilationUnit cu = JavaParser.parse(fis);
+            fis.close();
+            v.visit(cu, null);
+            String doc = v.doc;
+            String output = "This is a simple Java Doc.\nThe output should be without stars.";
+            assertTrue(doc.length() == output.length());
+            assertTrue(output.equals(doc));
+        } catch (IOException e) {
+            System.out.println("cannot open file.");
+        }
+    }
+
+
+    private class Visitor extends VoidVisitorAdapter{
+
+        String doc;
+        @Override
+        public void visit(JavadocComment n, Object arg) {
+            doc = n.getText();
+            super.visit(n, arg);
+        }
+    }
+
+}

--- a/javaparser-testing/temp/Test1.java
+++ b/javaparser-testing/temp/Test1.java
@@ -1,0 +1,13 @@
+
+/**
+ * This is a simple Java Doc.
+ * The output should be without stars.
+ */
+public class Test1 {
+
+	/* Block comment:
+	This is block comment.
+	 */
+	public void a() {}
+	public void b() {}	
+}


### PR DESCRIPTION
If user wants to get the content of the javadoc, all lines begin with *. getText method refine it.
