### PR TITLE
issue503: introduce NonEmptyImportDeclaration

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/imports/NonEmptyImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/imports/NonEmptyImportDeclaration.java
@@ -1,0 +1,17 @@
+package com.github.javaparser.ast.imports;
+
+import com.github.javaparser.Range;
+
+/**
+ * Common ancestor for all imports, aside EmptyImportDeclaration
+ */
+public abstract class NonEmptyImportDeclaration extends ImportDeclaration {
+
+    protected NonEmptyImportDeclaration(Range range) {
+        super(range);
+    }
+
+    abstract boolean isAsterisk();
+
+    abstract boolean isStatic();
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/imports/SingleStaticImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/imports/SingleStaticImportDeclaration.java
@@ -13,7 +13,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * and "parse" is the staticMember.
  * <p><a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5.3">7.5.3. Single-Static-Import Declarations</a></p>
  */
-public class SingleStaticImportDeclaration extends ImportDeclaration {
+public class SingleStaticImportDeclaration extends NonEmptyImportDeclaration {
     private ClassOrInterfaceType type;
     private String staticMember;
 
@@ -54,5 +54,15 @@ public class SingleStaticImportDeclaration extends ImportDeclaration {
     public SingleStaticImportDeclaration setStaticMember(String staticMember) {
         this.staticMember = assertNotNull(staticMember);
         return this;
+    }
+
+    @Override
+    boolean isAsterisk() {
+        return false;
+    }
+
+    @Override
+    boolean isStatic() {
+        return true;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/imports/SingleTypeImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/imports/SingleTypeImportDeclaration.java
@@ -11,7 +11,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * Example: <code>import com.github.javaparser.JavaParser;</code>
  * <p><a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5.1">JLS 7.5.1. Single-Type-Import Declarations</a></p>
  */
-public class SingleTypeImportDeclaration extends ImportDeclaration {
+public class SingleTypeImportDeclaration extends NonEmptyImportDeclaration {
     private ClassOrInterfaceType type;
 
     public SingleTypeImportDeclaration() {
@@ -41,5 +41,15 @@ public class SingleTypeImportDeclaration extends ImportDeclaration {
         this.type = assertNotNull(type);
         setAsParentNodeOf(type);
         return this;
+    }
+
+    @Override
+    boolean isAsterisk() {
+        return false;
+    }
+
+    @Override
+    boolean isStatic() {
+        return false;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/imports/StaticImportOnDemandDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/imports/StaticImportOnDemandDeclaration.java
@@ -11,7 +11,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * Example: <code>import static com.github.javaparser.JavaParser.*;</code>
  * <p><a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5.4">7.5.4. Static-Import-on-Demand Declarations</a></p>
  */
-public class StaticImportOnDemandDeclaration extends ImportDeclaration {
+public class StaticImportOnDemandDeclaration extends NonEmptyImportDeclaration {
     private ClassOrInterfaceType type;
 
     public StaticImportOnDemandDeclaration() {
@@ -41,5 +41,15 @@ public class StaticImportOnDemandDeclaration extends ImportDeclaration {
         this.type = assertNotNull(type);
         setAsParentNodeOf(type);
         return this;
+    }
+
+    @Override
+    boolean isAsterisk() {
+        return true;
+    }
+
+    @Override
+    boolean isStatic() {
+        return true;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/imports/TypeImportOnDemandDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/imports/TypeImportOnDemandDeclaration.java
@@ -17,7 +17,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * Since a parser cannot differentiate between a type name and a package name, we simply store a NameExpr.
  * <p><a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5.2">JLS 7.5.2. Type-Import-on-Demand Declarations</a></p>
  */
-public class TypeImportOnDemandDeclaration extends ImportDeclaration {
+public class TypeImportOnDemandDeclaration extends NonEmptyImportDeclaration {
     private NameExpr name;
 
     public TypeImportOnDemandDeclaration() {
@@ -59,5 +59,15 @@ public class TypeImportOnDemandDeclaration extends ImportDeclaration {
         this.name = assertNotNull(name);
         setAsParentNodeOf(this.name);
         return this;
+    }
+
+    @Override
+    boolean isAsterisk() {
+        return true;
+    }
+
+    @Override
+    boolean isStatic() {
+        return false;
     }
 }


### PR DESCRIPTION
Following discussion on #503 I introduced NonEmptyImportDeclaration as a common ancestor for all useful imports so that we can put back methods which makes sense for all imports but for the EmptyImportDeclaration
