### PR TITLE
Cosmetic changes

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -199,7 +199,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     public Node getParentNode() {
         return parentNode;
     }
-    
+
     /**
      * Contains all nodes that have this node set as their parent.
      * You can add nodes to it by setting a node's parent to this node.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -199,7 +199,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     public Node getParentNode() {
         return parentNode;
     }
-
+    
     /**
      * Contains all nodes that have this node set as their parent.
      * You can add nodes to it by setting a node's parent to this node.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
@@ -21,22 +21,18 @@
  
 package com.github.javaparser.ast.body;
 
-import java.util.List;
-
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.utils.Utils;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 
-import static com.github.javaparser.ast.NodeList.*;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * @author Julio Vilmar Gesser
  */
-public abstract class BodyDeclaration<T> extends Node implements NodeWithAnnotations<T> {
+public abstract class BodyDeclaration<T extends Node> extends Node implements NodeWithAnnotations<T> {
 
     private NodeList<AnnotationExpr> annotations;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -176,7 +176,7 @@ public final class Parameter extends Node implements
     public String getName() {
         return getId().getName();
     }
-    
+
     @Override
     public Parameter setName(String name) {
         assertNotNull(name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -35,9 +35,9 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Pair;
 
-import static com.github.javaparser.ast.type.ArrayType.wrapInArrayTypes;
 import java.util.EnumSet;
 
+import static com.github.javaparser.ast.type.ArrayType.wrapInArrayTypes;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -176,15 +176,15 @@ public final class Parameter extends Node implements
     public String getName() {
         return getId().getName();
     }
-
-    @SuppressWarnings("unchecked")
+    
     @Override
     public Parameter setName(String name) {
         assertNotNull(name);
-        if (id != null)
+        if (id != null) {
             id.setName(name);
-        else
+        } else {
             id = new VariableDeclaratorId(name);
+        }
         return this;
     }
 
@@ -204,7 +204,6 @@ public final class Parameter extends Node implements
      *            in the future, so please avoid passing null
      */
     @Override
-    @SuppressWarnings("unchecked")
     public Parameter setAnnotations(NodeList<AnnotationExpr> annotations) {
         this.annotations = assertNotNull(annotations);
         setAsParentNodeOf(this.annotations);
@@ -217,7 +216,6 @@ public final class Parameter extends Node implements
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Parameter setModifiers(EnumSet<Modifier> modifiers) {
         this.modifiers = assertNotNull(modifiers);
         return this;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -34,13 +35,13 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 
 import java.util.EnumSet;
 
-import static com.github.javaparser.ast.expr.NameExpr.*;
+import static com.github.javaparser.ast.expr.NameExpr.name;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * @author Julio Vilmar Gesser
  */
-public abstract class TypeDeclaration<T> extends BodyDeclaration<T>
+public abstract class TypeDeclaration<T extends Node> extends BodyDeclaration<T>
         implements NodeWithName<T>, NodeWithJavaDoc<T>, NodeWithModifiers<T>, NodeWithMembers<T> {
 
 	private NameExpr name;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
@@ -21,11 +21,6 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
-import static com.github.javaparser.ast.NodeList.*;
-import static com.github.javaparser.ast.expr.NameExpr.name;
-
-import java.lang.annotation.Annotation;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -33,13 +28,17 @@ import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 
+import java.lang.annotation.Annotation;
+
+import static com.github.javaparser.ast.expr.NameExpr.name;
+
 /**
  * An element which can be the target of annotations.
  *
  * @author Federico Tomassetti
  * @since July 2014
  */
-public interface NodeWithAnnotations<T> {
+public interface NodeWithAnnotations<T extends Node> {
     NodeList<AnnotationExpr> getAnnotations();
 
     T setAnnotations(NodeList<AnnotationExpr> annotations);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
@@ -38,10 +38,10 @@ import static com.github.javaparser.ast.expr.NameExpr.name;
  * @author Federico Tomassetti
  * @since July 2014
  */
-public interface NodeWithAnnotations<T extends Node> {
+public interface NodeWithAnnotations<N extends Node> {
     NodeList<AnnotationExpr> getAnnotations();
 
-    T setAnnotations(NodeList<AnnotationExpr> annotations);
+    N setAnnotations(NodeList<AnnotationExpr> annotations);
 
     /**
      * Annotates this
@@ -75,12 +75,12 @@ public interface NodeWithAnnotations<T extends Node> {
      * @return this
      */
     @SuppressWarnings("unchecked")
-    default T addMarkerAnnotation(String name) {
+    default N addMarkerAnnotation(String name) {
         MarkerAnnotationExpr markerAnnotationExpr = new MarkerAnnotationExpr(
                 name(name));
         getAnnotations().add(markerAnnotationExpr);
         markerAnnotationExpr.setParentNode((Node) this);
-        return (T) this;
+        return (N) this;
     }
 
     /**
@@ -89,7 +89,7 @@ public interface NodeWithAnnotations<T extends Node> {
      * @param clazz the class of the annotation
      * @return this
      */
-    default T addMarkerAnnotation(Class<? extends Annotation> clazz) {
+    default N addMarkerAnnotation(Class<? extends Annotation> clazz) {
         ((Node) this).tryAddImportToParentCompilationUnit(clazz);
         return addMarkerAnnotation(clazz.getSimpleName());
     }
@@ -102,12 +102,12 @@ public interface NodeWithAnnotations<T extends Node> {
      * @return this
      */
     @SuppressWarnings("unchecked")
-    default T addSingleMemberAnnotation(String name, String value) {
+    default N addSingleMemberAnnotation(String name, String value) {
         SingleMemberAnnotationExpr singleMemberAnnotationExpr = new SingleMemberAnnotationExpr(
                 name(name), name(value));
         getAnnotations().add(singleMemberAnnotationExpr);
         singleMemberAnnotationExpr.setParentNode((Node) this);
-        return (T) this;
+        return (N) this;
     }
 
     /**
@@ -117,8 +117,8 @@ public interface NodeWithAnnotations<T extends Node> {
      * @param value the value, don't forget to add \"\" for a string value
      * @return this
      */
-    default T addSingleMemberAnnotation(Class<? extends Annotation> clazz,
-                                               String value) {
+    default N addSingleMemberAnnotation(Class<? extends Annotation> clazz,
+                                        String value) {
         ((Node) this).tryAddImportToParentCompilationUnit(clazz);
         return addSingleMemberAnnotation(clazz.getSimpleName(), value);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
@@ -5,19 +5,19 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.NameExpr;
 
-public interface NodeWithArguments<T extends Node> {
-    T setArgs(NodeList<Expression> args);
+public interface NodeWithArguments<N extends Node> {
+    N setArgs(NodeList<Expression> args);
 
     NodeList<Expression> getArgs();
 
-    default T addArgument(String arg) {
+    default N addArgument(String arg) {
         addArgument(new NameExpr(arg));
-        return (T) this;
+        return (N) this;
     }
 
-    default T addArgument(Expression arg) {
+    default N addArgument(Expression arg) {
         getArgs().add(arg);
-        return (T) this;
+        return (N) this;
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
@@ -1,10 +1,11 @@
 package com.github.javaparser.ast.nodeTypes;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.NameExpr;
 
-public interface NodeWithArguments<T> {
+public interface NodeWithArguments<T extends Node> {
     T setArgs(NodeList<Expression> args);
 
     NodeList<Expression> getArgs();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBlockStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBlockStmt.java
@@ -3,7 +3,7 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.stmt.BlockStmt;
 
-public interface NodeWithBlockStmt<T> {
+public interface NodeWithBlockStmt<T extends Node> {
     BlockStmt getBody();
 
     T setBody(BlockStmt block);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBlockStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBlockStmt.java
@@ -3,10 +3,10 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.stmt.BlockStmt;
 
-public interface NodeWithBlockStmt<T extends Node> {
+public interface NodeWithBlockStmt<N extends Node> {
     BlockStmt getBody();
 
-    T setBody(BlockStmt block);
+    N setBody(BlockStmt block);
 
     default BlockStmt createBody() {
         BlockStmt block = new BlockStmt();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBody.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBody.java
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
 
-public interface NodeWithBody<T> {
+public interface NodeWithBody<T extends Node> {
     Statement getBody();
 
     T setBody(final Statement body);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBody.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithBody.java
@@ -4,10 +4,10 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
 
-public interface NodeWithBody<T extends Node> {
+public interface NodeWithBody<N extends Node> {
     Statement getBody();
 
-    T setBody(final Statement body);
+    N setBody(final Statement body);
 
     default BlockStmt createBlockStatementAsBody() {
         BlockStmt b = new BlockStmt();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithElementType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithElementType.java
@@ -25,11 +25,8 @@ import com.github.javaparser.ast.ArrayBracketPair;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
-
-import java.util.List;
 
 /**
  * A node having an element type.
@@ -40,7 +37,7 @@ import java.util.List;
  * The main reason for this interface is to permit users to manipulate homogeneously all nodes with getElementType/setElementType
  * methods
  */
-public interface NodeWithElementType<T> {
+public interface NodeWithElementType<T extends Node> {
     /**
      * @return the element type
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithElementType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithElementType.java
@@ -37,7 +37,7 @@ import com.github.javaparser.ast.type.Type;
  * The main reason for this interface is to permit users to manipulate homogeneously all nodes with getElementType/setElementType
  * methods
  */
-public interface NodeWithElementType<T extends Node> {
+public interface NodeWithElementType<N extends Node> {
     /**
      * @return the element type
      */
@@ -47,11 +47,11 @@ public interface NodeWithElementType<T extends Node> {
      * @param elementType the element elementType
      * @return this
      */
-    T setElementType(Type<?> elementType);
+    N setElementType(Type<?> elementType);
 
     NodeList<ArrayBracketPair> getArrayBracketPairsAfterElementType();
 
-    T setArrayBracketPairsAfterElementType(NodeList<ArrayBracketPair> arrayBracketPairsAfterElementType);
+    N setArrayBracketPairsAfterElementType(NodeList<ArrayBracketPair> arrayBracketPairsAfterElementType);
 
     /**
      * Sets this type to this class and try to import it to the {@link CompilationUnit} if needed
@@ -59,12 +59,12 @@ public interface NodeWithElementType<T extends Node> {
      * @param typeClass the type
      * @return this
      */
-    default T setElementType(Class<?> typeClass) {
+    default N setElementType(Class<?> typeClass) {
         ((Node) this).tryAddImportToParentCompilationUnit(typeClass);
         return setElementType(new ClassOrInterfaceType(typeClass.getSimpleName()));
     }
 
-    default T setElementType(final String type) {
+    default N setElementType(final String type) {
         ClassOrInterfaceType classOrInterfaceType = new ClassOrInterfaceType(type);
         return setElementType(classOrInterfaceType);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
@@ -4,10 +4,10 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
-public interface NodeWithExtends<T extends Node> {
+public interface NodeWithExtends<N extends Node> {
     NodeList<ClassOrInterfaceType> getExtends();
 
-    T setExtends(NodeList<ClassOrInterfaceType> extendsList);
+    N setExtends(NodeList<ClassOrInterfaceType> extendsList);
 
     /**
      * Add an extends to this and automatically add the import
@@ -15,7 +15,7 @@ public interface NodeWithExtends<T extends Node> {
      * @param clazz the class to extand from
      * @return this
      */
-    default T addExtends(Class<?> clazz) {
+    default N addExtends(Class<?> clazz) {
         ((Node) this).tryAddImportToParentCompilationUnit(clazz);
         return addExtends(clazz.getSimpleName());
     }
@@ -27,10 +27,10 @@ public interface NodeWithExtends<T extends Node> {
      * @return this
      */
     @SuppressWarnings("unchecked")
-    default T addExtends(String name) {
+    default N addExtends(String name) {
         ClassOrInterfaceType classOrInterfaceType = new ClassOrInterfaceType(name);
         getExtends().add(classOrInterfaceType);
         classOrInterfaceType.setParentNode((Node) this);
-        return (T) this;
+        return (N) this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
-public interface NodeWithExtends<T> {
+public interface NodeWithExtends<T extends Node> {
     NodeList<ClassOrInterfaceType> getExtends();
 
     T setExtends(NodeList<ClassOrInterfaceType> extendsList);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithImplements.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithImplements.java
@@ -4,10 +4,10 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
-public interface NodeWithImplements<T extends Node> {
+public interface NodeWithImplements<N extends Node> {
     NodeList<ClassOrInterfaceType> getImplements();
 
-    T setImplements(NodeList<ClassOrInterfaceType> implementsList);
+    N setImplements(NodeList<ClassOrInterfaceType> implementsList);
 
     /**
      * Add an implements to this
@@ -16,11 +16,11 @@ public interface NodeWithImplements<T extends Node> {
      * @return this
      */
     @SuppressWarnings("unchecked")
-    default T addImplements(String name) {
+    default N addImplements(String name) {
         ClassOrInterfaceType classOrInterfaceType = new ClassOrInterfaceType(name);
         getImplements().add(classOrInterfaceType);
         classOrInterfaceType.setParentNode((Node) this);
-        return (T) this;
+        return (N) this;
     }
 
     /**
@@ -29,7 +29,7 @@ public interface NodeWithImplements<T extends Node> {
      * @param clazz the type to implements from
      * @return this
      */
-    default T addImplements(Class<?> clazz) {
+    default N addImplements(Class<?> clazz) {
         ((Node) this).tryAddImportToParentCompilationUnit(clazz);
         return addImplements(clazz.getSimpleName());
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithImplements.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithImplements.java
@@ -1,12 +1,10 @@
 package com.github.javaparser.ast.nodeTypes;
 
-import java.util.List;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
-public interface NodeWithImplements<T> {
+public interface NodeWithImplements<T extends Node> {
     NodeList<ClassOrInterfaceType> getImplements();
 
     T setImplements(NodeList<ClassOrInterfaceType> implementsList);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavaDoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavaDoc.java
@@ -27,7 +27,7 @@ import com.github.javaparser.ast.comments.JavadocComment;
 /**
  * Node which can be documented through a Javadoc comment.
  */
-public interface NodeWithJavaDoc<T> {
+public interface NodeWithJavaDoc<T extends Node> {
     /**
      * Gets the JavaDoc for this node. You can set the JavaDoc by calling setComment with a JavadocComment.
      *

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavaDoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavaDoc.java
@@ -27,7 +27,7 @@ import com.github.javaparser.ast.comments.JavadocComment;
 /**
  * Node which can be documented through a Javadoc comment.
  */
-public interface NodeWithJavaDoc<T extends Node> {
+public interface NodeWithJavaDoc<N extends Node> {
     /**
      * Gets the JavaDoc for this node. You can set the JavaDoc by calling setComment with a JavadocComment.
      *
@@ -41,8 +41,8 @@ public interface NodeWithJavaDoc<T extends Node> {
      * @param comment to be set
      */
     @SuppressWarnings("unchecked")
-    default T setJavaDocComment(String comment) {
+    default N setJavaDocComment(String comment) {
         ((Node) this).setComment(new JavadocComment(comment));
-        return (T) this;
+        return (N) this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -24,10 +24,10 @@ import static java.util.stream.Collectors.*;
  * method.
  *
  */
-public interface NodeWithMembers<T extends Node> {
+public interface NodeWithMembers<N extends Node> {
     NodeList<BodyDeclaration<?>> getMembers();
 
-    T setMembers(NodeList<BodyDeclaration<?>> members);
+    N setMembers(NodeList<BodyDeclaration<?>> members);
 
     /**
      * Add a field to this and automatically add the import of the type if needed

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -1,30 +1,21 @@
 package com.github.javaparser.ast.nodeTypes;
 
-import static com.github.javaparser.ast.type.VoidType.VOID_TYPE;
-import static java.util.Collections.unmodifiableList;
-import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
 
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Stream;
 
-import com.github.javaparser.ast.Modifier;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.ConstructorDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.InitializerDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.TypeDeclaration;
-import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.body.VariableDeclaratorId;
-import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.Type;
+import static com.github.javaparser.ast.type.VoidType.VOID_TYPE;
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.*;
 
 /**
  * A node having members.
@@ -33,7 +24,7 @@ import com.github.javaparser.ast.type.Type;
  * method.
  *
  */
-public interface NodeWithMembers<T> {
+public interface NodeWithMembers<T extends Node> {
     NodeList<BodyDeclaration<?>> getMembers();
 
     T setMembers(NodeList<BodyDeclaration<?>> members);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
@@ -1,15 +1,16 @@
 package com.github.javaparser.ast.nodeTypes;
 
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
+
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.stream.Collectors;
 
-import com.github.javaparser.ast.Modifier;
-
 /**
  * A Node with Modifiers.
  */
-public interface NodeWithModifiers<T> {
+public interface NodeWithModifiers<T extends Node> {
     /**
      * Return the modifiers of this variable declaration.
      *

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 /**
  * A Node with Modifiers.
  */
-public interface NodeWithModifiers<T extends Node> {
+public interface NodeWithModifiers<N extends Node> {
     /**
      * Return the modifiers of this variable declaration.
      *
@@ -19,13 +19,13 @@ public interface NodeWithModifiers<T extends Node> {
      */
     EnumSet<Modifier> getModifiers();
 
-    T setModifiers(EnumSet<Modifier> modifiers);
+    N setModifiers(EnumSet<Modifier> modifiers);
 
     @SuppressWarnings("unchecked")
-    default T addModifier(Modifier... modifiers) {
+    default N addModifier(Modifier... modifiers) {
         getModifiers().addAll(Arrays.stream(modifiers)
                 .collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))));
-        return (T) this;
+        return (N) this;
     }
 
     default boolean isStatic() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
@@ -30,8 +30,8 @@ import com.github.javaparser.ast.Node;
  * 
  * @since 2.0.1 
  */
-public interface NodeWithName<T extends Node> {
+public interface NodeWithName<N extends Node> {
     String getName();
 
-    T setName(String name);
+    N setName(String name);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
@@ -21,6 +21,8 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
+import com.github.javaparser.ast.Node;
+
 /**
  * A node having a name.
  *  
@@ -28,7 +30,7 @@ package com.github.javaparser.ast.nodeTypes;
  * 
  * @since 2.0.1 
  */
-public interface NodeWithName<T> {
+public interface NodeWithName<T extends Node> {
     String getName();
 
     T setName(String name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
@@ -7,16 +7,16 @@ import com.github.javaparser.ast.body.VariableDeclaratorId;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 
-public interface NodeWithParameters<T extends Node> {
+public interface NodeWithParameters<N extends Node> {
     NodeList<Parameter> getParameters();
 
-    T setParameters(NodeList<Parameter> parameters);
+    N setParameters(NodeList<Parameter> parameters);
 
-    default T addParameter(Type type, String name) {
+    default N addParameter(Type type, String name) {
         return addParameter(new Parameter(type, new VariableDeclaratorId(name)));
     }
 
-    default T addParameter(Class<?> paramClass, String name) {
+    default N addParameter(Class<?> paramClass, String name) {
         ((Node) this).tryAddImportToParentCompilationUnit(paramClass);
         return addParameter(new ClassOrInterfaceType(paramClass.getSimpleName()), name);
     }
@@ -27,14 +27,14 @@ public interface NodeWithParameters<T extends Node> {
      * @param className the name of the class, ex : org.test.Foo or Foo if you added manually the import
      * @param name the name of the parameter
      */
-    default T addParameter(String className, String name) {
+    default N addParameter(String className, String name) {
         return addParameter(new ClassOrInterfaceType(className), name);
     }
 
     @SuppressWarnings("unchecked")
-    default T addParameter(Parameter parameter) {
+    default N addParameter(Parameter parameter) {
         getParameters().add(parameter);
-        return (T) this;
+        return (N) this;
     }
 
     default Parameter addAndGetParameter(Type type, String name) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
@@ -1,7 +1,5 @@
 package com.github.javaparser.ast.nodeTypes;
 
-import java.util.List;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.Parameter;
@@ -9,7 +7,7 @@ import com.github.javaparser.ast.body.VariableDeclaratorId;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 
-public interface NodeWithParameters<T> {
+public interface NodeWithParameters<T extends Node> {
     NodeList<Parameter> getParameters();
 
     T setParameters(NodeList<Parameter> parameters);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
@@ -7,7 +7,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 
-public interface NodeWithStatements<T> {
+public interface NodeWithStatements<T extends Node> {
     NodeList<Statement> getStmts();
 
     T setStmts(final NodeList<Statement> stmts);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
@@ -7,36 +7,36 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 
-public interface NodeWithStatements<T extends Node> {
+public interface NodeWithStatements<N extends Node> {
     NodeList<Statement> getStmts();
 
-    T setStmts(final NodeList<Statement> stmts);
+    N setStmts(final NodeList<Statement> stmts);
 
     @SuppressWarnings("unchecked")
-    default T addStatement(Statement statement) {
+    default N addStatement(Statement statement) {
         getStmts().add(statement);
         statement.setParentNode((Node) this);
-        return (T) this;
+        return (N) this;
     }
 
     @SuppressWarnings("unchecked")
-    default T addStatement(int index, final Statement statement) {
+    default N addStatement(int index, final Statement statement) {
         getStmts().add(index, statement);
         statement.setParentNode((Node) this);
-        return (T) this;
+        return (N) this;
     }
 
-    default T addStatement(Expression expr) {
+    default N addStatement(Expression expr) {
         ExpressionStmt statement = new ExpressionStmt(expr);
         expr.setParentNode(statement);
         return addStatement(statement);
     }
 
-    default T addStatement(String statement) {
+    default N addStatement(String statement) {
         return addStatement(new NameExpr(statement));
     }
 
-    default T addStatement(int index, final Expression expr) {
+    default N addStatement(int index, final Expression expr) {
         Statement stmt = new ExpressionStmt(expr);
         expr.setParentNode(stmt);
         return addStatement(index, stmt);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrowable.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrowable.java
@@ -5,7 +5,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
 
-public interface NodeWithThrowable<T> {
+public interface NodeWithThrowable<T extends Node> {
     T setThrows(NodeList<ReferenceType<?>> throws_);
 
     NodeList<ReferenceType<?>> getThrows();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrowable.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrowable.java
@@ -5,8 +5,8 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
 
-public interface NodeWithThrowable<T extends Node> {
-    T setThrows(NodeList<ReferenceType<?>> throws_);
+public interface NodeWithThrowable<N extends Node> {
+    N setThrows(NodeList<ReferenceType<?>> throws_);
 
     NodeList<ReferenceType<?>> getThrows();
 
@@ -17,10 +17,10 @@ public interface NodeWithThrowable<T extends Node> {
      * @return this
      */
     @SuppressWarnings("unchecked")
-    default T addThrows(ReferenceType<?> throwType) {
+    default N addThrows(ReferenceType<?> throwType) {
         getThrows().add(throwType);
         throwType.setParentNode((Node) this);
-        return (T) this;
+        return (N) this;
     }
 
     /**
@@ -29,7 +29,7 @@ public interface NodeWithThrowable<T extends Node> {
      * @param clazz the exception class
      * @return this
      */
-    default T addThrows(Class<? extends Throwable> clazz) {
+    default N addThrows(Class<? extends Throwable> clazz) {
         ((Node) this).tryAddImportToParentCompilationUnit(clazz);
         return addThrows(new ClassOrInterfaceType(clazz.getSimpleName()));
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
@@ -34,7 +34,7 @@ import com.github.javaparser.ast.type.Type;
  *
  * @since 2.3.1
  */
-public interface NodeWithType<N, T extends Type<?>> {
+public interface NodeWithType<N extends Node, T extends Type<?>> {
     /**
      * Gets the type
      * 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeArguments.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeArguments.java
@@ -35,7 +35,7 @@ import static com.github.javaparser.ast.NodeList.nodeList;
  *     new X&lt;C,D>();   --> typeArguments = [C,D], diamondOperator = false
  * </pre>
  */
-public interface NodeWithTypeArguments<T extends Node> {
+public interface NodeWithTypeArguments<N extends Node> {
     /**
      * @return the types that can be found in the type arguments: &lt;String, Integer>.
      */
@@ -47,7 +47,7 @@ public interface NodeWithTypeArguments<T extends Node> {
      * @param typeArguments The list of types of the generics
      */
     // TODO nullable
-    T setTypeArguments(NodeList<Type<?>> typeArguments);
+    N setTypeArguments(NodeList<Type<?>> typeArguments);
 
     /**
      * @return whether the type arguments look like &lt;>.
@@ -63,23 +63,23 @@ public interface NodeWithTypeArguments<T extends Node> {
      * Sets the type arguments to &lt>.
      */
     @SuppressWarnings("unchecked")
-    default T setDiamondOperator() {
+    default N setDiamondOperator() {
         setTypeArguments(new NodeList<>());
-        return (T) this;
+        return (N) this;
     }
 
     /**
      * Removes all type arguments, including the surrounding &lt;>.
      */
     @SuppressWarnings("unchecked")
-    default T removeTypeArguments() {
+    default N removeTypeArguments() {
         setTypeArguments((NodeList<Type<?>>) null);
-        return (T) this;
+        return (N) this;
     }
 
     @SuppressWarnings("unchecked")
-    default T setTypeArguments(Type<?>... typeArguments) {
+    default N setTypeArguments(Type<?>... typeArguments) {
         setTypeArguments(nodeList(typeArguments));
-        return (T) this;
+        return (N) this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeArguments.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeArguments.java
@@ -21,10 +21,11 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
-import static com.github.javaparser.ast.NodeList.*;
-
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.Type;
+
+import static com.github.javaparser.ast.NodeList.nodeList;
 
 /**
  * A node that can have type arguments.
@@ -34,7 +35,7 @@ import com.github.javaparser.ast.type.Type;
  *     new X&lt;C,D>();   --> typeArguments = [C,D], diamondOperator = false
  * </pre>
  */
-public interface NodeWithTypeArguments<T> {
+public interface NodeWithTypeArguments<T extends Node> {
     /**
      * @return the types that can be found in the type arguments: &lt;String, Integer>.
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeParameters.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeParameters.java
@@ -12,10 +12,10 @@ import com.github.javaparser.ast.type.TypeParameter;
  *     class X&lt;C,D> {}   --> typeParameters = [C,D] 
  * </pre>
  */
-public interface NodeWithTypeParameters<T extends Node> {
+public interface NodeWithTypeParameters<N extends Node> {
     NodeList<TypeParameter> getTypeParameters();
 
-    T setTypeParameters(NodeList<TypeParameter> typeParameters);
+    N setTypeParameters(NodeList<TypeParameter> typeParameters);
 
     default boolean isGeneric() {
         return getTypeParameters().size() > 0;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeParameters.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeParameters.java
@@ -1,5 +1,6 @@
 package com.github.javaparser.ast.nodeTypes;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.TypeParameter;
 
@@ -11,7 +12,7 @@ import com.github.javaparser.ast.type.TypeParameter;
  *     class X&lt;C,D> {}   --> typeParameters = [C,D] 
  * </pre>
  */
-public interface NodeWithTypeParameters<T> {
+public interface NodeWithTypeParameters<T extends Node> {
     NodeList<TypeParameter> getTypeParameters();
 
     T setTypeParameters(NodeList<TypeParameter> typeParameters);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
@@ -21,16 +21,14 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
-
-import java.util.List;
 
 /**
  * A node which has a list of variables.
  */
-public interface NodeWithVariables<T> {
+public interface NodeWithVariables<T extends Node> {
     NodeList<VariableDeclarator> getVariables();
 
     T setVariables(NodeList<VariableDeclarator> variables);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
@@ -28,8 +28,8 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 /**
  * A node which has a list of variables.
  */
-public interface NodeWithVariables<T extends Node> {
+public interface NodeWithVariables<N extends Node> {
     NodeList<VariableDeclarator> getVariables();
 
-    T setVariables(NodeList<VariableDeclarator> variables);
+    N setVariables(NodeList<VariableDeclarator> variables);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -1260,11 +1260,13 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @SuppressWarnings("unchecked")
     protected <T extends Node> T cloneNode(T _node, Object _arg) {
-        if (_node == null)
-            return null;
-        Node r = (Node)_node.accept(this, _arg);
-        if (r == null)
-            return null;
+        if (_node == null) {
+			return null;
+		}
+        Node r = (Node) _node.accept(this, _arg);
+        if (r == null) {
+			return null;
+		}
         return (T) r;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -1261,12 +1261,12 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @SuppressWarnings("unchecked")
     protected <T extends Node> T cloneNode(T _node, Object _arg) {
         if (_node == null) {
-			return null;
-		}
+            return null;
+        }
         Node r = (Node) _node.accept(this, _arg);
         if (r == null) {
-			return null;
-		}
+            return null;
+        }
         return (T) r;
     }
 


### PR DESCRIPTION
I started with the intention of changing some casts to use `Class.cast` but I found just one of those. In the process I changed a few minor things.

The biggest thing is that all node types (but NodeWithDeclaration) has as type parameter `N extends Node` while before it was `T`