### PR TITLE
Fix some discrepancies in the AST

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
@@ -24,6 +24,7 @@ package com.github.javaparser.ast.body;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt;
 import com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -34,28 +35,29 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.6">JLS</a>
- * A (possibly static) initializer block. "static { a=3; }" in this example: <code>class X { static { a=3; }  } </code> 
+ * A (possibly static) initializer body. "static { a=3; }" in this example: <code>class X { static { a=3; }  } </code> 
  * @author Julio Vilmar Gesser
  */
-public final class InitializerDeclaration extends BodyDeclaration<InitializerDeclaration>
-        implements NodeWithJavaDoc<InitializerDeclaration> {
+public final class InitializerDeclaration extends BodyDeclaration<InitializerDeclaration> implements 
+        NodeWithJavaDoc<InitializerDeclaration>,
+        NodeWithBlockStmt<InitializerDeclaration> {
 
     private boolean isStatic;
 
-    private BlockStmt block;
+    private BlockStmt body;
 
     public InitializerDeclaration() {
         this(null, false, new BlockStmt());
     }
 
-    public InitializerDeclaration(boolean isStatic, BlockStmt block) {
-        this(null, isStatic, block);
+    public InitializerDeclaration(boolean isStatic, BlockStmt body) {
+        this(null, isStatic, body);
     }
 
-    public InitializerDeclaration(Range range, boolean isStatic, BlockStmt block) {
+    public InitializerDeclaration(Range range, boolean isStatic, BlockStmt body) {
         super(range, new NodeList<>());
         setStatic(isStatic);
-        setBlock(block);
+        setBody(body);
     }
 
     @Override
@@ -68,18 +70,18 @@ public final class InitializerDeclaration extends BodyDeclaration<InitializerDec
         v.visit(this, arg);
     }
 
-    public BlockStmt getBlock() {
-        return block;
+    public BlockStmt getBody() {
+        return body;
     }
 
     public boolean isStatic() {
         return isStatic;
     }
 
-    public InitializerDeclaration setBlock(BlockStmt block) {
-        notifyPropertyChange(ObservableProperty.BLOCK, this.block, block);
-        this.block = assertNotNull(block);
-        setAsParentNodeOf(this.block);
+    public InitializerDeclaration setBody(BlockStmt body) {
+        notifyPropertyChange(ObservableProperty.BLOCK, this.body, body);
+        this.body = assertNotNull(body);
+        setAsParentNodeOf(this.body);
         return this;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
@@ -10,7 +10,6 @@ public enum ObservableProperty {
     BLOCK,
     BODY,
     CATCH_CLAUSES,
-    CATCH_BLOCK,
     CHECK,
     CLASS_BODY,
     CLASS_EXPR,

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
@@ -43,21 +43,21 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
 
     private Parameter parameter;
 
-    private BlockStmt catchBlock;
+    private BlockStmt body;
 
     public CatchClause() {
         this(null, new Parameter(), new BlockStmt());
     }
 
-    public CatchClause(final Parameter parameter, final BlockStmt catchBlock) {
-        this(null, parameter, catchBlock);
+    public CatchClause(final Parameter parameter, final BlockStmt body) {
+        this(null, parameter, body);
     }
 
     public CatchClause(final EnumSet<Modifier> exceptModifier,
                        final NodeList<AnnotationExpr> exceptAnnotations,
                        final ClassOrInterfaceType exceptType,
                        final SimpleName exceptName,
-                       final BlockStmt catchBlock) {
+                       final BlockStmt body) {
         this(null,
                 new Parameter(null,
                         exceptModifier,
@@ -65,15 +65,15 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
                         exceptType,
                         false,
                         exceptName),
-                catchBlock);
+                body);
     }
 
     public CatchClause(final Range range,
                        final Parameter parameter,
-                       final BlockStmt catchBlock) {
+                       final BlockStmt body) {
         super(range);
         setParameter(parameter);
-        setBody(catchBlock);
+        setBody(body);
     }
 
     @Override
@@ -87,28 +87,12 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
     }
 
     /**
-     * Use {@link #getBody()} instead
-     */
-    @Deprecated
-    public BlockStmt getCatchBlock() {
-        return catchBlock;
-    }
-
-    /**
      * Note that the type of the Parameter can be a UnionType. In this case, any annotations found at the start of the
      * catch(@X A a |...) are found directly in the Parameter. Annotations that are on the second or later type -
      * catch(A a | @X B b ...) are found on those types.
      */
     public Parameter getParameter() {
         return parameter;
-    }
-
-    /**
-     * Use {@link #setBody(BlockStmt)} instead
-     */
-    @Deprecated
-    public CatchClause setCatchBlock(final BlockStmt catchBlock) {
-        return setBody(catchBlock);
     }
 
     public CatchClause setParameter(final Parameter parameter) {
@@ -120,14 +104,14 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
 
     @Override
     public BlockStmt getBody() {
-        return catchBlock;
+        return body;
     }
 
     @Override
     public CatchClause setBody(BlockStmt block) {
-        notifyPropertyChange(ObservableProperty.CATCH_BLOCK, this.catchBlock, block);
-        this.catchBlock = block;
-        setAsParentNodeOf(this.catchBlock);
+        notifyPropertyChange(ObservableProperty.BODY, this.body, block);
+        this.body = block;
+        setAsParentNodeOf(this.body);
         return this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
@@ -41,20 +41,20 @@ public final class SynchronizedStmt extends Statement implements
 
     private Expression expression;
 
-    private BlockStmt block;
+    private BlockStmt body;
 
     public SynchronizedStmt() {
         this(null, new NameExpr(), new BlockStmt());
     }
 
-    public SynchronizedStmt(final Expression expression, final BlockStmt block) {
-        this(null, expression, block);
+    public SynchronizedStmt(final Expression expression, final BlockStmt body) {
+        this(null, expression, body);
     }
 
-    public SynchronizedStmt(Range range, final Expression expression, final BlockStmt block) {
+    public SynchronizedStmt(Range range, final Expression expression, final BlockStmt body) {
         super(range);
         setExpression(expression);
-        setBody(block);
+        setBody(body);
     }
 
     @Override
@@ -67,24 +67,8 @@ public final class SynchronizedStmt extends Statement implements
         v.visit(this, arg);
     }
 
-    /**
-     * @deprecated use {@link #getBody()}
-     */
-    @Deprecated
-    public BlockStmt getBlock() {
-        return block;
-    }
-
     public Expression getExpression() {
         return expression;
-    }
-
-    /**
-     * @deprecated Use {@link #setBody(BlockStmt)} instead
-     */
-    @Deprecated
-    public SynchronizedStmt setBlock(final BlockStmt block) {
-        return setBody(block);
     }
 
     public SynchronizedStmt setExpression(final Expression expression) {
@@ -96,14 +80,14 @@ public final class SynchronizedStmt extends Statement implements
 
     @Override
     public BlockStmt getBody() {
-        return block;
+        return body;
     }
 
     @Override
-    public SynchronizedStmt setBody(BlockStmt block) {
-        notifyPropertyChange(ObservableProperty.BLOCK, this.block, block);
-        this.block = assertNotNull(block);
-        setAsParentNodeOf(this.block);
+    public SynchronizedStmt setBody(BlockStmt body) {
+        notifyPropertyChange(ObservableProperty.BODY, this.body, body);
+        this.body = assertNotNull(body);
+        setAsParentNodeOf(this.body);
         return this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -277,7 +277,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(InitializerDeclaration _n, Object _arg) {
-        BlockStmt block = cloneNode(_n.getBlock(), _arg);
+        BlockStmt block = cloneNode(_n.getBody(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
         InitializerDeclaration r = new InitializerDeclaration(

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -509,7 +509,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     public Boolean visit(final InitializerDeclaration n1, final Visitable arg) {
         final InitializerDeclaration n2 = (InitializerDeclaration) arg;
 
-        if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
             return false;
         }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -810,7 +810,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     public R visit(final InitializerDeclaration n, final A arg) {
         visitComment(n, arg);
         {
-            R result = n.getBlock().accept(this, arg);
+            R result = n.getBody().accept(this, arg);
             if (result != null) {
                 return result;
             }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -423,7 +423,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     @Override
     public Visitable visit(final InitializerDeclaration n, final A arg) {
         visitComment(n, arg);
-        n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
+        n.setBody((BlockStmt) n.getBody().accept(this, arg));
         return n;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -396,7 +396,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     @Override
     public void visit(final InitializerDeclaration n, final A arg) {
         visitComment(n.getComment(), arg);
-        n.getBlock().accept(this, arg);
+        n.getBody().accept(this, arg);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -1017,7 +1017,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         if (n.isStatic()) {
             printer.print("static ");
         }
-        n.getBlock().accept(this, arg);
+        n.getBody().accept(this, arg);
     }
 
     @Override

--- a/javaparser-core/src/main/javacc/java_1_8.jj
+++ b/javaparser-core/src/main/javacc/java_1_8.jj
@@ -1745,7 +1745,7 @@ MethodDeclaration MethodDeclaration(ModifierHolder modifier):
 	ArrayBracketPair arrayBracketPair;
 	List<ArrayBracketPair> arrayBracketPairs = new ArrayList(0);
 	NodeList<ReferenceType> throws_ = emptyList();
-	BlockStmt block = null;
+	BlockStmt body = null;
 	Position begin = modifier.begin;
 	ReferenceType throwType;
 }
@@ -1756,10 +1756,10 @@ MethodDeclaration MethodDeclaration(ModifierHolder modifier):
     name = SimpleName() parameters = FormalParameters() ( arrayBracketPair = ArrayBracketPair() { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
     [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
       ("," throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); } )* ]
-    ( block = Block() | ";" )
+    ( body = Block() | ";" )
     { 
         type = juggleArrayType(type, arrayBracketPairs);
-        return new MethodDeclaration(range(begin, pos(token.endLine, token.endColumn)), modifier.modifiers, modifier.annotations, typeParameters.list, type, name, false, parameters, throws_, block);
+        return new MethodDeclaration(range(begin, pos(token.endLine, token.endColumn)), modifier.modifiers, modifier.annotations, typeParameters.list, type, name, false, parameters, throws_, body);
     }
 }
 
@@ -1902,14 +1902,14 @@ NodeList<Statement> Statements():
 
 InitializerDeclaration InitializerDeclaration():
 {
-	BlockStmt block;
+	BlockStmt body;
 	Position begin = INVALID;
 	boolean isStatic = false;
 }
 {
   [ "static" { isStatic = true; begin=tokenBegin();} ] 
-  block = Block() {begin = begin.orIfInvalid(block.getBegin().get());}
-  { return new InitializerDeclaration(range(begin, tokenEnd()), isStatic, block); }
+  body = Block() {begin = begin.orIfInvalid(body.getBegin().get());}
+  { return new InitializerDeclaration(range(begin, tokenEnd()), isStatic, body); }
 }
 
 
@@ -2834,7 +2834,7 @@ BlockStmt Block():
 }
 
 /*
- * Classes inside block stametents can only be abstract or final. The semantic must check it.
+ * Classes inside body stametents can only be abstract or final. The semantic must check it.
  */
 Statement BlockStatement():
 {
@@ -3120,12 +3120,12 @@ ThrowStmt ThrowStatement():
 SynchronizedStmt SynchronizedStatement():
 {
 	Expression expr;
-	BlockStmt block;
+	BlockStmt body;
 	Position begin;
 }
 {
-  "synchronized" {begin=tokenBegin();} "(" expr = Expression() ")" block = Block()
-  { return new SynchronizedStmt(range(begin, tokenEnd()),expr, block); }
+  "synchronized" {begin=tokenBegin();} "(" expr = Expression() ")" body = Block()
+  { return new SynchronizedStmt(range(begin, tokenEnd()),expr, body); }
 }
 
 TryStmt TryStatement():


### PR DESCRIPTION
Any {} is now called "body", not "block". These two names were use interchangably.