### PR TITLE
Add field after building it

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -67,11 +67,11 @@ public interface NodeWithMembers<N extends Node> {
      */
     default FieldDeclaration addField(Type type, String name, Modifier... modifiers) {
         FieldDeclaration fieldDeclaration = new FieldDeclaration();
-        getMembers().add(fieldDeclaration);
         VariableDeclarator variable = new VariableDeclarator(type, name);
         fieldDeclaration.getVariables().add(variable);
         fieldDeclaration.setModifiers(Arrays.stream(modifiers)
                 .collect(toCollection(() -> EnumSet.noneOf(Modifier.class))));
+        getMembers().add(fieldDeclaration);
         return fieldDeclaration;
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -137,7 +137,6 @@ public class NodeTest {
         assertEquals(Arrays.asList("ClassOrInterfaceDeclaration.name changed from A to MyCoolClass",
                 "VariableDeclarator.type changed from int to boolean",
                 "Parameter.name changed from p to myParam",
-                "FieldDeclaration.modifiers changed from [] to []",
                 "VariableDeclarator.initializer changed from null to 0"), changes);
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
@@ -29,11 +29,10 @@ public class PropagatingAstObserverTest {
         assertEquals(Arrays.asList(), changes);
 
         FieldDeclaration fieldDeclaration = cu.getClassByName("A").addField("String", "foo");
-        assertEquals(Arrays.asList("FieldDeclaration.modifiers changed from [] to []"), changes);
+        assertEquals(Arrays.asList(), changes);
         assertEquals(true, fieldDeclaration.isRegistered(observer));
 
         cu.getClassByName("A").getFieldByName("foo").getVariables().get(0).setName("Bar");
-        assertEquals(Arrays.asList("FieldDeclaration.modifiers changed from [] to []",
-                "VariableDeclarator.name changed from foo to Bar"), changes);
+        assertEquals(Arrays.asList("VariableDeclarator.name changed from foo to Bar"), changes);
     }
 }


### PR DESCRIPTION
Why? Because in this way observers on the class get the field when it is built, instead of getting an half-built Field that they could not process properly.