### PR TITLE
Clean up constructors and static factory methods

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayBracketPair.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayBracketPair.java
@@ -15,6 +15,14 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 public class ArrayBracketPair extends Node implements NodeWithAnnotations<ArrayBracketPair> {
     private NodeList<AnnotationExpr> annotations = new NodeList<>();
 
+    public ArrayBracketPair() {
+        this(Range.UNKNOWN, new NodeList<AnnotationExpr>());
+    }
+
+    public ArrayBracketPair(NodeList<AnnotationExpr> annotations) {
+        this(Range.UNKNOWN, annotations);
+    }
+
     public ArrayBracketPair(Range range, NodeList<AnnotationExpr> annotations) {
         super(range);
         setAnnotations(annotations);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
@@ -3,6 +3,7 @@ package com.github.javaparser.ast;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -19,17 +20,35 @@ public class ArrayCreationLevel extends Node implements NodeWithAnnotations<Arra
     private Expression dimension;
     private NodeList<AnnotationExpr> annotations = new NodeList<>();
 
+    public ArrayCreationLevel() {
+        this(Range.UNKNOWN, null, new NodeList<>());
+    }
+
+    public ArrayCreationLevel(int dimension) {
+        this(Range.UNKNOWN, new IntegerLiteralExpr("" + dimension), new NodeList<>());
+    }
+
+    public ArrayCreationLevel(Expression dimension) {
+        this(Range.UNKNOWN, dimension, new NodeList<>());
+    }
+
+    public ArrayCreationLevel(Expression dimension, NodeList<AnnotationExpr> annotations) {
+        this(Range.UNKNOWN, dimension, annotations);
+    }
+
     public ArrayCreationLevel(Range range, Expression dimension, NodeList<AnnotationExpr> annotations) {
         super(range);
         setDimension(dimension);
         setAnnotations(annotations);
     }
 
-    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
         return v.visit(this, arg);
     }
 
-    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
         v.visit(this, arg);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -67,7 +67,7 @@ public final class CompilationUnit extends Node {
     private NodeList<TypeDeclaration<?>> types;
 
     public CompilationUnit() {
-        this(Range.UNKNOWN, new PackageDeclaration(), new NodeList<>(), new NodeList<>());
+        this(Range.UNKNOWN, null, new NodeList<>(), new NodeList<>());
     }
 
     public CompilationUnit(PackageDeclaration pakage, NodeList<ImportDeclaration> imports, NodeList<TypeDeclaration<?>> types) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -49,7 +49,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
         NodeWithType<AnnotationMemberDeclaration, Type<?>>, 
         NodeWithModifiers<AnnotationMemberDeclaration> {
 
-    private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    private EnumSet<Modifier> modifiers;
 
     private Type<?> type;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
@@ -38,7 +38,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  */
 public abstract class BodyDeclaration<T> extends Node implements NodeWithAnnotations<T> {
 
-    private NodeList<AnnotationExpr> annotations = new NodeList<>();
+    private NodeList<AnnotationExpr> annotations;
 
     public BodyDeclaration() {
         this(Range.UNKNOWN, new NodeList<>());

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -53,7 +53,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
         NodeWithBlockStmt<ConstructorDeclaration>,
         NodeWithTypeParameters<ConstructorDeclaration> {
 
-    private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    private EnumSet<Modifier> modifiers;
 
     private NodeList<TypeParameter> typeParameters;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -56,9 +56,9 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
         NodeWithModifiers<FieldDeclaration>,
         NodeWithVariables<FieldDeclaration> {
 
-    private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    private EnumSet<Modifier> modifiers;
 
-    private Type elementType;
+    private Type<?> elementType;
 
     private NodeList<VariableDeclarator> variables;
 
@@ -117,31 +117,11 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
      *            modifiers
      * @param type
      *            type
-     * @param variable
-     *            variable declarator
-     * @return instance of {@link FieldDeclaration}
-     */
-    public static FieldDeclaration create(EnumSet<Modifier> modifiers, Type<?> type,
-                                                          VariableDeclarator variable) {
-        return new FieldDeclaration(modifiers, type, new NodeList<VariableDeclarator>().add(variable));
-    }
-
-    /**
-     * Creates a {@link FieldDeclaration}.
-     *
-     * @param modifiers
-     *            modifiers
-     * @param type
-     *            type
      * @param name
      *            field name
-     * @return instance of {@link FieldDeclaration}
      */
-    public static FieldDeclaration create(EnumSet<Modifier> modifiers, Type<?> type, String name) {
-        assertNotNull(type);
-        VariableDeclaratorId id = new VariableDeclaratorId(assertNotNull(name));
-        VariableDeclarator variable = new VariableDeclarator(assertNotNull(id));
-        return create(modifiers, type, variable);
+    public FieldDeclaration(EnumSet<Modifier> modifiers, Type<?> type, String name) {
+        this(assertNotNull(modifiers), assertNotNull(type), new VariableDeclarator(new VariableDeclaratorId(assertNotNull(name))));
     }
 
     @Override
@@ -259,12 +239,12 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
 
 
     @Override
-    public Type getElementType() {
+    public Type<?> getElementType() {
         return elementType;
     }
 
     @Override
-    public FieldDeclaration setElementType(final Type elementType) {
+    public FieldDeclaration setElementType(final Type<?> elementType) {
         this.elementType = assertNotNull(elementType);
         setAsParentNodeOf(this.elementType);
         return this;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -61,7 +61,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
         NodeWithBlockStmt<MethodDeclaration>,
         NodeWithTypeParameters<MethodDeclaration> {
 
-    private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    private EnumSet<Modifier> modifiers;
 
     private NodeList<TypeParameter> typeParameters;
 
@@ -76,7 +76,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
     // TODO nullable
     private BlockStmt body;
 
-    private boolean isDefault = false;
+    private boolean isDefault;
 
     private NodeList<ArrayBracketPair> arrayBracketPairsAfterType;
 
@@ -90,6 +90,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                 new ClassOrInterfaceType(),
                 new NodeList<>(),
                 new NameExpr(),
+                false,
                 new NodeList<>(),
                 new NodeList<>(),
                 new NodeList<>(),
@@ -104,6 +105,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                 elementType,
                 new NodeList<>(),
                 name(name),
+                false,
                 new NodeList<>(),
                 new NodeList<>(),
                 new NodeList<>(),
@@ -119,6 +121,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                 elementType,
                 new NodeList<>(),
                 name(name),
+                false,
                 parameters,
                 new NodeList<>(),
                 new NodeList<>(),
@@ -131,6 +134,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                              final Type elementType,
                              final NodeList<ArrayBracketPair> arrayBracketPairsAfterElementType,
                              final String name,
+                             final boolean isDefault,
                              final NodeList<Parameter> parameters, 
                              final NodeList<ArrayBracketPair> arrayBracketPairsAfterParameterList,
                              final NodeList<ReferenceType<?>> throws_, 
@@ -142,6 +146,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                 elementType,
                 arrayBracketPairsAfterElementType,
                 name(name),
+                isDefault,
                 parameters,
                 arrayBracketPairsAfterParameterList,
                 throws_,
@@ -155,6 +160,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                              final Type elementType,
                              final NodeList<ArrayBracketPair> arrayBracketPairsAfterElementType,
                              final NameExpr nameExpr,
+                             final boolean isDefault,
                              final NodeList<Parameter> parameters, 
                              final NodeList<ArrayBracketPair> arrayBracketPairsAfterParameterList,
                              final NodeList<ReferenceType<?>> throws_, 
@@ -169,6 +175,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
         setArrayBracketPairsAfterParameterList(arrayBracketPairsAfterParameterList);
         setThrows(throws_);
         setBody(body);
+        setDefault(isDefault);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -54,9 +54,9 @@ public final class Parameter extends Node implements
 
     private boolean isVarArgs;
 
-    private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    private EnumSet<Modifier> modifiers;
 
-    private NodeList<AnnotationExpr> annotations = new NodeList<>();
+    private NodeList<AnnotationExpr> annotations;
 
     private VariableDeclaratorId id;
 
@@ -89,10 +89,9 @@ public final class Parameter extends Node implements
      *            type of the parameter
      * @param name
      *            name of the parameter
-     * @return instance of {@link Parameter}
      */
-    public static Parameter create(Type elementType, String name) {
-        return new Parameter(Range.UNKNOWN,
+    public Parameter(Type<?> elementType, String name) {
+        this(Range.UNKNOWN,
                 EnumSet.noneOf(Modifier.class),
                 new NodeList<>(),
                 elementType,
@@ -101,7 +100,7 @@ public final class Parameter extends Node implements
                 new VariableDeclaratorId(name));
     }
 
-    public Parameter(EnumSet<Modifier> modifiers, Type elementType, VariableDeclaratorId id) {
+    public Parameter(EnumSet<Modifier> modifiers, Type<?> elementType, VariableDeclaratorId id) {
         this(Range.UNKNOWN,
                 modifiers,
                 new NodeList<>(),
@@ -114,7 +113,7 @@ public final class Parameter extends Node implements
     public Parameter(final Range range, 
                      EnumSet<Modifier> modifiers,
                      NodeList<AnnotationExpr> annotations,
-                     Type elementType,
+                     Type<?> elementType,
                      NodeList<ArrayBracketPair> arrayBracketPairsAfterElementType,
                      boolean isVarArgs, 
                      VariableDeclaratorId id) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -45,7 +45,7 @@ public abstract class TypeDeclaration<T> extends BodyDeclaration<T>
 
 	private NameExpr name;
 
-    private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    private EnumSet<Modifier> modifiers;
 
     private NodeList<BodyDeclaration<?>> members;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -18,7 +18,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
- 
+
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -30,20 +30,28 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  */
 public abstract class AnnotationExpr extends Expression {
 
-	protected NameExpr name;
+    protected NameExpr name;
 
-	public AnnotationExpr(Range range, NameExpr name) {
-		super(range);
+    public AnnotationExpr() {
+        this(Range.UNKNOWN, new NameExpr());
+    }
+
+    public AnnotationExpr(NameExpr name) {
+        this(Range.UNKNOWN, name);
+    }
+    
+    public AnnotationExpr(Range range, NameExpr name) {
+        super(range);
         setName(name);
-	}
+    }
 
-	public NameExpr getName() {
-		return name;
-	}
+    public NameExpr getName() {
+        return name;
+    }
 
-	public AnnotationExpr setName(NameExpr name) {
-		this.name = assertNotNull(name);
-		setAsParentNodeOf(name);
-		return this;
-	}
+    public AnnotationExpr setName(NameExpr name) {
+        this.name = assertNotNull(name);
+        setAsParentNodeOf(name);
+        return this;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
@@ -32,10 +32,11 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 public final class CharLiteralExpr extends StringLiteralExpr {
 
     public CharLiteralExpr() {
+        this(Range.UNKNOWN, "?");
     }
 
     public CharLiteralExpr(String value) {
-        super(value);
+        this(Range.UNKNOWN, value);
     }
 
     public CharLiteralExpr(Range range, String value) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
@@ -31,10 +31,11 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 public final class DoubleLiteralExpr extends StringLiteralExpr {
 
 	public DoubleLiteralExpr() {
+        this(Range.UNKNOWN, "0");
 	}
 
 	public DoubleLiteralExpr(final String value) {
-		super(value);
+		this(Range.UNKNOWN, value);
 	}
 
 	public DoubleLiteralExpr(final Range range, final String value) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -32,7 +32,7 @@ public class IntegerLiteralExpr extends StringLiteralExpr {
 
 	private static final String UNSIGNED_MIN_VALUE = "2147483648";
 
-	protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE;
+	static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE;
 
 	public IntegerLiteralExpr() {
         this(Range.UNKNOWN, "0");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralMinValueExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralMinValueExpr.java
@@ -31,7 +31,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 public final class IntegerLiteralMinValueExpr extends IntegerLiteralExpr {
 
 	public IntegerLiteralMinValueExpr() {
-		super(MIN_VALUE);
+		this(Range.UNKNOWN);
 	}
 
 	public IntegerLiteralMinValueExpr(final Range range) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -35,6 +35,7 @@ public class LongLiteralExpr extends StringLiteralExpr {
 	protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE + "L";
 
 	public LongLiteralExpr() {
+        this(Range.UNKNOWN, "0");
 	}
 
 	public LongLiteralExpr(final String value) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralMinValueExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralMinValueExpr.java
@@ -31,7 +31,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 public final class LongLiteralMinValueExpr extends LongLiteralExpr {
 
 	public LongLiteralMinValueExpr() {
-		super(MIN_VALUE);
+		this(Range.UNKNOWN);
 	}
 
 	public LongLiteralMinValueExpr(final Range range) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
@@ -18,7 +18,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
- 
+
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -30,25 +30,26 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class MarkerAnnotationExpr extends AnnotationExpr {
 
-	public MarkerAnnotationExpr() {
+    public MarkerAnnotationExpr() {
         this(Range.UNKNOWN, new NameExpr());
-        
-	}
+    }
 
-	public MarkerAnnotationExpr(final NameExpr name) {
-		this(Range.UNKNOWN, name);
-	}
+    public MarkerAnnotationExpr(final NameExpr name) {
+        this(Range.UNKNOWN, name);
+    }
 
-	public MarkerAnnotationExpr(final Range range, final NameExpr name) {
-		super(range, name);
-	}
+    public MarkerAnnotationExpr(final Range range, final NameExpr name) {
+        super(range, name);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -37,7 +37,7 @@ public final class NormalAnnotationExpr extends AnnotationExpr {
     private NodeList<MemberValuePair> pairs;
 
     public NormalAnnotationExpr() {
-        this(Range.UNKNOWN, name("empty"), new NodeList<>());
+        this(Range.UNKNOWN, new NameExpr(), new NodeList<>());
     }
 
     public NormalAnnotationExpr(final NameExpr name, final NodeList<MemberValuePair> pairs) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -59,7 +59,7 @@ public final class ObjectCreationExpr extends Expression implements
     private NodeList<Expression> args;
 
     // TODO This can be null, to indicate there is no body
-    private NodeList<BodyDeclaration<?>> anonymousClassBody = null;
+    private NodeList<BodyDeclaration<?>> anonymousClassBody;
 
     public ObjectCreationExpr() {
         this(Range.UNKNOWN, 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/QualifiedNameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/QualifiedNameExpr.java
@@ -25,6 +25,8 @@ import com.github.javaparser.Range;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
 /**
  * @author Julio Vilmar Gesser
  */
@@ -33,11 +35,11 @@ public final class QualifiedNameExpr extends NameExpr {
 	private NameExpr qualifier;
 
 	public QualifiedNameExpr() {
+        this(Range.UNKNOWN, new NameExpr(), "empty");
 	}
 
 	public QualifiedNameExpr(final NameExpr scope, final String name) {
-		super(name);
-		setQualifier(scope);
+        this(Range.UNKNOWN, scope, name);
 	}
 
 	public QualifiedNameExpr(final Range range, final NameExpr scope, final String name) {
@@ -58,7 +60,7 @@ public final class QualifiedNameExpr extends NameExpr {
 	}
 
 	public QualifiedNameExpr setQualifier(final NameExpr qualifier) {
-		this.qualifier = qualifier;
+		this.qualifier = assertNotNull(qualifier);
 		setAsParentNodeOf(this.qualifier);
 		return this;
 	}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -53,9 +53,6 @@ public class StringLiteralExpr extends LiteralExpr {
 
 	public StringLiteralExpr(final Range range, final String value) {
 		super(range);
-        if (value.contains("\n") || value.contains("\r")) {
-            throw new IllegalArgumentException("Illegal literal expression: newlines (line feed or carriage return) have to be escaped");
-        }
 		setValue(value);
 	}
 
@@ -73,6 +70,9 @@ public class StringLiteralExpr extends LiteralExpr {
 
 	public final StringLiteralExpr setValue(final String value) {
         this.value = assertNotNull(value);
+        if (value.contains("\n") || value.contains("\r")) {
+            throw new IllegalArgumentException("Illegal literal expression: newlines (line feed or carriage return) have to be escaped");
+        }
         return this;
 	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -53,9 +53,9 @@ public final class VariableDeclarationExpr extends Expression implements
         NodeWithAnnotations<VariableDeclarationExpr>,
         NodeWithVariables<VariableDeclarationExpr> {
 
-    private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    private EnumSet<Modifier> modifiers;
 
-    private NodeList<AnnotationExpr> annotations = new NodeList<>();
+    private NodeList<AnnotationExpr> annotations;
 
     private Type elementType;
 
@@ -139,15 +139,6 @@ public final class VariableDeclarationExpr extends Expression implements
         setElementType(elementType);
         setVariables(variables);
         setArrayBracketPairsAfterElementType(arrayBracketPairsAfterType);
-    }
-
-    /**
-     * Creates a {@link VariableDeclarationExpr}.
-     *
-     * @return instance of {@link VariableDeclarationExpr}
-     */
-    public static VariableDeclarationExpr create(Type type, String name) {
-        return new VariableDeclarationExpr(type, name);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/imports/EmptyImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/imports/EmptyImportDeclaration.java
@@ -9,6 +9,15 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  * This isn't described in the JLS, but accepted by most or all tools that parse Java.
  */
 public class EmptyImportDeclaration extends ImportDeclaration {
+    
+    public EmptyImportDeclaration() {
+        this(Range.UNKNOWN);
+    }
+
+    public EmptyImportDeclaration(Range range) {
+        super(range);
+    }
+
     @Override
     public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
         return v.visit(this, arg);
@@ -17,13 +26,5 @@ public class EmptyImportDeclaration extends ImportDeclaration {
     @Override
     public <A> void accept(VoidVisitor<A> v, A arg) {
         v.visit(this, arg);
-    }
-
-    public EmptyImportDeclaration() {
-        this(Range.UNKNOWN);
-    }
-
-    public EmptyImportDeclaration(Range range) {
-        super(range);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/imports/TypeImportOnDemandDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/imports/TypeImportOnDemandDeclaration.java
@@ -21,7 +21,7 @@ public class TypeImportOnDemandDeclaration extends NonEmptyImportDeclaration {
     private NameExpr name;
 
     public TypeImportOnDemandDeclaration() {
-        this(Range.UNKNOWN, name("empty"));
+        this(Range.UNKNOWN, new NameExpr());
     }
     
     public TypeImportOnDemandDeclaration(Range range, NameExpr name) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
@@ -38,7 +38,7 @@ public final class ReturnStmt extends Statement {
 	private Expression expr;
 
 	public ReturnStmt() {
-        this(Range.UNKNOWN, new BooleanLiteralExpr());
+        this(Range.UNKNOWN, null);
 	}
 
 	public ReturnStmt(final Expression expr) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -42,7 +42,7 @@ public final class SwitchEntryStmt extends Statement implements NodeWithStatemen
 	private NodeList<Statement> stmts;
 
 	public SwitchEntryStmt() {
-		this(Range.UNKNOWN, new CharLiteralExpr(), new NodeList<>());
+		this(Range.UNKNOWN, null, new NodeList<>());
 	}
 
 	public SwitchEntryStmt(final Expression label, final NodeList<Statement> stmts) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
@@ -47,8 +47,7 @@ public final class SynchronizedStmt extends Statement implements NodeWithBlockSt
         this(Range.UNKNOWN, expr, block);
     }
 
-    public SynchronizedStmt(Range range, final Expression expr,
-                            final BlockStmt block) {
+    public SynchronizedStmt(Range range, final Expression expr, final BlockStmt block) {
         super(range);
         setExpr(expr);
         setBody(block);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
@@ -47,9 +47,9 @@ public final class TryStmt extends Statement {
 	public TryStmt() {
 		this(Range.UNKNOWN,
 				new NodeList<>(),
-				new BlockStmt(),
+                new BlockStmt(),
 				new NodeList<>(),
-				new BlockStmt());
+				null);
 	}
 
 	public TryStmt(final BlockStmt tryBlock, final NodeList<CatchClause> catchs,

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Pair;
 
 import static com.github.javaparser.ast.NodeList.nodeList;
+import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * To indicate that a type is an array, it gets wrapped in an ArrayType for every array level it has.
@@ -19,12 +20,11 @@ import static com.github.javaparser.ast.NodeList.nodeList;
 public class ArrayType extends ReferenceType<ArrayType> implements NodeWithAnnotations<ArrayType> {
     private Type componentType;
 
-    public ArrayType(Type componentType, NodeList<AnnotationExpr> annotations) {
-        setComponentType(componentType);
-        setAnnotations(annotations);
+    public ArrayType(Type<?> componentType, NodeList<AnnotationExpr> annotations) {
+        this(Range.UNKNOWN, componentType, annotations);
     }
 
-    public ArrayType(Range range, Type componentType, NodeList<AnnotationExpr> annotations) {
+    public ArrayType(Range range, Type<?> componentType, NodeList<AnnotationExpr> annotations) {
         super(range);
         setComponentType(componentType);
         setAnnotations(annotations);
@@ -42,8 +42,8 @@ public class ArrayType extends ReferenceType<ArrayType> implements NodeWithAnnot
         return componentType;
     }
 
-    public ArrayType setComponentType(final Type type) {
-        this.componentType = type;
+    public ArrayType setComponentType(final Type<?> type) {
+        this.componentType = assertNotNull(type);
         setAsParentNodeOf(this.componentType);
         return this;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -33,7 +33,7 @@ import static com.github.javaparser.utils.Utils.*;
  */
 public abstract class Type<T extends Type> extends Node {
 
-    private NodeList<AnnotationExpr> annotations = new NodeList<>();
+    private NodeList<AnnotationExpr> annotations;
 
     public Type(Range range, NodeList<AnnotationExpr> annotations) {
         super(range);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -261,6 +261,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
                 type_,
                 arrayBracketPairsAfterElementType_,
                 nameExpr_, 
+                _n.isDefault(),
                 parameters_, 
                 arrayBracketPairsAfterParameterList_, 
                 throws_, 

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1722,7 +1722,7 @@ MethodDeclaration MethodDeclaration(ModifierHolder modifier):
   ( block = Block() | ";" )
   { 
         Pair<Type, NodeList<ArrayBracketPair>> typeListPair = unwrapArrayTypes(type);
-        return new MethodDeclaration(range(begin, pos(token.endLine, token.endColumn)), modifier.modifiers, modifier.annotations, typeParameters.list, typeListPair.a, typeListPair.b, name, parameters, arrayBracketPairs, throws_, block);
+        return new MethodDeclaration(range(begin, pos(token.endLine, token.endColumn)), modifier.modifiers, modifier.annotations, typeParameters.list, typeListPair.a, typeListPair.b, name, false, parameters, arrayBracketPairs, throws_, block);
   }
 }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
@@ -154,7 +154,7 @@ public class ManipulationSteps {
     public void whenVarargsCalledAreAddedToMethodInClass(String typeName, String parameterName, int methodPosition, int classPosition) {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
         MethodDeclaration method = getMethodByPositionAndClassPosition(compilationUnit, methodPosition, classPosition);
-        Parameter param = Parameter.create(new ClassOrInterfaceType(typeName), parameterName);
+        Parameter param = new Parameter(new ClassOrInterfaceType(typeName), parameterName);
         param.setVarArgs(true);
         method.addParameter(param);
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ClassCreator.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/junit/wiki_samples/ClassCreator.java
@@ -46,7 +46,7 @@ public class ClassCreator {
         type.addMember(method);
 
         // add a parameter to the method
-        Parameter param = Parameter.create(new ClassOrInterfaceType("String"), "args");
+        Parameter param = new Parameter(new ClassOrInterfaceType("String"), "args");
         param.setVarArgs(true);
         method.addParameter(param);
 


### PR DESCRIPTION
Deals with #427 and #513. Went through all nodes and made sure that:
- there are no "create" methods that can just as well be constructors
- there are no fields being initialized (since the constructors are supposed to do that)
- all constructors forward to one all-fields constructor
- there is a default constructor that initializes the node to something minimally sensible.
- there is an "easy" constructor for common use cases

^^^ this text is good to have in the architecture wiki page :)