### PR TITLE
Let FieldAccessExpr implement NodeWithSimpleName

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
@@ -39,28 +40,28 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class FieldAccessExpr extends Expression implements NodeWithTypeArguments<FieldAccessExpr> {
+public final class FieldAccessExpr extends Expression implements NodeWithSimpleName<FieldAccessExpr>, NodeWithTypeArguments<FieldAccessExpr> {
 
     private Expression scope;
 
     private NodeList<Type> typeArguments;
 
-    private SimpleName field;
+    private SimpleName name;
 
     public FieldAccessExpr() {
         this(null, new ThisExpr(), new NodeList<>(), new SimpleName());
     }
 
-    public FieldAccessExpr(final Expression scope, final String field) {
-        this(null, scope, new NodeList<>(), new SimpleName(field));
+    public FieldAccessExpr(final Expression scope, final String name) {
+        this(null, scope, new NodeList<>(), new SimpleName(name));
     }
 
     public FieldAccessExpr(final Range range, final Expression scope, final NodeList<Type> typeArguments,
-                           final SimpleName field) {
+                           final SimpleName name) {
         super(range);
         setScope(scope);
         setTypeArguments(typeArguments);
-        setFieldExpr(field);
+        setName(name);
     }
 
     @Override
@@ -73,24 +74,46 @@ public final class FieldAccessExpr extends Expression implements NodeWithTypeArg
         v.visit(this, arg);
     }
 
+    @Override
+    public SimpleName getName() {
+        return name;
+    }
+
+    @Override
+    public FieldAccessExpr setName(SimpleName name) {
+        notifyPropertyChange(ObservableProperty.NAME, this.name, name);
+        this.name = assertNotNull(name);
+        setAsParentNodeOf(this.name);
+        return this;
+    }
+
+    /**
+     * Use {@link #getName} instead.
+     */
+    @Deprecated
     public SimpleName getField() {
-        return field;
+        return name;
     }
 
     public Optional<Expression> getScope() {
         return Optional.ofNullable(scope);
     }
 
+    /**
+     * Use {@link #setName} with new SimpleName(field) instead.
+     */
+    @Deprecated
     public FieldAccessExpr setField(final String field) {
-        setFieldExpr(new SimpleName(field));
+        setName(new SimpleName(field));
         return this;
     }
 
+    /**
+     * Use {@link #setName} instead.
+     */
+    @Deprecated
     public FieldAccessExpr setFieldExpr(SimpleName inner) {
-        notifyPropertyChange(ObservableProperty.FIELD, this.field, inner);
-        this.field = assertNotNull(inner);
-        setAsParentNodeOf(this.field);
-        return this;
+        return setName(inner);
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -537,7 +537,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(FieldAccessExpr _n, Object _arg) {
         Expression scope_ = cloneNode(_n.getScope(), _arg);
         NodeList<Type> typeArguments_ = cloneList(_n.getTypeArguments().orElse(null), _arg);
-        SimpleName fieldExpr_ = cloneNode(_n.getField(), _arg);
+        SimpleName fieldExpr_ = cloneNode(_n.getName(), _arg);
         Comment comment = cloneNode(_n.getComment(), _arg);
 
         FieldAccessExpr r = new FieldAccessExpr(

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -837,7 +837,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
             return false;
         }
 
-        if (!objEquals(n1.getField(), n2.getField())) {
+        if (!objEquals(n1.getName(), n2.getName())) {
             return false;
         }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -345,7 +345,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
         visitComment(n.getComment(), arg);
         if (n.getScope().isPresent())
             n.getScope().get().accept(this, arg);
-        n.getField().accept(this, arg);
+        n.getName().accept(this, arg);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -551,7 +551,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         if (n.getScope().isPresent())
             n.getScope().get().accept(this, arg);
         printer.print(".");
-        n.getField().accept(this, arg);
+        n.getName().accept(this, arg);
     }
 
     @Override


### PR DESCRIPTION
I think like MethodCallExpr a FieldAccessExpr should also implement NodeWithSimpleName as this can be handy when trying to resolve method or field chains (eg. obj.a.b.method().stuff()).

I deprecated the old get-/setField methods with a reference to the new methods. All references to getField inside javaparser were replaced by getName.

I will deliver some tests tomorrow for this changes.