### PR TITLE
Issue683: when calling AnnotationMemberDeclaration.setName assign the parent of the name

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -158,6 +158,7 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
     public AnnotationMemberDeclaration setName(SimpleName name) {
         notifyPropertyChange(ObservableProperty.NAME, this.name, name);
         this.name = assertNotNull(name);
+        setAsParentNodeOf(name);
         return this;
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/body/AnnotationMemberDeclarationTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/body/AnnotationMemberDeclarationTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.body;
+
+import com.github.javaparser.ast.expr.SimpleName;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class AnnotationMemberDeclarationTest {
+
+    @Test
+    public void whenSettingNameTheParentOfNameIsAssigned() {
+        AnnotationMemberDeclaration annotationMemberDeclaration = new AnnotationMemberDeclaration();
+        SimpleName name = new SimpleName("foo");
+        annotationMemberDeclaration.setName(name);
+        assertTrue(name.getParentNode().isPresent());
+        assertTrue(annotationMemberDeclaration == name.getParentNode().get());
+    }
+}


### PR DESCRIPTION
Fix #683 and add a test to prevent regressions