### PR TITLE
Make NodeList NOT a Node.

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
@@ -60,7 +60,7 @@ class CommentsInserter {
         // so I could use some heuristics in these cases to distinguish the two
         // cases
 
-        List<Node> children = cu.getChildrenNodes();
+        List<Node> children = cu.getChildNodes();
 
         Comment firstComment = comments.iterator().next();
         if (cu.getPackage() != null
@@ -91,7 +91,7 @@ class CommentsInserter {
         // if they preceed a child they are assigned to it, otherweise they
         // remain "orphans"
 
-        List<Node> children = node.getChildrenNodes();
+        List<Node> children = node.getChildNodes();
 
         for (Node child : children) {
             TreeSet<Comment> commentsInsideChild = new TreeSet<>(NODE_BY_BEGIN_POSITION);

--- a/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
@@ -60,7 +60,7 @@ class CommentsInserter {
         // so I could use some heuristics in these cases to distinguish the two
         // cases
 
-        List<Node> children = cu.getBackwardsCompatibleChildrenNodes();
+        List<Node> children = cu.getChildrenNodes();
 
         Comment firstComment = comments.iterator().next();
         if (cu.getPackage() != null
@@ -91,7 +91,7 @@ class CommentsInserter {
         // if they preceed a child they are assigned to it, otherweise they
         // remain "orphans"
 
-        List<Node> children = node.getBackwardsCompatibleChildrenNodes();
+        List<Node> children = node.getChildrenNodes();
 
         for (Node child : children) {
             TreeSet<Comment> commentsInsideChild = new TreeSet<>(NODE_BY_BEGIN_POSITION);

--- a/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
@@ -1,0 +1,49 @@
+package com.github.javaparser;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+
+import java.util.List;
+
+/**
+ * An object that has a parent node.
+ */
+public interface HasParentNode<T> {
+    // TODO nullable
+    Node getParentNode();
+
+    T setParentNode(Node parentNode);
+
+    /**
+     * "this" for everything except NodeLists. NodeLists use their parent as their childrens parent.
+     */
+    Node getParentNodeForChildren();
+
+    @SuppressWarnings("unchecked")
+    default <N> N getParentNodeOfType(Class<N> classType) {
+        Node parent = getParentNode();
+        while (parent != null) {
+            if (classType.isAssignableFrom(parent.getClass()))
+                return (N) parent;
+            parent = parent.getParentNode();
+        }
+        return null;
+    }
+
+    // TODO should become protected once Java lets us
+    default void setAsParentNodeOf(List<? extends Node> childNodes) {
+        if (childNodes != null) {
+            for (HasParentNode current : childNodes) {
+                current.setParentNode(getParentNodeForChildren());
+            }
+        }
+    }
+
+    // TODO should become protected once Java lets us
+    default void setAsParentNodeOf(Node childNode) {
+        if (childNode != null) {
+            childNode.setParentNode(getParentNodeForChildren());
+        }
+    }
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -29,13 +29,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
+import com.github.javaparser.HasParentNode;
 import com.github.javaparser.Position;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.visitor.*;
-import com.github.javaparser.utils.PositionUtils;
 
 import java.util.*;
 
@@ -50,7 +50,8 @@ import static java.util.Collections.*;
  * 
  * @author Julio Vilmar Gesser
  */
-public abstract class Node implements Cloneable {
+// Use <Node> to prevent Node from becoming generic.
+public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable {
     /**
      * This can be used to sort nodes on position.
      */
@@ -70,34 +71,7 @@ public abstract class Node implements Cloneable {
     public Node(Range range) {
         this.range = range;
     }
-
-    /**
-     * Accept method for visitor support.
-     * 
-     * @param <R>
-     *            the type the return value of the visitor
-     * @param <A>
-     *            the type the argument passed to the visitor
-     * @param v
-     *            the visitor implementation
-     * @param arg
-     *            the argument passed to the visitor
-     * @return the result of the visit
-     */
-    public abstract <R, A> R accept(GenericVisitor<R, A> v, A arg);
-
-    /**
-     * Accept method for visitor support.
-     * 
-     * @param <A>
-     *            the type the argument passed for the visitor
-     * @param v
-     *            the visitor implementation
-     * @param arg
-     *            any value relevant for the visitor
-     */
-    public abstract <A> void accept(VoidVisitor<A> v, A arg);
-
+    
     /**
      * This is a comment associated with this node.
      *
@@ -222,22 +196,12 @@ public abstract class Node implements Cloneable {
 
     @Override
     public Node clone() {
-        return this.accept(new CloneVisitor(), null);
+        return (Node) accept(new CloneVisitor(), null);
     }
 
+    @Override
     public Node getParentNode() {
         return parentNode;
-    }
-
-    @SuppressWarnings("unchecked")
-    public <T> T getParentNodeOfType(Class<T> classType) {
-        Node parent = parentNode;
-        while (parent != null) {
-            if (classType.isAssignableFrom(parent.getClass()))
-                return (T) parent;
-            parent = parent.parentNode;
-        }
-        return null;
     }
 
     /**
@@ -249,30 +213,6 @@ public abstract class Node implements Cloneable {
      */
     public List<Node> getChildrenNodes() {
         return unmodifiableList(childrenNodes);
-    }
-
-    /**
-     * Before 3.0.0.alpha-5, if we had a list of nodes, those nodes would not have the list
-     * as its parent, but the node containing the list.
-     * This method returns the children in that way: there are no lists, and all nodes that are
-     * in lists are directly in this list.
-     * @deprecated this will be gone in 3.0.0 release.
-     */
-    @Deprecated
-    public List<Node> getBackwardsCompatibleChildrenNodes() {
-        List<Node> children = new ArrayList<>();
-        for (Node childNode : getChildrenNodes()) {
-            // Avoid attributing comments to NodeLists by pretending they don't exist.
-            if (childNode instanceof NodeList) {
-                for (Node subChildNode : ((NodeList<Node>) childNode)) {
-                    children.add(subChildNode);
-                }
-            } else {
-                children.add(childNode);
-            }
-        }
-        PositionUtils.sortByBeginPosition(children);
-        return children;
     }
 
     public <N extends Node> boolean containsWithin(N other) {
@@ -327,7 +267,8 @@ public abstract class Node implements Cloneable {
      *
      * @param parentNode node to be set as parent
      */
-    public void setParentNode(Node parentNode) {
+    @Override
+    public Node setParentNode(Node parentNode) {
         // remove from old parent, if any
         if (this.parentNode != null) {
             this.parentNode.childrenNodes.remove(this);
@@ -337,20 +278,7 @@ public abstract class Node implements Cloneable {
         if (this.parentNode != null) {
             this.parentNode.childrenNodes.add(this);
         }
-    }
-
-    protected void setAsParentNodeOf(List<? extends Node> childNodes) {
-        if (childNodes != null) {
-            for (Node current : childNodes) {
-                current.setParentNode(this);
-            }
-        }
-    }
-
-    protected void setAsParentNodeOf(Node childNode) {
-        if (childNode != null) {
-            childNode.setParentNode(this);
-        }
+        return this;
     }
 
     public static final int ABSOLUTE_BEGIN_LINE = -1;
@@ -473,5 +401,16 @@ public abstract class Node implements Cloneable {
         }
         setParentNode(null);
         return success;
+    }
+
+    @Override
+    public Node getParentNodeForChildren() {
+        return this;
+    }
+
+    protected void setAsParentNodeOf(NodeList<? extends Node> list) {
+        if (list != null) {
+            list.setParentNode(getParentNodeForChildren());
+        }
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -32,10 +32,10 @@ import com.github.javaparser.ast.imports.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
 
-public class CloneVisitor implements GenericVisitor<Node, Object> {
+public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
 	@Override
-	public Node visit(CompilationUnit _n, Object _arg) {
+	public Visitable visit(CompilationUnit _n, Object _arg) {
 		PackageDeclaration package_ = cloneNode(_n.getPackage(), _arg);
 		NodeList<ImportDeclaration> imports = cloneList(_n.getImports(), _arg);
 		NodeList<TypeDeclaration<?>> types = cloneList(_n.getTypes(), _arg);
@@ -47,7 +47,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(PackageDeclaration _n, Object _arg) {
+	public Visitable visit(PackageDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		NameExpr name = cloneNode(_n.getName(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -61,7 +61,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(TypeParameter _n, Object _arg) {
+	public Visitable visit(TypeParameter _n, Object _arg) {
         NodeList<ClassOrInterfaceType> typeBound = cloneList(_n.getTypeBound(), _arg);
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
         TypeParameter r = new TypeParameter(_n.getRange(),
@@ -73,17 +73,17 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(LineComment _n, Object _arg) {
+	public Visitable visit(LineComment _n, Object _arg) {
 		return new LineComment(_n.getRange(), _n.getContent());
 	}
 
 	@Override
-	public Node visit(BlockComment _n, Object _arg) {
+	public Visitable visit(BlockComment _n, Object _arg) {
 		return new BlockComment(_n.getRange(), _n.getContent());
 	}
 
 	@Override
-	public Node visit(ClassOrInterfaceDeclaration _n, Object _arg) {
+	public Visitable visit(ClassOrInterfaceDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		NodeList<TypeParameter> typeParameters = cloneList(_n.getTypeParameters(), _arg);
 		NodeList<ClassOrInterfaceType> extendsList = cloneList(_n.getExtends(), _arg);
@@ -101,7 +101,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(EnumDeclaration _n, Object _arg) {
+	public Visitable visit(EnumDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		NodeList<ClassOrInterfaceType> implementsList = cloneList(_n.getImplements(), _arg);
         NodeList<EnumConstantDeclaration> entries = cloneList(_n.getEntries(), _arg);
@@ -118,7 +118,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(EmptyTypeDeclaration _n, Object _arg) {
+	public Visitable visit(EmptyTypeDeclaration _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		EmptyTypeDeclaration r = new EmptyTypeDeclaration(
@@ -129,7 +129,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(EnumConstantDeclaration _n, Object _arg) {
+	public Visitable visit(EnumConstantDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		NodeList<Expression> args = cloneList(_n.getArgs(), _arg);
 		NodeList<BodyDeclaration<?>> classBody = cloneList(_n.getClassBody(), _arg);
@@ -144,7 +144,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(AnnotationDeclaration _n, Object _arg) {
+	public Visitable visit(AnnotationDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		NodeList<BodyDeclaration<?>> members = cloneList(_n.getMembers(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -159,7 +159,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(AnnotationMemberDeclaration _n, Object _arg) {
+	public Visitable visit(AnnotationMemberDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		Type<?> type_ = cloneNode(_n.getType(), _arg);
 		Expression defaultValue = cloneNode(_n.getDefaultValue(), _arg);
@@ -174,7 +174,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(FieldDeclaration _n, Object _arg) {
+	public Visitable visit(FieldDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations_ = cloneList(_n.getAnnotations(), _arg);
 		Type<?> elementType_ = cloneNode(_n.getElementType(), _arg);
 		NodeList<VariableDeclarator> variables_ = cloneList(_n.getVariables(), _arg);
@@ -195,7 +195,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(VariableDeclarator _n, Object _arg) {
+	public Visitable visit(VariableDeclarator _n, Object _arg) {
 		VariableDeclaratorId id = cloneNode(_n.getId(), _arg);
 		Expression init = cloneNode(_n.getInit(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -209,7 +209,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(VariableDeclaratorId _n, Object _arg) {
+	public Visitable visit(VariableDeclaratorId _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 		NodeList<ArrayBracketPair> arrayBracketPairsAfterId_ = cloneList(_n.getArrayBracketPairsAfterId(), _arg);
 
@@ -223,7 +223,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ConstructorDeclaration _n, Object _arg) {
+	public Visitable visit(ConstructorDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		NodeList<TypeParameter> typeParameters = cloneList(_n.getTypeParameters(), _arg);
 		NodeList<Parameter> parameters= cloneList(_n.getParameters(), _arg);
@@ -241,7 +241,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(MethodDeclaration _n, Object _arg) {
+	public Visitable visit(MethodDeclaration _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations_ = cloneList(_n.getAnnotations(), _arg);
 		NodeList<TypeParameter> typeParameters_ = cloneList(_n.getTypeParameters(), _arg);
 		Type<?> type_ = cloneNode(_n.getElementType(), _arg);
@@ -271,7 +271,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(Parameter _n, Object _arg) {
+	public Visitable visit(Parameter _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		Type<?> type_ = cloneNode(_n.getElementType(), _arg);
 		VariableDeclaratorId id = cloneNode(_n.getId(), _arg);
@@ -292,7 +292,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(EmptyMemberDeclaration _n, Object _arg) {
+	public Visitable visit(EmptyMemberDeclaration _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		EmptyMemberDeclaration r = new EmptyMemberDeclaration(
@@ -303,7 +303,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(InitializerDeclaration _n, Object _arg) {
+	public Visitable visit(InitializerDeclaration _n, Object _arg) {
 		BlockStmt block = cloneNode(_n.getBlock(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -316,7 +316,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(JavadocComment _n, Object _arg) {
+	public Visitable visit(JavadocComment _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 		JavadocComment r = new JavadocComment(
 				_n.getRange(),
@@ -327,7 +327,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ClassOrInterfaceType _n, Object _arg) {
+	public Visitable visit(ClassOrInterfaceType _n, Object _arg) {
 		ClassOrInterfaceType scope = cloneNode(_n.getScope(), _arg);
 		NodeList<Type<?>> typeArguments = cloneList(_n.getTypeArguments(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -343,7 +343,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(PrimitiveType _n, Object _arg) {
+	public Visitable visit(PrimitiveType _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 
@@ -357,7 +357,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ArrayType _n, Object _arg) {
+	public Visitable visit(ArrayType _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		Type<?> type_ = cloneNode(_n.getComponentType(), _arg);
 
@@ -368,7 +368,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ArrayCreationLevel _n, Object _arg) {
+	public Visitable visit(ArrayCreationLevel _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		Expression dimension_ = cloneNode(_n.getDimension(), _arg);
 
@@ -380,7 +380,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-    public Node visit(IntersectionType _n, Object _arg) {
+    public Visitable visit(IntersectionType _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
         NodeList<ReferenceType<?>> elements= cloneList(_n.getElements(), _arg);
 
@@ -392,7 +392,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
     }
 
     @Override
-    public Node visit(UnionType _n, Object _arg) {
+    public Visitable visit(UnionType _n, Object _arg) {
 	    NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
         NodeList<ReferenceType<?>> elements= cloneList(_n.getElements(), _arg);
 
@@ -404,7 +404,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
     }
 
 	@Override
-	public Node visit(VoidType _n, Object _arg) {
+	public Visitable visit(VoidType _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -415,7 +415,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(WildcardType _n, Object _arg) {
+	public Visitable visit(WildcardType _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		ReferenceType ext = cloneNode(_n.getExtends(), _arg);
 		ReferenceType sup = cloneNode(_n.getSuper(), _arg);
@@ -431,7 +431,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(UnknownType _n, Object _arg) {
+	public Visitable visit(UnknownType _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		UnknownType r = new UnknownType();
@@ -440,7 +440,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ArrayAccessExpr _n, Object _arg) {
+	public Visitable visit(ArrayAccessExpr _n, Object _arg) {
 		Expression name = cloneNode(_n.getName(), _arg);
 		Expression index = cloneNode(_n.getIndex(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -454,7 +454,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ArrayCreationExpr _n, Object _arg) {
+	public Visitable visit(ArrayCreationExpr _n, Object _arg) {
 		Type<?> type_ = cloneNode(_n.getElementType(), _arg);
         NodeList<ArrayCreationLevel> levels_ = cloneList(_n.getLevels(), _arg);
 		ArrayInitializerExpr initializer_ = cloneNode(_n.getInitializer(), _arg);
@@ -467,7 +467,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ArrayInitializerExpr _n, Object _arg) {
+	public Visitable visit(ArrayInitializerExpr _n, Object _arg) {
         NodeList<Expression> values = cloneList(_n.getValues(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -480,7 +480,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(AssignExpr _n, Object _arg) {
+	public Visitable visit(AssignExpr _n, Object _arg) {
 		Expression target = cloneNode(_n.getTarget(), _arg);
 		Expression value = cloneNode(_n.getValue(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -493,7 +493,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(BinaryExpr _n, Object _arg) {
+	public Visitable visit(BinaryExpr _n, Object _arg) {
 		Expression left = cloneNode(_n.getLeft(), _arg);
 		Expression right = cloneNode(_n.getRight(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -507,7 +507,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(CastExpr _n, Object _arg) {
+	public Visitable visit(CastExpr _n, Object _arg) {
 		Type<?> type_ = cloneNode(_n.getType(), _arg);
 		Expression expr = cloneNode(_n.getExpr(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -521,7 +521,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ClassExpr _n, Object _arg) {
+	public Visitable visit(ClassExpr _n, Object _arg) {
 		Type<?> type_ = cloneNode(_n.getType(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -534,7 +534,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ConditionalExpr _n, Object _arg) {
+	public Visitable visit(ConditionalExpr _n, Object _arg) {
 		Expression condition = cloneNode(_n.getCondition(), _arg);
 		Expression thenExpr = cloneNode(_n.getThenExpr(), _arg);
 		Expression elseExpr = cloneNode(_n.getElseExpr(), _arg);
@@ -549,7 +549,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(EnclosedExpr _n, Object _arg) {
+	public Visitable visit(EnclosedExpr _n, Object _arg) {
 		Expression inner = cloneNode(_n.getInner(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -562,7 +562,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(FieldAccessExpr _n, Object _arg) {
+	public Visitable visit(FieldAccessExpr _n, Object _arg) {
 		Expression scope_ = cloneNode(_n.getScope(), _arg);
 		NodeList<Type<?>> typeArguments_ = cloneList(_n.getTypeArguments(), _arg);
         NameExpr fieldExpr_ = cloneNode(_n.getFieldExpr(), _arg);
@@ -579,7 +579,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(InstanceOfExpr _n, Object _arg) {
+	public Visitable visit(InstanceOfExpr _n, Object _arg) {
 		Expression expr = cloneNode(_n.getExpr(), _arg);
 		ReferenceType<?> type_ = cloneNode(_n.getType(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -593,7 +593,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(StringLiteralExpr _n, Object _arg) {
+	public Visitable visit(StringLiteralExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 		StringLiteralExpr r = new StringLiteralExpr(
 				_n.getRange(),
@@ -604,7 +604,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(IntegerLiteralExpr _n, Object _arg) {
+	public Visitable visit(IntegerLiteralExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		IntegerLiteralExpr r = new IntegerLiteralExpr(
@@ -616,7 +616,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(LongLiteralExpr _n, Object _arg) {
+	public Visitable visit(LongLiteralExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		LongLiteralExpr r = new LongLiteralExpr(
@@ -628,7 +628,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(IntegerLiteralMinValueExpr _n, Object _arg) {
+	public Visitable visit(IntegerLiteralMinValueExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		IntegerLiteralMinValueExpr r = new IntegerLiteralMinValueExpr(_n.getRange());
@@ -637,7 +637,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(LongLiteralMinValueExpr _n, Object _arg) {
+	public Visitable visit(LongLiteralMinValueExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		LongLiteralMinValueExpr r = new LongLiteralMinValueExpr(_n.getRange());
@@ -646,7 +646,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(CharLiteralExpr _n, Object _arg) {
+	public Visitable visit(CharLiteralExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		CharLiteralExpr r = new CharLiteralExpr(
@@ -658,7 +658,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(DoubleLiteralExpr _n, Object _arg) {
+	public Visitable visit(DoubleLiteralExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		DoubleLiteralExpr r = new DoubleLiteralExpr(
@@ -670,7 +670,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(BooleanLiteralExpr _n, Object _arg) {
+	public Visitable visit(BooleanLiteralExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		BooleanLiteralExpr r = new BooleanLiteralExpr(
@@ -682,7 +682,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(NullLiteralExpr _n, Object _arg) {
+	public Visitable visit(NullLiteralExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		NullLiteralExpr r = new NullLiteralExpr(_n.getRange());
@@ -691,7 +691,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(MethodCallExpr _n, Object _arg) {
+	public Visitable visit(MethodCallExpr _n, Object _arg) {
 		Expression scope_ = cloneNode(_n.getScope(), _arg);
 		NodeList<Type<?>> typeArguments_ = cloneList(_n.getTypeArguments(), _arg);
         NodeList<Expression> args = cloneList(_n.getArgs(), _arg);
@@ -710,7 +710,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(NameExpr _n, Object _arg) {
+	public Visitable visit(NameExpr _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		NameExpr r = new NameExpr(
@@ -722,7 +722,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ObjectCreationExpr _n, Object _arg) {
+	public Visitable visit(ObjectCreationExpr _n, Object _arg) {
 		Expression scope = cloneNode(_n.getScope(), _arg);
 		ClassOrInterfaceType type_ = cloneNode(_n.getType(), _arg);
 		NodeList<Type<?>> typeArguments = cloneList(_n.getTypeArguments(), _arg);
@@ -739,7 +739,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(QualifiedNameExpr _n, Object _arg) {
+	public Visitable visit(QualifiedNameExpr _n, Object _arg) {
 		NameExpr scope = cloneNode(_n.getQualifier(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -752,7 +752,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ThisExpr _n, Object _arg) {
+	public Visitable visit(ThisExpr _n, Object _arg) {
 		Expression classExpr = cloneNode(_n.getClassExpr(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -765,7 +765,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(SuperExpr _n, Object _arg) {
+	public Visitable visit(SuperExpr _n, Object _arg) {
 		Expression classExpr = cloneNode(_n.getClassExpr(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -778,7 +778,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(UnaryExpr _n, Object _arg) {
+	public Visitable visit(UnaryExpr _n, Object _arg) {
 		Expression expr = cloneNode(_n.getExpr(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -791,7 +791,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(VariableDeclarationExpr _n, Object _arg) {
+	public Visitable visit(VariableDeclarationExpr _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 		Type<?> type_ = cloneNode(_n.getElementType(), _arg);
 		NodeList<VariableDeclarator> variables_ = cloneList(_n.getVariables(), _arg);
@@ -811,7 +811,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(MarkerAnnotationExpr _n, Object _arg) {
+	public Visitable visit(MarkerAnnotationExpr _n, Object _arg) {
 		NameExpr name = cloneNode(_n.getName(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -824,7 +824,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(SingleMemberAnnotationExpr _n, Object _arg) {
+	public Visitable visit(SingleMemberAnnotationExpr _n, Object _arg) {
 		NameExpr name = cloneNode(_n.getName(), _arg);
 		Expression memberValue = cloneNode(_n.getMemberValue(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -838,7 +838,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(NormalAnnotationExpr _n, Object _arg) {
+	public Visitable visit(NormalAnnotationExpr _n, Object _arg) {
 		NameExpr name = cloneNode(_n.getName(), _arg);
         NodeList<MemberValuePair> pairs = cloneList(_n.getPairs(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -852,7 +852,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(MemberValuePair _n, Object _arg) {
+	public Visitable visit(MemberValuePair _n, Object _arg) {
 		Expression value = cloneNode(_n.getValue(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -865,7 +865,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ExplicitConstructorInvocationStmt _n, Object _arg) {
+	public Visitable visit(ExplicitConstructorInvocationStmt _n, Object _arg) {
 		NodeList<Type<?>> typeArguments_ = cloneList(_n.getTypeArguments(), _arg);
 		Expression expr_ = cloneNode(_n.getExpr(), _arg);
         NodeList<Expression> args = cloneList(_n.getArgs(), _arg);
@@ -883,7 +883,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(TypeDeclarationStmt _n, Object _arg) {
+	public Visitable visit(TypeDeclarationStmt _n, Object _arg) {
         TypeDeclaration<?> typeDecl = cloneNode(_n.getTypeDeclaration(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -896,7 +896,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(AssertStmt _n, Object _arg) {
+	public Visitable visit(AssertStmt _n, Object _arg) {
 		Expression check = cloneNode(_n.getCheck(), _arg);
 		Expression message = cloneNode(_n.getMessage(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -910,7 +910,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(BlockStmt _n, Object _arg) {
+	public Visitable visit(BlockStmt _n, Object _arg) {
 		NodeList<Statement> stmts = cloneList(_n.getStmts(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -923,7 +923,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(LabeledStmt _n, Object _arg) {
+	public Visitable visit(LabeledStmt _n, Object _arg) {
 		Statement stmt = cloneNode(_n.getStmt(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -936,7 +936,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(EmptyStmt _n, Object _arg) {
+	public Visitable visit(EmptyStmt _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		EmptyStmt r = new EmptyStmt(_n.getRange());
@@ -945,7 +945,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ExpressionStmt _n, Object _arg) {
+	public Visitable visit(ExpressionStmt _n, Object _arg) {
 		Expression expr = cloneNode(_n.getExpression(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -958,7 +958,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(SwitchStmt _n, Object _arg) {
+	public Visitable visit(SwitchStmt _n, Object _arg) {
 		Expression selector = cloneNode(_n.getSelector(), _arg);
         NodeList<SwitchEntryStmt> entries = cloneList(_n.getEntries(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -972,7 +972,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(SwitchEntryStmt _n, Object _arg) {
+	public Visitable visit(SwitchEntryStmt _n, Object _arg) {
 		Expression label = cloneNode(_n.getLabel(), _arg);
 		NodeList<Statement> stmts = cloneList(_n.getStmts(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -986,7 +986,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(BreakStmt _n, Object _arg) {
+	public Visitable visit(BreakStmt _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		BreakStmt r = new BreakStmt(
@@ -998,7 +998,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ReturnStmt _n, Object _arg) {
+	public Visitable visit(ReturnStmt _n, Object _arg) {
 		Expression expr = cloneNode(_n.getExpr(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -1011,7 +1011,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(IfStmt _n, Object _arg) {
+	public Visitable visit(IfStmt _n, Object _arg) {
 		Expression condition = cloneNode(_n.getCondition(), _arg);
 		Statement thenStmt = cloneNode(_n.getThenStmt(), _arg);
 		Statement elseStmt = cloneNode(_n.getElseStmt(), _arg);
@@ -1026,7 +1026,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(WhileStmt _n, Object _arg) {
+	public Visitable visit(WhileStmt _n, Object _arg) {
 		Expression condition = cloneNode(_n.getCondition(), _arg);
 		Statement body = cloneNode(_n.getBody(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -1040,7 +1040,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ContinueStmt _n, Object _arg) {
+	public Visitable visit(ContinueStmt _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
 		ContinueStmt r = new ContinueStmt(
@@ -1052,7 +1052,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(DoStmt _n, Object _arg) {
+	public Visitable visit(DoStmt _n, Object _arg) {
 		Statement body = cloneNode(_n.getBody(), _arg);
 		Expression condition = cloneNode(_n.getCondition(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -1066,7 +1066,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ForeachStmt _n, Object _arg) {
+	public Visitable visit(ForeachStmt _n, Object _arg) {
 		VariableDeclarationExpr var = cloneNode(_n.getVariable(), _arg);
 		Expression iterable = cloneNode(_n.getIterable(), _arg);
 		Statement body = cloneNode(_n.getBody(), _arg);
@@ -1081,7 +1081,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ForStmt _n, Object _arg) {
+	public Visitable visit(ForStmt _n, Object _arg) {
 		NodeList<Expression> init = cloneList(_n.getInit(), _arg);
 		Expression compare = cloneNode(_n.getCompare(), _arg);
 		NodeList<Expression> update = cloneList(_n.getUpdate(), _arg);
@@ -1097,7 +1097,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ThrowStmt _n, Object _arg) {
+	public Visitable visit(ThrowStmt _n, Object _arg) {
 		Expression expr = cloneNode(_n.getExpr(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -1110,7 +1110,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(SynchronizedStmt _n, Object _arg) {
+	public Visitable visit(SynchronizedStmt _n, Object _arg) {
 		Expression expr = cloneNode(_n.getExpr(), _arg);
 		BlockStmt block = cloneNode(_n.getBody(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -1124,7 +1124,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(TryStmt _n, Object _arg) {
+	public Visitable visit(TryStmt _n, Object _arg) {
 		NodeList<VariableDeclarationExpr> resources = cloneList(_n.getResources(),_arg);
 		BlockStmt tryBlock = cloneNode(_n.getTryBlock(), _arg);
 		NodeList<CatchClause> catchs = cloneList(_n.getCatchs(), _arg);
@@ -1140,7 +1140,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(CatchClause _n, Object _arg) {
+	public Visitable visit(CatchClause _n, Object _arg) {
 		Parameter param = cloneNode(_n.getParam(), _arg);
 		BlockStmt catchBlock = cloneNode(_n.getBody(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
@@ -1151,7 +1151,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(LambdaExpr _n, Object _arg) {
+	public Visitable visit(LambdaExpr _n, Object _arg) {
 		NodeList<Parameter> lambdaParameters = cloneList(_n.getParameters(), _arg);
 
 		Statement body = cloneNode(_n.getBody(), _arg);
@@ -1161,7 +1161,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(MethodReferenceExpr _n, Object arg) {
+	public Visitable visit(MethodReferenceExpr _n, Object arg) {
 
 		Expression scope = cloneNode(_n.getScope(), arg);
 		NodeList<Type<?>> typeArguments = cloneList(_n.getTypeArguments(), arg);
@@ -1171,7 +1171,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(TypeExpr n, Object arg) {
+	public Visitable visit(TypeExpr n, Object arg) {
 
 		Type<?> t = cloneNode(n.getType(), arg);
 
@@ -1179,17 +1179,17 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(ArrayBracketPair _n, Object _arg) {
+	public Visitable visit(ArrayBracketPair _n, Object _arg) {
 		NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
 
 		return new ArrayBracketPair(_n.getRange(), annotations);
 	}
 
 	@Override
-	public Node visit(NodeList n, Object arg) {
-		NodeList<Node> newNodes = new NodeList<>(n.getRange(), null);
+	public Visitable visit(NodeList n, Object arg) {
+		NodeList<Node> newNodes = new NodeList<>(null);
 		for (Object node : n) {
-			Node resultNode = ((Node)node).accept(this, arg);
+			Node resultNode = (Node)((Node)node).accept(this, arg);
 			if(resultNode!=null){
 				newNodes.add(resultNode);
 			}
@@ -1198,13 +1198,13 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(EmptyImportDeclaration _n, Object _arg) {
+	public Visitable visit(EmptyImportDeclaration _n, Object _arg) {
 		Comment comment = cloneNode(_n.getComment(), _arg);
 		return new EmptyImportDeclaration(_n.getRange()).setComment(comment);
 	}
 
 	@Override
-	public Node visit(SingleStaticImportDeclaration _n, Object _arg) {
+	public Visitable visit(SingleStaticImportDeclaration _n, Object _arg) {
 		ClassOrInterfaceType type_ = cloneNode(_n.getType(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -1219,7 +1219,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(SingleTypeImportDeclaration _n, Object _arg) {
+	public Visitable visit(SingleTypeImportDeclaration _n, Object _arg) {
         ClassOrInterfaceType type_ = cloneNode(_n.getType(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -1232,7 +1232,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(StaticImportOnDemandDeclaration _n, Object _arg) {
+	public Visitable visit(StaticImportOnDemandDeclaration _n, Object _arg) {
         ClassOrInterfaceType type_ = cloneNode(_n.getType(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -1245,7 +1245,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 	}
 
 	@Override
-	public Node visit(TypeImportOnDemandDeclaration _n, Object _arg) {
+	public Visitable visit(TypeImportOnDemandDeclaration _n, Object _arg) {
 		NameExpr name = cloneNode(_n.getName(), _arg);
 		Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -1261,7 +1261,7 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
     protected <T extends Node> T cloneNode(T _node, Object _arg) {
         if (_node == null)
             return null;
-        Node r = _node.accept(this, _arg);
+        Node r = (Node)_node.accept(this, _arg);
         if (r == null)
             return null;
         return (T) r;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1627,12 +1627,9 @@ public class DumpVisitor implements VoidVisitor<Object> {
 		if (node instanceof Comment) return;
 
 		Node parent = node.getParentNode();
-		while (parent != null && parent instanceof NodeList) {
-			parent = parent.getParentNode();
-		}
 		if (parent == null) return;
 		List<Node> everything = new LinkedList<>();
-		everything.addAll(parent.getBackwardsCompatibleChildrenNodes());
+		everything.addAll(parent.getChildrenNodes());
 		sortByBeginPosition(everything);
 		int positionOfTheChild = -1;
 		for (int i = 0; i < everything.size(); i++) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -1629,7 +1629,7 @@ public class DumpVisitor implements VoidVisitor<Object> {
 		Node parent = node.getParentNode();
 		if (parent == null) return;
 		List<Node> everything = new LinkedList<>();
-		everything.addAll(parent.getChildrenNodes());
+		everything.addAll(parent.getChildNodes());
 		sortByBeginPosition(everything);
 		int positionOfTheChild = -1;
 		for (int i = 0; i < everything.size(); i++) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -36,7 +36,7 @@ import java.util.List;
 /**
  * @author Julio Vilmar Gesser
  */
-public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
+public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
 
 	private static final EqualsVisitor SINGLETON = new EqualsVisitor();
 
@@ -120,7 +120,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return n1.equals(n2);
 	}
 
-	@Override public Boolean visit(final CompilationUnit n1, final Node arg) {
+	@Override public Boolean visit(final CompilationUnit n1, final Visitable arg) {
 		final CompilationUnit n2 = (CompilationUnit) arg;
 
 		if (!nodeEquals(n1.getPackage(), n2.getPackage())) {
@@ -142,7 +142,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final PackageDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final PackageDeclaration n1, final Visitable arg) {
 		final PackageDeclaration n2 = (PackageDeclaration) arg;
 
 		if (!nodeEquals(n1.getName(), n2.getName())) {
@@ -156,7 +156,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final TypeParameter n1, final Node arg) {
+	@Override public Boolean visit(final TypeParameter n1, final Visitable arg) {
 		final TypeParameter n2 = (TypeParameter) arg;
 
 		if (!objEquals(n1.getName(), n2.getName())) {
@@ -172,7 +172,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final LineComment n1, final Node arg) {
+	@Override public Boolean visit(final LineComment n1, final Visitable arg) {
 		final LineComment n2 = (LineComment) arg;
 
 		if (!objEquals(n1.getContent(), n2.getContent())) {
@@ -186,7 +186,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final BlockComment n1, final Node arg) {
+	@Override public Boolean visit(final BlockComment n1, final Visitable arg) {
 		final BlockComment n2 = (BlockComment) arg;
 
 		if (!objEquals(n1.getContent(), n2.getContent())) {
@@ -200,7 +200,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ClassOrInterfaceDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final ClassOrInterfaceDeclaration n1, final Visitable arg) {
 		final ClassOrInterfaceDeclaration n2 = (ClassOrInterfaceDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -240,7 +240,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final EnumDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final EnumDeclaration n1, final Visitable arg) {
 		final EnumDeclaration n2 = (EnumDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -272,11 +272,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final EmptyTypeDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final EmptyTypeDeclaration n1, final Visitable arg) {
 		return true;
 	}
 
-	@Override public Boolean visit(final EnumConstantDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final EnumConstantDeclaration n1, final Visitable arg) {
 		final EnumConstantDeclaration n2 = (EnumConstantDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -300,7 +300,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final AnnotationDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final AnnotationDeclaration n1, final Visitable arg) {
 		final AnnotationDeclaration n2 = (AnnotationDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -324,7 +324,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final AnnotationMemberDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final AnnotationMemberDeclaration n1, final Visitable arg) {
 		final AnnotationMemberDeclaration n2 = (AnnotationMemberDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -352,7 +352,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final FieldDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final FieldDeclaration n1, final Visitable arg) {
 		final FieldDeclaration n2 = (FieldDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -380,7 +380,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final VariableDeclarator n1, final Node arg) {
+	@Override public Boolean visit(final VariableDeclarator n1, final Visitable arg) {
 		final VariableDeclarator n2 = (VariableDeclarator) arg;
 
 		if (!nodeEquals(n1.getId(), n2.getId())) {
@@ -394,7 +394,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final VariableDeclaratorId n1, final Node arg) {
+	@Override public Boolean visit(final VariableDeclaratorId n1, final Visitable arg) {
 		final VariableDeclaratorId n2 = (VariableDeclaratorId) arg;
 
 		if(!nodesEquals(n1.getArrayBracketPairsAfterId(), n2.getArrayBracketPairsAfterId())){
@@ -408,7 +408,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ConstructorDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final ConstructorDeclaration n1, final Visitable arg) {
 		final ConstructorDeclaration n2 = (ConstructorDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -444,7 +444,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final MethodDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final MethodDeclaration n1, final Visitable arg) {
 		final MethodDeclaration n2 = (MethodDeclaration) arg;
 
 		// javadoc are checked at CompilationUnit
@@ -494,7 +494,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 	
-	@Override public Boolean visit(final Parameter n1, final Node arg) {
+	@Override public Boolean visit(final Parameter n1, final Visitable arg) {
 		final Parameter n2 = (Parameter) arg;
 		if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
 			return false;
@@ -519,11 +519,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 	
-	@Override public Boolean visit(final EmptyMemberDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final EmptyMemberDeclaration n1, final Visitable arg) {
 		return true;
 	}
 
-	@Override public Boolean visit(final InitializerDeclaration n1, final Node arg) {
+	@Override public Boolean visit(final InitializerDeclaration n1, final Visitable arg) {
 		final InitializerDeclaration n2 = (InitializerDeclaration) arg;
 
 		if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
@@ -537,7 +537,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final JavadocComment n1, final Node arg) {
+	@Override public Boolean visit(final JavadocComment n1, final Visitable arg) {
 		final JavadocComment n2 = (JavadocComment) arg;
 
 		if (!objEquals(n1.getContent(), n2.getContent())) {
@@ -547,7 +547,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ClassOrInterfaceType n1, final Node arg) {
+	@Override public Boolean visit(final ClassOrInterfaceType n1, final Visitable arg) {
 		final ClassOrInterfaceType n2 = (ClassOrInterfaceType) arg;
 
 		if (!objEquals(n1.getName(), n2.getName())) {
@@ -569,7 +569,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final PrimitiveType n1, final Node arg) {
+	@Override public Boolean visit(final PrimitiveType n1, final Visitable arg) {
 		final PrimitiveType n2 = (PrimitiveType) arg;
 
 		if (n1.getType() != n2.getType()) {
@@ -582,7 +582,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 	}
 
 	@Override
-	public Boolean visit(ArrayType n1, Node arg) {
+	public Boolean visit(ArrayType n1, Visitable arg) {
 		final ArrayType n2 = (ArrayType) arg;
 
 		if (!nodeEquals(n1.getComponentType(), n2.getComponentType())) {
@@ -595,7 +595,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 	}
 
 	@Override
-	public Boolean visit(ArrayCreationLevel n1, Node arg) {
+	public Boolean visit(ArrayCreationLevel n1, Visitable arg) {
 		final ArrayCreationLevel n2 = (ArrayCreationLevel) arg;
 
 		if (!nodeEquals(n1.getDimension(), n2.getDimension())) {
@@ -607,7 +607,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final IntersectionType n1, final Node arg) {
+	@Override public Boolean visit(final IntersectionType n1, final Visitable arg) {
         final IntersectionType n2 = (IntersectionType) arg;
 
 		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
@@ -636,7 +636,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
         return true;
     }
 
-    @Override public Boolean visit(final UnionType n1, final Node arg) {
+    @Override public Boolean visit(final UnionType n1, final Visitable arg) {
         final UnionType n2 = (UnionType) arg;
 
 		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
@@ -666,7 +666,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     }
 
 	@Override
-	public Boolean visit(VoidType n1, Node arg) {
+	public Boolean visit(VoidType n1, Visitable arg) {
 		VoidType n2 = (VoidType) arg;
 		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
 			return false;
@@ -674,7 +674,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final WildcardType n1, final Node arg) {
+	@Override public Boolean visit(final WildcardType n1, final Visitable arg) {
 		final WildcardType n2 = (WildcardType) arg;
 
 		if (!nodeEquals(n1.getExtends(), n2.getExtends())) {
@@ -690,11 +690,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final UnknownType n1, final Node arg) {
+	@Override public Boolean visit(final UnknownType n1, final Visitable arg) {
 		return true;
 	}
 
-	@Override public Boolean visit(final ArrayAccessExpr n1, final Node arg) {
+	@Override public Boolean visit(final ArrayAccessExpr n1, final Visitable arg) {
 		final ArrayAccessExpr n2 = (ArrayAccessExpr) arg;
 
 		if (!nodeEquals(n1.getName(), n2.getName())) {
@@ -708,7 +708,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ArrayCreationExpr n1, final Node arg) {
+	@Override public Boolean visit(final ArrayCreationExpr n1, final Visitable arg) {
 		final ArrayCreationExpr n2 = (ArrayCreationExpr) arg;
 
 		if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
@@ -726,7 +726,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ArrayInitializerExpr n1, final Node arg) {
+	@Override public Boolean visit(final ArrayInitializerExpr n1, final Visitable arg) {
 		final ArrayInitializerExpr n2 = (ArrayInitializerExpr) arg;
 
 		if (!nodesEquals(n1.getValues(), n2.getValues())) {
@@ -736,7 +736,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final AssignExpr n1, final Node arg) {
+	@Override public Boolean visit(final AssignExpr n1, final Visitable arg) {
 		final AssignExpr n2 = (AssignExpr) arg;
 
 		if (n1.getOperator() != n2.getOperator()) {
@@ -754,7 +754,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final BinaryExpr n1, final Node arg) {
+	@Override public Boolean visit(final BinaryExpr n1, final Visitable arg) {
 		final BinaryExpr n2 = (BinaryExpr) arg;
 
 		if (n1.getOperator() != n2.getOperator()) {
@@ -772,7 +772,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final CastExpr n1, final Node arg) {
+	@Override public Boolean visit(final CastExpr n1, final Visitable arg) {
 		final CastExpr n2 = (CastExpr) arg;
 
 		if (!nodeEquals(n1.getType(), n2.getType())) {
@@ -786,7 +786,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ClassExpr n1, final Node arg) {
+	@Override public Boolean visit(final ClassExpr n1, final Visitable arg) {
 		final ClassExpr n2 = (ClassExpr) arg;
 
 		if (!nodeEquals(n1.getType(), n2.getType())) {
@@ -796,7 +796,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ConditionalExpr n1, final Node arg) {
+	@Override public Boolean visit(final ConditionalExpr n1, final Visitable arg) {
 		final ConditionalExpr n2 = (ConditionalExpr) arg;
 
 		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
@@ -814,7 +814,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final EnclosedExpr n1, final Node arg) {
+	@Override public Boolean visit(final EnclosedExpr n1, final Visitable arg) {
 		final EnclosedExpr n2 = (EnclosedExpr) arg;
 
 		if (!nodeEquals(n1.getInner(), n2.getInner())) {
@@ -824,7 +824,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final FieldAccessExpr n1, final Node arg) {
+	@Override public Boolean visit(final FieldAccessExpr n1, final Visitable arg) {
 		final FieldAccessExpr n2 = (FieldAccessExpr) arg;
 
 		if (!nodeEquals(n1.getScope(), n2.getScope())) {
@@ -842,7 +842,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final InstanceOfExpr n1, final Node arg) {
+	@Override public Boolean visit(final InstanceOfExpr n1, final Visitable arg) {
 		final InstanceOfExpr n2 = (InstanceOfExpr) arg;
 
 		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
@@ -856,7 +856,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final StringLiteralExpr n1, final Node arg) {
+	@Override public Boolean visit(final StringLiteralExpr n1, final Visitable arg) {
 		final StringLiteralExpr n2 = (StringLiteralExpr) arg;
 
 		if (!objEquals(n1.getValue(), n2.getValue())) {
@@ -866,7 +866,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final IntegerLiteralExpr n1, final Node arg) {
+	@Override public Boolean visit(final IntegerLiteralExpr n1, final Visitable arg) {
 		final IntegerLiteralExpr n2 = (IntegerLiteralExpr) arg;
 
 		if (!objEquals(n1.getValue(), n2.getValue())) {
@@ -876,7 +876,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final LongLiteralExpr n1, final Node arg) {
+	@Override public Boolean visit(final LongLiteralExpr n1, final Visitable arg) {
 		final LongLiteralExpr n2 = (LongLiteralExpr) arg;
 
 		if (!objEquals(n1.getValue(), n2.getValue())) {
@@ -886,7 +886,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final IntegerLiteralMinValueExpr n1, final Node arg) {
+	@Override public Boolean visit(final IntegerLiteralMinValueExpr n1, final Visitable arg) {
 		final IntegerLiteralMinValueExpr n2 = (IntegerLiteralMinValueExpr) arg;
 
 		if (!objEquals(n1.getValue(), n2.getValue())) {
@@ -896,7 +896,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final LongLiteralMinValueExpr n1, final Node arg) {
+	@Override public Boolean visit(final LongLiteralMinValueExpr n1, final Visitable arg) {
 		final LongLiteralMinValueExpr n2 = (LongLiteralMinValueExpr) arg;
 
 		if (!objEquals(n1.getValue(), n2.getValue())) {
@@ -906,7 +906,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final CharLiteralExpr n1, final Node arg) {
+	@Override public Boolean visit(final CharLiteralExpr n1, final Visitable arg) {
 		final CharLiteralExpr n2 = (CharLiteralExpr) arg;
 
 		if (!objEquals(n1.getValue(), n2.getValue())) {
@@ -916,7 +916,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final DoubleLiteralExpr n1, final Node arg) {
+	@Override public Boolean visit(final DoubleLiteralExpr n1, final Visitable arg) {
 		final DoubleLiteralExpr n2 = (DoubleLiteralExpr) arg;
 
 		if (!objEquals(n1.getValue(), n2.getValue())) {
@@ -926,7 +926,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final BooleanLiteralExpr n1, final Node arg) {
+	@Override public Boolean visit(final BooleanLiteralExpr n1, final Visitable arg) {
 		final BooleanLiteralExpr n2 = (BooleanLiteralExpr) arg;
 
 		if (n1.getValue() != n2.getValue()) {
@@ -936,11 +936,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final NullLiteralExpr n1, final Node arg) {
+	@Override public Boolean visit(final NullLiteralExpr n1, final Visitable arg) {
 		return true;
 	}
 
-	@Override public Boolean visit(final MethodCallExpr n1, final Node arg) {
+	@Override public Boolean visit(final MethodCallExpr n1, final Visitable arg) {
 		final MethodCallExpr n2 = (MethodCallExpr) arg;
 
 		if (!nodeEquals(n1.getScope(), n2.getScope())) {
@@ -962,7 +962,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final NameExpr n1, final Node arg) {
+	@Override public Boolean visit(final NameExpr n1, final Visitable arg) {
 		final NameExpr n2 = (NameExpr) arg;
 
 		if (!objEquals(n1.getName(), n2.getName())) {
@@ -972,7 +972,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ObjectCreationExpr n1, final Node arg) {
+	@Override public Boolean visit(final ObjectCreationExpr n1, final Visitable arg) {
 		final ObjectCreationExpr n2 = (ObjectCreationExpr) arg;
 
 		if (!nodeEquals(n1.getScope(), n2.getScope())) {
@@ -998,7 +998,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final QualifiedNameExpr n1, final Node arg) {
+	@Override public Boolean visit(final QualifiedNameExpr n1, final Visitable arg) {
 		final QualifiedNameExpr n2 = (QualifiedNameExpr) arg;
 
 		if (!nodeEquals(n1.getQualifier(), n2.getQualifier())) {
@@ -1012,7 +1012,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ThisExpr n1, final Node arg) {
+	@Override public Boolean visit(final ThisExpr n1, final Visitable arg) {
 		final ThisExpr n2 = (ThisExpr) arg;
 
 		if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
@@ -1022,7 +1022,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final SuperExpr n1, final Node arg) {
+	@Override public Boolean visit(final SuperExpr n1, final Visitable arg) {
 		final SuperExpr n2 = (SuperExpr) arg;
 
 		if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
@@ -1032,7 +1032,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final UnaryExpr n1, final Node arg) {
+	@Override public Boolean visit(final UnaryExpr n1, final Visitable arg) {
 		final UnaryExpr n2 = (UnaryExpr) arg;
 
 		if (n1.getOperator() != n2.getOperator()) {
@@ -1046,7 +1046,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final VariableDeclarationExpr n1, final Node arg) {
+	@Override public Boolean visit(final VariableDeclarationExpr n1, final Visitable arg) {
 		final VariableDeclarationExpr n2 = (VariableDeclarationExpr) arg;
 
         if (!n1.getModifiers().equals(n2.getModifiers())) {
@@ -1072,7 +1072,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final MarkerAnnotationExpr n1, final Node arg) {
+	@Override public Boolean visit(final MarkerAnnotationExpr n1, final Visitable arg) {
 		final MarkerAnnotationExpr n2 = (MarkerAnnotationExpr) arg;
 
 		if (!nodeEquals(n1.getName(), n2.getName())) {
@@ -1082,7 +1082,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final SingleMemberAnnotationExpr n1, final Node arg) {
+	@Override public Boolean visit(final SingleMemberAnnotationExpr n1, final Visitable arg) {
 		final SingleMemberAnnotationExpr n2 = (SingleMemberAnnotationExpr) arg;
 
 		if (!nodeEquals(n1.getName(), n2.getName())) {
@@ -1096,7 +1096,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final NormalAnnotationExpr n1, final Node arg) {
+	@Override public Boolean visit(final NormalAnnotationExpr n1, final Visitable arg) {
 		final NormalAnnotationExpr n2 = (NormalAnnotationExpr) arg;
 
 		if (!nodeEquals(n1.getName(), n2.getName())) {
@@ -1110,7 +1110,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final MemberValuePair n1, final Node arg) {
+	@Override public Boolean visit(final MemberValuePair n1, final Visitable arg) {
 		final MemberValuePair n2 = (MemberValuePair) arg;
 
 		if (!objEquals(n1.getName(), n2.getName())) {
@@ -1124,7 +1124,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ExplicitConstructorInvocationStmt n1, final Node arg) {
+	@Override public Boolean visit(final ExplicitConstructorInvocationStmt n1, final Visitable arg) {
 		final ExplicitConstructorInvocationStmt n2 = (ExplicitConstructorInvocationStmt) arg;
 
 		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
@@ -1142,7 +1142,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final TypeDeclarationStmt n1, final Node arg) {
+	@Override public Boolean visit(final TypeDeclarationStmt n1, final Visitable arg) {
 		final TypeDeclarationStmt n2 = (TypeDeclarationStmt) arg;
 
 		if (!nodeEquals(n1.getTypeDeclaration(), n2.getTypeDeclaration())) {
@@ -1152,7 +1152,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final AssertStmt n1, final Node arg) {
+	@Override public Boolean visit(final AssertStmt n1, final Visitable arg) {
 		final AssertStmt n2 = (AssertStmt) arg;
 
 		if (!nodeEquals(n1.getCheck(), n2.getCheck())) {
@@ -1166,7 +1166,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final BlockStmt n1, final Node arg) {
+	@Override public Boolean visit(final BlockStmt n1, final Visitable arg) {
 		final BlockStmt n2 = (BlockStmt) arg;
 
 		if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
@@ -1176,7 +1176,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final LabeledStmt n1, final Node arg) {
+	@Override public Boolean visit(final LabeledStmt n1, final Visitable arg) {
 		final LabeledStmt n2 = (LabeledStmt) arg;
 
 		if (!nodeEquals(n1.getStmt(), n2.getStmt())) {
@@ -1186,11 +1186,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final EmptyStmt n1, final Node arg) {
+	@Override public Boolean visit(final EmptyStmt n1, final Visitable arg) {
 		return true;
 	}
 
-	@Override public Boolean visit(final ExpressionStmt n1, final Node arg) {
+	@Override public Boolean visit(final ExpressionStmt n1, final Visitable arg) {
 		final ExpressionStmt n2 = (ExpressionStmt) arg;
 
 		if (!nodeEquals(n1.getExpression(), n2.getExpression())) {
@@ -1200,7 +1200,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final SwitchStmt n1, final Node arg) {
+	@Override public Boolean visit(final SwitchStmt n1, final Visitable arg) {
 		final SwitchStmt n2 = (SwitchStmt) arg;
 
 		if (!nodeEquals(n1.getSelector(), n2.getSelector())) {
@@ -1214,7 +1214,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final SwitchEntryStmt n1, final Node arg) {
+	@Override public Boolean visit(final SwitchEntryStmt n1, final Visitable arg) {
 		final SwitchEntryStmt n2 = (SwitchEntryStmt) arg;
 
 		if (!nodeEquals(n1.getLabel(), n2.getLabel())) {
@@ -1228,7 +1228,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final BreakStmt n1, final Node arg) {
+	@Override public Boolean visit(final BreakStmt n1, final Visitable arg) {
 		final BreakStmt n2 = (BreakStmt) arg;
 
 		if (!objEquals(n1.getId(), n2.getId())) {
@@ -1238,7 +1238,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ReturnStmt n1, final Node arg) {
+	@Override public Boolean visit(final ReturnStmt n1, final Visitable arg) {
 		final ReturnStmt n2 = (ReturnStmt) arg;
 
 		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
@@ -1248,7 +1248,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final IfStmt n1, final Node arg) {
+	@Override public Boolean visit(final IfStmt n1, final Visitable arg) {
 		final IfStmt n2 = (IfStmt) arg;
 
 		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
@@ -1266,7 +1266,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final WhileStmt n1, final Node arg) {
+	@Override public Boolean visit(final WhileStmt n1, final Visitable arg) {
 		final WhileStmt n2 = (WhileStmt) arg;
 
 		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
@@ -1280,7 +1280,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ContinueStmt n1, final Node arg) {
+	@Override public Boolean visit(final ContinueStmt n1, final Visitable arg) {
 		final ContinueStmt n2 = (ContinueStmt) arg;
 
 		if (!objEquals(n1.getId(), n2.getId())) {
@@ -1290,7 +1290,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final DoStmt n1, final Node arg) {
+	@Override public Boolean visit(final DoStmt n1, final Visitable arg) {
 		final DoStmt n2 = (DoStmt) arg;
 
 		if (!nodeEquals(n1.getBody(), n2.getBody())) {
@@ -1304,7 +1304,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ForeachStmt n1, final Node arg) {
+	@Override public Boolean visit(final ForeachStmt n1, final Visitable arg) {
 		final ForeachStmt n2 = (ForeachStmt) arg;
 
 		if (!nodeEquals(n1.getVariable(), n2.getVariable())) {
@@ -1322,7 +1322,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ForStmt n1, final Node arg) {
+	@Override public Boolean visit(final ForStmt n1, final Visitable arg) {
 		final ForStmt n2 = (ForStmt) arg;
 
 		if (!nodesEquals(n1.getInit(), n2.getInit())) {
@@ -1344,7 +1344,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final ThrowStmt n1, final Node arg) {
+	@Override public Boolean visit(final ThrowStmt n1, final Visitable arg) {
 		final ThrowStmt n2 = (ThrowStmt) arg;
 
 		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
@@ -1354,7 +1354,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final SynchronizedStmt n1, final Node arg) {
+	@Override public Boolean visit(final SynchronizedStmt n1, final Visitable arg) {
 		final SynchronizedStmt n2 = (SynchronizedStmt) arg;
 
 		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
@@ -1368,7 +1368,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final TryStmt n1, final Node arg) {
+	@Override public Boolean visit(final TryStmt n1, final Visitable arg) {
 		final TryStmt n2 = (TryStmt) arg;
 
 		if (!nodeEquals(n1.getTryBlock(), n2.getTryBlock())) {
@@ -1390,7 +1390,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 		return true;
 	}
 
-	@Override public Boolean visit(final CatchClause n1, final Node arg) {
+	@Override public Boolean visit(final CatchClause n1, final Visitable arg) {
 		final CatchClause n2 = (CatchClause) arg;
 
 		if (!nodeEquals(n1.getParam(), n2.getParam())) {
@@ -1405,7 +1405,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 	}
 
     @Override
-    public Boolean visit(LambdaExpr n1, Node arg) {
+    public Boolean visit(LambdaExpr n1, Visitable arg) {
         LambdaExpr n2 = (LambdaExpr) arg;
         if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
             return false;
@@ -1420,7 +1420,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     }
 
     @Override
-    public Boolean visit(MethodReferenceExpr n1, Node arg) {
+    public Boolean visit(MethodReferenceExpr n1, Visitable arg) {
         MethodReferenceExpr n2 = (MethodReferenceExpr) arg;
         if (!nodeEquals(n1.getScope(), n2.getScope())) {
             return false;
@@ -1435,7 +1435,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     }
 
     @Override
-    public Boolean visit(TypeExpr n, Node arg) {
+    public Boolean visit(TypeExpr n, Visitable arg) {
         TypeExpr n2 = (TypeExpr) arg;
         if (!nodeEquals(n.getType(), n2.getType())) {
             return false;
@@ -1444,7 +1444,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     }
 
 	@Override
-	public Boolean visit(ArrayBracketPair n1, Node arg) {
+	public Boolean visit(ArrayBracketPair n1, Visitable arg) {
 		ArrayBracketPair n2 = (ArrayBracketPair) arg;
 		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
 			return false;
@@ -1454,12 +1454,12 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 	}
 
     @Override
-	public Boolean visit(EmptyImportDeclaration n1, Node arg) {
+	public Boolean visit(EmptyImportDeclaration n1, Visitable arg) {
 		return true;
 	}
 
     @Override
-    public Boolean visit(SingleStaticImportDeclaration n1, Node arg) {
+    public Boolean visit(SingleStaticImportDeclaration n1, Visitable arg) {
         final SingleStaticImportDeclaration n2 = (SingleStaticImportDeclaration) arg;
 
         if (!nodeEquals(n1.getType(), n2.getType())) {
@@ -1474,7 +1474,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     }
 
     @Override
-    public Boolean visit(SingleTypeImportDeclaration n1, Node arg) {
+    public Boolean visit(SingleTypeImportDeclaration n1, Visitable arg) {
         final SingleTypeImportDeclaration n2 = (SingleTypeImportDeclaration) arg;
         if (!nodeEquals(n1.getType(), n2.getType())) {
             return false;
@@ -1484,7 +1484,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     }
 
     @Override
-    public Boolean visit(StaticImportOnDemandDeclaration n1, Node arg) {
+    public Boolean visit(StaticImportOnDemandDeclaration n1, Visitable arg) {
         final StaticImportOnDemandDeclaration n2 = (StaticImportOnDemandDeclaration) arg;
         if (!nodeEquals(n1.getType(), n2.getType())) {
             return false;
@@ -1494,7 +1494,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     }
 
     @Override
-    public Boolean visit(TypeImportOnDemandDeclaration n1, Node arg) {
+    public Boolean visit(TypeImportOnDemandDeclaration n1, Visitable arg) {
         final TypeImportOnDemandDeclaration n2 = (TypeImportOnDemandDeclaration) arg;
         if (!nodeEquals(n1.getName(), n2.getName())) {
             return false;
@@ -1504,7 +1504,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 	}
 
     @Override
-    public Boolean visit(NodeList n, Node arg) {
+    public Boolean visit(NodeList n, Visitable arg) {
         return nodesEquals((NodeList<Node>) n, (NodeList<Node>) arg);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -42,7 +42,7 @@ import java.util.List;
  * 
  * @author Julio Vilmar Gesser
  */
-public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
+public class ModifierVisitorAdapter<A> implements GenericVisitor<Visitable, A> {
 
 	private void removeNulls(final List<?> list) {
 		for (int i = list.size() - 1; i >= 0; i--) {
@@ -52,7 +52,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		}
 	}
 
-	@Override public Node visit(final AnnotationDeclaration n, final A arg) {
+	@Override public Visitable visit(final AnnotationDeclaration n, final A arg) {
 		visitAnnotations(n, arg);
 		visitComment(n, arg);
         n.setMembers((NodeList<BodyDeclaration<?>>) n.getMembers().accept(this, arg));
@@ -63,7 +63,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
 	}
 
-	@Override public Node visit(final AnnotationMemberDeclaration n, final A arg) {
+	@Override public Visitable visit(final AnnotationMemberDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
 		n.setType((Type) n.getType().accept(this, arg));
@@ -73,14 +73,14 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ArrayAccessExpr n, final A arg) {
+	@Override public Visitable visit(final ArrayAccessExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setName((Expression) n.getName().accept(this, arg));
 		n.setIndex((Expression) n.getIndex().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final ArrayCreationExpr n, final A arg) {
+	@Override public Visitable visit(final ArrayCreationExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setElementType((Type) n.getElementType().accept(this, arg));
 
@@ -92,13 +92,13 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ArrayInitializerExpr n, final A arg) {
+	@Override public Visitable visit(final ArrayInitializerExpr n, final A arg) {
 		visitComment(n, arg);
         n.setValues((NodeList<Expression>)n.getValues().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final AssertStmt n, final A arg) {
+	@Override public Visitable visit(final AssertStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setCheck((Expression) n.getCheck().accept(this, arg));
 		if (n.getMessage() != null) {
@@ -107,7 +107,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final AssignExpr n, final A arg) {
+	@Override public Visitable visit(final AssignExpr n, final A arg) {
 		visitComment(n, arg);
 		final Expression target = (Expression) n.getTarget().accept(this, arg);
 		if (target == null) {
@@ -124,7 +124,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final BinaryExpr n, final A arg) {
+	@Override public Visitable visit(final BinaryExpr n, final A arg) {
 		visitComment(n, arg);
 		final Expression left = (Expression) n.getLeft().accept(this, arg);
 		final Expression right = (Expression) n.getRight().accept(this, arg);
@@ -139,23 +139,23 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final BlockStmt n, final A arg) {
+	@Override public Visitable visit(final BlockStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setStmts((NodeList<Statement>) n.getStmts().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final BooleanLiteralExpr n, final A arg) {
+	@Override public Visitable visit(final BooleanLiteralExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final BreakStmt n, final A arg) {
+	@Override public Visitable visit(final BreakStmt n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final CastExpr n, final A arg) {
+	@Override public Visitable visit(final CastExpr n, final A arg) {
 		visitComment(n, arg);
 		final Type type = (Type) n.getType().accept(this, arg);
 		final Expression expr = (Expression) n.getExpr().accept(this, arg);
@@ -170,7 +170,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final CatchClause n, final A arg) {
+	@Override public Visitable visit(final CatchClause n, final A arg) {
 		visitComment(n, arg);
 		n.setParam((Parameter)n.getParam().accept(this, arg));
 		n.setBody((BlockStmt) n.getBody().accept(this, arg));
@@ -178,18 +178,18 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 
 	}
 
-	@Override public Node visit(final CharLiteralExpr n, final A arg) {
+	@Override public Visitable visit(final CharLiteralExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final ClassExpr n, final A arg) {
+	@Override public Visitable visit(final ClassExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setType((Type) n.getType().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final ClassOrInterfaceDeclaration n, final A arg) {
+	@Override public Visitable visit(final ClassOrInterfaceDeclaration n, final A arg) {
 		visitAnnotations(n, arg);
 		visitComment(n, arg);
 		n.setTypeParameters(modifyList(n.getTypeParameters(), arg));
@@ -206,7 +206,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
         return (NodeList<N>) list.accept(this, arg);
     }
 
-    @Override public Node visit(final ClassOrInterfaceType n, final A arg) {
+    @Override public Visitable visit(final ClassOrInterfaceType n, final A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
 		if (n.getScope() != null) {
@@ -216,7 +216,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final CompilationUnit n, final A arg) {
+	@Override public Visitable visit(final CompilationUnit n, final A arg) {
 		visitComment(n, arg);
 		if (n.getPackage() != null) {
 			n.setPackage((PackageDeclaration) n.getPackage().accept(this, arg));
@@ -226,7 +226,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ConditionalExpr n, final A arg) {
+	@Override public Visitable visit(final ConditionalExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setCondition((Expression) n.getCondition().accept(this, arg));
 		n.setThenExpr((Expression) n.getThenExpr().accept(this, arg));
@@ -234,7 +234,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ConstructorDeclaration n, final A arg) {
+	@Override public Visitable visit(final ConstructorDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
         n.setTypeParameters(modifyList(n.getTypeParameters(), arg));
@@ -244,12 +244,12 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ContinueStmt n, final A arg) {
+	@Override public Visitable visit(final ContinueStmt n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final DoStmt n, final A arg) {
+	@Override public Visitable visit(final DoStmt n, final A arg) {
 		visitComment(n, arg);
 		final Statement body = (Statement) n.getBody().accept(this, arg);
 		if (body == null) {
@@ -266,33 +266,33 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final DoubleLiteralExpr n, final A arg) {
+	@Override public Visitable visit(final DoubleLiteralExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final EmptyMemberDeclaration n, final A arg) {
+	@Override public Visitable visit(final EmptyMemberDeclaration n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final EmptyStmt n, final A arg) {
+	@Override public Visitable visit(final EmptyStmt n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final EmptyTypeDeclaration n, final A arg) {
+	@Override public Visitable visit(final EmptyTypeDeclaration n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final EnclosedExpr n, final A arg) {
+	@Override public Visitable visit(final EnclosedExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setInner((Expression) n.getInner().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final EnumConstantDeclaration n, final A arg) {
+	@Override public Visitable visit(final EnumConstantDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
         n.setArgs((NodeList<Expression>)n.getArgs().accept(this, arg));
@@ -300,7 +300,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final EnumDeclaration n, final A arg) {
+	@Override public Visitable visit(final EnumDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
 		n.setImplements((NodeList<ClassOrInterfaceType>) n.getImplements().accept(this, arg));
@@ -309,7 +309,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ExplicitConstructorInvocationStmt n, final A arg) {
+	@Override public Visitable visit(final ExplicitConstructorInvocationStmt n, final A arg) {
 		visitComment(n, arg);
 		if (!n.isThis() && n.getExpr() != null) {
 			n.setExpr((Expression) n.getExpr().accept(this, arg));
@@ -319,7 +319,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ExpressionStmt n, final A arg) {
+	@Override public Visitable visit(final ExpressionStmt n, final A arg) {
 		visitComment(n, arg);
 		final Expression expr = (Expression) n.getExpression().accept(this, arg);
 		if (expr == null) {
@@ -329,7 +329,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final FieldAccessExpr n, final A arg) {
+	@Override public Visitable visit(final FieldAccessExpr n, final A arg) {
 		visitComment(n, arg);
 		final Expression scope = (Expression) n.getScope().accept(this, arg);
 		if (scope == null) {
@@ -339,7 +339,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final FieldDeclaration n, final A arg) {
+	@Override public Visitable visit(final FieldDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
 		n.setElementType((Type) n.getElementType().accept(this, arg));
@@ -347,7 +347,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ForeachStmt n, final A arg) {
+	@Override public Visitable visit(final ForeachStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setVariable((VariableDeclarationExpr) n.getVariable().accept(this, arg));
 		n.setIterable((Expression) n.getIterable().accept(this, arg));
@@ -355,7 +355,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ForStmt n, final A arg) {
+	@Override public Visitable visit(final ForStmt n, final A arg) {
 		visitComment(n, arg);
         n.setInit((NodeList<Expression>)n.getInit().accept(this, arg));
 		if (n.getCompare() != null) {
@@ -366,7 +366,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final IfStmt n, final A arg) {
+	@Override public Visitable visit(final IfStmt n, final A arg) {
 		visitComment(n, arg);
 		final Expression condition = (Expression)
 			n.getCondition().accept(this, arg);
@@ -388,62 +388,62 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final InitializerDeclaration n, final A arg) {
+	@Override public Visitable visit(final InitializerDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final InstanceOfExpr n, final A arg) {
+	@Override public Visitable visit(final InstanceOfExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setExpr((Expression) n.getExpr().accept(this, arg));
 		n.setType((ReferenceType<?>) n.getType().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final IntegerLiteralExpr n, final A arg) {
+	@Override public Visitable visit(final IntegerLiteralExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final IntegerLiteralMinValueExpr n, final A arg) {
+	@Override public Visitable visit(final IntegerLiteralMinValueExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final JavadocComment n, final A arg) {
+	@Override public Visitable visit(final JavadocComment n, final A arg) {
 		return n;
 	}
 
-	@Override public Node visit(final LabeledStmt n, final A arg) {
+	@Override public Visitable visit(final LabeledStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setStmt((Statement) n.getStmt().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final LongLiteralExpr n, final A arg) {
+	@Override public Visitable visit(final LongLiteralExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final LongLiteralMinValueExpr n, final A arg) {
+	@Override public Visitable visit(final LongLiteralMinValueExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final MarkerAnnotationExpr n, final A arg) {
+	@Override public Visitable visit(final MarkerAnnotationExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setName((NameExpr) n.getName().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final MemberValuePair n, final A arg) {
+	@Override public Visitable visit(final MemberValuePair n, final A arg) {
 		visitComment(n, arg);
 		n.setValue((Expression) n.getValue().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final MethodCallExpr n, final A arg) {
+	@Override public Visitable visit(final MethodCallExpr n, final A arg) {
 		visitComment(n, arg);
 		if (n.getScope() != null) {
 			n.setScope((Expression) n.getScope().accept(this, arg));
@@ -453,7 +453,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final MethodDeclaration n, final A arg) {
+	@Override public Visitable visit(final MethodDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
         n.setTypeParameters(modifyList(n.getTypeParameters(), arg));
@@ -466,24 +466,24 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final NameExpr n, final A arg) {
+	@Override public Visitable visit(final NameExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final NormalAnnotationExpr n, final A arg) {
+	@Override public Visitable visit(final NormalAnnotationExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setName((NameExpr) n.getName().accept(this, arg));
         n.setPairs((NodeList<MemberValuePair>)n.getPairs().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final NullLiteralExpr n, final A arg) {
+	@Override public Visitable visit(final NullLiteralExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final ObjectCreationExpr n, final A arg) {
+	@Override public Visitable visit(final ObjectCreationExpr n, final A arg) {
 		visitComment(n, arg);
 		if (n.getScope() != null) {
 			n.setScope((Expression) n.getScope().accept(this, arg));
@@ -495,14 +495,14 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final PackageDeclaration n, final A arg) {
+	@Override public Visitable visit(final PackageDeclaration n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
 		n.setName((NameExpr) n.getName().accept(this, arg));
 		return n;
 	}
 	
-	@Override public Node visit(final Parameter n, final A arg) {
+	@Override public Visitable visit(final Parameter n, final A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
 		n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
@@ -510,20 +510,20 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 	
-	@Override public Node visit(final PrimitiveType n, final A arg) {
+	@Override public Visitable visit(final PrimitiveType n, final A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final QualifiedNameExpr n, final A arg) {
+	@Override public Visitable visit(final QualifiedNameExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setQualifier((NameExpr) n.getQualifier().accept(this, arg));
 		return n;
 	}
 
 	@Override
-	public Node visit(ArrayType n, A arg) {
+	public Visitable visit(ArrayType n, A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
 		n.setComponentType((Type) n.getComponentType().accept(this, arg));
@@ -531,7 +531,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 	}
 
 	@Override
-	public Node visit(ArrayCreationLevel n, A arg) {
+	public Visitable visit(ArrayCreationLevel n, A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
 		if(n.getDimension()!=null) {
@@ -541,7 +541,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 	}
 
 	@Override
-    public Node visit(final IntersectionType n, final A arg) {
+    public Visitable visit(final IntersectionType n, final A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
         n.setElements((NodeList<ReferenceType<?>>)n.getElements().accept(this, arg));
@@ -549,14 +549,14 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
     }
 
     @Override
-    public Node visit(final UnionType n, final A arg) {
+    public Visitable visit(final UnionType n, final A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
         n.setElements((NodeList<ReferenceType<?>>)n.getElements().accept(this, arg));
         return n;
     }
 
-	@Override public Node visit(final ReturnStmt n, final A arg) {
+	@Override public Visitable visit(final ReturnStmt n, final A arg) {
 		visitComment(n, arg);
 		if (n.getExpr() != null) {
 			n.setExpr((Expression) n.getExpr().accept(this, arg));
@@ -564,19 +564,19 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final SingleMemberAnnotationExpr n, final A arg) {
+	@Override public Visitable visit(final SingleMemberAnnotationExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setName((NameExpr) n.getName().accept(this, arg));
 		n.setMemberValue((Expression) n.getMemberValue().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final StringLiteralExpr n, final A arg) {
+	@Override public Visitable visit(final StringLiteralExpr n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final SuperExpr n, final A arg) {
+	@Override public Visitable visit(final SuperExpr n, final A arg) {
 		visitComment(n, arg);
 		if (n.getClassExpr() != null) {
 			n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
@@ -584,7 +584,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final SwitchEntryStmt n, final A arg) {
+	@Override public Visitable visit(final SwitchEntryStmt n, final A arg) {
 		visitComment(n, arg);
 		if (n.getLabel() != null) {
 			n.setLabel((Expression) n.getLabel().accept(this, arg));
@@ -593,7 +593,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final SwitchStmt n, final A arg) {
+	@Override public Visitable visit(final SwitchStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setSelector((Expression) n.getSelector().accept(this, arg));
         n.setEntries((NodeList<SwitchEntryStmt>)n.getEntries().accept(this, arg));
@@ -601,14 +601,14 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 
 	}
 
-	@Override public Node visit(final SynchronizedStmt n, final A arg) {
+	@Override public Visitable visit(final SynchronizedStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setExpr((Expression) n.getExpr().accept(this, arg));
 		n.setBody((BlockStmt) n.getBody().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final ThisExpr n, final A arg) {
+	@Override public Visitable visit(final ThisExpr n, final A arg) {
 		visitComment(n, arg);
 		if (n.getClassExpr() != null) {
 			n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
@@ -616,13 +616,13 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final ThrowStmt n, final A arg) {
+	@Override public Visitable visit(final ThrowStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setExpr((Expression) n.getExpr().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final TryStmt n, final A arg) {
+	@Override public Visitable visit(final TryStmt n, final A arg) {
 		visitComment(n, arg);
         n.setResources((NodeList<VariableDeclarationExpr>)n.getResources().accept(this, arg));
 		n.setTryBlock((BlockStmt) n.getTryBlock().accept(this, arg));
@@ -633,30 +633,30 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final TypeDeclarationStmt n, final A arg) {
+	@Override public Visitable visit(final TypeDeclarationStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setTypeDeclaration((TypeDeclaration<?>) n.getTypeDeclaration().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final TypeParameter n, final A arg) {
+	@Override public Visitable visit(final TypeParameter n, final A arg) {
 		visitComment(n, arg);
         n.setTypeBound((NodeList<ClassOrInterfaceType>)n.getTypeBound().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final UnaryExpr n, final A arg) {
+	@Override public Visitable visit(final UnaryExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setExpr((Expression) n.getExpr().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final UnknownType n, final A arg) {
+	@Override public Visitable visit(final UnknownType n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final VariableDeclarationExpr n, final A arg) {
+	@Override public Visitable visit(final VariableDeclarationExpr n, final A arg) {
 		visitComment(n, arg);
 		n.setAnnotations((NodeList<AnnotationExpr>)n.getAnnotations().accept(this, arg));
 
@@ -671,7 +671,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final VariableDeclarator n, final A arg) {
+	@Override public Visitable visit(final VariableDeclarator n, final A arg) {
 		visitComment(n, arg);
 		final VariableDeclaratorId id = (VariableDeclaratorId)
 			n.getId().accept(this, arg);
@@ -685,25 +685,25 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 		return n;
 	}
 
-	@Override public Node visit(final VariableDeclaratorId n, final A arg) {
+	@Override public Visitable visit(final VariableDeclaratorId n, final A arg) {
 		visitComment(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final VoidType n, final A arg) {
+	@Override public Visitable visit(final VoidType n, final A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
 		return n;
 	}
 
-	@Override public Node visit(final WhileStmt n, final A arg) {
+	@Override public Visitable visit(final WhileStmt n, final A arg) {
 		visitComment(n, arg);
 		n.setCondition((Expression) n.getCondition().accept(this, arg));
 		n.setBody((Statement) n.getBody().accept(this, arg));
 		return n;
 	}
 
-	@Override public Node visit(final WildcardType n, final A arg) {
+	@Override public Visitable visit(final WildcardType n, final A arg) {
 		visitComment(n, arg);
 		visitAnnotations(n, arg);
 		if (n.getExtends() != null) {
@@ -716,7 +716,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 	}
 
 	@Override
-	public Node visit(final LambdaExpr n, final A arg) {
+	public Visitable visit(final LambdaExpr n, final A arg) {
 		visitComment(n, arg);
         n.setParameters((NodeList<Parameter>)n.getParameters().accept(this, arg));
 		if (n.getBody() != null) {
@@ -726,7 +726,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 	}
 
 	@Override
-	public Node visit(final MethodReferenceExpr n, final A arg) {
+	public Visitable visit(final MethodReferenceExpr n, final A arg) {
 		visitComment(n, arg);
         n.setTypeArguments(modifyList(n.getTypeArguments(), arg));
 		if (n.getScope() != null) {
@@ -736,7 +736,7 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 	}
 
 	@Override
-	public Node visit(final TypeExpr n, final A arg) {
+	public Visitable visit(final TypeExpr n, final A arg) {
 		visitComment(n, arg);
 		if (n.getType() != null) {
             n.setType((Type<?>) n.getType().accept(this, arg));
@@ -745,15 +745,15 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 	}
 
 	@Override
-	public Node visit(ArrayBracketPair n, A arg) {
+	public Visitable visit(ArrayBracketPair n, A arg) {
 		visitAnnotations(n, arg);
 		return n;
 	}
 
 	@Override
-	public Node visit(NodeList n, A arg) {
+	public Visitable visit(NodeList n, A arg) {
 		for (int i = 0; i < n.size(); i++) {
-			n.set(i, n.get(i).accept(this, arg));
+			n.set(i, (Node) n.get(i).accept(this, arg));
 		}
 		for (int i = n.size() - 1; i >= 0; i--) {
 			if (n.get(i) == null) {
@@ -764,46 +764,46 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 	}
 
     @Override
-	public Node visit(EmptyImportDeclaration n, A arg) {
+	public Visitable visit(EmptyImportDeclaration n, A arg) {
         visitComment(n, arg);
         return n;
 	}
 
 	@Override
-	public Node visit(SingleStaticImportDeclaration n, A arg) {
-        visitComment(n, arg);
-        n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
-        return n;
-	}
-
-	@Override
-	public Node visit(SingleTypeImportDeclaration n, A arg) {
+	public Visitable visit(SingleStaticImportDeclaration n, A arg) {
         visitComment(n, arg);
         n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
         return n;
 	}
 
 	@Override
-	public Node visit(StaticImportOnDemandDeclaration n, A arg) {
+	public Visitable visit(SingleTypeImportDeclaration n, A arg) {
         visitComment(n, arg);
         n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
         return n;
 	}
 
 	@Override
-	public Node visit(TypeImportOnDemandDeclaration n, A arg) {
+	public Visitable visit(StaticImportOnDemandDeclaration n, A arg) {
+        visitComment(n, arg);
+        n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
+        return n;
+	}
+
+	@Override
+	public Visitable visit(TypeImportOnDemandDeclaration n, A arg) {
         visitComment(n, arg);
         n.setName((NameExpr) n.getName().accept(this, arg));
         return n;
 	}
 
 	@Override
-	public Node visit(final BlockComment n, final A arg) {
+	public Visitable visit(final BlockComment n, final A arg) {
 		return n;
 	}
 
 	@Override
-	public Node visit(final LineComment n, final A arg) {
+	public Visitable visit(final LineComment n, final A arg) {
 		return n;
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/Visitable.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/Visitable.java
@@ -1,0 +1,30 @@
+package com.github.javaparser.ast.visitor;
+
+public interface Visitable {
+    /**
+     * Accept method for visitor support.
+     *
+     * @param <R>
+     *            the type of the return value of the visitor
+     * @param <A>
+     *            the type the user argument passed to the visitor
+     * @param v
+     *            the visitor implementation
+     * @param arg
+     *            the argument passed to the visitor (of type A)
+     * @return the result of the visit (of type R)
+     */
+    <R, A> R accept(GenericVisitor<R, A> v, A arg);
+
+    /**
+     * Accept method for visitor support.
+     *
+     * @param <A>
+     *            the type the argument passed for the visitor
+     * @param v
+     *            the visitor implementation
+     * @param arg
+     *            any value relevant for the visitor (of type A)
+     */
+    <A> void accept(VoidVisitor<A> v, A arg);
+}

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -73,6 +73,10 @@ final class ASTParser {
         ReInit(new StreamProvider(in, encoding));
     }
 
+    private static <X extends Node> NodeList<X> emptyList() {
+        return new NodeList<X>();
+    }
+    
     private <T extends Node> NodeList<T> add(NodeList<T> list, T obj) {
     	if (list == null) {
     		list = new NodeList<T>();
@@ -89,11 +93,21 @@ final class ASTParser {
     	return list;
     }
     
-    private static <X extends Node> NodeList<X> emptyList() {
-        return new NodeList<X>();
+    private <T> List<T> add(List<T> list, T obj) {
+    	if (list == null) {
+    		list = new LinkedList<T>();
+    	}
+    	list.add(obj);
+    	return list;
     }
-    
 
+    private <T> List<T> add(int pos, List<T> list, T obj) {
+    	if (list == null) {
+    		list = new LinkedList<T>();
+    	}
+    	list.add(pos, obj);
+    	return list;
+    }
 
 	private class ModifierHolder {
 		final EnumSet<Modifier> modifiers;
@@ -169,7 +183,7 @@ final class ASTParser {
         return ret;
     }
     
-    private ArrayCreationExpr juggleArrayCreation(Range range, Type type, NodeList<Expression> dimensions, NodeList<NodeList<AnnotationExpr>> arrayAnnotations, ArrayInitializerExpr arrayInitializerExpr)  {
+    private ArrayCreationExpr juggleArrayCreation(Range range, Type type, NodeList<Expression> dimensions, List<NodeList<AnnotationExpr>> arrayAnnotations, ArrayInitializerExpr arrayInitializerExpr)  {
         NodeList<ArrayCreationLevel> levels = new NodeList<ArrayCreationLevel>();
         
         for(int i = 0; i < arrayAnnotations.size(); i++){
@@ -2702,7 +2716,7 @@ ArrayCreationExpr ArrayCreation(Position begin, Type type):
 	Expression expr = null;
 	ArrayInitializerExpr arrayInitializerExpr = null;
 	NodeList<Expression> inits = emptyList();
-	NodeList<NodeList<AnnotationExpr>> accum = emptyList();
+	List<NodeList<AnnotationExpr>> accum = new ArrayList<NodeList<AnnotationExpr>>();
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 }
 { 

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/NodePositionTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/NodePositionTest.java
@@ -30,7 +30,7 @@ public class NodePositionTest {
 
         CompilationUnit cu = res.getResult().get();
         getAllNodes(cu).forEach(n -> {
-            if (n.getBegin().line == 0 && !n.toString().isEmpty() && !(n instanceof NodeList) && !(n instanceof ArrayBracketPair)) {
+            if (n.getBegin().line == 0 && !n.toString().isEmpty() && !(n instanceof ArrayBracketPair)) {
                 throw new IllegalArgumentException("There should be no node at line 0: " + n + " (class: "
                         + n.getClass().getCanonicalName()+ ")");
             }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ExistenceOfParentNodeVerifier.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ExistenceOfParentNodeVerifier.java
@@ -21,6 +21,7 @@
  
 package com.github.javaparser.bdd.steps;
 
+import com.github.javaparser.HasParentNode;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
@@ -46,7 +47,7 @@ class ExistenceOfParentNodeVerifier {
     }
 
     private static class Verifier extends VoidVisitorAdapter<Void> {
-        private static void assertParentIsSet(Node n) {
+        private static void assertParentIsSet(HasParentNode<?> n) {
             assertThat(n + " has no parent set!", n.getParentNode(), is(notNullValue()));
         }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
@@ -238,7 +238,7 @@ public class ManipulationSteps {
     @Then("all the VariableDeclarations parent is the TryStmt")
     public void thenAllTheVariableDeclarationsParentIsTheTryStmt() {
         for(VariableDeclarationExpr expr : variableDeclarationExprList){
-            assertThat(expr.getParentNode().getParentNode(), is((Node)tryStmt));
+            assertThat(expr.getParentNode(), is(tryStmt));
         }
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ParsingSteps.java
@@ -196,14 +196,14 @@ public class ParsingSteps {
     public void thenLambdaInStatementInMethodInClassIsParentOfContainedBody(int statementPosition, int methodPosition, int classPosition) {
         LambdaExpr lambdaExpr = getLambdaExprInStatementInMethodInClass(statementPosition, methodPosition, classPosition);
         Statement body = lambdaExpr.getBody();
-        assertThat(body.getParentNode(), is((Node) lambdaExpr));
+        assertThat(body.getParentNode(), is(lambdaExpr));
     }
 
     @Then("lambda in statement $statementPosition in method $methodPosition in class $classPosition is parent of contained parameter")
     public void thenLambdaInStatementInMethodInClassIsParentOfContainedParameter(int statementPosition, int methodPosition, int classPosition) {
         LambdaExpr lambdaExpr = getLambdaExprInStatementInMethodInClass(statementPosition, methodPosition, classPosition);
         Parameter parameter = lambdaExpr.getParameters().get(0);
-        assertThat(parameter.getParentNode().getParentNode(), is((Node) lambdaExpr));
+        assertThat(parameter.getParentNode(), is(lambdaExpr));
     }
 
     @Then("method reference in statement $statementPosition in method $methodPosition in class $classPosition scope is $expectedName")

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/visitors/PositionTestVisitor.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/visitors/PositionTestVisitor.java
@@ -138,12 +138,6 @@ public class PositionTestVisitor extends VoidVisitorAdapter<Object> {
     }
 
     @Override
-    public void visit(NodeList n, Object arg) {
-        doTest(n);
-        super.visit(n, arg);
-    }
-
-    @Override
     public void visit(EmptyImportDeclaration n, Object arg) {
         doTest(n);
         super.visit(n, arg);


### PR DESCRIPTION
Fix issue #504.

NodeList is now a stand alone class that shares functionality from Node only by using two (new) interfaces: HasParentNode to integrate into the general parent node setting mechanism, and Visitable to integrate into visitors.

Since NodeList is no longer a Node, it will no longer show up as a child or parent node.
