### PR TITLE
Get rid of infuriating useless <?> on Type

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -51,12 +51,12 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 public final class AnnotationMemberDeclaration extends BodyDeclaration<AnnotationMemberDeclaration> implements
         NodeWithJavaDoc<AnnotationMemberDeclaration>,
         NodeWithSimpleName<AnnotationMemberDeclaration>,
-        NodeWithType<AnnotationMemberDeclaration, Type<?>>,
+        NodeWithType<AnnotationMemberDeclaration, Type>,
         NodeWithModifiers<AnnotationMemberDeclaration> {
 
     private EnumSet<Modifier> modifiers;
 
-    private Type<?> type;
+    private Type type;
 
     private SimpleName name;
 
@@ -71,7 +71,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
                 null);
     }
 
-    public AnnotationMemberDeclaration(EnumSet<Modifier> modifiers, Type<?> type, String name, Expression defaultValue) {
+    public AnnotationMemberDeclaration(EnumSet<Modifier> modifiers, Type type, String name, Expression defaultValue) {
         this(null,
                 modifiers,
                 new NodeList<>(),
@@ -80,7 +80,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
                 defaultValue);
     }
 
-    public AnnotationMemberDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type<?> type, SimpleName name,
+    public AnnotationMemberDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, SimpleName name,
                                        Expression defaultValue) {
         this(null,
                 modifiers,
@@ -130,7 +130,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
     }
 
     @Override
-    public Type<?> getType() {
+    public Type getType() {
         return type;
     }
 
@@ -162,7 +162,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
     }
 
     @Override
-    public AnnotationMemberDeclaration setType(Type<?> type) {
+    public AnnotationMemberDeclaration setType(Type type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = assertNotNull(type);
         setAsParentNodeOf(type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -65,7 +65,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
 
     private NodeList<Parameter> parameters;
 
-    private NodeList<ReferenceType<?>> thrownExceptions;
+    private NodeList<ReferenceType> thrownExceptions;
 
     private BlockStmt body;
 
@@ -93,7 +93,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
 
     public ConstructorDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations,
                                   NodeList<TypeParameter> typeParameters,
-                                  SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType<?>> thrownExceptions,
+                                  SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions,
                                   BlockStmt block) {
         this(null,
                 modifiers,
@@ -107,7 +107,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
 
     public ConstructorDeclaration(Range range, EnumSet<Modifier> modifiers,
                                   NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name,
-                                  NodeList<Parameter> parameters, NodeList<ReferenceType<?>> thrownExceptions, BlockStmt block) {
+                                  NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt block) {
         super(range, annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
@@ -149,7 +149,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
     }
 
     @Override
-    public NodeList<ReferenceType<?>> getThrownExceptions() {
+    public NodeList<ReferenceType> getThrownExceptions() {
         return thrownExceptions;
     }
 
@@ -180,7 +180,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
     }
 
     @Override
-    public ConstructorDeclaration setThrownExceptions(NodeList<ReferenceType<?>> thrownExceptions) {
+    public ConstructorDeclaration setThrownExceptions(NodeList<ReferenceType> thrownExceptions) {
         notifyPropertyChange(ObservableProperty.THROWN_TYPES, this.thrownExceptions, thrownExceptions);
         this.thrownExceptions = assertNotNull(thrownExceptions);
         setAsParentNodeOf(this.thrownExceptions);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -105,7 +105,7 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
      * @param type type
      * @param name field name
      */
-    public FieldDeclaration(EnumSet<Modifier> modifiers, Type<?> type, String name) {
+    public FieldDeclaration(EnumSet<Modifier> modifiers, Type type, String name) {
         this(assertNotNull(modifiers), new VariableDeclarator(type, assertNotNull(name)));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -54,7 +54,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
         NodeWithJavaDoc<MethodDeclaration>,
         NodeWithDeclaration,
         NodeWithSimpleName<MethodDeclaration>,
-        NodeWithType<MethodDeclaration, Type<?>>,
+        NodeWithType<MethodDeclaration, Type>,
         NodeWithModifiers<MethodDeclaration>,
         NodeWithParameters<MethodDeclaration>,
         NodeWithThrownExceptions<MethodDeclaration>,
@@ -69,13 +69,13 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
 
     private NodeList<Parameter> parameters;
 
-    private NodeList<ReferenceType<?>> thrownExceptions;
+    private NodeList<ReferenceType> thrownExceptions;
 
     private BlockStmt body;
 
     private boolean isDefault;
 
-    private Type<?> type;
+    private Type type;
 
     public MethodDeclaration() {
         this(null,
@@ -90,7 +90,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                 new BlockStmt());
     }
 
-    public MethodDeclaration(final EnumSet<Modifier> modifiers, final Type<?> type, final String name) {
+    public MethodDeclaration(final EnumSet<Modifier> modifiers, final Type type, final String name) {
         this(null,
                 modifiers,
                 new NodeList<>(),
@@ -103,7 +103,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                 new BlockStmt());
     }
 
-    public MethodDeclaration(final EnumSet<Modifier> modifiers, final String name, final Type<?> type,
+    public MethodDeclaration(final EnumSet<Modifier> modifiers, final String name, final Type type,
                              final NodeList<Parameter> parameters) {
         this(null,
                 modifiers,
@@ -120,11 +120,11 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
     public MethodDeclaration(final EnumSet<Modifier> modifiers,
                              final NodeList<AnnotationExpr> annotations,
                              final NodeList<TypeParameter> typeParameters,
-                             final Type<?> type,
+                             final Type type,
                              final SimpleName name,
                              final boolean isDefault,
                              final NodeList<Parameter> parameters,
-                             final NodeList<ReferenceType<?>> thrownExceptions,
+                             final NodeList<ReferenceType> thrownExceptions,
                              final BlockStmt body) {
         this(null,
                 modifiers,
@@ -142,11 +142,11 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
                              final EnumSet<Modifier> modifiers,
                              final NodeList<AnnotationExpr> annotations,
                              final NodeList<TypeParameter> typeParameters,
-                             final Type<?> type,
+                             final Type type,
                              final SimpleName name,
                              final boolean isDefault,
                              final NodeList<Parameter> parameters,
-                             final NodeList<ReferenceType<?>> thrownExceptions,
+                             final NodeList<ReferenceType> thrownExceptions,
                              final BlockStmt body) {
         super(range, annotations);
         setModifiers(modifiers);
@@ -196,7 +196,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
     }
 
     @Override
-    public NodeList<ReferenceType<?>> getThrownExceptions() {
+    public NodeList<ReferenceType> getThrownExceptions() {
         return thrownExceptions;
     }
 
@@ -243,7 +243,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
     }
 
     @Override
-    public MethodDeclaration setThrownExceptions(final NodeList<ReferenceType<?>> thrownExceptions) {
+    public MethodDeclaration setThrownExceptions(final NodeList<ReferenceType> thrownExceptions) {
         notifyPropertyChange(ObservableProperty.THROWN_TYPES, this.thrownExceptions, thrownExceptions);
         this.thrownExceptions = assertNotNull(thrownExceptions);
         setAsParentNodeOf(this.thrownExceptions);
@@ -251,12 +251,12 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
     }
 
     @Override
-    public Type<?> getType() {
+    public Type getType() {
         return type;
     }
 
     @Override
-    public MethodDeclaration setType(Type<?> type) {
+    public MethodDeclaration setType(Type type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = type;
         setAsParentNodeOf(this.type);
@@ -347,7 +347,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
         sb.append(")");
         if (includingThrows) {
             boolean firstThrow = true;
-            for (ReferenceType<?> thr : getThrownExceptions()) {
+            for (ReferenceType thr : getThrownExceptions()) {
                 if (firstThrow) {
                     firstThrow = false;
                     sb.append(" throws ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -48,12 +48,12 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * @author Julio Vilmar Gesser
  */
 public final class Parameter extends Node implements
-        NodeWithType<Parameter,Type<?>>,
+        NodeWithType<Parameter,Type>,
         NodeWithAnnotations<Parameter>,
         NodeWithSimpleName<Parameter>,
         NodeWithModifiers<Parameter> {
 
-    private Type<?> type;
+    private Type type;
 
     private boolean isVarArgs;
 
@@ -72,7 +72,7 @@ public final class Parameter extends Node implements
                 new SimpleName());
     }
 
-    public Parameter(Type<?> type, SimpleName name) {
+    public Parameter(Type type, SimpleName name) {
         this(null,
                 EnumSet.noneOf(Modifier.class),
                 new NodeList<>(),
@@ -87,7 +87,7 @@ public final class Parameter extends Node implements
      * @param type type of the parameter
      * @param name name of the parameter
      */
-    public Parameter(Type<?> type, String name) {
+    public Parameter(Type type, String name) {
         this(null,
                 EnumSet.noneOf(Modifier.class),
                 new NodeList<>(),
@@ -96,7 +96,7 @@ public final class Parameter extends Node implements
                 new SimpleName(name));
     }
 
-    public Parameter(EnumSet<Modifier> modifiers, Type<?> type, SimpleName name) {
+    public Parameter(EnumSet<Modifier> modifiers, Type type, SimpleName name) {
         this(null,
                 modifiers,
                 new NodeList<>(),
@@ -108,7 +108,7 @@ public final class Parameter extends Node implements
     public Parameter(final Range range,
                      EnumSet<Modifier> modifiers,
                      NodeList<AnnotationExpr> annotations,
-                     Type<?> type,
+                     Type type,
                      boolean isVarArgs,
                      SimpleName name) {
         super(range);
@@ -130,7 +130,7 @@ public final class Parameter extends Node implements
     }
 
     @Override
-    public Type<?> getType() {
+    public Type getType() {
         return type;
     }
     
@@ -139,7 +139,7 @@ public final class Parameter extends Node implements
     }
 
     @Override
-    public Parameter setType(Type<?> type) {
+    public Parameter setType(Type type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = type;
         setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -44,24 +44,24 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * @author Julio Vilmar Gesser
  */
 public final class VariableDeclarator extends Node implements
-        NodeWithType<VariableDeclarator, Type<?>>,
+        NodeWithType<VariableDeclarator, Type>,
         NodeWithSimpleName<VariableDeclarator> {
 
     private SimpleName name;
 
     private Expression initializer;
 
-    private Type<?> type;
+    private Type type;
 
     public VariableDeclarator() {
         this(null, new SimpleName(), null);
     }
 
-    public VariableDeclarator(Type<?> type, SimpleName name) {
+    public VariableDeclarator(Type type, SimpleName name) {
         this(null, type, name, null);
     }
 
-    public VariableDeclarator(Type<?> type, String variableName) {
+    public VariableDeclarator(Type type, String variableName) {
         this(null, type, new SimpleName(variableName), null);
     }
 
@@ -72,15 +72,15 @@ public final class VariableDeclarator extends Node implements
      * @param initializer What this variable should be initialized to. An {@link com.github.javaparser.ast.expr.AssignExpr}
      * is unnecessary as the <code>=</code> operator is already added.
      */
-    public VariableDeclarator(Type<?> type, SimpleName name, Expression initializer) {
+    public VariableDeclarator(Type type, SimpleName name, Expression initializer) {
         this(null, type, name, initializer);
     }
 
-    public VariableDeclarator(Type<?> type, String variableName, Expression initializer) {
+    public VariableDeclarator(Type type, String variableName, Expression initializer) {
         this(null, type, new SimpleName(variableName), initializer);
     }
 
-    public VariableDeclarator(Range range, Type<?> type, SimpleName name, Expression initializer) {
+    public VariableDeclarator(Range range, Type type, SimpleName name, Expression initializer) {
         super(range);
         setName(name);
         setInitializer(initializer);
@@ -138,12 +138,12 @@ public final class VariableDeclarator extends Node implements
     }
 
     @Override
-    public Type<?> getType() {
+    public Type getType() {
         return type;
     }
 
     @Override
-    public VariableDeclarator setType(Type<?> type) {
+    public VariableDeclarator setType(Type type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = type;
         setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -48,7 +48,7 @@ public final class ArrayCreationExpr extends Expression {
 
     private NodeList<ArrayCreationLevel> levels;
 
-    private Type<?> elementType;
+    private Type elementType;
 
     private ArrayInitializerExpr initializer;
 
@@ -59,28 +59,28 @@ public final class ArrayCreationExpr extends Expression {
                 new ArrayInitializerExpr());
     }
 
-    public ArrayCreationExpr(Type<?> elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
+    public ArrayCreationExpr(Type elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
         this(null,
                 elementType,
                 levels,
                 initializer);
     }
 
-    public ArrayCreationExpr(Type<?> elementType) {
+    public ArrayCreationExpr(Type elementType) {
         this(null,
                 elementType,
                 new NodeList<>(),
                 new ArrayInitializerExpr());
     }
 
-    public ArrayCreationExpr(Range range, Type<?> elementType) {
+    public ArrayCreationExpr(Range range, Type elementType) {
         this(range,
                 elementType,
                 new NodeList<>(),
                 new ArrayInitializerExpr());
     }
 
-    public ArrayCreationExpr(Range range, Type<?> elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
+    public ArrayCreationExpr(Range range, Type elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
         super(range);
         setLevels(levels);
         setElementType(elementType);
@@ -101,7 +101,7 @@ public final class ArrayCreationExpr extends Expression {
         return Optional.ofNullable(initializer);
     }
 
-    public Type<?> getElementType() {
+    public Type getElementType() {
         return elementType;
     }
 
@@ -118,7 +118,7 @@ public final class ArrayCreationExpr extends Expression {
         return this;
     }
 
-    public ArrayCreationExpr setElementType(Type<?> elementType) {
+    public ArrayCreationExpr setElementType(Type elementType) {
         notifyPropertyChange(ObservableProperty.ELEMENT_TYPE, this.elementType, elementType);
         this.elementType = assertNotNull(elementType);
         setAsParentNodeOf(this.elementType);
@@ -139,8 +139,8 @@ public final class ArrayCreationExpr extends Expression {
     /**
      * Takes the element type and wraps it in an ArrayType for every array creation level.
      */
-    public Type<?> createdType() {
-        Type<?> result = elementType;
+    public Type createdType() {
+        Type result = elementType;
         for (int i = 0; i < levels.size(); i++) {
             result = new ArrayType(result, new NodeList<>());
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
@@ -36,10 +36,10 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * @author Julio Vilmar Gesser
  */
 public final class CastExpr extends Expression implements
-        NodeWithType<CastExpr, Type<?>>,
+        NodeWithType<CastExpr, Type>,
         NodeWithExpression<CastExpr> {
 
-    private Type<?> type;
+    private Type type;
 
     private Expression expression;
 
@@ -47,11 +47,11 @@ public final class CastExpr extends Expression implements
         this(null, new ClassOrInterfaceType(), new NameExpr());
     }
 
-    public CastExpr(Type<?> type, Expression expression) {
+    public CastExpr(Type type, Expression expression) {
         this(null, type, expression);
     }
 
-    public CastExpr(Range range, Type<?> type, Expression expression) {
+    public CastExpr(Range range, Type type, Expression expression) {
         super(range);
         setType(type);
         setExpression(expression);
@@ -73,7 +73,7 @@ public final class CastExpr extends Expression implements
     }
 
     @Override
-    public Type<?> getType() {
+    public Type getType() {
         return type;
     }
 
@@ -86,7 +86,7 @@ public final class CastExpr extends Expression implements
     }
 
     @Override
-    public CastExpr setType(Type<?> type) {
+    public CastExpr setType(Type type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = assertNotNull(type);
         setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
@@ -38,15 +38,15 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ClassExpr extends Expression implements NodeWithType<ClassExpr, Type<?>> {
+public final class ClassExpr extends Expression implements NodeWithType<ClassExpr, Type> {
 
-    private Type<?> type;
+    private Type type;
 
     public ClassExpr() {
         this(null, new ClassOrInterfaceType());
     }
 
-    public ClassExpr(Type<?> type) {
+    public ClassExpr(Type type) {
         this(null, type);
     }
 
@@ -66,12 +66,12 @@ public final class ClassExpr extends Expression implements NodeWithType<ClassExp
     }
 
     @Override
-    public Type<?> getType() {
+    public Type getType() {
         return type;
     }
 
     @Override
-    public ClassExpr setType(Type<?> type) {
+    public ClassExpr setType(Type type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = type;
         setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -40,7 +40,7 @@ public final class FieldAccessExpr extends Expression implements NodeWithTypeArg
 
     private Expression scope;
 
-    private NodeList<Type<?>> typeArguments;
+    private NodeList<Type> typeArguments;
 
     private SimpleName field;
 
@@ -52,7 +52,7 @@ public final class FieldAccessExpr extends Expression implements NodeWithTypeArg
         this(null, scope, new NodeList<>(), new SimpleName(field));
     }
 
-    public FieldAccessExpr(final Range range, final Expression scope, final NodeList<Type<?>> typeArguments,
+    public FieldAccessExpr(final Range range, final Expression scope, final NodeList<Type> typeArguments,
                            final SimpleName field) {
         super(range);
         setScope(scope);
@@ -104,7 +104,7 @@ public final class FieldAccessExpr extends Expression implements NodeWithTypeArg
     }
 
     @Override
-    public Optional<NodeList<Type<?>>> getTypeArguments() {
+    public Optional<NodeList<Type>> getTypeArguments() {
         return Optional.ofNullable(typeArguments);
     }
 
@@ -115,7 +115,7 @@ public final class FieldAccessExpr extends Expression implements NodeWithTypeArg
      * @return this, the FieldAccessExpr
      */
     @Override
-    public FieldAccessExpr setTypeArguments(final NodeList<Type<?>> types) {
+    public FieldAccessExpr setTypeArguments(final NodeList<Type> types) {
         notifyPropertyChange(ObservableProperty.TYPE_ARGUMENTS, this.typeArguments, typeArguments);
         this.typeArguments = types;
         setAsParentNodeOf(this.typeArguments);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -36,22 +36,22 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * @author Julio Vilmar Gesser
  */
 public final class InstanceOfExpr extends Expression implements
-        NodeWithType<InstanceOfExpr, ReferenceType<?>>,
+        NodeWithType<InstanceOfExpr, ReferenceType>,
         NodeWithExpression<InstanceOfExpr> {
 
     private Expression expression;
 
-    private ReferenceType<?> type;
+    private ReferenceType type;
 
     public InstanceOfExpr() {
         this(null, new NameExpr(), new ClassOrInterfaceType());
     }
 
-    public InstanceOfExpr(final Expression expression, final ReferenceType<?> type) {
+    public InstanceOfExpr(final Expression expression, final ReferenceType type) {
         this(null, expression, type);
     }
 
-    public InstanceOfExpr(final Range range, final Expression expression, final ReferenceType<?> type) {
+    public InstanceOfExpr(final Range range, final Expression expression, final ReferenceType type) {
         super(range);
         setExpression(expression);
         setType(type);
@@ -73,7 +73,7 @@ public final class InstanceOfExpr extends Expression implements
     }
 
     @Override
-    public ReferenceType<?> getType() {
+    public ReferenceType getType() {
         return type;
     }
 
@@ -86,7 +86,7 @@ public final class InstanceOfExpr extends Expression implements
     }
 
     @Override
-    public InstanceOfExpr setType(final ReferenceType<?> type) {
+    public InstanceOfExpr setType(final ReferenceType type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = assertNotNull(type);
         setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -45,7 +45,7 @@ public final class MethodCallExpr extends Expression implements
 
     private Expression scope;
 
-    private NodeList<Type<?>> typeArguments;
+    private NodeList<Type> typeArguments;
 
     private SimpleName name;
 
@@ -75,7 +75,7 @@ public final class MethodCallExpr extends Expression implements
                 arguments);
     }
 
-    public MethodCallExpr(final Range range, final Expression scope, final NodeList<Type<?>> typeArguments, final SimpleName name, final NodeList<Expression> arguments) {
+    public MethodCallExpr(final Range range, final Expression scope, final NodeList<Type> typeArguments, final SimpleName name, final NodeList<Expression> arguments) {
         super(range);
         setScope(scope);
         setTypeArguments(typeArguments);
@@ -129,7 +129,7 @@ public final class MethodCallExpr extends Expression implements
     }
 
     @Override
-    public Optional<NodeList<Type<?>>> getTypeArguments() {
+    public Optional<NodeList<Type>> getTypeArguments() {
         return Optional.ofNullable(typeArguments);
     }
 
@@ -140,7 +140,7 @@ public final class MethodCallExpr extends Expression implements
      * @return this, the MethodCallExpr
      */
     @Override
-    public MethodCallExpr setTypeArguments(final NodeList<Type<?>> typeArguments) {
+    public MethodCallExpr setTypeArguments(final NodeList<Type> typeArguments) {
         notifyPropertyChange(ObservableProperty.TYPE_ARGUMENTS, this.typeArguments, typeArguments);
         this.typeArguments = typeArguments;
         setAsParentNodeOf(this.typeArguments);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
@@ -48,7 +48,7 @@ public class MethodReferenceExpr extends Expression implements
 
     private Expression scope;
 
-    private NodeList<Type<?>> typeArguments;
+    private NodeList<Type> typeArguments;
 
     private String identifier;
 
@@ -60,7 +60,7 @@ public class MethodReferenceExpr extends Expression implements
     }
 
     public MethodReferenceExpr(Range range, Expression scope,
-                               NodeList<Type<?>> typeArguments, String identifier) {
+                               NodeList<Type> typeArguments, String identifier) {
         super(range);
         setIdentifier(identifier);
         setScope(scope);
@@ -90,7 +90,7 @@ public class MethodReferenceExpr extends Expression implements
     }
 
     @Override
-    public Optional<NodeList<Type<?>>> getTypeArguments() {
+    public Optional<NodeList<Type>> getTypeArguments() {
         return Optional.ofNullable(typeArguments);
     }
 
@@ -101,7 +101,7 @@ public class MethodReferenceExpr extends Expression implements
      * @return this, the MethodReferenceExpr
      */
     @Override
-    public MethodReferenceExpr setTypeArguments(final NodeList<Type<?>> typeArguments) {
+    public MethodReferenceExpr setTypeArguments(final NodeList<Type> typeArguments) {
         notifyPropertyChange(ObservableProperty.TYPE, this.typeArguments, typeArguments);
         this.typeArguments = typeArguments;
         setAsParentNodeOf(this.typeArguments);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -55,7 +55,7 @@ public final class ObjectCreationExpr extends Expression implements
 
     private ClassOrInterfaceType type;
 
-    private NodeList<Type<?>> typeArguments;
+    private NodeList<Type> typeArguments;
 
     private NodeList<Expression> arguments;
 
@@ -89,7 +89,7 @@ public final class ObjectCreationExpr extends Expression implements
 
     public ObjectCreationExpr(final Range range,
                               final Expression scope, final ClassOrInterfaceType type,
-                              final NodeList<Type<?>> typeArguments,
+                              final NodeList<Type> typeArguments,
                               final NodeList<Expression> arguments, final NodeList<BodyDeclaration<?>> anonymousBody) {
         super(range);
         setScope(scope);
@@ -179,7 +179,7 @@ public final class ObjectCreationExpr extends Expression implements
     }
 
     @Override
-    public Optional<NodeList<Type<?>>> getTypeArguments() {
+    public Optional<NodeList<Type>> getTypeArguments() {
         return Optional.ofNullable(typeArguments);
     }
 
@@ -190,7 +190,7 @@ public final class ObjectCreationExpr extends Expression implements
      * @return this, the ObjectCreationExpr
      */
     @Override
-    public ObjectCreationExpr setTypeArguments(final NodeList<Type<?>> typeArguments) {
+    public ObjectCreationExpr setTypeArguments(final NodeList<Type> typeArguments) {
         notifyPropertyChange(ObservableProperty.TYPE_ARGUMENTS, this.typeArguments, typeArguments);
         this.typeArguments = typeArguments;
         setAsParentNodeOf(this.typeArguments);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
@@ -36,15 +36,15 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Raquel Pau
  */
-public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type<?>> {
+public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type> {
 
-    private Type<?> type;
+    private Type type;
 
     public TypeExpr() {
         this(null, new ClassOrInterfaceType());
     }
 
-    public TypeExpr(Range range, Type<?> type) {
+    public TypeExpr(Range range, Type type) {
         super(range);
         setType(type);
     }
@@ -60,12 +60,12 @@ public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type<
     }
 
     @Override
-    public Type<?> getType() {
+    public Type getType() {
         return type;
     }
 
     @Override
-    public TypeExpr setType(Type<?> type) {
+    public TypeExpr setType(Type type) {
         notifyPropertyChange(ObservableProperty.TYPE, this.type, type);
         this.type = assertNotNull(type);
         setAsParentNodeOf(this.type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -61,7 +61,7 @@ public final class VariableDeclarationExpr extends Expression implements
                 new NodeList<>());
     }
 
-    public VariableDeclarationExpr(final Type<?> type, String variableName) {
+    public VariableDeclarationExpr(final Type type, String variableName) {
         this(null,
                 EnumSet.noneOf(Modifier.class),
                 new NodeList<>(),
@@ -75,7 +75,7 @@ public final class VariableDeclarationExpr extends Expression implements
                 nodeList(var));
     }
 
-    public VariableDeclarationExpr(final Type<?> type, String variableName, Modifier... modifiers) {
+    public VariableDeclarationExpr(final Type type, String variableName, Modifier... modifiers) {
         this(null,
                 Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))),
                 new NodeList<>(),

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -65,7 +65,7 @@ public interface NodeWithMembers<N extends Node> {
      * @param modifiers the modifiers like {@link Modifier#PUBLIC}
      * @return the {@link FieldDeclaration} created
      */
-    default FieldDeclaration addField(Type<?> type, String name, Modifier... modifiers) {
+    default FieldDeclaration addField(Type type, String name, Modifier... modifiers) {
         FieldDeclaration fieldDeclaration = new FieldDeclaration();
         getMembers().add(fieldDeclaration);
         VariableDeclarator variable = new VariableDeclarator(type, name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrownExceptions.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrownExceptions.java
@@ -6,9 +6,9 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
 
 public interface NodeWithThrownExceptions<N extends Node> {
-    N setThrownExceptions(NodeList<ReferenceType<?>> thrownExceptions);
+    N setThrownExceptions(NodeList<ReferenceType> thrownExceptions);
 
-    NodeList<ReferenceType<?>> getThrownExceptions();
+    NodeList<ReferenceType> getThrownExceptions();
 
     default ReferenceType getThrownException(int i) {
         return getThrownExceptions().get(i);
@@ -21,7 +21,7 @@ public interface NodeWithThrownExceptions<N extends Node> {
      * @return this
      */
     @SuppressWarnings("unchecked")
-    default N addThrownException(ReferenceType<?> throwType) {
+    default N addThrownException(ReferenceType throwType) {
         getThrownExceptions().add(throwType);
         throwType.setParentNode((Node) this);
         return (N) this;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
@@ -34,7 +34,7 @@ import com.github.javaparser.ast.type.Type;
  *
  * @since 2.3.1
  */
-public interface NodeWithType<N extends Node, T extends Type<?>> {
+public interface NodeWithType<N extends Node, T extends Type> {
     /**
      * Gets the type
      *

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeArguments.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeArguments.java
@@ -42,14 +42,14 @@ public interface NodeWithTypeArguments<N extends Node> {
     /**
      * @return the types that can be found in the type arguments: &lt;String, Integer&gt;.
      */
-    Optional<NodeList<Type<?>>> getTypeArguments();
+    Optional<NodeList<Type>> getTypeArguments();
 
     /**
      * Allows you to set the generic arguments
      *
      * @param typeArguments The list of types of the generics, can be null
      */
-    N setTypeArguments(NodeList<Type<?>> typeArguments);
+    N setTypeArguments(NodeList<Type> typeArguments);
 
     /**
      * @return whether the type arguments look like &lt;>.
@@ -75,12 +75,12 @@ public interface NodeWithTypeArguments<N extends Node> {
      */
     @SuppressWarnings("unchecked")
     default N removeTypeArguments() {
-        setTypeArguments((NodeList<Type<?>>) null);
+        setTypeArguments((NodeList<Type>) null);
         return (N) this;
     }
 
     @SuppressWarnings("unchecked")
-    default N setTypeArguments(Type<?>... typeArguments) {
+    default N setTypeArguments(Type... typeArguments) {
         setTypeArguments(nodeList(typeArguments));
         return (N) this;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
@@ -47,12 +47,12 @@ public interface NodeWithVariables<N extends Node> {
      * <br/>For <code>int a,b[],c;</code> this is an assertion error since b is an int[], not an int.
      * <br/>For <code>int a,b;</code>, then doing setType(String) on b, this is an assertion error. It is also a situation that you don't really want.
      */
-    default Type<?> getCommonType() {
+    default Type getCommonType() {
         NodeList<VariableDeclarator> variables = getVariables();
         if (variables.isEmpty()) {
             throw new AssertionError("There is no common type since there are no variables.");
         }
-        Type<?> type = variables.get(0).getType();
+        Type type = variables.get(0).getType();
         for (int i = 1; i < variables.size(); i++) {
             if (!variables.get(i).getType().equals(type)) {
                 throw new AssertionError("The variables do not have a common type.");
@@ -68,12 +68,12 @@ public interface NodeWithVariables<N extends Node> {
      * <br/>For <code>int a,b[],c;</code> this is also int. Note: no mention of b being an array.
      * <br/>For <code>int a,b;</code>, then doing setType(String) on b, this is an assertion error. It is also a situation that you don't really want.
      */
-    default Type<?> getElementType() {
+    default Type getElementType() {
         NodeList<VariableDeclarator> variables = getVariables();
         if (variables.isEmpty()) {
             throw new AssertionError("There is no element type since there are no variables.");
         }
-        Type<?> type = variables.get(0).getType().getElementType();
+        Type type = variables.get(0).getType().getElementType();
         for (int i = 1; i < variables.size(); i++) {
             if (!variables.get(i).getType().getElementType().equals(type)) {
                 throw new AssertionError("The variables do not have a common type.");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -39,7 +39,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  */
 public final class ExplicitConstructorInvocationStmt extends Statement implements NodeWithTypeArguments<ExplicitConstructorInvocationStmt> {
 
-    private NodeList<Type<?>> typeArguments;
+    private NodeList<Type> typeArguments;
 
     private boolean isThis;
 
@@ -57,7 +57,7 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
     }
 
     public ExplicitConstructorInvocationStmt(Range range,
-                                             final NodeList<Type<?>> typeArguments, final boolean isThis,
+                                             final NodeList<Type> typeArguments, final boolean isThis,
                                              final Expression expression, final NodeList<Expression> arguments) {
         super(range);
         setTypeArguments(typeArguments);
@@ -119,7 +119,7 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
     }
 
     @Override
-    public Optional<NodeList<Type<?>>> getTypeArguments() {
+    public Optional<NodeList<Type>> getTypeArguments() {
         return Optional.ofNullable(typeArguments);
     }
 
@@ -130,7 +130,7 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
      * @return this, the ExplicitConstructorInvocationStmt
      */
     @Override
-    public ExplicitConstructorInvocationStmt setTypeArguments(final NodeList<Type<?>> typeArguments) {
+    public ExplicitConstructorInvocationStmt setTypeArguments(final NodeList<Type> typeArguments) {
         notifyPropertyChange(ObservableProperty.TYPE_ARGUMENTS, this.typeArguments, typeArguments);
         this.typeArguments = typeArguments;
         setAsParentNodeOf(this.typeArguments);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -20,18 +20,18 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * To indicate that a type is an array, it gets wrapped in an ArrayType for every array level it has.
  * So, int[][] becomes ArrayType(ArrayType(int)).
  */
-public class ArrayType extends ReferenceType<ArrayType> implements NodeWithAnnotations<ArrayType> {
+public class ArrayType extends ReferenceType implements NodeWithAnnotations<ArrayType> {
     private Type componentType;
 
-    public ArrayType(Type<?> componentType, NodeList<AnnotationExpr> annotations) {
+    public ArrayType(Type componentType, NodeList<AnnotationExpr> annotations) {
         this(null, componentType, annotations);
     }
 
-    public ArrayType(Type<?> type, AnnotationExpr... annotations) {
+    public ArrayType(Type type, AnnotationExpr... annotations) {
         this(type, nodeList(annotations));
     }
 
-    public ArrayType(Range range, Type<?> componentType, NodeList<AnnotationExpr> annotations) {
+    public ArrayType(Range range, Type componentType, NodeList<AnnotationExpr> annotations) {
         super(range);
         setComponentType(componentType);
         setAnnotations(annotations);
@@ -51,7 +51,7 @@ public class ArrayType extends ReferenceType<ArrayType> implements NodeWithAnnot
         return componentType;
     }
 
-    public ArrayType setComponentType(final Type<?> type) {
+    public ArrayType setComponentType(final Type type) {
         notifyPropertyChange(ObservableProperty.COMPONENT_TYPE, this.componentType, componentType);
         this.componentType = assertNotNull(type);
         setAsParentNodeOf(this.componentType);
@@ -82,7 +82,7 @@ public class ArrayType extends ReferenceType<ArrayType> implements NodeWithAnnot
      *
      * @return a pair of the element type, and the unwrapped ArrayTypes, if any.
      */
-    public static Pair<Type<?>, List<ArrayBracketPair>> unwrapArrayTypes(Type<?> type) {
+    public static Pair<Type, List<ArrayBracketPair>> unwrapArrayTypes(Type type) {
         final List<ArrayBracketPair> arrayBracketPairs = new ArrayList<>(0);
         while (type instanceof ArrayType) {
             ArrayType arrayType = (ArrayType) type;
@@ -123,4 +123,8 @@ public class ArrayType extends ReferenceType<ArrayType> implements NodeWithAnnot
         }
     }
 
+    @Override
+    public ArrayType setAnnotations(NodeList<AnnotationExpr> annotations) {
+        return (ArrayType) super.setAnnotations(annotations);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
@@ -38,7 +39,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class ClassOrInterfaceType extends ReferenceType<ClassOrInterfaceType> implements
+public final class ClassOrInterfaceType extends ReferenceType implements
         NodeWithSimpleName<ClassOrInterfaceType>,
         NodeWithAnnotations<ClassOrInterfaceType>,
         NodeWithTypeArguments<ClassOrInterfaceType> {
@@ -47,7 +48,7 @@ public final class ClassOrInterfaceType extends ReferenceType<ClassOrInterfaceTy
 
     private SimpleName name;
 
-    private NodeList<Type<?>> typeArguments;
+    private NodeList<Type> typeArguments;
 
     public ClassOrInterfaceType() {
         this(null,
@@ -71,7 +72,7 @@ public final class ClassOrInterfaceType extends ReferenceType<ClassOrInterfaceTy
     }
 
     public ClassOrInterfaceType(final Range range, final ClassOrInterfaceType scope, final SimpleName name,
-                                final NodeList<Type<?>> typeArguments) {
+                                final NodeList<Type> typeArguments) {
         super(range);
         setScope(scope);
         setName(name);
@@ -98,14 +99,14 @@ public final class ClassOrInterfaceType extends ReferenceType<ClassOrInterfaceTy
     }
 
     public boolean isBoxedType() {
-        return PrimitiveType.unboxMap.containsKey(name);
+        return PrimitiveType.unboxMap.containsKey(name.getIdentifier());
     }
 
     public PrimitiveType toUnboxedType() throws UnsupportedOperationException {
         if (!isBoxedType()) {
             throw new UnsupportedOperationException(name + " isn't a boxed type.");
         }
-        return new PrimitiveType(PrimitiveType.unboxMap.get(name));
+        return new PrimitiveType(PrimitiveType.unboxMap.get(name.getIdentifier()));
     }
 
     @Override
@@ -129,7 +130,7 @@ public final class ClassOrInterfaceType extends ReferenceType<ClassOrInterfaceTy
     }
 
     @Override
-    public Optional<NodeList<Type<?>>> getTypeArguments() {
+    public Optional<NodeList<Type>> getTypeArguments() {
         return Optional.ofNullable(typeArguments);
     }
 
@@ -140,10 +141,15 @@ public final class ClassOrInterfaceType extends ReferenceType<ClassOrInterfaceTy
      * @return this, the ClassOrInterfaceType
      */
     @Override
-    public ClassOrInterfaceType setTypeArguments(final NodeList<Type<?>> typeArguments) {
+    public ClassOrInterfaceType setTypeArguments(final NodeList<Type> typeArguments) {
         notifyPropertyChange(ObservableProperty.TYPE_ARGUMENTS, this.typeArguments, typeArguments);
         this.typeArguments = typeArguments;
         setAsParentNodeOf(this.typeArguments);
         return this;
+    }
+
+    @Override
+    public ClassOrInterfaceType setAnnotations(NodeList<AnnotationExpr> annotations) {
+        return (ClassOrInterfaceType) super.setAnnotations(annotations);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -2,6 +2,7 @@ package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -21,15 +22,15 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @since 3.0.0
  */
-public class IntersectionType extends Type<IntersectionType> implements NodeWithAnnotations<IntersectionType> {
+public class IntersectionType extends Type implements NodeWithAnnotations<IntersectionType> {
 
-    private NodeList<ReferenceType<?>> elements;
+    private NodeList<ReferenceType> elements;
 
-    public IntersectionType(NodeList<ReferenceType<?>> elements) {
+    public IntersectionType(NodeList<ReferenceType> elements) {
         this(null, elements);
     }
 
-    public IntersectionType(Range range, NodeList<ReferenceType<?>> elements) {
+    public IntersectionType(Range range, NodeList<ReferenceType> elements) {
         super(range, new NodeList<>());
         setElements(elements);
     }
@@ -44,14 +45,19 @@ public class IntersectionType extends Type<IntersectionType> implements NodeWith
         v.visit(this, arg);
     }
 
-    public NodeList<ReferenceType<?>> getElements() {
+    public NodeList<ReferenceType> getElements() {
         return elements;
     }
 
-    public IntersectionType setElements(NodeList<ReferenceType<?>> elements) {
+    public IntersectionType setElements(NodeList<ReferenceType> elements) {
         notifyPropertyChange(ObservableProperty.ELEMENTS, this.elements, elements);
         this.elements = assertNotNull(elements);
         setAsParentNodeOf(this.elements);
         return this;
+    }
+
+    @Override
+    public IntersectionType setAnnotations(NodeList<AnnotationExpr> annotations) {
+        return (IntersectionType) super.setAnnotations(annotations);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -33,7 +34,7 @@ import java.util.HashMap;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class PrimitiveType extends Type<PrimitiveType> implements NodeWithAnnotations<PrimitiveType> {
+public final class PrimitiveType extends Type implements NodeWithAnnotations<PrimitiveType> {
 
     public static final PrimitiveType BYTE_TYPE = new PrimitiveType(Primitive.BYTE);
 
@@ -127,5 +128,10 @@ public final class PrimitiveType extends Type<PrimitiveType> implements NodeWith
 
     public String asString() {
         return type.asString();
+    }
+
+    @Override
+    public PrimitiveType setAnnotations(NodeList<AnnotationExpr> annotations) {
+        return (PrimitiveType) super.setAnnotations(annotations);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -27,7 +27,7 @@ import com.github.javaparser.ast.NodeList;
 /**
  * @author Julio Vilmar Gesser
  */
-public abstract class ReferenceType<T extends ReferenceType> extends Type<T> {
+public abstract class ReferenceType<T extends ReferenceType> extends Type {
 
     public ReferenceType() {
         this(null);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -32,7 +32,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 /**
  * @author Julio Vilmar Gesser
  */
-public abstract class Type<T extends Type> extends Node {
+public abstract class Type extends Node {
 
     private NodeList<AnnotationExpr> annotations;
 
@@ -49,11 +49,11 @@ public abstract class Type<T extends Type> extends Node {
         return getAnnotations().get(i);
     }
 
-    public T setAnnotations(NodeList<AnnotationExpr> annotations) {
+    public Type setAnnotations(NodeList<AnnotationExpr> annotations) {
         notifyPropertyChange(ObservableProperty.ANNOTATIONS, this.annotations, annotations);
         this.annotations = assertNotNull(annotations);
         setAsParentNodeOf(annotations);
-        return (T) this;
+        return this;
     }
 
     /**
@@ -61,7 +61,7 @@ public abstract class Type<T extends Type> extends Node {
      * 
      * In "<code>int[] a[];</code>", the element type is int.
      */
-    public Type<?> getElementType() {
+    public Type getElementType() {
         if (this instanceof ArrayType) {
             return ((ArrayType) this).getComponentType().getElementType();
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -2,6 +2,7 @@ package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -13,28 +14,33 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * Represents a set of types. A given value of this type has to be assignable to at least one of the element types.
  * As of Java 8 it is only used in catch clauses.
  */
-public class UnionType extends Type<UnionType> implements NodeWithAnnotations<UnionType> {
+public class UnionType extends Type implements NodeWithAnnotations<UnionType> {
 
-    private NodeList<ReferenceType<?>> elements;
+    private NodeList<ReferenceType> elements;
 
-    public UnionType(Range range, NodeList<ReferenceType<?>> elements) {
+    public UnionType(Range range, NodeList<ReferenceType> elements) {
         super(range, new NodeList<>());
         setElements(elements);
     }
 
-    public UnionType(NodeList<ReferenceType<?>> elements) {
+    public UnionType(NodeList<ReferenceType> elements) {
         this(null, elements);
     }
 
-    public NodeList<ReferenceType<?>> getElements() {
+    public NodeList<ReferenceType> getElements() {
         return elements;
     }
 
-    public UnionType setElements(NodeList<ReferenceType<?>> elements) {
+    public UnionType setElements(NodeList<ReferenceType> elements) {
         notifyPropertyChange(ObservableProperty.ELEMENTS, this.elements, elements);
         this.elements = assertNotNull(elements);
         setAsParentNodeOf(this.elements);
         return this;
+    }
+
+    @Override
+    public UnionType setAnnotations(NodeList<AnnotationExpr> annotations) {
+        return (UnionType) super.setAnnotations(annotations);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -34,7 +34,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  *
  * @author Didier Villevalois
  */
-public final class UnknownType extends Type<UnknownType> {
+public final class UnknownType extends Type {
 
     public UnknownType() {
         super(null, new NodeList<>());

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -30,7 +31,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class VoidType extends Type<VoidType> implements NodeWithAnnotations<VoidType> {
+public final class VoidType extends Type implements NodeWithAnnotations<VoidType> {
 
     public static final VoidType VOID_TYPE = new VoidType();
 
@@ -50,6 +51,11 @@ public final class VoidType extends Type<VoidType> implements NodeWithAnnotation
     @Override
     public <A> void accept(final VoidVisitor<A> v, final A arg) {
         v.visit(this, arg);
+    }
+
+    @Override
+    public VoidType setAnnotations(NodeList<AnnotationExpr> annotations) {
+        return (VoidType) super.setAnnotations(annotations);
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -33,26 +34,26 @@ import java.util.Optional;
 /**
  * @author Julio Vilmar Gesser
  */
-public final class WildcardType extends Type<WildcardType> implements NodeWithAnnotations<WildcardType> {
+public final class WildcardType extends Type implements NodeWithAnnotations<WildcardType> {
 
-    private ReferenceType<?> extendedTypes;
+    private ReferenceType extendedTypes;
 
-    private ReferenceType<?> superTypes;
+    private ReferenceType superTypes;
 
     public WildcardType() {
         this(null, null, null);
     }
 
-    public WildcardType(final ReferenceType<?> extendedTypes) {
+    public WildcardType(final ReferenceType extendedTypes) {
         this(null, extendedTypes, null);
     }
 
-    public WildcardType(final ReferenceType<?> extendedTypes, final ReferenceType<?> superTypes) {
+    public WildcardType(final ReferenceType extendedTypes, final ReferenceType superTypes) {
         this(null, extendedTypes, superTypes);
     }
 
     public WildcardType(final Range range,
-                        final ReferenceType<?> extendedTypes, final ReferenceType<?> superTypes) {
+                        final ReferenceType extendedTypes, final ReferenceType superTypes) {
         super(range, new NodeList<>());
         setExtendedTypes(extendedTypes);
         setSuperTypes(superTypes);
@@ -68,11 +69,11 @@ public final class WildcardType extends Type<WildcardType> implements NodeWithAn
         v.visit(this, arg);
     }
 
-    public Optional<ReferenceType<?>> getExtendedTypes() {
+    public Optional<ReferenceType> getExtendedTypes() {
         return Optional.ofNullable(extendedTypes);
     }
 
-    public Optional<ReferenceType<?>> getSuperTypes() {
+    public Optional<ReferenceType> getSuperTypes() {
         return Optional.ofNullable(superTypes);
     }
 
@@ -82,7 +83,7 @@ public final class WildcardType extends Type<WildcardType> implements NodeWithAn
      * @param ext the extends, can be null
      * @return this, the WildcardType
      */
-    public WildcardType setExtendedTypes(final ReferenceType<?> ext) {
+    public WildcardType setExtendedTypes(final ReferenceType ext) {
         notifyPropertyChange(ObservableProperty.EXTENDED_TYPES, this.extendedTypes, ext);
         this.extendedTypes = ext;
         setAsParentNodeOf(this.extendedTypes);
@@ -95,11 +96,15 @@ public final class WildcardType extends Type<WildcardType> implements NodeWithAn
      * @param sup the super, can be null
      * @return this, the WildcardType
      */
-    public WildcardType setSuperTypes(final ReferenceType<?> sup) {
+    public WildcardType setSuperTypes(final ReferenceType sup) {
         notifyPropertyChange(ObservableProperty.SUPER, this.superTypes, sup);
         this.superTypes = sup;
         setAsParentNodeOf(this.superTypes);
         return this;
     }
 
+    @Override
+    public WildcardType setAnnotations(NodeList<AnnotationExpr> annotations) {
+        return (WildcardType) super.setAnnotations(annotations);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -155,7 +155,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(AnnotationMemberDeclaration _n, Object _arg) {
         NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
-        Type<?> type_ = cloneNode(_n.getType(), _arg);
+        Type type_ = cloneNode(_n.getType(), _arg);
         Expression defaultValue = cloneNode(_n.getDefaultValue(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -188,7 +188,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName id = cloneNode(_n.getName(), _arg);
         Expression init = cloneNode(_n.getInitializer(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
-        Type<?> type = cloneNode(_n.getType(), _arg);
+        Type type = cloneNode(_n.getType(), _arg);
 
         VariableDeclarator r = new VariableDeclarator(
                 _n.getRange().orElse(null),
@@ -205,7 +205,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
         NodeList<TypeParameter> typeParameters = cloneList(_n.getTypeParameters(), _arg);
         NodeList<Parameter> parameters = cloneList(_n.getParameters(), _arg);
-        NodeList<ReferenceType<?>> throws_ = cloneList(_n.getThrownExceptions(), _arg);
+        NodeList<ReferenceType> throws_ = cloneList(_n.getThrownExceptions(), _arg);
         BlockStmt block = cloneNode(_n.getBody(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
         SimpleName nameExpr_ = cloneNode(_n.getName(), _arg);
@@ -222,10 +222,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(MethodDeclaration _n, Object _arg) {
         NodeList<AnnotationExpr> annotations_ = cloneList(_n.getAnnotations(), _arg);
         NodeList<TypeParameter> typeParameters_ = cloneList(_n.getTypeParameters(), _arg);
-        Type<?> type_ = cloneNode(_n.getType(), _arg);
+        Type type_ = cloneNode(_n.getType(), _arg);
         SimpleName nameExpr_ = cloneNode(_n.getName(), _arg);
         NodeList<Parameter> parameters_ = cloneList(_n.getParameters(), _arg);
-        NodeList<ReferenceType<?>> throws_ = cloneList(_n.getThrownExceptions(), _arg);
+        NodeList<ReferenceType> throws_ = cloneList(_n.getThrownExceptions(), _arg);
         BlockStmt block_ = cloneNode(_n.getBody(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -248,7 +248,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(Parameter _n, Object _arg) {
         NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
-        Type<?> type_ = cloneNode(_n.getType(), _arg);
+        Type type_ = cloneNode(_n.getType(), _arg);
         SimpleName id = cloneNode(_n.getName(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -302,7 +302,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(ClassOrInterfaceType _n, Object _arg) {
         ClassOrInterfaceType scope = cloneNode(_n.getScope(), _arg);
-        NodeList<Type<?>> typeArguments = cloneList(_n.getTypeArguments().orElse(null), _arg);
+        NodeList<Type> typeArguments = cloneList(_n.getTypeArguments().orElse(null), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
         ClassOrInterfaceType r = new ClassOrInterfaceType(
@@ -332,7 +332,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(ArrayType _n, Object _arg) {
         NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
-        Type<?> type_ = cloneNode(_n.getComponentType(), _arg);
+        Type type_ = cloneNode(_n.getComponentType(), _arg);
 
         ArrayType r = new ArrayType(_n.getRange().orElse(null), type_, annotations);
         Comment comment = cloneNode(_n.getComment(), _arg);
@@ -355,7 +355,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(IntersectionType _n, Object _arg) {
         NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
-        NodeList<ReferenceType<?>> elements = cloneList(_n.getElements(), _arg);
+        NodeList<ReferenceType> elements = cloneList(_n.getElements(), _arg);
 
         IntersectionType r = new IntersectionType(_n.getRange().orElse(null), elements);
         Comment comment = cloneNode(_n.getComment(), _arg);
@@ -367,7 +367,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(UnionType _n, Object _arg) {
         NodeList<AnnotationExpr> annotations = cloneList(_n.getAnnotations(), _arg);
-        NodeList<ReferenceType<?>> elements = cloneList(_n.getElements(), _arg);
+        NodeList<ReferenceType> elements = cloneList(_n.getElements(), _arg);
 
         UnionType r = new UnionType(_n.getRange().orElse(null), elements);
         Comment comment = cloneNode(_n.getComment(), _arg);
@@ -428,7 +428,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(ArrayCreationExpr _n, Object _arg) {
-        Type<?> type_ = cloneNode(_n.getElementType(), _arg);
+        Type type_ = cloneNode(_n.getElementType(), _arg);
         NodeList<ArrayCreationLevel> levels_ = cloneList(_n.getLevels(), _arg);
         ArrayInitializerExpr initializer_ = cloneNode(_n.getInitializer(), _arg);
 
@@ -481,7 +481,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(CastExpr _n, Object _arg) {
-        Type<?> type_ = cloneNode(_n.getType(), _arg);
+        Type type_ = cloneNode(_n.getType(), _arg);
         Expression expr = cloneNode(_n.getExpression(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -495,7 +495,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(ClassExpr _n, Object _arg) {
-        Type<?> type_ = cloneNode(_n.getType(), _arg);
+        Type type_ = cloneNode(_n.getType(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
         ClassExpr r = new ClassExpr(
@@ -537,7 +537,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(FieldAccessExpr _n, Object _arg) {
         Expression scope_ = cloneNode(_n.getScope(), _arg);
-        NodeList<Type<?>> typeArguments_ = cloneList(_n.getTypeArguments().orElse(null), _arg);
+        NodeList<Type> typeArguments_ = cloneList(_n.getTypeArguments().orElse(null), _arg);
         SimpleName fieldExpr_ = cloneNode(_n.getField(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
@@ -554,7 +554,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(InstanceOfExpr _n, Object _arg) {
         Expression expr = cloneNode(_n.getExpression(), _arg);
-        ReferenceType<?> type_ = cloneNode(_n.getType(), _arg);
+        ReferenceType type_ = cloneNode(_n.getType(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
         InstanceOfExpr r = new InstanceOfExpr(
@@ -648,7 +648,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(MethodCallExpr _n, Object _arg) {
         Expression scope_ = cloneNode(_n.getScope(), _arg);
-        NodeList<Type<?>> typeArguments_ = cloneList(_n.getTypeArguments().orElse(null), _arg);
+        NodeList<Type> typeArguments_ = cloneList(_n.getTypeArguments().orElse(null), _arg);
         NodeList<Expression> args = cloneList(_n.getArguments(), _arg);
         SimpleName nameExpr = cloneNode(_n.getName(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
@@ -680,7 +680,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ObjectCreationExpr _n, Object _arg) {
         Expression scope = cloneNode(_n.getScope(), _arg);
         ClassOrInterfaceType type_ = cloneNode(_n.getType(), _arg);
-        NodeList<Type<?>> typeArguments = cloneList(_n.getTypeArguments().orElse(null), _arg);
+        NodeList<Type> typeArguments = cloneList(_n.getTypeArguments().orElse(null), _arg);
         NodeList<Expression> args = cloneList(_n.getArguments(), _arg);
         NodeList<BodyDeclaration<?>> anonymousBody = cloneList(_n.getAnonymousClassBody().orElse(null), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
@@ -823,7 +823,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(ExplicitConstructorInvocationStmt _n, Object _arg) {
-        NodeList<Type<?>> typeArguments_ = cloneList(_n.getTypeArguments().orElse(null), _arg);
+        NodeList<Type> typeArguments_ = cloneList(_n.getTypeArguments().orElse(null), _arg);
         Expression expr_ = cloneNode(_n.getExpression(), _arg);
         NodeList<Expression> args = cloneList(_n.getArguments(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
@@ -1121,7 +1121,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(MethodReferenceExpr _n, Object arg) {
 
         Expression scope = cloneNode(_n.getScope(), arg);
-        NodeList<Type<?>> typeArguments = cloneList(_n.getTypeArguments().orElse(null), arg);
+        NodeList<Type> typeArguments = cloneList(_n.getTypeArguments().orElse(null), arg);
 
         return new MethodReferenceExpr(_n.getRange().orElse(null), scope,
                 typeArguments, _n.getIdentifier());
@@ -1130,7 +1130,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(TypeExpr n, Object arg) {
 
-        Type<?> t = cloneNode(n.getType(), arg);
+        Type t = cloneNode(n.getType(), arg);
 
         return new TypeExpr(n.getRange().orElse(null), t);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -601,15 +601,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
             return false;
         }
 
-        NodeList<ReferenceType<?>> n1Elements = n1.getElements();
-        NodeList<ReferenceType<?>> n2Elements = n2.getElements();
+        NodeList<ReferenceType> n1Elements = n1.getElements();
+        NodeList<ReferenceType> n2Elements = n2.getElements();
 
         if (n1Elements != null && n2Elements != null) {
             if (n1Elements.size() != n2Elements.size()) {
                 return false;
             } else {
                 int i = 0;
-                for (ReferenceType<?> aux : n1Elements) {
+                for (ReferenceType aux : n1Elements) {
                     if (aux.accept(this, n2Elements.get(i))) {
                         return false;
                     }
@@ -630,15 +630,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
             return false;
         }
 
-        NodeList<ReferenceType<?>> n1Elements = n1.getElements();
-        NodeList<ReferenceType<?>> n2Elements = n2.getElements();
+        NodeList<ReferenceType> n1Elements = n1.getElements();
+        NodeList<ReferenceType> n2Elements = n2.getElements();
 
         if (n1Elements != null && n2Elements != null) {
             if (n1Elements.size() != n2Elements.size()) {
                 return false;
             } else {
                 int i = 0;
-                for (ReferenceType<?> aux : n1Elements) {
+                for (ReferenceType aux : n1Elements) {
                     if (aux.accept(this, n2Elements.get(i))) {
                         return false;
                     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -366,7 +366,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             }
         }
         if (n.getTypeArguments().isPresent()) {
-            for (Type<?> type : n.getTypeArguments().get()) {
+            for (Type type : n.getTypeArguments().get()) {
                 R result = type.accept(this, arg);
                 if (result != null) {
                     return result;
@@ -636,7 +636,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             }
         }
         if (n.getTypeArguments().isPresent()) {
-            for (Type<?> type : n.getTypeArguments().get()) {
+            for (Type type : n.getTypeArguments().get()) {
                 R result = type.accept(this, arg);
                 if (result != null) {
                     return result;
@@ -681,7 +681,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
         }
         {
             if (n.getTypeArguments().isPresent()) {
-                for (Type<?> type : n.getTypeArguments().get()) {
+                for (Type type : n.getTypeArguments().get()) {
                     R result = type.accept(this, arg);
                     if (result != null) {
                         return result;
@@ -901,7 +901,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             }
         }
         if (n.getTypeArguments().isPresent()) {
-            for (Type<?> type : n.getTypeArguments().get()) {
+            for (Type type : n.getTypeArguments().get()) {
                 R result = type.accept(this, arg);
                 if (result != null) {
                     return result;
@@ -961,7 +961,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             }
         }
         if (n.getThrownExceptions() != null) {
-            for (final ReferenceType<?> name : n.getThrownExceptions()) {
+            for (final ReferenceType name : n.getThrownExceptions()) {
                 {
                     R result = name.accept(this, arg);
                     if (result != null) {
@@ -1027,7 +1027,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             }
         }
         if (n.getTypeArguments().isPresent()) {
-            for (Type<?> type : n.getTypeArguments().get()) {
+            for (Type type : n.getTypeArguments().get()) {
                 R result = type.accept(this, arg);
                 if (result != null) {
                     return result;
@@ -1581,7 +1581,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
         visitComment(n, arg);
         {
             if (n.getTypeArguments().isPresent()) {
-                for (Type<?> type : n.getTypeArguments().get()) {
+                for (Type type : n.getTypeArguments().get()) {
                     R result = type.accept(this, arg);
                     if (result != null) {
                         return result;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -259,7 +259,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
         n.setAnnotations((NodeList<AnnotationExpr>) n.getAnnotations().accept(this, arg));
         n.setTypeParameters(modifyList(n.getTypeParameters(), arg));
         n.setParameters((NodeList<Parameter>) n.getParameters().accept(this, arg));
-        n.setThrownExceptions((NodeList<ReferenceType<?>>) n.getThrownExceptions().accept(this, arg));
+        n.setThrownExceptions((NodeList<ReferenceType>) n.getThrownExceptions().accept(this, arg));
         n.setBody((BlockStmt) n.getBody().accept(this, arg));
         return n;
     }
@@ -431,7 +431,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     public Visitable visit(final InstanceOfExpr n, final A arg) {
         visitComment(n, arg);
         n.setExpression((Expression) n.getExpression().accept(this, arg));
-        n.setType((ReferenceType<?>) n.getType().accept(this, arg));
+        n.setType((ReferenceType) n.getType().accept(this, arg));
         return n;
     }
 
@@ -491,7 +491,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
         n.setTypeParameters(modifyList(n.getTypeParameters(), arg));
         n.setType((Type) n.getType().accept(this, arg));
         n.setParameters((NodeList<Parameter>) n.getParameters().accept(this, arg));
-        n.setThrownExceptions((NodeList<ReferenceType<?>>) n.getThrownExceptions().accept(this, arg));
+        n.setThrownExceptions((NodeList<ReferenceType>) n.getThrownExceptions().accept(this, arg));
         if (n.getBody().isPresent()) {
             n.setBody((BlockStmt) n.getBody().get().accept(this, arg));
         }
@@ -592,7 +592,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     public Visitable visit(final IntersectionType n, final A arg) {
         visitComment(n, arg);
         visitAnnotations(n, arg);
-        n.setElements((NodeList<ReferenceType<?>>) n.getElements().accept(this, arg));
+        n.setElements((NodeList<ReferenceType>) n.getElements().accept(this, arg));
         return n;
     }
 
@@ -600,7 +600,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     public Visitable visit(final UnionType n, final A arg) {
         visitComment(n, arg);
         visitAnnotations(n, arg);
-        n.setElements((NodeList<ReferenceType<?>>) n.getElements().accept(this, arg));
+        n.setElements((NodeList<ReferenceType>) n.getElements().accept(this, arg));
         return n;
     }
 
@@ -739,7 +739,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
             return null;
         }
         n.setName(id);
-        Type<?> type = (Type) n.getType().accept(this, arg);
+        Type type = (Type) n.getType().accept(this, arg);
         if (type == null) {
             return null;
         }
@@ -802,7 +802,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     public Visitable visit(final TypeExpr n, final A arg) {
         visitComment(n, arg);
         if (n.getType() != null) {
-            n.setType((Type<?>) n.getType().accept(this, arg));
+            n.setType((Type) n.getType().accept(this, arg));
         }
         return n;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -188,7 +188,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
             n.getScope().get().accept(this, arg);
         }
         if (n.getTypeArguments().isPresent()) {
-            for (final Type<?> t : n.getTypeArguments().get()) {
+            for (final Type t : n.getTypeArguments().get()) {
                 t.accept(this, arg);
             }
         }
@@ -322,7 +322,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
             n.getExpression().get().accept(this, arg);
         }
         if (n.getTypeArguments().isPresent()) {
-            for (final Type<?> t : n.getTypeArguments().get()) {
+            for (final Type t : n.getTypeArguments().get()) {
                 t.accept(this, arg);
             }
         }
@@ -449,7 +449,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
             n.getScope().accept(this, arg);
         }
         if (n.getTypeArguments().isPresent()) {
-            for (final Type<?> t : n.getTypeArguments().get()) {
+            for (final Type t : n.getTypeArguments().get()) {
                 t.accept(this, arg);
             }
         }
@@ -478,7 +478,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
             }
         }
         if (n.getThrownExceptions() != null) {
-            for (final ReferenceType<?> name : n.getThrownExceptions()) {
+            for (final ReferenceType name : n.getThrownExceptions()) {
                 name.accept(this, arg);
             }
         }
@@ -515,7 +515,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
             n.getScope().get().accept(this, arg);
         }
         if (n.getTypeArguments().isPresent()) {
-            for (final Type<?> t : n.getTypeArguments().get()) {
+            for (final Type t : n.getTypeArguments().get()) {
                 t.accept(this, arg);
             }
         }
@@ -781,7 +781,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     public void visit(MethodReferenceExpr n, final A arg) {
         visitComment(n.getComment(), arg);
         if (n.getTypeArguments().isPresent()) {
-            for (final Type<?> t : n.getTypeArguments().get()) {
+            for (final Type t : n.getTypeArguments().get()) {
                 t.accept(this, arg);
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -100,11 +100,11 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
     }
 
     private void printTypeArgs(final NodeWithTypeArguments<?> nodeWithTypeArguments, final Void arg) {
-        NodeList<Type<?>> typeArguments = nodeWithTypeArguments.getTypeArguments().orElse(null);
+        NodeList<Type> typeArguments = nodeWithTypeArguments.getTypeArguments().orElse(null);
         if (!isNullOrEmpty(typeArguments)) {
             printer.print("<");
-            for (final Iterator<Type<?>> i = typeArguments.iterator(); i.hasNext(); ) {
-                final Type<?> t = i.next();
+            for (final Iterator<Type> i = typeArguments.iterator(); i.hasNext(); ) {
+                final Type t = i.next();
                 t.accept(this, arg);
                 if (i.hasNext()) {
                     printer.print(", ");
@@ -707,8 +707,8 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
 
         if (!isNullOrEmpty(n.getThrownExceptions())) {
             printer.print(" throws ");
-            for (final Iterator<ReferenceType<?>> i = n.getThrownExceptions().iterator(); i.hasNext(); ) {
-                final ReferenceType<?> name = i.next();
+            for (final Iterator<ReferenceType> i = n.getThrownExceptions().iterator(); i.hasNext(); ) {
+                final ReferenceType name = i.next();
                 name.accept(this, arg);
                 if (i.hasNext()) {
                     printer.print(", ");
@@ -752,7 +752,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
 
         if (!isNullOrEmpty(n.getThrownExceptions())) {
             printer.print(" throws ");
-            for (final Iterator<ReferenceType<?>> i = n.getThrownExceptions().iterator(); i.hasNext(); ) {
+            for (final Iterator<ReferenceType> i = n.getThrownExceptions().iterator(); i.hasNext(); ) {
                 final ReferenceType name = i.next();
                 name.accept(this, arg);
                 if (i.hasNext()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/PositionUtils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/PositionUtils.java
@@ -116,7 +116,7 @@ public final class PositionUtils {
 
     private static Node beginNodeWithoutConsideringAnnotations(Node node) {
         if (node instanceof MethodDeclaration || node instanceof FieldDeclaration) {
-            NodeWithType<?, Type<?>> casted = (NodeWithType<?, Type<?>>) node;
+            NodeWithType<?, Type> casted = (NodeWithType<?, Type>) node;
             return casted.getType();
         } else if (node instanceof ClassOrInterfaceDeclaration) {
             ClassOrInterfaceDeclaration casted = (ClassOrInterfaceDeclaration) node;

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -202,9 +202,9 @@ final class ASTParser {
         return new ArrayCreationExpr(range, type, levels, arrayInitializerExpr);
     }
 
-    private Type<?> juggleArrayType(Type<?> partialType, List<ArrayBracketPair> additionalBrackets) {
-        Pair<Type<?>, List<ArrayBracketPair>> partialParts = ArrayType.unwrapArrayTypes(partialType);
-        Type<?> elementType = partialParts.a;
+    private Type juggleArrayType(Type partialType, List<ArrayBracketPair> additionalBrackets) {
+        Pair<Type, List<ArrayBracketPair>> partialParts = ArrayType.unwrapArrayTypes(partialType);
+        Type elementType = partialParts.a;
         List<ArrayBracketPair> leftMostBrackets = partialParts.b;
         return ArrayType.wrapInArrayTypes(elementType, leftMostBrackets, additionalBrackets);
     }
@@ -1735,12 +1735,12 @@ ArrayInitializerExpr ArrayInitializer():
 MethodDeclaration MethodDeclaration(ModifierHolder modifier):
 {
 	RangedList<TypeParameter> typeParameters = new RangedList<TypeParameter>(emptyList());
-	Type<?> type;
+	Type type;
 	SimpleName name;
 	NodeList<Parameter> parameters = emptyList();
 	ArrayBracketPair arrayBracketPair;
 	List<ArrayBracketPair> arrayBracketPairs = new ArrayList(0);
-	NodeList<ReferenceType<?>> throws_ = emptyList();
+	NodeList<ReferenceType> throws_ = emptyList();
 	BlockStmt block = null;
 	Position begin = modifier.begin;
 	ReferenceType throwType;
@@ -1834,7 +1834,7 @@ ConstructorDeclaration ConstructorDeclaration(ModifierHolder modifier):
 	RangedList<TypeParameter> typeParameters = new RangedList<TypeParameter>(emptyList());
 	SimpleName name;
 	NodeList<Parameter> parameters = emptyList();
-	NodeList<ReferenceType<?>> throws_ = emptyList();
+	NodeList<ReferenceType> throws_ = emptyList();
 	ExplicitConstructorInvocationStmt exConsInv = null;
 	NodeList<Statement> stmts = emptyList();
     Position begin = modifier.begin;
@@ -1864,7 +1864,7 @@ ExplicitConstructorInvocationStmt ExplicitConstructorInvocation():
 	boolean isThis = false;
 	NodeList<Expression> args;
 	Expression expr = null;
-	RangedList<Type<?>> typeArgs = new RangedList<Type<?>>(null);
+	RangedList<Type> typeArgs = new RangedList<Type>(null);
 	Position begin = INVALID;
 }
 {
@@ -1913,9 +1913,9 @@ InitializerDeclaration InitializerDeclaration():
  * Type, name and expression syntax follows.
  */
 
-Type<?> Type():
+Type Type():
 {
-	Type<?> ret;
+	Type ret;
 }
 {
  (
@@ -1926,9 +1926,9 @@ Type<?> Type():
  { return ret; }
 }
 
-ReferenceType<?> ReferenceType():
+ReferenceType ReferenceType():
 {
-	Type<?> type;
+	Type type;
 	ArrayBracketPair arrayBracketPair;
 	List<ArrayBracketPair> arrayBracketPairs = new ArrayList(0);
 }
@@ -1938,7 +1938,7 @@ ReferenceType<?> ReferenceType():
   |
    type = ClassOrInterfaceType()  ( LOOKAHEAD(2) arrayBracketPair = ArrayBracketPair() { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
   )
-  { return (ReferenceType<?>)wrapInArrayTypes(type, arrayBracketPairs); }
+  { return (ReferenceType)wrapInArrayTypes(type, arrayBracketPairs); }
 }
 
 ArrayBracketPair ArrayBracketPair():
@@ -1955,8 +1955,8 @@ ArrayBracketPair ArrayBracketPair():
 IntersectionType IntersectionType():
 {
 	Position begin;
-	ReferenceType<?> elementType;
-	NodeList<ReferenceType<?>> elements = emptyList();
+	ReferenceType elementType;
+	NodeList<ReferenceType> elements = emptyList();
 }
 {
     elementType=ReferenceType() { begin=elementType.getBegin().get(); elements = add(elements, elementType); }
@@ -1986,7 +1986,7 @@ ClassOrInterfaceType ClassOrInterfaceType():
 {
 	ClassOrInterfaceType ret;
 	SimpleName name;
-	RangedList<Type<?>> typeArgs = new RangedList<Type<?>>(null);
+	RangedList<Type> typeArgs = new RangedList<Type>(null);
 	Position begin;
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 }
@@ -2008,9 +2008,9 @@ ClassOrInterfaceType ClassOrInterfaceType():
   { return ret; }
 }
 
-RangedList<Type<?>> TypeArguments():
+RangedList<Type> TypeArguments():
 {
-	RangedList<Type<?>> ret = new RangedList<Type<?>>(new NodeList<Type<?>>());
+	RangedList<Type> ret = new RangedList<Type>(new NodeList<Type>());
 	Type type;
 }
 {
@@ -2087,9 +2087,9 @@ PrimitiveType PrimitiveType():
 { return ret; }
 }
 
-Type<?> ResultType():
+Type ResultType():
 {
-	Type<?> ret;
+	Type ret;
 }
 {
   (
@@ -2142,7 +2142,7 @@ Expression Expression():
 	AssignExpr.Operator op;
 	Expression value;
 	Statement lambdaBody = null;
-	RangedList<Type<?>> typeArgs = new RangedList<Type<?>>(null);
+	RangedList<Type> typeArgs = new RangedList<Type>(null);
 }
 {
   ret = ConditionalExpression()
@@ -2281,7 +2281,7 @@ Expression EqualityExpression():
 Expression InstanceOfExpression():
 {
 	Expression ret;
-	ReferenceType<?> type;
+	ReferenceType type;
 }
 {
   ret = RelationalExpression() [ "instanceof" type = ReferenceType() { ret = new InstanceOfExpr(range(ret.getBegin().get(), pos(token.endLine, token.endColumn)), ret, type); } ]
@@ -2443,7 +2443,7 @@ Expression CastExpression():
 	PrimitiveType primitiveType;
 	Position begin = INVALID;
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
-	NodeList<ReferenceType<?>> typesOfMultiCast = emptyList();
+	NodeList<ReferenceType> typesOfMultiCast = emptyList();
 }
 {
   "(" {begin=tokenBegin();}
@@ -2491,7 +2491,7 @@ Expression PrimaryPrefix():
 {
 	Expression ret = null;
 	SimpleName name;
-	RangedList<Type<?>> typeArgs = new RangedList<Type<?>>(null);
+	RangedList<Type> typeArgs = new RangedList<Type>(null);
 	NodeList<Expression> args = emptyList();
 	NodeList<Parameter> params = emptyList();
 	boolean hasArgs = false;
@@ -2595,7 +2595,7 @@ Expression PrimarySuffix(Expression scope):
 Expression PrimarySuffixWithoutSuper(Expression scope):
 {
 	Expression ret;
-	RangedList<Type<?>> typeArgs = new RangedList<Type<?>>(null);
+	RangedList<Type> typeArgs = new RangedList<Type>(null);
 	NodeList<Expression> args = emptyList();
 	boolean hasArgs = false;
 	SimpleName name;
@@ -2701,8 +2701,8 @@ NodeList<Expression> ArgumentList():
 Expression AllocationExpression(Expression scope):
 {
 	Expression ret;
-	Type<?> type;
-	RangedList<Type<?>> typeArgs = new RangedList<Type<?>>(null);
+	Type type;
+	RangedList<Type> typeArgs = new RangedList<Type>(null);
 	NodeList<BodyDeclaration<?>> anonymousBody = null;
 	NodeList<Expression> args;
 	Position begin;
@@ -2906,7 +2906,7 @@ ExpressionStmt StatementExpression():
 	Expression expr;
 	AssignExpr.Operator op;
 	Expression value;
-	RangedList<Type<?>> typeArgs = new RangedList<Type<?>>(null);
+	RangedList<Type> typeArgs = new RangedList<Type>(null);
 	Statement lambdaBody;
 }
 {
@@ -3133,7 +3133,7 @@ TryStmt TryStatement():
 	BlockStmt catchBlock;
 	ModifierHolder exceptModifier;
 	ReferenceType exceptionType;
-	NodeList<ReferenceType<?>> exceptionTypes = emptyList();
+	NodeList<ReferenceType> exceptionTypes = emptyList();
 	Pair<SimpleName, List<ArrayBracketPair>> exceptId;
 	Position begin;
 	Position catchBegin;

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/type/TypeConstructionTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/type/TypeConstructionTest.java
@@ -135,7 +135,7 @@ public class TypeConstructionTest {
     public void getArrayCreationType() {
         ArrayCreationExpr expr = parseExpression("new int[]");
         ArrayType outerType = (ArrayType) expr.createdType();
-        Type<?> innerType = outerType.getComponentType();
+        Type innerType = outerType.getComponentType();
         assertThat(innerType).isEqualTo(expr.getElementType());
     }
 }


### PR DESCRIPTION
It's only use is to get the correct return type for setAnnotations. Worked around that by adding methods with the correct return type to its subclasses.