### PR TITLE
Change return type of MethodCallExpr.getScope() to Optional<Expression>

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -105,8 +105,8 @@ public final class MethodCallExpr extends Expression implements
         return name;
     }
 
-    public Expression getScope() {
-        return scope;
+    public Optional<Expression> getScope() {
+        return Optional.ofNullable(scope);
     }
 
     public MethodCallExpr setArguments(final NodeList<Expression> arguments) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -908,12 +908,10 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final MethodCallExpr n, final A arg) {
         visitComment(n, arg);
-        if (n.getScope() != null) {
-            {
-                R result = n.getScope().accept(this, arg);
-                if (result != null) {
-                    return result;
-                }
+        if (n.getScope().isPresent()) {
+            R result = n.getScope().get().accept(this, arg);
+            if (result != null) {
+                return result;
             }
         }
         if (n.getTypeArguments().isPresent()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -477,8 +477,8 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     @Override
     public Visitable visit(final MethodCallExpr n, final A arg) {
         visitComment(n, arg);
-        if (n.getScope() != null) {
-            n.setScope((Expression) n.getScope().accept(this, arg));
+        if (n.getScope().isPresent()) {
+            n.setScope((Expression) n.getScope().get().accept(this, arg));
         }
         n.setTypeArguments(modifyList(n.getTypeArguments().orElse(null), arg));
         n.setArguments((NodeList<Expression>) n.getArguments().accept(this, arg));

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -446,8 +446,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     @Override
     public void visit(final MethodCallExpr n, final A arg) {
         visitComment(n.getComment(), arg);
-        if (n.getScope() != null) {
-            n.getScope().accept(this, arg);
+        if (n.getScope().isPresent()) {
+            n.getScope().get().accept(this, arg);
         }
         if (n.getTypeArguments().isPresent()) {
             for (final Type t : n.getTypeArguments().get()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -631,8 +631,8 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
     @Override
     public void visit(final MethodCallExpr n, final Void arg) {
         printJavaComment(n.getComment(), arg);
-        if (n.getScope() != null) {
-            n.getScope().accept(this, arg);
+        if (n.getScope().isPresent()) {
+            n.getScope().get().accept(this, arg);
             printer.print(".");
         }
         printTypeArgs(n, arg);


### PR DESCRIPTION
Scope can be null - #695