### PR TITLE
Check that users don't put empty strings in places where they make no sense

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -141,6 +141,7 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
     }
 
     public EnumConstantDeclaration addEnumConstant(String name) {
+        assertNonEmpty(name);
         EnumConstantDeclaration enumConstant = new EnumConstantDeclaration(name);
         getEntries().add(enumConstant);
         enumConstant.setParentNode(this);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -36,6 +36,7 @@ import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -109,12 +110,12 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
         return getEntries().get(i);
     }
 
-    public EnumDeclaration setEntry(int i, EnumConstantDeclaration element){
+    public EnumDeclaration setEntry(int i, EnumConstantDeclaration element) {
         getEntries().set(i, element);
         return this;
     }
 
-    public EnumDeclaration addEntry(EnumConstantDeclaration element){
+    public EnumDeclaration addEntry(EnumConstantDeclaration element) {
         getEntries().add(element);
         return this;
     }
@@ -140,7 +141,7 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
     }
 
     public EnumConstantDeclaration addEnumConstant(String name) {
-        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration(assertNotNull(name));
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration(assertNonEmpty(name));
         getEntries().add(enumConstant);
         enumConstant.setParentNode(this);
         return enumConstant;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -141,7 +141,7 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
     }
 
     public EnumConstantDeclaration addEnumConstant(String name) {
-        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration(assertNonEmpty(name));
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration(name);
         getEntries().add(enumConstant);
         enumConstant.setParentNode(this);
         return enumConstant;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -181,10 +181,8 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
         String fieldName = variable.getNameAsString();
         String fieldNameUpper = fieldName.toUpperCase().substring(0, 1) + fieldName.substring(1, fieldName.length());
         final MethodDeclaration getter;
-        if (parentClass.isPresent())
-            getter = parentClass.get().addMethod("get" + fieldNameUpper, PUBLIC);
-        else
-            getter = parentEnum.get().addMethod("get" + fieldNameUpper, PUBLIC);
+        getter = parentClass.map(clazz -> clazz.addMethod("get" + fieldNameUpper, PUBLIC))
+                .orElseGet(() -> parentEnum.get().addMethod("get" + fieldNameUpper, PUBLIC));
         getter.setType(variable.getType());
         BlockStmt blockStmt = new BlockStmt();
         getter.setBody(blockStmt);
@@ -214,10 +212,8 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
         String fieldNameUpper = fieldName.toUpperCase().substring(0, 1) + fieldName.substring(1, fieldName.length());
 
         final MethodDeclaration setter;
-        if (parentClass.isPresent())
-            setter = parentClass.get().addMethod("set" + fieldNameUpper, PUBLIC);
-        else
-            setter = parentEnum.get().addMethod("set" + fieldNameUpper, PUBLIC);
+        setter = parentClass.map(clazz -> clazz.addMethod("set" + fieldNameUpper, PUBLIC))
+                .orElseGet(() -> parentEnum.get().addMethod("set" + fieldNameUpper, PUBLIC));
         setter.setType(new VoidType());
         setter.getParameters().add(new Parameter(variable.getType(), fieldName));
         BlockStmt blockStmt2 = new BlockStmt();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 
 import java.util.Optional;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -133,7 +134,7 @@ public final class VariableDeclarator extends Node implements
      * @return this, the VariableDeclarator
      */
     public VariableDeclarator setInitializer(String init) {
-        return setInitializer(new NameExpr(assertNotNull(init)));
+        return setInitializer(new NameExpr(assertNonEmpty(init)));
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
@@ -32,6 +32,8 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 
 import java.util.Optional;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
+
 /**
  * Method reference expressions introduced in Java 8 specifically designed to simplify lambda Expressions.
  * Note that the field "identifier", indicating the word to the right of the ::, is not always a method name,
@@ -116,6 +118,7 @@ public class MethodReferenceExpr extends Expression implements
 
     @Override
     public MethodReferenceExpr setIdentifier(String identifier) {
+        assertNonEmpty(identifier);
         notifyPropertyChange(ObservableProperty.IDENTIFIER, this.identifier, identifier);
         this.identifier = identifier;
         return this;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -31,7 +31,6 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
-import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * A name that may consist of multiple identifiers.
@@ -86,7 +85,7 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
     public Name setIdentifier(final String identifier) {
         assertNonEmpty(identifier);
         notifyPropertyChange(ObservableProperty.IDENTIFIER, this.identifier, identifier);
-        this.identifier = assertNotNull(identifier);
+        this.identifier = identifier;
         return this;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 
 import java.util.Optional;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -62,6 +63,7 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
 
     public Name(Range range, Name qualifier, final String identifier) {
         super(range);
+        assertNonEmpty(identifier);
         setIdentifier(identifier);
         setQualifier(qualifier);
     }
@@ -76,11 +78,14 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
         v.visit(this, arg);
     }
 
+    @Override
     public final String getIdentifier() {
         return identifier;
     }
 
+    @Override
     public Name setIdentifier(final String identifier) {
+        assertNonEmpty(identifier);
         notifyPropertyChange(ObservableProperty.IDENTIFIER, this.identifier, identifier);
         this.identifier = assertNotNull(identifier);
         return this;
@@ -94,6 +99,7 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
      * @return instanceof {@link Name}
      */
     public static Name parse(String qualifiedName) {
+        assertNonEmpty(qualifiedName);
         String[] split = qualifiedName.split("\\.");
         Name ret = new Name(split[0]);
         for (int i = 1; i < split.length; i++) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -63,7 +63,6 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
 
     public Name(Range range, Name qualifier, final String identifier) {
         super(range);
-        assertNonEmpty(identifier);
         setIdentifier(identifier);
         setQualifier(qualifier);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
@@ -28,7 +28,7 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
-import static com.github.javaparser.utils.Utils.assertNotNull;
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**
  * A name that consists of a single identifier.
@@ -49,6 +49,7 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
 
     public SimpleName(Range range, final String identifier) {
         super(range);
+        assertNonEmpty(identifier);
         setIdentifier(identifier);
     }
 
@@ -70,7 +71,7 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
     @Override
     public SimpleName setIdentifier(final String identifier) {
         notifyPropertyChange(ObservableProperty.IDENTIFIER, this.identifier, identifier);
-        this.identifier = assertNotNull(identifier);
+        this.identifier = assertNonEmpty(identifier);
         return this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
@@ -49,7 +49,6 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
 
     public SimpleName(Range range, final String identifier) {
         super(range);
-        assertNonEmpty(identifier);
         setIdentifier(identifier);
     }
 
@@ -70,8 +69,9 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
 
     @Override
     public SimpleName setIdentifier(final String identifier) {
+        assertNonEmpty(identifier);
         notifyPropertyChange(ObservableProperty.IDENTIFIER, this.identifier, identifier);
-        this.identifier = assertNonEmpty(identifier);
+        this.identifier = identifier;
         return this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -27,7 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Utils;
 
-import static com.github.javaparser.utils.Utils.assertNotNull;
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**
  * A literal string.
@@ -59,6 +59,7 @@ public class StringLiteralExpr extends LiteralExpr {
 
     public StringLiteralExpr(final Range range, final String value) {
         super(range);
+        assertNonEmpty(value);
         setValue(value);
     }
 
@@ -78,7 +79,7 @@ public class StringLiteralExpr extends LiteralExpr {
 
     public final StringLiteralExpr setValue(final String value) {
         notifyPropertyChange(ObservableProperty.VALUE, this.value, value);
-        this.value = assertNotNull(value);
+        this.value = assertNonEmpty(value);
         if (value.contains("\n") || value.contains("\r")) {
             throw new IllegalArgumentException("Illegal literal expression: newlines (line feed or carriage return) have to be escaped");
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -27,7 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Utils;
 
-import static com.github.javaparser.utils.Utils.assertNonEmpty;
+import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * A literal string.
@@ -59,7 +59,6 @@ public class StringLiteralExpr extends LiteralExpr {
 
     public StringLiteralExpr(final Range range, final String value) {
         super(range);
-        assertNonEmpty(value);
         setValue(value);
     }
 
@@ -79,7 +78,7 @@ public class StringLiteralExpr extends LiteralExpr {
 
     public final StringLiteralExpr setValue(final String value) {
         notifyPropertyChange(ObservableProperty.VALUE, this.value, value);
-        this.value = assertNonEmpty(value);
+        this.value = assertNotNull(value);
         if (value.contains("\n") || value.contains("\r")) {
             throw new IllegalArgumentException("Illegal literal expression: newlines (line feed or carriage return) have to be escaped");
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
@@ -28,8 +28,6 @@ import com.github.javaparser.ast.expr.*;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
-import static com.github.javaparser.ast.expr.Name.parse;
-
 /**
  * A node that can be annotated.
  *
@@ -66,7 +64,7 @@ public interface NodeWithAnnotations<N extends Node> {
      */
     default NormalAnnotationExpr addAnnotation(String name) {
         NormalAnnotationExpr normalAnnotationExpr = new NormalAnnotationExpr(
-                parse(name), new NodeList<>());
+                Name.parse(name), new NodeList<>());
         getAnnotations().add(normalAnnotationExpr);
         normalAnnotationExpr.setParentNode((Node) this);
         return normalAnnotationExpr;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithIdentifier.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithIdentifier.java
@@ -23,6 +23,8 @@ package com.github.javaparser.ast.nodeTypes;
 
 import com.github.javaparser.ast.Node;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
+
 public interface NodeWithIdentifier<N extends Node> {
     String getIdentifier();
 
@@ -33,6 +35,7 @@ public interface NodeWithIdentifier<N extends Node> {
     }
 
     default N setId(String identifier) {
+        assertNonEmpty(identifier);
         return setIdentifier(identifier);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
@@ -24,6 +24,8 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Name;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
+
 /**
  * A node with a (qualified) name.
  * <p>
@@ -38,6 +40,7 @@ public interface NodeWithName<N extends Node> {
 
     @SuppressWarnings("unchecked")
     default N setName(String name) {
+        assertNonEmpty(name);
         return setName(Name.parse(name));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
@@ -24,8 +24,6 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Name;
 
-import static com.github.javaparser.ast.expr.Name.parse;
-
 /**
  * A node with a (qualified) name.
  * <p>
@@ -40,7 +38,7 @@ public interface NodeWithName<N extends Node> {
 
     @SuppressWarnings("unchecked")
     default N setName(String name) {
-        return setName(parse(name));
+        return setName(Name.parse(name));
     }
 
     default String getNameAsString() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithOptionalBlockStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithOptionalBlockStmt.java
@@ -38,7 +38,6 @@ public interface NodeWithOptionalBlockStmt<N extends Node> {
         BlockStmt block = new BlockStmt();
         setBody(block);
         block.setParentNode((Node) this);
-
         return block;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithOptionalLabel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithOptionalLabel.java
@@ -5,6 +5,8 @@ import com.github.javaparser.ast.expr.SimpleName;
 
 import java.util.Optional;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
+
 /**
  * A node that can have a label.
  */
@@ -14,6 +16,7 @@ public interface NodeWithOptionalLabel<T extends Node> {
     T setLabel(SimpleName label);
 
     default T setLabel(String label) {
+        assertNonEmpty(label);
         return setLabel(new SimpleName(label));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithOptionalScope.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithOptionalScope.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2017 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
 package com.github.javaparser.ast.nodeTypes;
 
 import com.github.javaparser.ast.Node;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithSimpleName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithSimpleName.java
@@ -24,6 +24,8 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.SimpleName;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
+
 /**
  * A node with a name.
  * <p>
@@ -36,6 +38,7 @@ public interface NodeWithSimpleName<N extends Node> {
 
     @SuppressWarnings("unchecked")
     default N setName(String name) {
+        assertNonEmpty(name);
         return setName(new SimpleName(name));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
@@ -26,6 +26,8 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 
+import static com.github.javaparser.utils.Utils.assertNonEmpty;
+
 /**
  * A node with a type.
  * <p>
@@ -64,6 +66,7 @@ public interface NodeWithType<N extends Node, T extends Type> {
 
     @SuppressWarnings("unchecked")
     default N setType(final String type) {
+        assertNonEmpty(type);
         ClassOrInterfaceType classOrInterfaceType = new ClassOrInterfaceType(type);
         return setType((T) classOrInterfaceType);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
@@ -24,7 +24,6 @@ package com.github.javaparser.javadoc;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -37,6 +36,7 @@ import java.util.List;
  * of this writing this comment does not contain any block tags (such as <code>@see AnotherClass</code>)
  */
 public class Javadoc {
+
     private JavadocDescription description;
     private List<JavadocBlockTag> blockTags;
 
@@ -102,6 +102,14 @@ public class Javadoc {
         return new JavadocComment(sb.toString());
     }
 
+    public JavadocDescription getDescription() {
+        return description;
+    }
+
+    public List<JavadocBlockTag> getBlockTags() {
+        return blockTags;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -109,8 +117,7 @@ public class Javadoc {
 
         Javadoc document = (Javadoc) o;
 
-        if (!description.equals(document.description)) return false;
-        return blockTags.equals(document.blockTags);
+        return description.equals(document.description) && blockTags.equals(document.blockTags);
 
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -50,11 +50,11 @@ public class Utils {
         return o;
     }
 
-    public static String assertNonEmpty(String id) {
-        if (id == null || id.isEmpty()) {
-            throw new AssertionError("An identifier was unexpectedly empty.");
+    public static String assertNonEmpty(String string) {
+        if (string == null || string.isEmpty()) {
+            throw new AssertionError("A string was unexpectedly empty.");
         }
-        return id;
+        return string;
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -49,6 +49,13 @@ public class Utils {
         return o;
     }
 
+    public static String assertNonEmpty(String id) {
+        if (id == null || id.isEmpty()) {
+            throw new AssertionError("An identifier was unexpectedly empty.");
+        }
+        return id;
+    }
+
     /**
      * @return string with ASCII characters 10 and 13 replaced by the text "\n" and "\r".
      */

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
@@ -37,4 +37,9 @@ public class NameTest {
         Name name = Name.parse("a.b.c");
         assertEquals("a.b.c", name.asString());
     }
+
+    @Test(expected = AssertionError.class)
+    public void parsingEmptyNameThrowsException() {
+        Name.parse("");
+    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
- * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ * Copyright (C) 2011, 2013-2017 The JavaParser Team.
  *
  * This file is part of JavaParser.
  *

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2017 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
 package com.github.javaparser.ast.expr;
 
 import org.junit.Test;

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
@@ -1,0 +1,24 @@
+package com.github.javaparser.ast.expr;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class SimpleNameTest {
+
+    @Test
+    public void defaultConstructorSetsIdentifierToEmpty() {
+        assertEquals("empty", new SimpleName().getIdentifier());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void identifierMustNotBeEmpty() {
+        new SimpleName("");
+    }
+
+    @Test(expected = AssertionError.class)
+    public void identifierMustNotBeNull() {
+        new SimpleName(null);
+    }
+
+}

--- a/javaparser-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.javadoc;
 
+import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import org.junit.Test;
@@ -67,6 +68,13 @@ public class JavadocTest {
         Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line\nsecond line"));
         javadoc.addBlockTag("foo", "something useful");
         assertEquals(new JavadocComment("\n\t\t * first line\n\t\t * second line\n\t\t * \n\t\t * @foo something useful\n\t\t "), javadoc.toComment("\t\t"));
+    }
+
+    @Test
+    public void descriptionAndBlockTagsAreRetrievable() {
+        Javadoc javadoc = JavaParser.parseJavadoc("first line\nsecond line\n\n@param node a node\n@return result the result");
+        assertEquals(javadoc.getDescription().toText(), "first line\nsecond line");
+        assertEquals(javadoc.getBlockTags().size(), 2);
     }
 
 }


### PR DESCRIPTION
Proposal to fix #502 

Changes are mostly in SimpleName as this now handles all identifiers :)

In StringLiteralExpr.setValue() was a nullCheck. I'm not sure if non-empty check would be right here as some JavadocExtractorTest-Cases fail then?