### PR TITLE
Correct Range contains to consider equal ranges as contained

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/Range.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Range.java
@@ -52,7 +52,19 @@ public class Range {
         return range(this.begin, end);
     }
 
+    /**
+     * As strictlyContains, but two exactly matching ranges are also considered contained one in each other.
+     */
     public boolean contains(Range other) {
+        return (begin.isBefore(other.begin) || begin.equals(other.begin)) &&
+                (end.isAfter(other.end) || end.equals(other.end));
+    }
+
+    /**
+     * Do this strictly contains other? It means that this has to be larger than other and it has to start as other
+     * or before and end as other or after.
+     */
+    public boolean strictlyContains(Range other) {
         return begin.isBefore(other.begin) && end.isAfter(other.end);
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaTokenTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaTokenTest.java
@@ -1,6 +1,5 @@
 package com.github.javaparser;
 
-import com.github.javaparser.*;
 import com.github.javaparser.ast.expr.Expression;
 import org.junit.Test;
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/ProvidersTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ProvidersTest.java
@@ -31,9 +31,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-/**
- *
- */
 public class ProvidersTest {
 
     @Test

--- a/javaparser-testing/src/test/java/com/github/javaparser/RangeTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/RangeTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class RangeTest {
+
+    @Test
+    public void aRangeContainsItself() throws IOException {
+        Range r = Range.range(1, 1, 3, 10);
+        assertEquals(true, r.contains(r));
+    }
+
+    @Test
+    public void aRangeDoesNotStrictlyContainsItself() throws IOException {
+        Range r = Range.range(1, 1, 3, 10);
+        assertEquals(false, r.strictlyContains(r));
+    }
+
+    @Test
+    public void overlappingButNotContainedRangesAreNotOnContains() throws IOException {
+        Range r1 = Range.range(1, 1, 3, 10);
+        Range r2 = Range.range(2, 1, 7, 10);
+        assertEquals(false, r1.contains(r2));
+        assertEquals(false, r2.contains(r1));
+    }
+
+    @Test
+    public void overlappingButNotContainedRangesAreNotOnStrictlyContains() throws IOException {
+        Range r1 = Range.range(1, 1, 3, 10);
+        Range r2 = Range.range(2, 1, 7, 10);
+        assertEquals(false, r1.strictlyContains(r2));
+        assertEquals(false, r2.strictlyContains(r1));
+    }
+
+    @Test
+    public void unrelatedRangesAreNotOnContains() throws IOException {
+        Range r1 = Range.range(1, 1, 3, 10);
+        Range r2 = Range.range(5, 1, 7, 10);
+        assertEquals(false, r1.contains(r2));
+        assertEquals(false, r2.contains(r1));
+    }
+
+    @Test
+    public void unrelatedRangesAreNotOnStrictlyContains() throws IOException {
+        Range r1 = Range.range(1, 1, 3, 10);
+        Range r2 = Range.range(5, 1, 7, 10);
+        assertEquals(false, r1.strictlyContains(r2));
+        assertEquals(false, r2.strictlyContains(r1));
+    }
+
+    @Test
+    public void strictlyContainedRangesOnContains() throws IOException {
+        Range r1 = Range.range(1, 1, 3, 10);
+        Range r2 = Range.range(2, 1, 3, 4);
+        assertEquals(true, r1.contains(r2));
+        assertEquals(false, r2.contains(r1));
+    }
+
+    @Test
+    public void strictlyContainedRangesOnStrictlyContains() throws IOException {
+        Range r1 = Range.range(1, 1, 3, 10);
+        Range r2 = Range.range(2, 1, 3, 4);
+        assertEquals(true, r1.strictlyContains(r2));
+        assertEquals(false, r2.strictlyContains(r1));
+    }
+
+}


### PR DESCRIPTION
Introduce `strictlyContains` with the same logic `contains` had before.

Add tests for several cases, considering both `contains` and `strictlyContains`.