### PR TITLE
Remove "download as zip/tar.gz" from http://javaparser.org/

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,6 @@
       <h1 class="project-name">JavaParser</h1>
       <h2 class="project-tagline">Java Parser and Abstract Syntax Tree</h2>
       <a href="https://github.com/javaparser/javaparser" class="btn">View on GitHub</a>
-      <a href="https://github.com/javaparser/javaparser/zipball/master" class="btn">Download .zip</a>
-      <a href="https://github.com/javaparser/javaparser/tarball/master" class="btn">Download .tar.gz</a>
     </section>
 
     <section class="main-content">


### PR DESCRIPTION
Removed "download as zip/tar.gz" from http://javaparser.org/
