### PR TITLE
bug of empty ImportDeclaration toString

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -278,8 +278,11 @@ public class DumpVisitor implements VoidVisitor<Object> {
 			if (n.isAsterisk()) {
 				printer.print(".*");
 			}
+			printer.printLn(";");
+		} else {
+			//eclipse organize imports add blank line
+			printer.printLn("");
 		}
-		printer.printLn(";");
 
 		printOrphanCommentsEnding(n);
 	}


### PR DESCRIPTION
see code when create an  empty ImportDeclaration meens like eclipse organize then imports add blank line
