### PR TITLE
Issue 666 generate nodelists

### DIFF
--- a/javaparser-core-generators/pom.xml
+++ b/javaparser-core-generators/pom.xml
@@ -9,8 +9,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>javaparser-visitor-generator</artifactId>
-    <description>A visitor generator framework, and the generators for the javaparser-core visitors</description>
+    <artifactId>javaparser-core-generators</artifactId>
+    <description>A visitor generator framework, and the generators for javaparser-core</description>
 
     <dependencies>
         <dependency>

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
@@ -4,6 +4,9 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 
+/**
+ * A general pattern that the generators in this module will follow.
+ */
 public abstract class Generator {
     protected final JavaParser javaParser;
     protected final SourceRoot sourceRoot;

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
@@ -2,7 +2,6 @@ package com.github.javaparser.generator;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.generator.utils.SourceRoot;
-import com.github.javaparser.metamodel.JavaParserMetaModel;
 
 /**
  * A general pattern that the generators in this module will follow.
@@ -10,12 +9,10 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 public abstract class Generator {
     protected final JavaParser javaParser;
     protected final SourceRoot sourceRoot;
-    protected final JavaParserMetaModel javaParserMetaModel;
 
-    protected Generator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    protected Generator(JavaParser javaParser, SourceRoot sourceRoot) {
         this.javaParser = javaParser;
         this.sourceRoot = sourceRoot;
-        this.javaParserMetaModel = javaParserMetaModel;
     }
 
     public abstract void generate() throws Exception;

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
@@ -1,0 +1,19 @@
+package com.github.javaparser.generator;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.generator.utils.SourceRoot;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+
+public abstract class Generator {
+    protected final JavaParser javaParser;
+    protected final SourceRoot sourceRoot;
+    protected final JavaParserMetaModel javaParserMetaModel;
+
+    protected Generator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+        this.javaParser = javaParser;
+        this.sourceRoot = sourceRoot;
+        this.javaParserMetaModel = javaParserMetaModel;
+    }
+
+    public abstract void generate() throws Exception;
+}

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
@@ -1,0 +1,28 @@
+package com.github.javaparser.generator;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.generator.utils.SourceRoot;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+
+import java.io.IOException;
+
+import static com.github.javaparser.generator.utils.GeneratorUtils.f;
+
+public abstract class NodeGenerator extends Generator {
+    protected NodeGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+        super(javaParser, sourceRoot, javaParserMetaModel);
+    }
+
+    public final void generate() throws IOException {
+        for (BaseNodeMetaModel nodeMetaModel : javaParserMetaModel.getNodeMetaModels()) {
+            CompilationUnit nodeCu = sourceRoot.parse(nodeMetaModel.getPackageName(), nodeMetaModel.getTypeName() + ".java", javaParser).orElseThrow(() -> new IOException(f("java file for %s not found", nodeMetaModel.getTypeName())));
+            ClassOrInterfaceDeclaration nodeCoid = nodeCu.getClassByName(nodeMetaModel.getTypeName()).orElseThrow(() -> new IOException("Can't find class"));
+            generateNode(nodeMetaModel, nodeCu, nodeCoid);
+        }
+    }
+
+    protected abstract void generateNode(BaseNodeMetaModel nodeMetaModel, CompilationUnit nodeCu, ClassOrInterfaceDeclaration nodeCoid);
+}

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
@@ -11,6 +11,10 @@ import java.io.IOException;
 
 import static com.github.javaparser.generator.utils.GeneratorUtils.f;
 
+/**
+ * Makes it easier to generate code in the core AST nodes. The generateNode method will get every node type passed to it,
+ * ready for modification.
+ */
 public abstract class NodeGenerator extends Generator {
     protected NodeGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, javaParserMetaModel);

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
@@ -16,12 +16,12 @@ import static com.github.javaparser.generator.utils.GeneratorUtils.f;
  * ready for modification.
  */
 public abstract class NodeGenerator extends Generator {
-    protected NodeGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
-        super(javaParser, sourceRoot, javaParserMetaModel);
+    protected NodeGenerator(JavaParser javaParser, SourceRoot sourceRoot) {
+        super(javaParser, sourceRoot);
     }
 
     public final void generate() throws IOException {
-        for (BaseNodeMetaModel nodeMetaModel : javaParserMetaModel.getNodeMetaModels()) {
+        for (BaseNodeMetaModel nodeMetaModel : JavaParserMetaModel.getNodeMetaModels()) {
             CompilationUnit nodeCu = sourceRoot.parse(nodeMetaModel.getPackageName(), nodeMetaModel.getTypeName() + ".java", javaParser).orElseThrow(() -> new IOException(f("java file for %s not found", nodeMetaModel.getTypeName())));
             ClassOrInterfaceDeclaration nodeCoid = nodeCu.getClassByName(nodeMetaModel.getTypeName()).orElseThrow(() -> new IOException("Can't find class"));
             generateNode(nodeMetaModel, nodeCu, nodeCoid);

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
@@ -2,20 +2,16 @@ package com.github.javaparser.generator;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.metamodel.PropertyMetaModel;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
-import static com.github.javaparser.ast.Modifier.*;
+import static com.github.javaparser.ast.Modifier.PUBLIC;
 
 /**
  * Makes it easier to generate visitor classes.
@@ -29,8 +25,8 @@ public abstract class VisitorGenerator extends Generator {
     private final String argumentType;
     private final boolean createMissingVisitMethods;
 
-    public VisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, String pkg, String visitorClassName, String returnType, String argumentType, boolean createMissingVisitMethods) {
-        super(javaParser, sourceRoot, javaParserMetaModel);
+    protected VisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, String pkg, String visitorClassName, String returnType, String argumentType, boolean createMissingVisitMethods) {
+        super(javaParser, sourceRoot);
         this.pkg = pkg;
         this.visitorClassName = visitorClassName;
         this.returnType = returnType;

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
@@ -1,4 +1,4 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -19,28 +19,23 @@ import java.util.Optional;
  * It will create missing visit methods on the fly,
  * and will ask you to fill in the bodies of the visit methods.
  */
-public abstract class VisitorGenerator {
-    protected final JavaParser javaParser;
-    protected final SourceRoot sourceRoot;
+public abstract class VisitorGenerator extends Generator {
     private final String pkg;
     private final String visitorClassName;
     private final String returnType;
     private final String argumentType;
     private final boolean createMissingVisitMethods;
-    protected final JavaParserMetaModel javaParserMetaModel;
 
     public VisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, String pkg, String visitorClassName, String returnType, String argumentType, boolean createMissingVisitMethods, JavaParserMetaModel javaParserMetaModel) {
-        this.javaParser = javaParser;
-        this.sourceRoot = sourceRoot;
+        super(javaParser, sourceRoot, javaParserMetaModel);
         this.pkg = pkg;
         this.visitorClassName = visitorClassName;
         this.returnType = returnType;
         this.argumentType = argumentType;
         this.createMissingVisitMethods = createMissingVisitMethods;
-        this.javaParserMetaModel = javaParserMetaModel;
     }
 
-    public void generate() throws IOException {
+    public final void generate() throws IOException {
         CompilationUnit compilationUnit = sourceRoot.parse(pkg, visitorClassName + ".java", javaParser).get();
 
         Optional<ClassOrInterfaceDeclaration> visitorClassOptional = compilationUnit.getClassByName(visitorClassName);
@@ -55,33 +50,21 @@ public abstract class VisitorGenerator {
     }
 
     private void generateVisitMethodForNode(BaseNodeMetaModel node, ClassOrInterfaceDeclaration visitorClass, CompilationUnit compilationUnit) {
-        List<PropertyMetaModel> allPropertyMetaModels = collectAllPropertyMetaModels(node);
-
         Optional<MethodDeclaration> visitMethod = visitorClass.getMethods().stream()
                 .filter(m -> m.getNameAsString().equals("visit"))
                 .filter(m -> m.getParameter(0).getType().toString().equals(node.getTypeName()))
                 .findFirst();
 
         if (visitMethod.isPresent()) {
-            generateVisitMethodBody(node, visitMethod.get(), allPropertyMetaModels, compilationUnit);
+            generateVisitMethodBody(node, visitMethod.get(), compilationUnit);
         } else if (createMissingVisitMethods) {
             MethodDeclaration methodDeclaration = visitorClass.addMethod("visit")
                     .addParameter(node.getTypeNameGenerified(), "n")
                     .addParameter(argumentType, "arg")
                     .setType(returnType);
-            generateVisitMethodBody(node, methodDeclaration, allPropertyMetaModels, compilationUnit);
+            generateVisitMethodBody(node, methodDeclaration, compilationUnit);
         }
     }
 
-    private List<PropertyMetaModel> collectAllPropertyMetaModels(BaseNodeMetaModel node) {
-        List<PropertyMetaModel> allPropertyMetaModels = new ArrayList<>(node.getDeclaredPropertyMetaModels());
-        BaseNodeMetaModel walkNode = node;
-        while (walkNode.getSuperNodeMetaModel().isPresent()) {
-            walkNode = walkNode.getSuperNodeMetaModel().get();
-            allPropertyMetaModels.addAll(walkNode.getDeclaredPropertyMetaModels());
-        }
-        return allPropertyMetaModels;
-    }
-
-    protected abstract void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit);
+    protected abstract void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit);
 }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A class that makes it easier to generate visitor classes.
+ * Makes it easier to generate visitor classes.
  * It will create missing visit methods on the fly,
  * and will ask you to fill in the bodies of the visit methods.
  */

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
@@ -1,12 +1,10 @@
 package com.github.javaparser.generator.core;
 
 import com.github.javaparser.JavaParser;
-import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.core.node.GetNodeListsGenerator;
 import com.github.javaparser.generator.core.visitor.*;
 import com.github.javaparser.generator.utils.GeneratorUtils;
 import com.github.javaparser.generator.utils.SourceRoot;
-import com.github.javaparser.metamodel.JavaParserMetaModel;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -32,7 +30,7 @@ public class CoreGenerator {
         new CloneVisitorGenerator(javaParser, sourceRoot).generate();
         new TreeStructureVisitorGenerator(javaParser, sourceRoot).generate();
 
-        new GetNodeListsGenerator(javaParser, sourceRoot, javaParserMetaModel).generate();
+        new GetNodeListsGenerator(javaParser, sourceRoot).generate();
         
         sourceRoot.saveAll();
     }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
@@ -1,6 +1,9 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.generator.VisitorGenerator;
+import com.github.javaparser.generator.core.node.GetNodeListsGenerator;
+import com.github.javaparser.generator.core.visitor.*;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 
@@ -11,7 +14,7 @@ import java.nio.file.Paths;
 /**
  * Generates all generated visitors in the javaparser-core module.
  */
-public class CoreVisitorsGenerator {
+public class CoreGenerator {
     public static void main(String[] args) throws IOException {
         final JavaParserMetaModel javaParserMetaModel = new JavaParserMetaModel();
 
@@ -29,6 +32,8 @@ public class CoreVisitorsGenerator {
         new HashCodeVisitorGenerator(javaParser, sourceRoot, javaParserMetaModel).generate();
         new CloneVisitorGenerator(javaParser, sourceRoot, javaParserMetaModel).generate();
 
+        new GetNodeListsGenerator(javaParser, sourceRoot, javaParserMetaModel).generate();
+        
         sourceRoot.saveAll();
     }
 }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetNodeListsGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetNodeListsGenerator.java
@@ -2,6 +2,7 @@ package com.github.javaparser.generator.core.node;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -12,6 +13,11 @@ import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 
+import java.util.List;
+
+import static com.github.javaparser.JavaParser.parseClassBodyDeclaration;
+import static com.github.javaparser.generator.utils.GeneratorUtils.f;
+
 public class GetNodeListsGenerator extends NodeGenerator {
     public GetNodeListsGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, javaParserMetaModel);
@@ -19,14 +25,33 @@ public class GetNodeListsGenerator extends NodeGenerator {
 
     @Override
     protected void generateNode(BaseNodeMetaModel nodeMetaModel, CompilationUnit nodeCu, ClassOrInterfaceDeclaration nodeCoid) {
-        MethodDeclaration getNodeListsMethod = nodeCoid.getMethodsByName("getNodeLists").get(0);
+        if (nodeMetaModel.isAbstract()) {
+            return;
+        }
+
         SeparatedItemStringBuilder statement = new SeparatedItemStringBuilder("return Arrays.asList(", ",", ");");
         for (PropertyMetaModel property : nodeMetaModel.getAllPropertyMetaModels()) {
             if (property.isNodeList()) {
-                statement.append(property.getName());
+                if (property.isOptional()) {
+                    statement.append(f("%s().orElse(null)", property.getGetterMethodName()));
+                } else {
+                    statement.append(f("%s()", property.getGetterMethodName()));
+                }
             }
         }
-        BlockStmt block = getNodeListsMethod.getBody().get();
+
+        List<MethodDeclaration> getNodeListsMethods = nodeCoid.getMethodsByName("getNodeLists");
+        if (!statement.hasItems()) {
+            getNodeListsMethods.forEach(Node::remove);
+            return;
+        }
+
+        if (getNodeListsMethods.isEmpty()) {
+            nodeCoid.addMember(parseClassBodyDeclaration(f("@Override public List<NodeList<?>> getNodeLists() {%s}", statement)));
+            return;
+        }
+
+        BlockStmt block = getNodeListsMethods.get(0).getBody().get();
         block.getStatements().clear();
         block.addStatement(statement.toString());
     }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetNodeListsGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetNodeListsGenerator.java
@@ -1,0 +1,33 @@
+package com.github.javaparser.generator.core.node;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.NodeGenerator;
+import com.github.javaparser.generator.utils.SeparatedItemStringBuilder;
+import com.github.javaparser.generator.utils.SourceRoot;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+import com.github.javaparser.metamodel.PropertyMetaModel;
+
+public class GetNodeListsGenerator extends NodeGenerator {
+    public GetNodeListsGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+        super(javaParser, sourceRoot, javaParserMetaModel);
+    }
+
+    @Override
+    protected void generateNode(BaseNodeMetaModel nodeMetaModel, CompilationUnit nodeCu, ClassOrInterfaceDeclaration nodeCoid) {
+        MethodDeclaration getNodeListsMethod = nodeCoid.getMethodsByName("getNodeLists").get(0);
+        SeparatedItemStringBuilder statement = new SeparatedItemStringBuilder("return Arrays.asList(", ",", ");");
+        for (PropertyMetaModel property : nodeMetaModel.getAllPropertyMetaModels()) {
+            if (property.isNodeList()) {
+                statement.append(property.getName());
+            }
+        }
+        BlockStmt block = getNodeListsMethod.getBody().get();
+        block.getStatements().clear();
+        block.addStatement(statement.toString());
+    }
+}

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetNodeListsGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetNodeListsGenerator.java
@@ -10,7 +10,6 @@ import com.github.javaparser.generator.NodeGenerator;
 import com.github.javaparser.generator.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
-import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 
 import java.util.List;
@@ -19,8 +18,8 @@ import static com.github.javaparser.JavaParser.parseClassBodyDeclaration;
 import static com.github.javaparser.generator.utils.GeneratorUtils.f;
 
 public class GetNodeListsGenerator extends NodeGenerator {
-    public GetNodeListsGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
-        super(javaParser, sourceRoot, javaParserMetaModel);
+    public GetNodeListsGenerator(JavaParser javaParser, SourceRoot sourceRoot) {
+        super(javaParser, sourceRoot);
     }
 
     @Override

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
@@ -1,16 +1,15 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
-
-import java.util.List;
 
 import static com.github.javaparser.generator.utils.GeneratorUtils.f;
 
@@ -18,16 +17,16 @@ import static com.github.javaparser.generator.utils.GeneratorUtils.f;
  * Generates JavaParser's CloneVisitor.
  */
 public class CloneVisitorGenerator extends VisitorGenerator {
-    CloneVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    public CloneVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, "com.github.javaparser.ast.visitor", "CloneVisitor", "void", "A", true, javaParserMetaModel);
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit) {
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
-        for (PropertyMetaModel field : allPropertyMetaModels) {
+        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isOptional() && field.isNodeList()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/EqualsVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/EqualsVisitorGenerator.java
@@ -1,15 +1,14 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
-
-import java.util.List;
 
 import static com.github.javaparser.generator.utils.GeneratorUtils.f;
 
@@ -17,18 +16,18 @@ import static com.github.javaparser.generator.utils.GeneratorUtils.f;
  * Generates JavaParser's EqualsVisitor.
  */
 public class EqualsVisitorGenerator extends VisitorGenerator {
-    EqualsVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    public EqualsVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, "com.github.javaparser.ast.visitor", "EqualsVisitor", "Boolean", "Node", true, javaParserMetaModel);
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit) {
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
         body.addStatement(f("final %s n2 = (%s) arg;", node.getTypeName(), node.getTypeName()));
 
-        for (PropertyMetaModel field : allPropertyMetaModels) {
+        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isNodeList()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericVisitorAdapterGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericVisitorAdapterGenerator.java
@@ -1,15 +1,14 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
-
-import java.util.List;
 
 import static com.github.javaparser.generator.utils.GeneratorUtils.f;
 
@@ -17,12 +16,12 @@ import static com.github.javaparser.generator.utils.GeneratorUtils.f;
  * Generates JavaParser's VoidVisitorAdapter.
  */
 public class GenericVisitorAdapterGenerator extends VisitorGenerator {
-    GenericVisitorAdapterGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    public GenericVisitorAdapterGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, "com.github.javaparser.ast.visitor", "GenericVisitorAdapter", "void", "A", true, javaParserMetaModel);
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit) {
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
         
@@ -30,7 +29,7 @@ public class GenericVisitorAdapterGenerator extends VisitorGenerator {
 
         final String resultCheck = "if (result != null) return result;";
 
-        for (PropertyMetaModel field : allPropertyMetaModels) {
+        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isOptional()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericVisitorGenerator.java
@@ -1,25 +1,23 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.metamodel.PropertyMetaModel;
-
-import java.util.List;
 
 /**
  * Generates JavaParser's GenericVisitor.
  */
 public class GenericVisitorGenerator extends VisitorGenerator {
-    GenericVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    public GenericVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, "com.github.javaparser.ast.visitor", "GenericVisitor", "R", "A", true, javaParserMetaModel);
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit) {
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
         visitMethod.setBody(null);
     }
 }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/HashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/HashCodeVisitorGenerator.java
@@ -1,9 +1,10 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
@@ -18,16 +19,17 @@ import static com.github.javaparser.JavaParser.parseStatement;
  * Generates JavaParser's HashCodeVisitor.
  */
 public class HashCodeVisitorGenerator extends VisitorGenerator {
-    HashCodeVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    public HashCodeVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, "com.github.javaparser.ast.visitor", "HashCodeVisitor", "Integer", "Void", true, javaParserMetaModel);
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> propertyMetaModels, CompilationUnit compilationUnit) {
-        BlockStmt body = visitMethod.getBody().get();
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
+        final BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
-        SeparatedItemStringBuilder builder = new SeparatedItemStringBuilder("return ", "* 31 +", ";");
+        final SeparatedItemStringBuilder builder = new SeparatedItemStringBuilder("return ", "* 31 +", ";");
+        final List<PropertyMetaModel> propertyMetaModels= node.getAllPropertyMetaModels();
         if (propertyMetaModels.isEmpty()) {
             builder.append("0");
         } else {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/TreeStructureVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/TreeStructureVisitorGenerator.java
@@ -1,9 +1,10 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
@@ -19,7 +20,9 @@ public class TreeStructureVisitorGenerator extends VisitorGenerator {
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit) {
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
+        final List<PropertyMetaModel> allPropertyMetaModels = node.getAllPropertyMetaModels();
+        
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/VoidVisitorAdapterGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/VoidVisitorAdapterGenerator.java
@@ -1,15 +1,14 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
-
-import java.util.List;
 
 import static com.github.javaparser.generator.utils.GeneratorUtils.f;
 
@@ -17,16 +16,16 @@ import static com.github.javaparser.generator.utils.GeneratorUtils.f;
  * Generates JavaParser's VoidVisitorAdapter.
  */
 public class VoidVisitorAdapterGenerator extends VisitorGenerator {
-    VoidVisitorAdapterGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    public VoidVisitorAdapterGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, "com.github.javaparser.ast.visitor", "VoidVisitorAdapter", "void", "A", true, javaParserMetaModel);
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit) {
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
-        for (PropertyMetaModel field : allPropertyMetaModels) {
+        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isOptional() && field.isNodeList()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/VoidVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/VoidVisitorGenerator.java
@@ -1,25 +1,23 @@
-package com.github.javaparser.generator.visitor;
+package com.github.javaparser.generator.core.visitor;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.generator.VisitorGenerator;
 import com.github.javaparser.generator.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.metamodel.PropertyMetaModel;
-
-import java.util.List;
 
 /**
  * Generates JavaParser's VoidVisitor.
  */
 public class VoidVisitorGenerator extends VisitorGenerator {
-    VoidVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
+    public VoidVisitorGenerator(JavaParser javaParser, SourceRoot sourceRoot, JavaParserMetaModel javaParserMetaModel) {
         super(javaParser, sourceRoot, "com.github.javaparser.ast.visitor", "VoidVisitor", "void", "A", true, javaParserMetaModel);
     }
 
     @Override
-    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, List<PropertyMetaModel> allPropertyMetaModels, CompilationUnit compilationUnit) {
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
         visitMethod.setBody(null);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast;
 
 import com.github.javaparser.Range;
@@ -29,11 +28,9 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -42,7 +39,9 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * the second the expression "2".
  */
 public class ArrayCreationLevel extends Node implements NodeWithAnnotations<ArrayCreationLevel> {
+
     private Expression dimension;
+
     private NodeList<AnnotationExpr> annotations = new NodeList<>();
 
     public ArrayCreationLevel() {
@@ -110,10 +109,11 @@ public class ArrayCreationLevel extends Node implements NodeWithAnnotations<Arra
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        return Arrays.asList(annotations);
+        return Arrays.asList(getAnnotations());
     }
 
     public void removeDimension() {
         setDimension(null);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast;
 
 import com.github.javaparser.JavaParser;
@@ -34,13 +33,11 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.ClassUtils;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -78,8 +75,7 @@ public final class CompilationUnit extends Node {
         this(null, packageDeclaration, imports, types);
     }
 
-    public CompilationUnit(Range range, PackageDeclaration packageDeclaration, NodeList<ImportDeclaration> imports,
-                           NodeList<TypeDeclaration<?>> types) {
+    public CompilationUnit(Range range, PackageDeclaration packageDeclaration, NodeList<ImportDeclaration> imports, NodeList<TypeDeclaration<?>> types) {
         super(range);
         setPackageDeclaration(packageDeclaration);
         setImports(imports);
@@ -252,8 +248,7 @@ public final class CompilationUnit extends Node {
     public CompilationUnit addImport(Class<?> clazz) {
         if (ClassUtils.isPrimitiveOrWrapper(clazz) || clazz.getName().startsWith("java.lang"))
             return this;
-        else if (clazz.isArray() && !ClassUtils.isPrimitiveOrWrapper(clazz.getComponentType())
-                && !clazz.getComponentType().getName().startsWith("java.lang"))
+        else if (clazz.isArray() && !ClassUtils.isPrimitiveOrWrapper(clazz.getComponentType()) && !clazz.getComponentType().getName().startsWith("java.lang"))
             return addImport(clazz.getComponentType().getName());
         return addImport(clazz.getName());
     }
@@ -278,7 +273,7 @@ public final class CompilationUnit extends Node {
         }
         i.append(";");
         ImportDeclaration importDeclaration = JavaParser.parseImport(i.toString());
-        if (getImports().stream().anyMatch(im -> im.toString().equals(importDeclaration.toString())))
+        if (getImports().stream().anyMatch( im -> im.toString().equals(importDeclaration.toString())))
             return this;
         else {
             getImports().add(importDeclaration);
@@ -305,10 +300,7 @@ public final class CompilationUnit extends Node {
      * @return the newly created class
      */
     public ClassOrInterfaceDeclaration addClass(String name, Modifier... modifiers) {
-        ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration(
-                Arrays.stream(modifiers)
-                        .collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))),
-                false, name);
+        ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration(Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), false, name);
         getTypes().add(classOrInterfaceDeclaration);
         classOrInterfaceDeclaration.setParentNode(this);
         return classOrInterfaceDeclaration;
@@ -332,10 +324,7 @@ public final class CompilationUnit extends Node {
      * @return the newly created class
      */
     public ClassOrInterfaceDeclaration addInterface(String name, Modifier... modifiers) {
-        ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration(
-                Arrays.stream(modifiers)
-                        .collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))),
-                true, name);
+        ClassOrInterfaceDeclaration classOrInterfaceDeclaration = new ClassOrInterfaceDeclaration(Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), true, name);
         getTypes().add(classOrInterfaceDeclaration);
         classOrInterfaceDeclaration.setParentNode(this);
         return classOrInterfaceDeclaration;
@@ -359,8 +348,7 @@ public final class CompilationUnit extends Node {
      * @return the newly created class
      */
     public EnumDeclaration addEnum(String name, Modifier... modifiers) {
-        EnumDeclaration enumDeclaration = new EnumDeclaration(Arrays.stream(modifiers)
-                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), name);
+        EnumDeclaration enumDeclaration = new EnumDeclaration(Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), name);
         getTypes().add(enumDeclaration);
         enumDeclaration.setParentNode(this);
         return enumDeclaration;
@@ -384,8 +372,7 @@ public final class CompilationUnit extends Node {
      * @return the newly created class
      */
     public AnnotationDeclaration addAnnotationDeclaration(String name, Modifier... modifiers) {
-        AnnotationDeclaration annotationDeclaration = new AnnotationDeclaration(Arrays.stream(modifiers)
-                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), name);
+        AnnotationDeclaration annotationDeclaration = new AnnotationDeclaration(Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), name);
         getTypes().add(annotationDeclaration);
         annotationDeclaration.setParentNode(this);
         return annotationDeclaration;
@@ -397,10 +384,7 @@ public final class CompilationUnit extends Node {
      * @param className the class name (case-sensitive)
      */
     public Optional<ClassOrInterfaceDeclaration> getClassByName(String className) {
-        return getTypes().stream().filter(type -> type.getNameAsString().equals(className)
-                && type instanceof ClassOrInterfaceDeclaration && !((ClassOrInterfaceDeclaration) type).isInterface())
-                .findFirst()
-                .map(t -> (ClassOrInterfaceDeclaration) t);
+        return getTypes().stream().filter( type -> type.getNameAsString().equals(className) && type instanceof ClassOrInterfaceDeclaration && !((ClassOrInterfaceDeclaration) type).isInterface()).findFirst().map( t -> (ClassOrInterfaceDeclaration) t);
     }
 
     /**
@@ -409,10 +393,7 @@ public final class CompilationUnit extends Node {
      * @param interfaceName the interface name (case-sensitive)
      */
     public Optional<ClassOrInterfaceDeclaration> getInterfaceByName(String interfaceName) {
-        return getTypes().stream().filter(type -> type.getNameAsString().equals(interfaceName)
-                && type instanceof ClassOrInterfaceDeclaration && ((ClassOrInterfaceDeclaration) type).isInterface())
-                .findFirst()
-                .map(t -> (ClassOrInterfaceDeclaration) t);
+        return getTypes().stream().filter( type -> type.getNameAsString().equals(interfaceName) && type instanceof ClassOrInterfaceDeclaration && ((ClassOrInterfaceDeclaration) type).isInterface()).findFirst().map( t -> (ClassOrInterfaceDeclaration) t);
     }
 
     /**
@@ -421,10 +402,7 @@ public final class CompilationUnit extends Node {
      * @param enumName the enum name (case-sensitive)
      */
     public Optional<EnumDeclaration> getEnumByName(String enumName) {
-        return getTypes().stream().filter(type -> type.getNameAsString().equals(enumName)
-                && type instanceof EnumDeclaration)
-                .findFirst()
-                .map(t -> (EnumDeclaration) t);
+        return getTypes().stream().filter( type -> type.getNameAsString().equals(enumName) && type instanceof EnumDeclaration).findFirst().map( t -> (EnumDeclaration) t);
     }
 
     /**
@@ -433,14 +411,12 @@ public final class CompilationUnit extends Node {
      * @param annotationName the annotation name (case-sensitive)
      */
     public Optional<AnnotationDeclaration> getAnnotationDeclarationByName(String annotationName) {
-        return getTypes().stream().filter(type -> type.getNameAsString().equals(annotationName)
-                && type instanceof AnnotationDeclaration)
-                .findFirst()
-                .map(t -> (AnnotationDeclaration) t);
+        return getTypes().stream().filter( type -> type.getNameAsString().equals(annotationName) && type instanceof AnnotationDeclaration).findFirst().map( t -> (AnnotationDeclaration) t);
     }
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        return Arrays.asList(imports, types);
+        return Arrays.asList(getImports(), getTypes());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
- 
 package com.github.javaparser.ast;
 
 import com.github.javaparser.Range;
@@ -39,11 +38,12 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  * <p>The name does not include the asterisk or the static keyword.</p>
  * @author Julio Vilmar Gesser
  */
-public final class ImportDeclaration extends Node implements 
-        NodeWithName<ImportDeclaration> {
+public final class ImportDeclaration extends Node implements NodeWithName<ImportDeclaration> {
 
     private Name name;
+
     private boolean isStatic;
+
     private boolean isAsterisk;
 
     private ImportDeclaration() {
@@ -109,3 +109,4 @@ public final class ImportDeclaration extends Node implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast;
 
 import com.github.javaparser.HasParentNode;
@@ -37,60 +36,16 @@ import com.github.javaparser.ast.visitor.HashCodeVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
-
 import static java.util.Collections.unmodifiableList;
 
-/**
- * Base class for all nodes of the abstract syntax tree.
- * <h2>Construction</h2>
- * <p>The tree is built by instantiating the required nodes, then adding them to other nodes.
- * If it is the parser who is building the tree, it will use the largest constructor,
- * the one with "range" as the first parameter.
- * If you want to manually instantiate nodes, we suggest to...
- * <ul>
- * <li>use a convenience method, like "addStatement(...)", or if none are available...</li>
- * <li>use a convenient constructor, like ClassOrInterfaceType(String name), or if none are available...</li>
- * <li>use the default constructor.</li>
- * <li>Alternatively, use one of the JavaParser.parse(snippet) methods.</li>
- * </ul>
- * ... and use the various methods on the node to initialize it further, if needed.
- * <h2>Parent/child</h2>
- * <p>The parent node field is managed automatically and can be seen as read only.
- * Note that there is only one parent,
- * and trying to use the same node in two places will lead to unexpected behaviour.
- * It is advised to clone() a node before moving it around.
- * <h2>Comments</h2>
- * <p>Each Node can have one associated comment which describes it and
- * a number of "orphan comments" which it contains but are not specifically
- * associated to any child.
- * <h2>Positions</h2>
- * <p>When the parser creates nodes, it sets their source code position in the "range" field.
- * When you manually instantiate nodes, their range is not set.
- * The top left character is position 1, 1.
- * Note that since this is an <i>abstract</i> syntax tree,
- * it leaves out a lot of text from the original source file,
- * like where braces or comma's are exactly.
- * Therefore there is no position information on everything in the original source file.
- * <h2>Observers</h2>
- * <p>It is possible to add observers to the the tree.
- * Any change in the tree is sent as an event to any observers watching.
- * <h2>Visitors</h2>
- * <p>The most comfortable way of working with an abstract syntax tree is using visitors.
- * You can use one of the visitors in the visitor package, or extend one of them.
- * A visitor can be "run" by calling accept on a node:
- * <pre>node.accept(visitor, argument);</pre>
- * where argument is an object of your choice (often simply null.)
- *
- * @author Julio Vilmar Gesser
- */
 // Use <Node> to prevent Node from becoming generic.
 public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable {
+
     /**
      * Different registration mode for observers on nodes.
      */
@@ -99,15 +54,11 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
         /**
          * Notify exclusively for changes happening on this node alone.
          */
-        JUST_THIS_NODE,
-
-        /**
+        JUST_THIS_NODE, /**
          * Notify for changes happening on this node and all its descendants existing at the moment in
          * which the observer was registered. Nodes attached later will not be observed.
          */
-        THIS_NODE_AND_EXISTING_DESCENDANTS,
-
-        /**
+        THIS_NODE_AND_EXISTING_DESCENDANTS, /**
          * Notify for changes happening on this node and all its descendants. The descendants existing at the moment in
          * which the observer was registered will be observed immediately. As new nodes are attached later they are
          * automatically registered to be observed.
@@ -118,7 +69,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     /**
      * This can be used to sort nodes on position.
      */
-    public static Comparator<Node> NODE_BY_BEGIN_POSITION = (a, b) -> {
+    public static Comparator<Node> NODE_BY_BEGIN_POSITION = ( a,  b) -> {
         if (a.getRange().isPresent() && b.getRange().isPresent()) {
             return a.getRange().get().begin.compareTo(b.getRange().get().begin);
         }
@@ -129,10 +80,10 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
             return -1;
         }
         return 0;
-
     };
 
     private static final PrettyPrinter toStringPrinter = new PrettyPrinter(new PrettyPrinterConfiguration());
+
     protected static final PrettyPrinterConfiguration prettyPrinterNoCommentsConfiguration = new PrettyPrinterConfiguration().setPrintComments(false);
 
     private Range range;
@@ -140,6 +91,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     private Node parentNode;
 
     private List<Node> childNodes = new LinkedList<>();
+
     private List<Comment> orphanComments = new LinkedList<>();
 
     private IdentityHashMap<DataKey<?>, Object> data = null;
@@ -332,12 +284,10 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     public List<Comment> getAllContainedComments() {
         List<Comment> comments = new LinkedList<>();
         comments.addAll(getOrphanComments());
-
         for (Node child : getChildNodes()) {
             child.getComment().ifPresent(comments::add);
             comments.addAll(child.getAllContainedComments());
         }
-
         return comments;
     }
 
@@ -349,8 +299,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
      */
     @Override
     public Node setParentNode(Node parentNode) {
-        observers.forEach(o -> o.parentChange(this, this.parentNode, parentNode));
-
+        observers.forEach( o -> o.parentChange(this, this.parentNode, parentNode));
         // remove from old parent, if any
         if (this.parentNode != null) {
             this.parentNode.childNodes.remove(this);
@@ -364,6 +313,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     public static final int ABSOLUTE_BEGIN_LINE = -1;
+
     public static final int ABSOLUTE_END_LINE = -2;
 
     @Deprecated
@@ -388,7 +338,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     public void tryAddImportToParentCompilationUnit(Class<?> clazz) {
-        getAncestorOfType(CompilationUnit.class).ifPresent(p -> p.addImport(clazz));
+        getAncestorOfType(CompilationUnit.class).ifPresent( p -> p.addImport(clazz));
     }
 
     /**
@@ -452,10 +402,6 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
         }
         boolean removed = false;
         Class<?> parentClass = parentNode.getClass();
-
-        // we are going to look to remove the node either by checking if it is part of a NodeList
-        // of if there is an explicit setter for it
-
         for (Method method : parentClass.getMethods()) {
             if (!removed && !java.lang.reflect.Modifier.isStatic(method.getModifiers())) {
                 // looking for methods returning a NodeList
@@ -464,22 +410,13 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
                         NodeList result = (NodeList) method.invoke(parentNode);
                         removed = result.remove(this);
                     } catch (IllegalAccessException | InvocationTargetException e) {
-                        // nothing to do here
                     }
-                } else if ((method.getReturnType().isAssignableFrom(this.getClass()) || isOptionalAssignableFrom(method.getGenericReturnType(), this.getClass()))
-                        && method.getParameterCount() == 0
-                        && method.getName().startsWith("get")) {
-                    final Class<?> setterParamType = isOptionalAssignableFrom(method.getGenericReturnType(), this.getClass()) ?
-                            getOptionalParameterType(method.getGenericReturnType()) : method.getReturnType();
+                } else if ((method.getReturnType().isAssignableFrom(this.getClass()) || isOptionalAssignableFrom(method.getGenericReturnType(), this.getClass())) && method.getParameterCount() == 0 && method.getName().startsWith("get")) {
+                    final Class<?> setterParamType = isOptionalAssignableFrom(method.getGenericReturnType(), this.getClass()) ? getOptionalParameterType(method.getGenericReturnType()) : method.getReturnType();
                     // ok, we found a potential getter. Before invoking let's check there is a corresponding setter,
                     // otherwise there is no point
                     String setterName = "set" + method.getName().substring("get".length());
-                    Optional<Method> optSetter = Arrays.stream(parentClass.getMethods())
-                            .filter(m -> m.getName().equals(setterName))
-                            .filter(m -> !java.lang.reflect.Modifier.isStatic(m.getModifiers()))
-                            .filter(m -> m.getParameterCount() == 1)
-                            .filter(m -> m.getParameterTypes()[0].equals(setterParamType))
-                            .findFirst();
+                    Optional<Method> optSetter = Arrays.stream(parentClass.getMethods()).filter( m -> m.getName().equals(setterName)).filter( m -> !java.lang.reflect.Modifier.isStatic(m.getModifiers())).filter( m -> m.getParameterCount() == 1).filter( m -> m.getParameterTypes()[0].equals(setterParamType)).findFirst();
                     if (optSetter.isPresent()) {
                         try {
                             Object resultRaw = method.invoke(parentNode);
@@ -490,8 +427,10 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
                                     Object o = optionalResultRaw.get();
                                     if (Node.class.isAssignableFrom(o.getClass())) {
                                         result = (Node) o;
-                                    } else continue;
-                                } else continue;
+                                    } else
+                                        continue;
+                                } else
+                                    continue;
                             } else {
                                 result = (Node) resultRaw;
                             }
@@ -500,7 +439,6 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
                                 removed = true;
                             }
                         } catch (IllegalAccessException | InvocationTargetException e) {
-                            // nothing to do here
                         }
                     }
                 }
@@ -521,7 +459,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     protected <P> void notifyPropertyChange(ObservableProperty property, P oldValue, P newValue) {
-        this.observers.forEach(o -> o.propertyChange(this, property, oldValue, newValue));
+        this.observers.forEach( o -> o.propertyChange(this, property, oldValue, newValue));
     }
 
     @Override
@@ -542,7 +480,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
         if (mode == null) {
             throw new IllegalArgumentException("Mode should be not null");
         }
-        switch (mode) {
+        switch(mode) {
             case JUST_THIS_NODE:
                 register(observer);
                 break;
@@ -562,8 +500,8 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
      */
     public void registerForSubtree(AstObserver observer) {
         register(observer);
-        this.getChildNodes().forEach(c -> c.registerForSubtree(observer));
-        this.getNodeLists().forEach(nl -> nl.register(observer));
+        this.getChildNodes().forEach( c -> c.registerForSubtree(observer));
+        this.getNodeLists().forEach( nl -> nl.register(observer));
     }
 
     @Override
@@ -610,3 +548,4 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
         return Optional.of(parameterType);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -44,7 +44,49 @@ import java.util.*;
 
 import static java.util.Collections.unmodifiableList;
 
-// Use <Node> to prevent Node from becoming generic.
+/**
+ * Base class for all nodes of the abstract syntax tree.
+ * <h2>Construction</h2>
+ * <p>The tree is built by instantiating the required nodes, then adding them to other nodes.
+ * If it is the parser who is building the tree, it will use the largest constructor,
+ * the one with "range" as the first parameter.
+ * If you want to manually instantiate nodes, we suggest to...
+ * <ul>
+ * <li>use a convenience method, like "addStatement(...)", or if none are available...</li>
+ * <li>use a convenient constructor, like ClassOrInterfaceType(String name), or if none are available...</li>
+ * <li>use the default constructor.</li>
+ * <li>Alternatively, use one of the JavaParser.parse(snippet) methods.</li>
+ * </ul>
+ * ... and use the various methods on the node to initialize it further, if needed.
+ * <h2>Parent/child</h2>
+ * <p>The parent node field is managed automatically and can be seen as read only.
+ * Note that there is only one parent,
+ * and trying to use the same node in two places will lead to unexpected behaviour.
+ * It is advised to clone() a node before moving it around.
+ * <h2>Comments</h2>
+ * <p>Each Node can have one associated comment which describes it and
+ * a number of "orphan comments" which it contains but are not specifically
+ * associated to any child.
+ * <h2>Positions</h2>
+ * <p>When the parser creates nodes, it sets their source code position in the "range" field.
+ * When you manually instantiate nodes, their range is not set.
+ * The top left character is position 1, 1.
+ * Note that since this is an <i>abstract</i> syntax tree,
+ * it leaves out a lot of text from the original source file,
+ * like where braces or comma's are exactly.
+ * Therefore there is no position information on everything in the original source file.
+ * <h2>Observers</h2>
+ * <p>It is possible to add observers to the the tree.
+ * Any change in the tree is sent as an event to any observers watching.
+ * <h2>Visitors</h2>
+ * <p>The most comfortable way of working with an abstract syntax tree is using visitors.
+ * You can use one of the visitors in the visitor package, or extend one of them.
+ * A visitor can be "run" by calling accept on a node:
+ * <pre>node.accept(visitor, argument);</pre>
+ * where argument is an object of your choice (often simply null.)
+ *
+ * @author Julio Vilmar Gesser
+ */
 public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable {
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -25,7 +25,6 @@ import com.github.javaparser.Position;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.ObservableProperty;
@@ -36,11 +35,13 @@ import com.github.javaparser.ast.visitor.HashCodeVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
+
 import static java.util.Collections.unmodifiableList;
 
 // Use <Node> to prevent Node from becoming generic.
@@ -69,7 +70,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     /**
      * This can be used to sort nodes on position.
      */
-    public static Comparator<Node> NODE_BY_BEGIN_POSITION = ( a,  b) -> {
+    public static Comparator<Node> NODE_BY_BEGIN_POSITION = (a, b) -> {
         if (a.getRange().isPresent() && b.getRange().isPresent()) {
             return a.getRange().get().begin.compareTo(b.getRange().get().begin);
         }
@@ -299,7 +300,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
      */
     @Override
     public Node setParentNode(Node parentNode) {
-        observers.forEach( o -> o.parentChange(this, this.parentNode, parentNode));
+        observers.forEach(o -> o.parentChange(this, this.parentNode, parentNode));
         // remove from old parent, if any
         if (this.parentNode != null) {
             this.parentNode.childNodes.remove(this);
@@ -338,7 +339,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     public void tryAddImportToParentCompilationUnit(Class<?> clazz) {
-        getAncestorOfType(CompilationUnit.class).ifPresent( p -> p.addImport(clazz));
+        getAncestorOfType(CompilationUnit.class).ifPresent(p -> p.addImport(clazz));
     }
 
     /**
@@ -416,7 +417,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
                     // ok, we found a potential getter. Before invoking let's check there is a corresponding setter,
                     // otherwise there is no point
                     String setterName = "set" + method.getName().substring("get".length());
-                    Optional<Method> optSetter = Arrays.stream(parentClass.getMethods()).filter( m -> m.getName().equals(setterName)).filter( m -> !java.lang.reflect.Modifier.isStatic(m.getModifiers())).filter( m -> m.getParameterCount() == 1).filter( m -> m.getParameterTypes()[0].equals(setterParamType)).findFirst();
+                    Optional<Method> optSetter = Arrays.stream(parentClass.getMethods()).filter(m -> m.getName().equals(setterName)).filter(m -> !java.lang.reflect.Modifier.isStatic(m.getModifiers())).filter(m -> m.getParameterCount() == 1).filter(m -> m.getParameterTypes()[0].equals(setterParamType)).findFirst();
                     if (optSetter.isPresent()) {
                         try {
                             Object resultRaw = method.invoke(parentNode);
@@ -459,7 +460,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     protected <P> void notifyPropertyChange(ObservableProperty property, P oldValue, P newValue) {
-        this.observers.forEach( o -> o.propertyChange(this, property, oldValue, newValue));
+        this.observers.forEach(o -> o.propertyChange(this, property, oldValue, newValue));
     }
 
     @Override
@@ -480,7 +481,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
         if (mode == null) {
             throw new IllegalArgumentException("Mode should be not null");
         }
-        switch(mode) {
+        switch (mode) {
             case JUST_THIS_NODE:
                 register(observer);
                 break;
@@ -500,8 +501,10 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
      */
     public void registerForSubtree(AstObserver observer) {
         register(observer);
-        this.getChildNodes().forEach( c -> c.registerForSubtree(observer));
-        this.getNodeLists().forEach( nl -> nl.register(observer));
+        this.getChildNodes().forEach(c -> c.registerForSubtree(observer));
+        this.getNodeLists().forEach(nl -> {
+            if (nl != null) nl.register(observer);
+        });
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -35,13 +35,11 @@ import com.github.javaparser.ast.visitor.HashCodeVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
-
 import static java.util.Collections.unmodifiableList;
 
 /**
@@ -112,7 +110,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     /**
      * This can be used to sort nodes on position.
      */
-    public static Comparator<Node> NODE_BY_BEGIN_POSITION = (a, b) -> {
+    public static Comparator<Node> NODE_BY_BEGIN_POSITION = ( a,  b) -> {
         if (a.getRange().isPresent() && b.getRange().isPresent()) {
             return a.getRange().get().begin.compareTo(b.getRange().get().begin);
         }
@@ -342,7 +340,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
      */
     @Override
     public Node setParentNode(Node parentNode) {
-        observers.forEach(o -> o.parentChange(this, this.parentNode, parentNode));
+        observers.forEach( o -> o.parentChange(this, this.parentNode, parentNode));
         // remove from old parent, if any
         if (this.parentNode != null) {
             this.parentNode.childNodes.remove(this);
@@ -381,7 +379,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     public void tryAddImportToParentCompilationUnit(Class<?> clazz) {
-        getAncestorOfType(CompilationUnit.class).ifPresent(p -> p.addImport(clazz));
+        getAncestorOfType(CompilationUnit.class).ifPresent( p -> p.addImport(clazz));
     }
 
     /**
@@ -459,7 +457,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
                     // ok, we found a potential getter. Before invoking let's check there is a corresponding setter,
                     // otherwise there is no point
                     String setterName = "set" + method.getName().substring("get".length());
-                    Optional<Method> optSetter = Arrays.stream(parentClass.getMethods()).filter(m -> m.getName().equals(setterName)).filter(m -> !java.lang.reflect.Modifier.isStatic(m.getModifiers())).filter(m -> m.getParameterCount() == 1).filter(m -> m.getParameterTypes()[0].equals(setterParamType)).findFirst();
+                    Optional<Method> optSetter = Arrays.stream(parentClass.getMethods()).filter( m -> m.getName().equals(setterName)).filter( m -> !java.lang.reflect.Modifier.isStatic(m.getModifiers())).filter( m -> m.getParameterCount() == 1).filter( m -> m.getParameterTypes()[0].equals(setterParamType)).findFirst();
                     if (optSetter.isPresent()) {
                         try {
                             Object resultRaw = method.invoke(parentNode);
@@ -502,7 +500,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     protected <P> void notifyPropertyChange(ObservableProperty property, P oldValue, P newValue) {
-        this.observers.forEach(o -> o.propertyChange(this, property, oldValue, newValue));
+        this.observers.forEach( o -> o.propertyChange(this, property, oldValue, newValue));
     }
 
     @Override
@@ -523,7 +521,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
         if (mode == null) {
             throw new IllegalArgumentException("Mode should be not null");
         }
-        switch (mode) {
+        switch(mode) {
             case JUST_THIS_NODE:
                 register(observer);
                 break;
@@ -543,9 +541,10 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
      */
     public void registerForSubtree(AstObserver observer) {
         register(observer);
-        this.getChildNodes().forEach(c -> c.registerForSubtree(observer));
-        this.getNodeLists().forEach(nl -> {
-            if (nl != null) nl.register(observer);
+        this.getChildNodes().forEach( c -> c.registerForSubtree(observer));
+        this.getNodeLists().forEach( nl -> {
+            if (nl != null)
+                nl.register(observer);
         });
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast;
 
 import com.github.javaparser.Range;
@@ -29,10 +28,8 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -42,9 +39,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class PackageDeclaration extends Node implements
-        NodeWithAnnotations<PackageDeclaration>,
-        NodeWithName<PackageDeclaration> {
+public final class PackageDeclaration extends Node implements NodeWithAnnotations<PackageDeclaration>, NodeWithName<PackageDeclaration> {
 
     private NodeList<AnnotationExpr> annotations = new NodeList<>();
 
@@ -126,7 +121,7 @@ public final class PackageDeclaration extends Node implements
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        return Arrays.asList(annotations);
+        return Arrays.asList(getAnnotations());
     }
-
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -29,8 +28,9 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 
 /**
  * An annotation type declaration.<br/><code>@interface X { ... }</code>
@@ -40,33 +40,19 @@ import java.util.EnumSet;
 public final class AnnotationDeclaration extends TypeDeclaration<AnnotationDeclaration> {
 
     public AnnotationDeclaration() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new SimpleName(),
-                new NodeList<>());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new SimpleName(), new NodeList<>());
     }
 
     public AnnotationDeclaration(EnumSet<Modifier> modifiers, String name) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                new SimpleName(name),
-                new NodeList<>());
+        this(null, modifiers, new NodeList<>(), new SimpleName(name), new NodeList<>());
     }
 
     @AllFieldsConstructor
-    public AnnotationDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name,
-                                 NodeList<BodyDeclaration<?>> members) {
-        this(null,
-                modifiers,
-                annotations,
-                name,
-                members);
+    public AnnotationDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<BodyDeclaration<?>> members) {
+        this(null, modifiers, annotations, name, members);
     }
 
-    public AnnotationDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name,
-                                 NodeList<BodyDeclaration<?>> members) {
+    public AnnotationDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<BodyDeclaration<?>> members) {
         super(range, annotations, modifiers, name, members);
     }
 
@@ -80,4 +66,9 @@ public final class AnnotationDeclaration extends TypeDeclaration<AnnotationDecla
         v.visit(this, arg);
     }
 
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getMembers(), getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -38,10 +37,10 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -49,11 +48,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class AnnotationMemberDeclaration extends BodyDeclaration<AnnotationMemberDeclaration> implements
-        NodeWithJavadoc<AnnotationMemberDeclaration>,
-        NodeWithSimpleName<AnnotationMemberDeclaration>,
-        NodeWithType<AnnotationMemberDeclaration, Type>,
-        NodeWithModifiers<AnnotationMemberDeclaration> {
+public final class AnnotationMemberDeclaration extends BodyDeclaration<AnnotationMemberDeclaration> implements NodeWithJavadoc<AnnotationMemberDeclaration>, NodeWithSimpleName<AnnotationMemberDeclaration>, NodeWithType<AnnotationMemberDeclaration, Type>, NodeWithModifiers<AnnotationMemberDeclaration> {
 
     private EnumSet<Modifier> modifiers;
 
@@ -64,36 +59,19 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
     private Expression defaultValue;
 
     public AnnotationMemberDeclaration() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new ClassOrInterfaceType(),
-                new SimpleName(),
-                null);
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new ClassOrInterfaceType(), new SimpleName(), null);
     }
 
     public AnnotationMemberDeclaration(EnumSet<Modifier> modifiers, Type type, String name, Expression defaultValue) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                type,
-                new SimpleName(name),
-                defaultValue);
+        this(null, modifiers, new NodeList<>(), type, new SimpleName(name), defaultValue);
     }
 
     @AllFieldsConstructor
-    public AnnotationMemberDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, SimpleName name,
-                                       Expression defaultValue) {
-        this(null,
-                modifiers,
-                annotations,
-                type,
-                name,
-                defaultValue);
+    public AnnotationMemberDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, SimpleName name, Expression defaultValue) {
+        this(null, modifiers, annotations, type, name, defaultValue);
     }
 
-    public AnnotationMemberDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type,
-                                       SimpleName name, Expression defaultValue) {
+    public AnnotationMemberDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, SimpleName name, Expression defaultValue) {
         super(range, annotations);
         setModifiers(modifiers);
         setType(type);
@@ -182,4 +160,10 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
         setAsParentNodeOf(type);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -27,10 +26,8 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -78,3 +75,4 @@ public abstract class BodyDeclaration<T extends Node> extends Node implements No
         return Arrays.asList(annotations);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -35,12 +34,7 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
-import java.util.EnumSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
+import java.util.*;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -48,10 +42,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ClassOrInterfaceDeclaration extends TypeDeclaration<ClassOrInterfaceDeclaration> implements
-        NodeWithImplements<ClassOrInterfaceDeclaration>,
-        NodeWithExtends<ClassOrInterfaceDeclaration>,
-        NodeWithTypeParameters<ClassOrInterfaceDeclaration> {
+public final class ClassOrInterfaceDeclaration extends TypeDeclaration<ClassOrInterfaceDeclaration> implements NodeWithImplements<ClassOrInterfaceDeclaration>, NodeWithExtends<ClassOrInterfaceDeclaration>, NodeWithTypeParameters<ClassOrInterfaceDeclaration> {
 
     private boolean isInterface;
 
@@ -63,48 +54,19 @@ public final class ClassOrInterfaceDeclaration extends TypeDeclaration<ClassOrIn
     private NodeList<ClassOrInterfaceType> implementedTypes;
 
     public ClassOrInterfaceDeclaration() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                false,
-                new SimpleName(),
-                new NodeList<>(),
-                new NodeList<>(),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), false, new SimpleName(), new NodeList<>(), new NodeList<>(), new NodeList<>(), new NodeList<>());
     }
 
-    public ClassOrInterfaceDeclaration(final EnumSet<Modifier> modifiers, final boolean isInterface,
-                                       final String name) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                isInterface,
-                new SimpleName(name),
-                new NodeList<>(),
-                new NodeList<>(),
-                new NodeList<>(),
-                new NodeList<>());
+    public ClassOrInterfaceDeclaration(final EnumSet<Modifier> modifiers, final boolean isInterface, final String name) {
+        this(null, modifiers, new NodeList<>(), isInterface, new SimpleName(name), new NodeList<>(), new NodeList<>(), new NodeList<>(), new NodeList<>());
     }
 
     @AllFieldsConstructor
-    public ClassOrInterfaceDeclaration(final EnumSet<Modifier> modifiers,
-                                       final NodeList<AnnotationExpr> annotations, final boolean isInterface,
-                                       final SimpleName name,
-                                       final NodeList<TypeParameter> typeParameters,
-                                       final NodeList<ClassOrInterfaceType> extendedTypes,
-                                       final NodeList<ClassOrInterfaceType> implementedTypes,
-                                       final NodeList<BodyDeclaration<?>> members) {
+    public ClassOrInterfaceDeclaration(final EnumSet<Modifier> modifiers, final NodeList<AnnotationExpr> annotations, final boolean isInterface, final SimpleName name, final NodeList<TypeParameter> typeParameters, final NodeList<ClassOrInterfaceType> extendedTypes, final NodeList<ClassOrInterfaceType> implementedTypes, final NodeList<BodyDeclaration<?>> members) {
         this(null, modifiers, annotations, isInterface, name, typeParameters, extendedTypes, implementedTypes, members);
     }
 
-    public ClassOrInterfaceDeclaration(Range range, final EnumSet<Modifier> modifiers,
-                                       final NodeList<AnnotationExpr> annotations, final boolean isInterface,
-                                       final SimpleName name,
-                                       final NodeList<TypeParameter> typeParameters,
-                                       final NodeList<ClassOrInterfaceType> extendedTypes,
-                                       final NodeList<ClassOrInterfaceType> implementedTypes,
-                                       final NodeList<BodyDeclaration<?>> members) {
+    public ClassOrInterfaceDeclaration(Range range, final EnumSet<Modifier> modifiers, final NodeList<AnnotationExpr> annotations, final boolean isInterface, final SimpleName name, final NodeList<TypeParameter> typeParameters, final NodeList<ClassOrInterfaceType> extendedTypes, final NodeList<ClassOrInterfaceType> implementedTypes, final NodeList<BodyDeclaration<?>> members) {
         super(range, annotations, modifiers, name, members);
         setInterface(isInterface);
         setTypeParameters(typeParameters);
@@ -176,19 +138,12 @@ public final class ClassOrInterfaceDeclaration extends TypeDeclaration<ClassOrIn
      * @return the methods found (multiple in case of polymorphism)
      */
     public Optional<ConstructorDeclaration> getDefaultConstructor() {
-        return getMembers().stream()
-                .filter(bd -> bd instanceof ConstructorDeclaration)
-                .map(bd -> (ConstructorDeclaration) bd)
-                .filter(cd -> cd.getParameters().isEmpty())
-                .findFirst();
+        return getMembers().stream().filter( bd -> bd instanceof ConstructorDeclaration).map( bd -> (ConstructorDeclaration) bd).filter( cd -> cd.getParameters().isEmpty()).findFirst();
     }
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        List<NodeList<?>> res = new LinkedList<>(super.getNodeLists());
-        res.add(typeParameters);
-        res.add(extendedTypes);
-        res.add(implementedTypes);
-        return res;
+        return Arrays.asList(getExtendedTypes(), getImplementedTypes(), getTypeParameters(), getMembers(), getAnnotations());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -36,11 +35,10 @@ import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -48,15 +46,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDeclaration> implements
-        NodeWithJavadoc<ConstructorDeclaration>,
-        NodeWithDeclaration,
-        NodeWithSimpleName<ConstructorDeclaration>,
-        NodeWithModifiers<ConstructorDeclaration>,
-        NodeWithParameters<ConstructorDeclaration>,
-        NodeWithThrownExceptions<ConstructorDeclaration>,
-        NodeWithBlockStmt<ConstructorDeclaration>,
-        NodeWithTypeParameters<ConstructorDeclaration> {
+public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDeclaration> implements NodeWithJavadoc<ConstructorDeclaration>, NodeWithDeclaration, NodeWithSimpleName<ConstructorDeclaration>, NodeWithModifiers<ConstructorDeclaration>, NodeWithParameters<ConstructorDeclaration>, NodeWithThrownExceptions<ConstructorDeclaration>, NodeWithBlockStmt<ConstructorDeclaration>, NodeWithTypeParameters<ConstructorDeclaration> {
 
     private EnumSet<Modifier> modifiers;
 
@@ -71,45 +61,19 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
     private BlockStmt body;
 
     public ConstructorDeclaration() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new NodeList<>(),
-                new SimpleName(),
-                new NodeList<>(),
-                new NodeList<>(),
-                new BlockStmt());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new NodeList<>(), new SimpleName(), new NodeList<>(), new NodeList<>(), new BlockStmt());
     }
 
     public ConstructorDeclaration(EnumSet<Modifier> modifiers, String name) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                new NodeList<>(),
-                new SimpleName(name),
-                new NodeList<>(),
-                new NodeList<>(),
-                new BlockStmt());
+        this(null, modifiers, new NodeList<>(), new NodeList<>(), new SimpleName(name), new NodeList<>(), new NodeList<>(), new BlockStmt());
     }
 
     @AllFieldsConstructor
-    public ConstructorDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations,
-                                  NodeList<TypeParameter> typeParameters,
-                                  SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions,
-                                  BlockStmt body) {
-        this(null,
-                modifiers,
-                annotations,
-                typeParameters,
-                name,
-                parameters,
-                thrownExceptions,
-                body);
+    public ConstructorDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt body) {
+        this(null, modifiers, annotations, typeParameters, name, parameters, thrownExceptions, body);
     }
 
-    public ConstructorDeclaration(Range range, EnumSet<Modifier> modifiers,
-                                  NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name,
-                                  NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt body) {
+    public ConstructorDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt body) {
         super(range, annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
@@ -206,8 +170,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
      * [throws exceptionsList]
      */
     @Override
-    public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows,
-                                         boolean includingParameterName) {
+    public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows, boolean includingParameterName) {
         StringBuilder sb = new StringBuilder();
         if (includingModifiers) {
             AccessSpecifier accessSpecifier = Modifier.getAccessSpecifier(getModifiers());
@@ -269,10 +232,7 @@ public final class ConstructorDeclaration extends BodyDeclaration<ConstructorDec
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        List<NodeList<?>> res = new LinkedList<>(super.getNodeLists());
-        res.add(typeParameters);
-        res.add(parameters);
-        res.add(thrownExceptions);
-        return res;
+        return Arrays.asList(getParameters(), getThrownExceptions(), getTypeParameters(), getAnnotations());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EmptyMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EmptyMemberDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -28,6 +27,8 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A loose ";" inside a body.<br/><code>class X { ; }</code>
@@ -36,8 +37,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  * @deprecated these ;'s should be ignored
  */
 @Deprecated
-public final class EmptyMemberDeclaration extends BodyDeclaration<EmptyMemberDeclaration>
-        implements NodeWithJavadoc<EmptyMemberDeclaration> {
+public final class EmptyMemberDeclaration extends BodyDeclaration<EmptyMemberDeclaration> implements NodeWithJavadoc<EmptyMemberDeclaration> {
 
     @AllFieldsConstructor
     public EmptyMemberDeclaration() {
@@ -57,4 +57,10 @@ public final class EmptyMemberDeclaration extends BodyDeclaration<EmptyMemberDec
     public <A> void accept(VoidVisitor<A> v, A arg) {
         v.visit(this, arg);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -34,10 +33,9 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -45,10 +43,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantDeclaration> implements
-        NodeWithJavadoc<EnumConstantDeclaration>,
-        NodeWithSimpleName<EnumConstantDeclaration>,
-        NodeWithArguments<EnumConstantDeclaration> {
+public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantDeclaration> implements NodeWithJavadoc<EnumConstantDeclaration>, NodeWithSimpleName<EnumConstantDeclaration>, NodeWithArguments<EnumConstantDeclaration> {
 
     private SimpleName name;
 
@@ -57,29 +52,19 @@ public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantD
     private NodeList<BodyDeclaration<?>> classBody;
 
     public EnumConstantDeclaration() {
-        this(null,
-                new NodeList<>(),
-                new SimpleName(),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, new NodeList<>(), new SimpleName(), new NodeList<>(), new NodeList<>());
     }
 
     public EnumConstantDeclaration(String name) {
-        this(null,
-                new NodeList<>(),
-                new SimpleName(name),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, new NodeList<>(), new SimpleName(name), new NodeList<>(), new NodeList<>());
     }
 
     @AllFieldsConstructor
-    public EnumConstantDeclaration(NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<Expression> arguments,
-                                   NodeList<BodyDeclaration<?>> classBody) {
+    public EnumConstantDeclaration(NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<Expression> arguments, NodeList<BodyDeclaration<?>> classBody) {
         this(null, annotations, name, arguments, classBody);
     }
 
-    public EnumConstantDeclaration(Range range, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<Expression> arguments,
-                                   NodeList<BodyDeclaration<?>> classBody) {
+    public EnumConstantDeclaration(Range range, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<Expression> arguments, NodeList<BodyDeclaration<?>> classBody) {
         super(range, annotations);
         setName(name);
         setArguments(arguments);
@@ -133,9 +118,7 @@ public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantD
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        List<NodeList<?>> res = new LinkedList<>(super.getNodeLists());
-        res.add(arguments);
-        res.add(classBody);
-        return res;
+        return Arrays.asList(getArguments(), getClassBody(), getAnnotations());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -32,11 +31,10 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -45,49 +43,26 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> implements
-        NodeWithImplements<EnumDeclaration> {
+public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> implements NodeWithImplements<EnumDeclaration> {
 
     private NodeList<ClassOrInterfaceType> implementedTypes;
 
     private NodeList<EnumConstantDeclaration> entries;
 
     public EnumDeclaration() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new SimpleName(),
-                new NodeList<>(),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new SimpleName(), new NodeList<>(), new NodeList<>(), new NodeList<>());
     }
 
     public EnumDeclaration(EnumSet<Modifier> modifiers, String name) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                new SimpleName(name),
-                new NodeList<>(),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, modifiers, new NodeList<>(), new SimpleName(name), new NodeList<>(), new NodeList<>(), new NodeList<>());
     }
 
     @AllFieldsConstructor
-    public EnumDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name,
-                           NodeList<ClassOrInterfaceType> implementedTypes, NodeList<EnumConstantDeclaration> entries,
-                           NodeList<BodyDeclaration<?>> members) {
-        this(null,
-                modifiers,
-                annotations,
-                name,
-                implementedTypes,
-                entries,
-                members);
+    public EnumDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<ClassOrInterfaceType> implementedTypes, NodeList<EnumConstantDeclaration> entries, NodeList<BodyDeclaration<?>> members) {
+        this(null, modifiers, annotations, name, implementedTypes, entries, members);
     }
 
-    public EnumDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name,
-                           NodeList<ClassOrInterfaceType> implementedTypes, NodeList<EnumConstantDeclaration> entries,
-                           NodeList<BodyDeclaration<?>> members) {
+    public EnumDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<ClassOrInterfaceType> implementedTypes, NodeList<EnumConstantDeclaration> entries, NodeList<BodyDeclaration<?>> members) {
         super(range, annotations, modifiers, name, members);
         setImplementedTypes(implementedTypes);
         setEntries(entries);
@@ -97,7 +72,6 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
     public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
         return v.visit(this, arg);
     }
-
 
     @Override
     public <A> void accept(VoidVisitor<A> v, A arg) {
@@ -152,9 +126,7 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        List<NodeList<?>> res = new LinkedList<>(super.getNodeLists());
-        res.add(implementedTypes);
-        res.add(entries);
-        return res;
+        return Arrays.asList(getEntries(), getImplementedTypes(), getMembers(), getAnnotations());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -40,12 +39,7 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
-import java.util.EnumSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
+import java.util.*;
 import static com.github.javaparser.ast.Modifier.PUBLIC;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
@@ -56,47 +50,30 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> implements
-        NodeWithJavadoc<FieldDeclaration>,
-        NodeWithModifiers<FieldDeclaration>,
-        NodeWithVariables<FieldDeclaration> {
+public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> implements NodeWithJavadoc<FieldDeclaration>, NodeWithModifiers<FieldDeclaration>, NodeWithVariables<FieldDeclaration> {
 
     private EnumSet<Modifier> modifiers;
 
     private NodeList<VariableDeclarator> variables;
 
     public FieldDeclaration() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new NodeList<>());
     }
 
     public FieldDeclaration(EnumSet<Modifier> modifiers, VariableDeclarator variable) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                nodeList(variable));
+        this(null, modifiers, new NodeList<>(), nodeList(variable));
     }
 
     public FieldDeclaration(EnumSet<Modifier> modifiers, NodeList<VariableDeclarator> variables) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                variables);
+        this(null, modifiers, new NodeList<>(), variables);
     }
 
     @AllFieldsConstructor
-    public FieldDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations,
-                            NodeList<VariableDeclarator> variables) {
-        this(null,
-                modifiers,
-                annotations,
-                variables);
+    public FieldDeclaration(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<VariableDeclarator> variables) {
+        this(null, modifiers, annotations, variables);
     }
 
-    public FieldDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations,
-                            NodeList<VariableDeclarator> variables) {
+    public FieldDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<VariableDeclarator> variables) {
         super(range, annotations);
         setModifiers(modifiers);
         setVariables(variables);
@@ -168,15 +145,12 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
         Optional<ClassOrInterfaceDeclaration> parentClass = getAncestorOfType(ClassOrInterfaceDeclaration.class);
         Optional<EnumDeclaration> parentEnum = getAncestorOfType(EnumDeclaration.class);
         if (!(parentClass.isPresent() || parentEnum.isPresent()) || (parentClass.isPresent() && parentClass.get().isInterface()))
-            throw new IllegalStateException(
-                    "You can use this only when the field is attached to a class or an enum");
-
+            throw new IllegalStateException("You can use this only when the field is attached to a class or an enum");
         VariableDeclarator variable = getVariable(0);
         String fieldName = variable.getNameAsString();
         String fieldNameUpper = fieldName.toUpperCase().substring(0, 1) + fieldName.substring(1, fieldName.length());
         final MethodDeclaration getter;
-        getter = parentClass.map(clazz -> clazz.addMethod("get" + fieldNameUpper, PUBLIC))
-                .orElseGet(() -> parentEnum.get().addMethod("get" + fieldNameUpper, PUBLIC));
+        getter = parentClass.map( clazz -> clazz.addMethod("get" + fieldNameUpper, PUBLIC)).orElseGet(() -> parentEnum.get().addMethod("get" + fieldNameUpper, PUBLIC));
         getter.setType(variable.getType());
         BlockStmt blockStmt = new BlockStmt();
         getter.setBody(blockStmt);
@@ -198,16 +172,12 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
         Optional<ClassOrInterfaceDeclaration> parentClass = getAncestorOfType(ClassOrInterfaceDeclaration.class);
         Optional<EnumDeclaration> parentEnum = getAncestorOfType(EnumDeclaration.class);
         if (!(parentClass.isPresent() || parentEnum.isPresent()) || (parentClass.isPresent() && parentClass.get().isInterface()))
-            throw new IllegalStateException(
-                    "You can use this only when the field is attached to a class or an enum");
-
+            throw new IllegalStateException("You can use this only when the field is attached to a class or an enum");
         VariableDeclarator variable = getVariable(0);
         String fieldName = variable.getNameAsString();
         String fieldNameUpper = fieldName.toUpperCase().substring(0, 1) + fieldName.substring(1, fieldName.length());
-
         final MethodDeclaration setter;
-        setter = parentClass.map(clazz -> clazz.addMethod("set" + fieldNameUpper, PUBLIC))
-                .orElseGet(() -> parentEnum.get().addMethod("set" + fieldNameUpper, PUBLIC));
+        setter = parentClass.map( clazz -> clazz.addMethod("set" + fieldNameUpper, PUBLIC)).orElseGet(() -> parentEnum.get().addMethod("set" + fieldNameUpper, PUBLIC));
         setter.setType(new VoidType());
         setter.getParameters().add(new Parameter(variable.getType(), fieldName));
         BlockStmt blockStmt2 = new BlockStmt();
@@ -218,8 +188,7 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        List<NodeList<?>> res = new LinkedList<>(super.getNodeLists());
-        res.add(variables);
-        return res;
+        return Arrays.asList(getVariables(), getAnnotations());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -31,9 +30,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -41,9 +40,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class InitializerDeclaration extends BodyDeclaration<InitializerDeclaration> implements
-        NodeWithJavadoc<InitializerDeclaration>,
-        NodeWithBlockStmt<InitializerDeclaration> {
+public final class InitializerDeclaration extends BodyDeclaration<InitializerDeclaration> implements NodeWithJavadoc<InitializerDeclaration>, NodeWithBlockStmt<InitializerDeclaration> {
 
     private boolean isStatic;
 
@@ -94,4 +91,10 @@ public final class InitializerDeclaration extends BodyDeclaration<InitializerDec
         this.isStatic = isStatic;
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -38,12 +37,7 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
-import java.util.EnumSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
+import java.util.*;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -52,16 +46,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> implements
-        NodeWithJavadoc<MethodDeclaration>,
-        NodeWithDeclaration,
-        NodeWithSimpleName<MethodDeclaration>,
-        NodeWithType<MethodDeclaration, Type>,
-        NodeWithModifiers<MethodDeclaration>,
-        NodeWithParameters<MethodDeclaration>,
-        NodeWithThrownExceptions<MethodDeclaration>,
-        NodeWithOptionalBlockStmt<MethodDeclaration>,
-        NodeWithTypeParameters<MethodDeclaration> {
+public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> implements NodeWithJavadoc<MethodDeclaration>, NodeWithDeclaration, NodeWithSimpleName<MethodDeclaration>, NodeWithType<MethodDeclaration, Type>, NodeWithModifiers<MethodDeclaration>, NodeWithParameters<MethodDeclaration>, NodeWithThrownExceptions<MethodDeclaration>, NodeWithOptionalBlockStmt<MethodDeclaration>, NodeWithTypeParameters<MethodDeclaration> {
 
     private EnumSet<Modifier> modifiers;
 
@@ -80,77 +65,23 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
     private Type type;
 
     public MethodDeclaration() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new NodeList<>(),
-                new ClassOrInterfaceType(),
-                new SimpleName(),
-                false,
-                new NodeList<>(),
-                new NodeList<>(),
-                new BlockStmt());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new NodeList<>(), new ClassOrInterfaceType(), new SimpleName(), false, new NodeList<>(), new NodeList<>(), new BlockStmt());
     }
 
     public MethodDeclaration(final EnumSet<Modifier> modifiers, final Type type, final String name) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                new NodeList<>(),
-                type,
-                new SimpleName(name),
-                false,
-                new NodeList<>(),
-                new NodeList<>(),
-                new BlockStmt());
+        this(null, modifiers, new NodeList<>(), new NodeList<>(), type, new SimpleName(name), false, new NodeList<>(), new NodeList<>(), new BlockStmt());
     }
 
-    public MethodDeclaration(final EnumSet<Modifier> modifiers, final String name, final Type type,
-                             final NodeList<Parameter> parameters) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                new NodeList<>(),
-                type,
-                new SimpleName(name),
-                false,
-                parameters,
-                new NodeList<>(),
-                new BlockStmt());
+    public MethodDeclaration(final EnumSet<Modifier> modifiers, final String name, final Type type, final NodeList<Parameter> parameters) {
+        this(null, modifiers, new NodeList<>(), new NodeList<>(), type, new SimpleName(name), false, parameters, new NodeList<>(), new BlockStmt());
     }
 
     @AllFieldsConstructor
-    public MethodDeclaration(final EnumSet<Modifier> modifiers,
-                             final NodeList<AnnotationExpr> annotations,
-                             final NodeList<TypeParameter> typeParameters,
-                             final Type type,
-                             final SimpleName name,
-                             final boolean isDefault,
-                             final NodeList<Parameter> parameters,
-                             final NodeList<ReferenceType> thrownExceptions,
-                             final BlockStmt body) {
-        this(null,
-                modifiers,
-                annotations,
-                typeParameters,
-                type,
-                name,
-                isDefault,
-                parameters,
-                thrownExceptions,
-                body);
+    public MethodDeclaration(final EnumSet<Modifier> modifiers, final NodeList<AnnotationExpr> annotations, final NodeList<TypeParameter> typeParameters, final Type type, final SimpleName name, final boolean isDefault, final NodeList<Parameter> parameters, final NodeList<ReferenceType> thrownExceptions, final BlockStmt body) {
+        this(null, modifiers, annotations, typeParameters, type, name, isDefault, parameters, thrownExceptions, body);
     }
 
-    public MethodDeclaration(Range range,
-                             final EnumSet<Modifier> modifiers,
-                             final NodeList<AnnotationExpr> annotations,
-                             final NodeList<TypeParameter> typeParameters,
-                             final Type type,
-                             final SimpleName name,
-                             final boolean isDefault,
-                             final NodeList<Parameter> parameters,
-                             final NodeList<ReferenceType> thrownExceptions,
-                             final BlockStmt body) {
+    public MethodDeclaration(Range range, final EnumSet<Modifier> modifiers, final NodeList<AnnotationExpr> annotations, final NodeList<TypeParameter> typeParameters, final Type type, final SimpleName name, final boolean isDefault, final NodeList<Parameter> parameters, final NodeList<ReferenceType> thrownExceptions, final BlockStmt body) {
         super(range, annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
@@ -303,8 +234,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
      * @return method declaration as String
      */
     @Override
-    public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows,
-                                         boolean includingParameterName) {
+    public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows, boolean includingParameterName) {
         StringBuilder sb = new StringBuilder();
         if (includingModifiers) {
             AccessSpecifier accessSpecifier = Modifier.getAccessSpecifier(getModifiers());
@@ -365,10 +295,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        List<NodeList<?>> res = new LinkedList<>(super.getNodeLists());
-        res.add(typeParameters);
-        res.add(parameters);
-        res.add(thrownExceptions);
-        return res;
+        return Arrays.asList(getParameters(), getThrownExceptions(), getTypeParameters(), getAnnotations());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -37,11 +36,9 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -52,11 +49,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class Parameter extends Node implements
-        NodeWithType<Parameter, Type>,
-        NodeWithAnnotations<Parameter>,
-        NodeWithSimpleName<Parameter>,
-        NodeWithModifiers<Parameter> {
+public final class Parameter extends Node implements NodeWithType<Parameter, Type>, NodeWithAnnotations<Parameter>, NodeWithSimpleName<Parameter>, NodeWithModifiers<Parameter> {
 
     private Type type;
 
@@ -69,21 +62,11 @@ public final class Parameter extends Node implements
     private SimpleName name;
 
     public Parameter() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new ClassOrInterfaceType(),
-                false,
-                new SimpleName());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new ClassOrInterfaceType(), false, new SimpleName());
     }
 
     public Parameter(Type type, SimpleName name) {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                type,
-                false,
-                name);
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), type, false, name);
     }
 
     /**
@@ -93,38 +76,19 @@ public final class Parameter extends Node implements
      * @param name name of the parameter
      */
     public Parameter(Type type, String name) {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                type,
-                false,
-                new SimpleName(name));
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), type, false, new SimpleName(name));
     }
 
     public Parameter(EnumSet<Modifier> modifiers, Type type, SimpleName name) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                type,
-                false,
-                name);
+        this(null, modifiers, new NodeList<>(), type, false, name);
     }
 
     @AllFieldsConstructor
-    public Parameter(EnumSet<Modifier> modifiers,
-                     NodeList<AnnotationExpr> annotations,
-                     Type type,
-                     boolean isVarArgs,
-                     SimpleName name) {
+    public Parameter(EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, boolean isVarArgs, SimpleName name) {
         this(null, modifiers, annotations, type, isVarArgs, name);
     }
 
-    public Parameter(final Range range,
-                     EnumSet<Modifier> modifiers,
-                     NodeList<AnnotationExpr> annotations,
-                     Type type,
-                     boolean isVarArgs,
-                     SimpleName name) {
+    public Parameter(final Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, boolean isVarArgs, SimpleName name) {
         super(range);
         setModifiers(modifiers);
         setAnnotations(annotations);
@@ -219,6 +183,7 @@ public final class Parameter extends Node implements
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        return Arrays.asList(annotations);
+        return Arrays.asList(getAnnotations());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -33,11 +32,9 @@ import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
 import com.github.javaparser.ast.nodeTypes.NodeWithModifiers;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -45,11 +42,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public abstract class TypeDeclaration<T extends Node> extends BodyDeclaration<T> implements
-        NodeWithSimpleName<T>,
-        NodeWithJavadoc<T>,
-        NodeWithModifiers<T>,
-        NodeWithMembers<T> {
+public abstract class TypeDeclaration<T extends Node> extends BodyDeclaration<T> implements NodeWithSimpleName<T>, NodeWithJavadoc<T>, NodeWithModifiers<T>, NodeWithMembers<T> {
 
     private SimpleName name;
 
@@ -58,34 +51,18 @@ public abstract class TypeDeclaration<T extends Node> extends BodyDeclaration<T>
     private NodeList<BodyDeclaration<?>> members;
 
     public TypeDeclaration() {
-        this(null,
-                new NodeList<>(),
-                EnumSet.noneOf(Modifier.class),
-                new SimpleName(),
-                new NodeList<>());
+        this(null, new NodeList<>(), EnumSet.noneOf(Modifier.class), new SimpleName(), new NodeList<>());
     }
 
     public TypeDeclaration(EnumSet<Modifier> modifiers, String name) {
-        this(null,
-                new NodeList<>(),
-                modifiers,
-                new SimpleName(name),
-                new NodeList<>());
+        this(null, new NodeList<>(), modifiers, new SimpleName(name), new NodeList<>());
     }
 
-    public TypeDeclaration(NodeList<AnnotationExpr> annotations,
-                           EnumSet<Modifier> modifiers, SimpleName name,
-                           NodeList<BodyDeclaration<?>> members) {
-        this(null,
-                annotations,
-                modifiers,
-                name,
-                members);
+    public TypeDeclaration(NodeList<AnnotationExpr> annotations, EnumSet<Modifier> modifiers, SimpleName name, NodeList<BodyDeclaration<?>> members) {
+        this(null, annotations, modifiers, name, members);
     }
 
-    public TypeDeclaration(Range range, NodeList<AnnotationExpr> annotations,
-                           EnumSet<Modifier> modifiers, SimpleName name,
-                           NodeList<BodyDeclaration<?>> members) {
+    public TypeDeclaration(Range range, NodeList<AnnotationExpr> annotations, EnumSet<Modifier> modifiers, SimpleName name, NodeList<BodyDeclaration<?>> members) {
         super(range, annotations);
         setName(name);
         setModifiers(modifiers);
@@ -157,3 +134,4 @@ public abstract class TypeDeclaration<T extends Node> extends BodyDeclaration<T>
         return res;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.body;
 
 import com.github.javaparser.Range;
@@ -33,9 +32,7 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -44,9 +41,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class VariableDeclarator extends Node implements
-        NodeWithType<VariableDeclarator, Type>,
-        NodeWithSimpleName<VariableDeclarator> {
+public final class VariableDeclarator extends Node implements NodeWithType<VariableDeclarator, Type>, NodeWithSimpleName<VariableDeclarator> {
 
     private SimpleName name;
 
@@ -65,11 +60,11 @@ public final class VariableDeclarator extends Node implements
     public VariableDeclarator(Type type, SimpleName name) {
         this(null, type, name, null);
     }
-    
+
     public VariableDeclarator(Type type, String variableName, Expression initializer) {
         this(null, type, new SimpleName(variableName), initializer);
     }
-    
+
     /**
      * Defines the declaration of a variable.
      *
@@ -152,3 +147,4 @@ public final class VariableDeclarator extends Node implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.comments;
 
 import com.github.javaparser.Range;
@@ -60,3 +59,4 @@ public final class BlockComment extends Comment {
         v.visit(this, arg);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -18,15 +18,12 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.comments;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -40,6 +37,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 public abstract class Comment extends Node {
 
     private String content;
+
     private Node commentedNode;
 
     public Comment(Range range, String content) {
@@ -111,15 +109,15 @@ public abstract class Comment extends Node {
 
     @Override
     public boolean remove() {
-        // This is necessary only for the nodes associated to a node,
         // the other are orphan comments and remove should work with them
         if (this.commentedNode != null) {
             this.commentedNode.setComment(null);
             return true;
-        } else if (this.getParentNode().isPresent()){
+        } else if (this.getParentNode().isPresent()) {
             return this.getParentNode().get().removeOrphanComment(this);
         } else {
             return false;
         }
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.comments;
 
 import com.github.javaparser.JavaParser;
@@ -62,3 +61,4 @@ public final class JavadocComment extends Comment {
         return JavaParser.parseJavadoc(getContent());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.comments;
 
 import com.github.javaparser.Range;
@@ -64,3 +63,4 @@ public final class LineComment extends Comment {
         return true;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -18,13 +18,11 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -62,3 +60,4 @@ public abstract class AnnotationExpr extends Expression implements NodeWithName<
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -26,7 +25,6 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -88,3 +86,4 @@ public final class ArrayAccessExpr extends Expression {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -32,9 +31,9 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -54,32 +53,20 @@ public final class ArrayCreationExpr extends Expression {
     private ArrayInitializerExpr initializer;
 
     public ArrayCreationExpr() {
-        this(null,
-                new ClassOrInterfaceType(),
-                new NodeList<>(),
-                new ArrayInitializerExpr());
+        this(null, new ClassOrInterfaceType(), new NodeList<>(), new ArrayInitializerExpr());
     }
 
     @AllFieldsConstructor
     public ArrayCreationExpr(Type elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
-        this(null,
-                elementType,
-                levels,
-                initializer);
+        this(null, elementType, levels, initializer);
     }
 
     public ArrayCreationExpr(Type elementType) {
-        this(null,
-                elementType,
-                new NodeList<>(),
-                new ArrayInitializerExpr());
+        this(null, elementType, new NodeList<>(), new ArrayInitializerExpr());
     }
 
     public ArrayCreationExpr(Range range, Type elementType) {
-        this(range,
-                elementType,
-                new NodeList<>(),
-                new ArrayInitializerExpr());
+        this(range, elementType, new NodeList<>(), new ArrayInitializerExpr());
     }
 
     public ArrayCreationExpr(Range range, Type elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
@@ -164,4 +151,10 @@ public final class ArrayCreationExpr extends Expression {
         ClassOrInterfaceType classOrInterfaceType = new ClassOrInterfaceType(type);
         return setElementType(classOrInterfaceType);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getLevels());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -27,7 +26,8 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
+import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -76,4 +76,10 @@ public final class ArrayInitializerExpr extends Expression {
         setAsParentNodeOf(this.values);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getValues());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -37,18 +36,8 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 public final class AssignExpr extends Expression {
 
     public enum Operator {
-        ASSIGN("="),
-        PLUS("+="),
-        MINUS("-="),
-        MULTIPLY("*="),
-        DIVIDE("/="),
-        AND("&="),
-        OR("|="),
-        XOR("^="),
-        REMAINDER("%="),
-        LEFT_SHIFT("<<="),
-        SIGNED_RIGHT_SHIFT(">>="),
-        UNSIGNED_RIGHT_SHIFT(">>>=");
+
+        ASSIGN("="), PLUS("+="), MINUS("-="), MULTIPLY("*="), DIVIDE("/="), AND("&="), OR("|="), XOR("^="), REMAINDER("%="), LEFT_SHIFT("<<="), SIGNED_RIGHT_SHIFT(">>="), UNSIGNED_RIGHT_SHIFT(">>>=");
 
         private final String codeRepresentation;
 
@@ -124,3 +113,4 @@ public final class AssignExpr extends Expression {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -38,25 +37,8 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 public final class BinaryExpr extends Expression {
 
     public enum Operator {
-        OR("||"),
-        AND("&&"),
-        BINARY_OR("|"),
-        BINARY_AND("&"),
-        XOR("^"),
-        EQUALS("=="),
-        NOT_EQUALS("!="),
-        LESS("<"),
-        GREATER(">"),
-        LESS_EQUALS("<="),
-        GREATER_EQUALS(">="),
-        LEFT_SHIFT("<<"),
-        SIGNED_RIGHT_SHIFT(">>"),
-        UNSIGNED_RIGHT_SHIFT(">>>"),
-        PLUS("+"),
-        MINUS("-"),
-        MULTIPLY("*"),
-        DIVIDE("/"),
-        REMAINDER("%");
+
+        OR("||"), AND("&&"), BINARY_OR("|"), BINARY_AND("&"), XOR("^"), EQUALS("=="), NOT_EQUALS("!="), LESS("<"), GREATER(">"), LESS_EQUALS("<="), GREATER_EQUALS(">="), LEFT_SHIFT("<<"), SIGNED_RIGHT_SHIFT(">>"), UNSIGNED_RIGHT_SHIFT(">>>"), PLUS("+"), MINUS("-"), MULTIPLY("*"), DIVIDE("/"), REMAINDER("%");
 
         private final String codeRepresentation;
 
@@ -133,3 +115,4 @@ public final class BinaryExpr extends Expression {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -72,3 +71,4 @@ public final class BooleanLiteralExpr extends LiteralExpr {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -30,7 +29,6 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -38,9 +36,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class CastExpr extends Expression implements
-        NodeWithType<CastExpr, Type>,
-        NodeWithExpression<CastExpr> {
+public final class CastExpr extends Expression implements NodeWithType<CastExpr, Type>, NodeWithExpression<CastExpr> {
 
     private Type type;
 
@@ -97,3 +93,4 @@ public final class CastExpr extends Expression implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -31,7 +30,7 @@ import com.github.javaparser.utils.Utils;
  * A literal character.
  * <br/><code>'a'</code>
  * <br/><code>'\t'</code>
- * <br/><code>'\u03a9'</code>
+ * <br/><code>'Ω'</code>
  * <br/><code>'\177'</code>
  * <br/><code>'💩'</code>
  *
@@ -69,3 +68,4 @@ public final class CharLiteralExpr extends StringLiteralExpr {
         v.visit(this, arg);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -77,3 +76,4 @@ public final class ClassExpr extends Expression implements NodeWithType<ClassExp
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -26,7 +25,6 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -102,3 +100,4 @@ public final class ConditionalExpr extends Expression {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -59,3 +58,4 @@ public final class DoubleLiteralExpr extends StringLiteralExpr {
         v.visit(this, arg);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -26,7 +25,6 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
 
 /**
@@ -80,3 +78,4 @@ public final class EnclosedExpr extends Expression {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -30,7 +29,9 @@ import com.github.javaparser.ast.Node;
  * @author Julio Vilmar Gesser
  */
 public abstract class Expression extends Node {
+
     public Expression(Range range) {
         super(range);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -31,9 +30,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -42,10 +41,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class FieldAccessExpr extends Expression implements
-        NodeWithSimpleName<FieldAccessExpr>,
-        NodeWithTypeArguments<FieldAccessExpr>,
-        NodeWithOptionalScope<FieldAccessExpr> {
+public final class FieldAccessExpr extends Expression implements NodeWithSimpleName<FieldAccessExpr>, NodeWithTypeArguments<FieldAccessExpr>, NodeWithOptionalScope<FieldAccessExpr> {
 
     private Expression scope;
 
@@ -62,13 +58,11 @@ public final class FieldAccessExpr extends Expression implements
     }
 
     @AllFieldsConstructor
-    public FieldAccessExpr(final Expression scope, final NodeList<Type> typeArguments,
-                           final SimpleName name) {
+    public FieldAccessExpr(final Expression scope, final NodeList<Type> typeArguments, final SimpleName name) {
         this(null, scope, typeArguments, name);
     }
 
-    public FieldAccessExpr(final Range range, final Expression scope, final NodeList<Type> typeArguments,
-                           final SimpleName name) {
+    public FieldAccessExpr(final Range range, final Expression scope, final NodeList<Type> typeArguments, final SimpleName name) {
         super(range);
         setScope(scope);
         setTypeArguments(typeArguments);
@@ -160,4 +154,10 @@ public final class FieldAccessExpr extends Expression implements
         setAsParentNodeOf(this.typeArguments);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getTypeArguments().orElse(null));
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -30,7 +29,6 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -39,9 +37,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class InstanceOfExpr extends Expression implements
-        NodeWithType<InstanceOfExpr, ReferenceType>,
-        NodeWithExpression<InstanceOfExpr> {
+public final class InstanceOfExpr extends Expression implements NodeWithType<InstanceOfExpr, ReferenceType>, NodeWithExpression<InstanceOfExpr> {
 
     private Expression expression;
 
@@ -98,3 +94,4 @@ public final class InstanceOfExpr extends Expression implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -61,3 +60,4 @@ public class IntegerLiteralExpr extends StringLiteralExpr {
         v.visit(this, arg);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -31,7 +30,8 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
+import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -45,8 +45,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Raquel Pau
  */
-public class LambdaExpr extends Expression implements
-        NodeWithParameters<LambdaExpr> {
+public class LambdaExpr extends Expression implements NodeWithParameters<LambdaExpr> {
 
     private NodeList<Parameter> parameters;
 
@@ -55,20 +54,15 @@ public class LambdaExpr extends Expression implements
     private Statement body;
 
     public LambdaExpr() {
-        this(null,
-                new NodeList<>(),
-                new ReturnStmt(),
-                false);
+        this(null, new NodeList<>(), new ReturnStmt(), false);
     }
 
     @AllFieldsConstructor
-    public LambdaExpr(NodeList<Parameter> parameters, Statement body,
-                      boolean isEnclosingParameters) {
+    public LambdaExpr(NodeList<Parameter> parameters, Statement body, boolean isEnclosingParameters) {
         this(null, parameters, body, isEnclosingParameters);
     }
 
-    public LambdaExpr(Range range, NodeList<Parameter> parameters, Statement body,
-                      boolean isEnclosingParameters) {
+    public LambdaExpr(Range range, NodeList<Parameter> parameters, Statement body, boolean isEnclosingParameters) {
         super(range);
         setParameters(parameters);
         setBody(body);
@@ -118,4 +112,9 @@ public class LambdaExpr extends Expression implements
         return this;
     }
 
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getParameters());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -29,7 +28,9 @@ import com.github.javaparser.Range;
  * @author Julio Vilmar Gesser
  */
 public abstract class LiteralExpr extends Expression {
+
     protected LiteralExpr(Range range) {
         super(range);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -61,3 +60,4 @@ public class LongLiteralExpr extends StringLiteralExpr {
         v.visit(this, arg);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -56,5 +55,5 @@ public final class MarkerAnnotationExpr extends AnnotationExpr {
     public <A> void accept(final VoidVisitor<A> v, final A arg) {
         v.visit(this, arg);
     }
-
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -28,7 +27,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -96,3 +94,4 @@ public final class MemberValuePair extends Node implements NodeWithSimpleName<Me
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -32,9 +31,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -43,11 +42,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class MethodCallExpr extends Expression implements
-        NodeWithTypeArguments<MethodCallExpr>,
-        NodeWithArguments<MethodCallExpr>,
-        NodeWithSimpleName<MethodCallExpr>,
-        NodeWithOptionalScope<MethodCallExpr> {
+public final class MethodCallExpr extends Expression implements NodeWithTypeArguments<MethodCallExpr>, NodeWithArguments<MethodCallExpr>, NodeWithSimpleName<MethodCallExpr>, NodeWithOptionalScope<MethodCallExpr> {
 
     private Expression scope;
 
@@ -58,27 +53,15 @@ public final class MethodCallExpr extends Expression implements
     private NodeList<Expression> arguments;
 
     public MethodCallExpr() {
-        this(null,
-                null,
-                new NodeList<>(),
-                new SimpleName(),
-                new NodeList<>());
+        this(null, null, new NodeList<>(), new SimpleName(), new NodeList<>());
     }
 
     public MethodCallExpr(final Expression scope, final String name) {
-        this(null,
-                scope,
-                new NodeList<>(),
-                new SimpleName(name),
-                new NodeList<>());
+        this(null, scope, new NodeList<>(), new SimpleName(name), new NodeList<>());
     }
 
     public MethodCallExpr(final Expression scope, final SimpleName name, final NodeList<Expression> arguments) {
-        this(null,
-                scope,
-                new NodeList<>(),
-                name,
-                arguments);
+        this(null, scope, new NodeList<>(), name, arguments);
     }
 
     @AllFieldsConstructor
@@ -159,4 +142,10 @@ public final class MethodCallExpr extends Expression implements
         setAsParentNodeOf(this.typeArguments);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getArguments(), getTypeArguments().orElse(null));
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -30,9 +29,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**
@@ -46,9 +45,7 @@ import static com.github.javaparser.utils.Utils.assertNonEmpty;
  *
  * @author Raquel Pau
  */
-public class MethodReferenceExpr extends Expression implements
-        NodeWithTypeArguments<MethodReferenceExpr>,
-        NodeWithIdentifier<MethodReferenceExpr> {
+public class MethodReferenceExpr extends Expression implements NodeWithTypeArguments<MethodReferenceExpr>, NodeWithIdentifier<MethodReferenceExpr> {
 
     private Expression scope;
 
@@ -57,20 +54,15 @@ public class MethodReferenceExpr extends Expression implements
     private String identifier;
 
     public MethodReferenceExpr() {
-        this(null,
-                new ClassExpr(),
-                null,
-                "empty");
+        this(null, new ClassExpr(), null, "empty");
     }
 
     @AllFieldsConstructor
-    public MethodReferenceExpr(Expression scope,
-                               NodeList<Type> typeArguments, String identifier) {
+    public MethodReferenceExpr(Expression scope, NodeList<Type> typeArguments, String identifier) {
         this(null, scope, typeArguments, identifier);
     }
 
-    public MethodReferenceExpr(Range range, Expression scope,
-                               NodeList<Type> typeArguments, String identifier) {
+    public MethodReferenceExpr(Range range, Expression scope, NodeList<Type> typeArguments, String identifier) {
         super(range);
         setIdentifier(identifier);
         setScope(scope);
@@ -79,7 +71,6 @@ public class MethodReferenceExpr extends Expression implements
 
     @Override
     public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
-
         return v.visit(this, arg);
     }
 
@@ -130,4 +121,10 @@ public class MethodReferenceExpr extends Expression implements
         this.identifier = identifier;
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getTypeArguments().orElse(null));
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -28,9 +27,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithIdentifier;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**
@@ -46,7 +43,9 @@ import static com.github.javaparser.utils.Utils.assertNonEmpty;
  * @see SimpleName
  */
 public class Name extends Node implements NodeWithIdentifier<Name> {
+
     private String identifier;
+
     private Name qualifier;
 
     public Name() {
@@ -129,3 +128,4 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -27,7 +26,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -81,3 +79,4 @@ public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -27,6 +26,9 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -93,4 +95,10 @@ public final class NormalAnnotationExpr extends AnnotationExpr {
         memberValuePair.setParentNode(this);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getPairs());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -26,10 +26,8 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NullLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NullLiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -53,3 +52,4 @@ public final class NullLiteralExpr extends LiteralExpr {
         v.visit(this, arg);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -33,7 +33,6 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -35,8 +34,9 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -46,11 +46,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ObjectCreationExpr extends Expression implements
-        NodeWithTypeArguments<ObjectCreationExpr>,
-        NodeWithType<ObjectCreationExpr, ClassOrInterfaceType>,
-        NodeWithArguments<ObjectCreationExpr>,
-        NodeWithOptionalScope<ObjectCreationExpr> {
+public final class ObjectCreationExpr extends Expression implements NodeWithTypeArguments<ObjectCreationExpr>, NodeWithType<ObjectCreationExpr, ClassOrInterfaceType>, NodeWithArguments<ObjectCreationExpr>, NodeWithOptionalScope<ObjectCreationExpr> {
 
     private Expression scope;
 
@@ -63,12 +59,7 @@ public final class ObjectCreationExpr extends Expression implements
     private NodeList<BodyDeclaration<?>> anonymousClassBody;
 
     public ObjectCreationExpr() {
-        this(null,
-                null,
-                new ClassOrInterfaceType(),
-                new NodeList<>(),
-                new NodeList<>(),
-                null);
+        this(null, null, new ClassOrInterfaceType(), new NodeList<>(), new NodeList<>(), null);
     }
 
     /**
@@ -78,28 +69,16 @@ public final class ObjectCreationExpr extends Expression implements
      * @param type this is the class that the constructor is being called for.
      * @param arguments Any arguments to pass to the constructor
      */
-    public ObjectCreationExpr(final Expression scope, final ClassOrInterfaceType type,
-                              final NodeList<Expression> arguments) {
-        this(null,
-                scope,
-                type,
-                new NodeList<>(),
-                arguments,
-                null);
+    public ObjectCreationExpr(final Expression scope, final ClassOrInterfaceType type, final NodeList<Expression> arguments) {
+        this(null, scope, type, new NodeList<>(), arguments, null);
     }
 
     @AllFieldsConstructor
-    public ObjectCreationExpr(
-            final Expression scope, final ClassOrInterfaceType type,
-            final NodeList<Type> typeArguments,
-            final NodeList<Expression> arguments, final NodeList<BodyDeclaration<?>> anonymousClassBody) {
+    public ObjectCreationExpr(final Expression scope, final ClassOrInterfaceType type, final NodeList<Type> typeArguments, final NodeList<Expression> arguments, final NodeList<BodyDeclaration<?>> anonymousClassBody) {
         this(null, scope, type, typeArguments, arguments, anonymousClassBody);
     }
 
-    public ObjectCreationExpr(final Range range,
-                              final Expression scope, final ClassOrInterfaceType type,
-                              final NodeList<Type> typeArguments,
-                              final NodeList<Expression> arguments, final NodeList<BodyDeclaration<?>> anonymousClassBody) {
+    public ObjectCreationExpr(final Range range, final Expression scope, final ClassOrInterfaceType type, final NodeList<Type> typeArguments, final NodeList<Expression> arguments, final NodeList<BodyDeclaration<?>> anonymousClassBody) {
         super(range);
         setScope(scope);
         setType(type);
@@ -207,4 +186,10 @@ public final class ObjectCreationExpr extends Expression implements
         setAsParentNodeOf(this.typeArguments);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnonymousClassBody().orElse(null), getArguments(), getTypeArguments().orElse(null));
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -28,7 +27,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithIdentifier;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**
@@ -38,6 +36,7 @@ import static com.github.javaparser.utils.Utils.assertNonEmpty;
  * @see Name
  */
 public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
+
     private String identifier;
 
     public SimpleName() {
@@ -77,3 +76,4 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -71,3 +70,4 @@ public final class SingleMemberAnnotationExpr extends AnnotationExpr {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -27,14 +26,13 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Utils;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * A literal string.
  * <br/><code>"Hello World!"</code>
  * <br/><code>"\"\n"</code>
- * <br/><code>"\u2122"</code>
+ * <br/><code>"™"</code>
  * <br/><code>"💩"</code>
  *
  * @author Julio Vilmar Gesser
@@ -87,3 +85,4 @@ public class StringLiteralExpr extends LiteralExpr {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -26,7 +25,6 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
 
 /**
@@ -83,3 +81,4 @@ public final class SuperExpr extends Expression {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -26,7 +25,6 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
 
 /**
@@ -77,3 +75,4 @@ public final class ThisExpr extends Expression {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -29,7 +28,6 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -79,6 +77,5 @@ public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type>
         setAsParentNodeOf(this.type);
         return this;
     }
-
-
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -38,20 +37,14 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  *
  * @author Julio Vilmar Gesser
  */
-public final class UnaryExpr extends Expression implements
-        NodeWithExpression<UnaryExpr> {
+public final class UnaryExpr extends Expression implements NodeWithExpression<UnaryExpr> {
 
     public enum Operator {
-        PLUS("+", false),
-        MINUS("-", false),
-        PREFIX_INCREMENT("++", false),
-        PREFIX_DECREMENT("--", false),
-        LOGICAL_COMPLEMENT("!", false),
-        BITWISE_COMPLEMENT("~", false),
-        POSTFIX_INCREMENT("++", true),
-        POSTFIX_DECREMENT("--", true);
+
+        PLUS("+", false), MINUS("-", false), PREFIX_INCREMENT("++", false), PREFIX_DECREMENT("--", false), LOGICAL_COMPLEMENT("!", false), BITWISE_COMPLEMENT("~", false), POSTFIX_INCREMENT("++", true), POSTFIX_DECREMENT("--", true);
 
         private final String codeRepresentation;
+
         private final boolean isPostfix;
 
         Operator(String codeRepresentation, boolean isPostfix) {
@@ -124,3 +117,4 @@ public final class UnaryExpr extends Expression implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
@@ -33,11 +32,10 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.stream.Collectors;
-
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -49,10 +47,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class VariableDeclarationExpr extends Expression implements
-        NodeWithModifiers<VariableDeclarationExpr>,
-        NodeWithAnnotations<VariableDeclarationExpr>,
-        NodeWithVariables<VariableDeclarationExpr> {
+public final class VariableDeclarationExpr extends Expression implements NodeWithModifiers<VariableDeclarationExpr>, NodeWithAnnotations<VariableDeclarationExpr>, NodeWithVariables<VariableDeclarationExpr> {
 
     private EnumSet<Modifier> modifiers;
 
@@ -61,65 +56,39 @@ public final class VariableDeclarationExpr extends Expression implements
     private NodeList<VariableDeclarator> variables;
 
     public VariableDeclarationExpr() {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), new NodeList<>());
     }
 
     public VariableDeclarationExpr(final Type type, String variableName) {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                nodeList(new VariableDeclarator(type, variableName)));
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), nodeList(new VariableDeclarator(type, variableName)));
     }
 
     public VariableDeclarationExpr(VariableDeclarator var) {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                nodeList(var));
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), nodeList(var));
     }
 
     public VariableDeclarationExpr(final Type type, String variableName, Modifier... modifiers) {
-        this(null,
-                Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))),
-                new NodeList<>(),
-                nodeList(new VariableDeclarator(type, variableName)));
+        this(null, Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), new NodeList<>(), nodeList(new VariableDeclarator(type, variableName)));
     }
 
     public VariableDeclarationExpr(VariableDeclarator var, Modifier... modifiers) {
-        this(null,
-                Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))),
-                new NodeList<>(),
-                nodeList(var));
+        this(null, Arrays.stream(modifiers).collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class))), new NodeList<>(), nodeList(var));
     }
 
     public VariableDeclarationExpr(final NodeList<VariableDeclarator> variables) {
-        this(null,
-                EnumSet.noneOf(Modifier.class),
-                new NodeList<>(),
-                variables);
+        this(null, EnumSet.noneOf(Modifier.class), new NodeList<>(), variables);
     }
 
     public VariableDeclarationExpr(final EnumSet<Modifier> modifiers, final NodeList<VariableDeclarator> variables) {
-        this(null,
-                modifiers,
-                new NodeList<>(),
-                variables);
+        this(null, modifiers, new NodeList<>(), variables);
     }
 
     @AllFieldsConstructor
-    public VariableDeclarationExpr(final EnumSet<Modifier> modifiers,
-                                   final NodeList<AnnotationExpr> annotations,
-                                   final NodeList<VariableDeclarator> variables) {
+    public VariableDeclarationExpr(final EnumSet<Modifier> modifiers, final NodeList<AnnotationExpr> annotations, final NodeList<VariableDeclarator> variables) {
         this(null, modifiers, annotations, variables);
     }
 
-    public VariableDeclarationExpr(final Range range,
-                                   final EnumSet<Modifier> modifiers,
-                                   final NodeList<AnnotationExpr> annotations,
-                                   final NodeList<VariableDeclarator> variables) {
+    public VariableDeclarationExpr(final Range range, final EnumSet<Modifier> modifiers, final NodeList<AnnotationExpr> annotations, final NodeList<VariableDeclarator> variables) {
         super(range);
         setModifiers(modifiers);
         setAnnotations(annotations);
@@ -179,4 +148,10 @@ public final class VariableDeclarationExpr extends Expression implements
         setAsParentNodeOf(this.variables);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations(), getVariables());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -28,9 +27,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -101,3 +98,4 @@ public final class AssertStmt extends Statement {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BlockStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BlockStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -28,10 +27,8 @@ import com.github.javaparser.ast.nodeTypes.NodeWithStatements;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -50,7 +47,6 @@ public final class BlockStmt extends Statement implements NodeWithStatements<Blo
     @AllFieldsConstructor
     public BlockStmt(final NodeList<Statement> statements) {
         this(null, statements);
-
     }
 
     public BlockStmt(final Range range, final NodeList<Statement> statements) {
@@ -81,7 +77,7 @@ public final class BlockStmt extends Statement implements NodeWithStatements<Blo
 
     @Override
     public List<NodeList<?>> getNodeLists() {
-        return Arrays.asList(statements);
+        return Arrays.asList(getStatements());
     }
-
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -27,9 +26,7 @@ import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -86,3 +83,4 @@ public final class BreakStmt extends Statement {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -34,7 +33,6 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.EnumSet;
 
 /**
@@ -53,19 +51,8 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
         this(null, new Parameter(), new BlockStmt());
     }
 
-    public CatchClause(final EnumSet<Modifier> exceptModifier,
-                       final NodeList<AnnotationExpr> exceptAnnotations,
-                       final ClassOrInterfaceType exceptType,
-                       final SimpleName exceptName,
-                       final BlockStmt body) {
-        this(null,
-                new Parameter(null,
-                        exceptModifier,
-                        exceptAnnotations,
-                        exceptType,
-                        false,
-                        exceptName),
-                body);
+    public CatchClause(final EnumSet<Modifier> exceptModifier, final NodeList<AnnotationExpr> exceptAnnotations, final ClassOrInterfaceType exceptType, final SimpleName exceptName, final BlockStmt body) {
+        this(null, new Parameter(null, exceptModifier, exceptAnnotations, exceptType, false, exceptName), body);
     }
 
     @AllFieldsConstructor
@@ -73,9 +60,7 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
         this(null, parameter, body);
     }
 
-    public CatchClause(final Range range,
-                       final Parameter parameter,
-                       final BlockStmt body) {
+    public CatchClause(final Range range, final Parameter parameter, final BlockStmt body) {
         super(range);
         setParameter(parameter);
         setBody(body);
@@ -120,3 +105,4 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -28,9 +27,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithOptionalLabel;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -40,8 +37,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ContinueStmt extends Statement implements
-        NodeWithOptionalLabel<ContinueStmt> {
+public final class ContinueStmt extends Statement implements NodeWithOptionalLabel<ContinueStmt> {
 
     private SimpleName label;
 
@@ -91,3 +87,4 @@ public final class ContinueStmt extends Statement implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -91,3 +90,4 @@ public final class DoStmt extends Statement implements NodeWithBody<DoStmt> {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/EmptyStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/EmptyStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -52,3 +51,4 @@ public final class EmptyStmt extends Statement {
         v.visit(this, arg);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -29,7 +29,6 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -31,8 +30,9 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -58,20 +58,16 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
         this(null, new NodeList<>(), true, null, new NodeList<>());
     }
 
-    public ExplicitConstructorInvocationStmt(final boolean isThis,
-                                             final Expression expression, final NodeList<Expression> arguments) {
+    public ExplicitConstructorInvocationStmt(final boolean isThis, final Expression expression, final NodeList<Expression> arguments) {
         this(null, new NodeList<>(), isThis, expression, arguments);
     }
 
     @AllFieldsConstructor
-    public ExplicitConstructorInvocationStmt(final NodeList<Type> typeArguments, final boolean isThis,
-                                             final Expression expression, final NodeList<Expression> arguments) {
+    public ExplicitConstructorInvocationStmt(final NodeList<Type> typeArguments, final boolean isThis, final Expression expression, final NodeList<Expression> arguments) {
         this(null, typeArguments, isThis, expression, arguments);
     }
 
-    public ExplicitConstructorInvocationStmt(Range range,
-                                             final NodeList<Type> typeArguments, final boolean isThis,
-                                             final Expression expression, final NodeList<Expression> arguments) {
+    public ExplicitConstructorInvocationStmt(Range range, final NodeList<Type> typeArguments, final boolean isThis, final Expression expression, final NodeList<Expression> arguments) {
         super(range);
         setTypeArguments(typeArguments);
         setThis(isThis);
@@ -159,4 +155,10 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
         setAsParentNodeOf(this.typeArguments);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getArguments(), getTypeArguments().orElse(null));
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -29,7 +28,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithExpression;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -37,8 +35,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ExpressionStmt extends Statement implements
-        NodeWithExpression<ExpressionStmt> {
+public final class ExpressionStmt extends Statement implements NodeWithExpression<ExpressionStmt> {
 
     private Expression expression;
 
@@ -79,3 +76,4 @@ public final class ExpressionStmt extends Statement implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
@@ -29,7 +29,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithBody;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -31,8 +30,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -53,22 +53,15 @@ public final class ForStmt extends Statement implements NodeWithBody<ForStmt> {
     private Statement body;
 
     public ForStmt() {
-        this(null,
-                new NodeList<>(),
-                new BooleanLiteralExpr(),
-                new NodeList<>(),
-                new ReturnStmt());
+        this(null, new NodeList<>(), new BooleanLiteralExpr(), new NodeList<>(), new ReturnStmt());
     }
 
     @AllFieldsConstructor
-    public ForStmt(final NodeList<Expression> initialization, final Expression compare,
-                   final NodeList<Expression> update, final Statement body) {
+    public ForStmt(final NodeList<Expression> initialization, final Expression compare, final NodeList<Expression> update, final Statement body) {
         this(null, initialization, compare, update, body);
     }
 
-    public ForStmt(Range range,
-                   final NodeList<Expression> initialization, final Expression compare,
-                   final NodeList<Expression> update, final Statement body) {
+    public ForStmt(Range range, final NodeList<Expression> initialization, final Expression compare, final NodeList<Expression> update, final Statement body) {
         super(range);
         setCompare(compare);
         setInitialization(initialization);
@@ -137,4 +130,10 @@ public final class ForStmt extends Statement implements NodeWithBody<ForStmt> {
         setAsParentNodeOf(this.update);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getInitialization(), getUpdate());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -30,7 +29,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithBody;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -48,21 +46,15 @@ public final class ForeachStmt extends Statement implements NodeWithBody<Foreach
     private Statement body;
 
     public ForeachStmt() {
-        this(null,
-                new VariableDeclarationExpr(),
-                new NameExpr(),
-                new ReturnStmt());
+        this(null, new VariableDeclarationExpr(), new NameExpr(), new ReturnStmt());
     }
 
     @AllFieldsConstructor
-    public ForeachStmt(final VariableDeclarationExpr variable,
-                       final Expression iterable, final Statement body) {
+    public ForeachStmt(final VariableDeclarationExpr variable, final Expression iterable, final Statement body) {
         this(null, variable, iterable, body);
     }
 
-    public ForeachStmt(Range range,
-                       final VariableDeclarationExpr variable, final Expression iterable,
-                       final Statement body) {
+    public ForeachStmt(Range range, final VariableDeclarationExpr variable, final Expression iterable, final Statement body) {
         super(range);
         setVariable(variable);
         setIterable(iterable);
@@ -118,3 +110,4 @@ public final class ForeachStmt extends Statement implements NodeWithBody<Foreach
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -28,9 +27,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -49,10 +46,7 @@ public final class IfStmt extends Statement {
     private Statement elseStmt;
 
     public IfStmt() {
-        this(null,
-                new BooleanLiteralExpr(),
-                new ReturnStmt(),
-                null);
+        this(null, new BooleanLiteralExpr(), new ReturnStmt(), null);
     }
 
     @AllFieldsConstructor
@@ -60,8 +54,7 @@ public final class IfStmt extends Statement {
         this(null, condition, thenStmt, elseStmt);
     }
 
-    public IfStmt(Range range,
-                  final Expression condition, final Statement thenStmt, final Statement elseStmt) {
+    public IfStmt(Range range, final Expression condition, final Statement thenStmt, final Statement elseStmt) {
         super(range);
         setCondition(condition);
         setThenStmt(thenStmt);
@@ -117,3 +110,4 @@ public final class IfStmt extends Statement {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -27,7 +26,6 @@ import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -92,3 +90,4 @@ public final class LabeledStmt extends Statement {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -28,7 +27,6 @@ import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -78,3 +76,4 @@ public final class LocalClassDeclarationStmt extends Statement {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -28,7 +27,6 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Optional;
 
 /**
@@ -88,3 +86,4 @@ public final class ReturnStmt extends Statement {
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -30,7 +29,9 @@ import com.github.javaparser.ast.Node;
  * @author Julio Vilmar Gesser
  */
 public abstract class Statement extends Node {
+
     public Statement(final Range range) {
         super(range);
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -30,8 +29,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -69,8 +69,7 @@ public final class SwitchEntryStmt extends Statement implements NodeWithStatemen
         this(null, label, statements);
     }
 
-    public SwitchEntryStmt(Range range, final Expression label,
-                           final NodeList<Statement> statements) {
+    public SwitchEntryStmt(Range range, final Expression label, final NodeList<Statement> statements) {
         super(range);
         setLabel(label);
         setStatements(statements);
@@ -113,4 +112,10 @@ public final class SwitchEntryStmt extends Statement implements NodeWithStatemen
         setAsParentNodeOf(this.statements);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getStatements());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -28,7 +28,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithStatements;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -29,6 +28,9 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -51,13 +53,11 @@ public final class SwitchStmt extends Statement {
     }
 
     @AllFieldsConstructor
-    public SwitchStmt(final Expression selector,
-                      final NodeList<SwitchEntryStmt> entries) {
+    public SwitchStmt(final Expression selector, final NodeList<SwitchEntryStmt> entries) {
         this(null, selector, entries);
     }
 
-    public SwitchStmt(Range range, final Expression selector,
-                      final NodeList<SwitchEntryStmt> entries) {
+    public SwitchStmt(Range range, final Expression selector, final NodeList<SwitchEntryStmt> entries) {
         super(range);
         setSelector(selector);
         setEntries(entries);
@@ -108,4 +108,10 @@ public final class SwitchStmt extends Statement {
         setAsParentNodeOf(this.selector);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getEntries());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
@@ -28,10 +28,8 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -30,7 +29,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithExpression;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -39,9 +37,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class SynchronizedStmt extends Statement implements
-        NodeWithBlockStmt<SynchronizedStmt>,
-        NodeWithExpression<SynchronizedStmt> {
+public final class SynchronizedStmt extends Statement implements NodeWithBlockStmt<SynchronizedStmt>, NodeWithExpression<SynchronizedStmt> {
 
     private Expression expression;
 
@@ -96,3 +92,4 @@ public final class SynchronizedStmt extends Statement implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -36,8 +35,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ThrowStmt extends Statement implements
-        NodeWithExpression<ThrowStmt> {
+public final class ThrowStmt extends Statement implements NodeWithExpression<ThrowStmt> {
 
     private Expression expression;
 
@@ -78,3 +76,4 @@ public final class ThrowStmt extends Statement implements
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
@@ -27,7 +27,6 @@ import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -29,8 +28,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -62,30 +62,19 @@ public final class TryStmt extends Statement {
     private BlockStmt finallyBlock;
 
     public TryStmt() {
-        this(null,
-                new NodeList<>(),
-                new BlockStmt(),
-                new NodeList<>(),
-                null);
+        this(null, new NodeList<>(), new BlockStmt(), new NodeList<>(), null);
     }
 
-    public TryStmt(final BlockStmt tryBlock, final NodeList<CatchClause> catchClauses,
-                   final BlockStmt finallyBlock) {
-        this(null,
-                new NodeList<>(),
-                tryBlock,
-                catchClauses,
-                finallyBlock);
+    public TryStmt(final BlockStmt tryBlock, final NodeList<CatchClause> catchClauses, final BlockStmt finallyBlock) {
+        this(null, new NodeList<>(), tryBlock, catchClauses, finallyBlock);
     }
 
     @AllFieldsConstructor
-    public TryStmt(NodeList<VariableDeclarationExpr> resources,
-                   final BlockStmt tryBlock, final NodeList<CatchClause> catchClauses, final BlockStmt finallyBlock) {
+    public TryStmt(NodeList<VariableDeclarationExpr> resources, final BlockStmt tryBlock, final NodeList<CatchClause> catchClauses, final BlockStmt finallyBlock) {
         this(null, resources, tryBlock, catchClauses, finallyBlock);
     }
 
-    public TryStmt(Range range, NodeList<VariableDeclarationExpr> resources,
-                   final BlockStmt tryBlock, final NodeList<CatchClause> catchClauses, final BlockStmt finallyBlock) {
+    public TryStmt(Range range, NodeList<VariableDeclarationExpr> resources, final BlockStmt tryBlock, final NodeList<CatchClause> catchClauses, final BlockStmt finallyBlock) {
         super(range);
         setResources(resources);
         setTryBlock(tryBlock);
@@ -146,4 +135,10 @@ public final class TryStmt extends Statement {
         setAsParentNodeOf(this.resources);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getCatchClauses(), getResources());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
@@ -91,3 +90,4 @@ public final class WhileStmt extends Statement implements NodeWithBody<WhileStmt
         return this;
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -30,11 +29,10 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Pair;
-
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -43,6 +41,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * So, int[][] becomes ArrayType(ArrayType(int)).
  */
 public class ArrayType extends ReferenceType implements NodeWithAnnotations<ArrayType> {
+
     private Type componentType;
 
     @AllFieldsConstructor
@@ -123,7 +122,9 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
      * Helper class that stores information about a pair of brackets.
      */
     public static class ArrayBracketPair {
+
         private Range range;
+
         private NodeList<AnnotationExpr> annotations = new NodeList<>();
 
         public ArrayBracketPair(Range range, NodeList<AnnotationExpr> annotations) {
@@ -154,4 +155,10 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
     public ArrayType setAnnotations(NodeList<AnnotationExpr> annotations) {
         return (ArrayType) super.setAnnotations(annotations);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -33,8 +32,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -49,10 +49,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ClassOrInterfaceType extends ReferenceType implements
-        NodeWithSimpleName<ClassOrInterfaceType>,
-        NodeWithAnnotations<ClassOrInterfaceType>,
-        NodeWithTypeArguments<ClassOrInterfaceType> {
+public final class ClassOrInterfaceType extends ReferenceType implements NodeWithSimpleName<ClassOrInterfaceType>, NodeWithAnnotations<ClassOrInterfaceType>, NodeWithTypeArguments<ClassOrInterfaceType> {
 
     private ClassOrInterfaceType scope;
 
@@ -61,34 +58,23 @@ public final class ClassOrInterfaceType extends ReferenceType implements
     private NodeList<Type> typeArguments;
 
     public ClassOrInterfaceType() {
-        this(null,
-                null,
-                new SimpleName(),
-                null);
+        this(null, null, new SimpleName(), null);
     }
 
     public ClassOrInterfaceType(final String name) {
-        this(null,
-                null,
-                new SimpleName(name),
-                null);
+        this(null, null, new SimpleName(name), null);
     }
 
     public ClassOrInterfaceType(final ClassOrInterfaceType scope, final String name) {
-        this(null,
-                scope,
-                new SimpleName(name),
-                null);
+        this(null, scope, new SimpleName(name), null);
     }
 
     @AllFieldsConstructor
-    public ClassOrInterfaceType(final ClassOrInterfaceType scope, final SimpleName name,
-                                final NodeList<Type> typeArguments) {
+    public ClassOrInterfaceType(final ClassOrInterfaceType scope, final SimpleName name, final NodeList<Type> typeArguments) {
         this(null, scope, name, typeArguments);
     }
 
-    public ClassOrInterfaceType(final Range range, final ClassOrInterfaceType scope, final SimpleName name,
-                                final NodeList<Type> typeArguments) {
+    public ClassOrInterfaceType(final Range range, final ClassOrInterfaceType scope, final SimpleName name, final NodeList<Type> typeArguments) {
         super(range);
         setScope(scope);
         setName(name);
@@ -169,4 +155,10 @@ public final class ClassOrInterfaceType extends ReferenceType implements
     public ClassOrInterfaceType setAnnotations(NodeList<AnnotationExpr> annotations) {
         return (ClassOrInterfaceType) super.setAnnotations(annotations);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getTypeArguments().orElse(null), getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -31,7 +31,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -29,6 +28,9 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -83,4 +85,10 @@ public class IntersectionType extends Type implements NodeWithAnnotations<Inters
     public IntersectionType setAnnotations(NodeList<AnnotationExpr> annotations) {
         return (IntersectionType) super.setAnnotations(annotations);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getElements(), getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -28,10 +28,8 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -30,7 +29,9 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * A primitive type.
@@ -41,6 +42,7 @@ import java.util.HashMap;
  * @author Julio Vilmar Gesser
  */
 public final class PrimitiveType extends Type implements NodeWithAnnotations<PrimitiveType> {
+
     public static PrimitiveType booleanType() {
         return new PrimitiveType(Primitive.BOOLEAN);
     }
@@ -74,16 +76,11 @@ public final class PrimitiveType extends Type implements NodeWithAnnotations<Pri
     }
 
     public enum Primitive {
-        BOOLEAN("Boolean"),
-        CHAR("Character"),
-        BYTE("Byte"),
-        SHORT("Short"),
-        INT("Integer"),
-        LONG("Long"),
-        FLOAT("Float"),
-        DOUBLE("Double");
+
+        BOOLEAN("Boolean"), CHAR("Character"), BYTE("Byte"), SHORT("Short"), INT("Integer"), LONG("Long"), FLOAT("Float"), DOUBLE("Double");
 
         final String nameOfBoxedType;
+
         private String codeRepresentation;
 
         public ClassOrInterfaceType toBoxedType() {
@@ -156,4 +153,10 @@ public final class PrimitiveType extends Type implements NodeWithAnnotations<Pri
     public PrimitiveType setAnnotations(NodeList<AnnotationExpr> annotations) {
         return (PrimitiveType) super.setAnnotations(annotations);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -28,7 +28,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -39,3 +38,4 @@ public abstract class ReferenceType<T extends ReferenceType> extends Type {
         super(range, new NodeList<>());
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -26,7 +25,6 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -78,3 +76,4 @@ public abstract class Type extends Node {
         }
     }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
@@ -30,10 +30,8 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -31,6 +30,9 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -46,40 +48,26 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * @author Julio Vilmar Gesser
  * @see com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters
  */
-public final class TypeParameter extends ReferenceType<TypeParameter> implements
-        NodeWithSimpleName<TypeParameter>,
-        NodeWithAnnotations<TypeParameter> {
+public final class TypeParameter extends ReferenceType<TypeParameter> implements NodeWithSimpleName<TypeParameter>, NodeWithAnnotations<TypeParameter> {
 
     private SimpleName name;
 
     private NodeList<ClassOrInterfaceType> typeBound;
 
     public TypeParameter() {
-        this(null,
-                new SimpleName(),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, new SimpleName(), new NodeList<>(), new NodeList<>());
     }
 
     public TypeParameter(final String name) {
-        this(null,
-                new SimpleName(name),
-                new NodeList<>(),
-                new NodeList<>());
+        this(null, new SimpleName(name), new NodeList<>(), new NodeList<>());
     }
 
     public TypeParameter(final String name, final NodeList<ClassOrInterfaceType> typeBound) {
-        this(null,
-                new SimpleName(name),
-                typeBound,
-                new NodeList<>());
+        this(null, new SimpleName(name), typeBound, new NodeList<>());
     }
 
     public TypeParameter(Range range, final SimpleName name, final NodeList<ClassOrInterfaceType> typeBound) {
-        this(range,
-                name,
-                typeBound,
-                new NodeList<>());
+        this(range, name, typeBound, new NodeList<>());
     }
 
     @AllFieldsConstructor
@@ -144,4 +132,10 @@ public final class TypeParameter extends ReferenceType<TypeParameter> implements
         super.setAnnotations(annotations);
         return this;
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getTypeBound(), getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -29,8 +28,9 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -46,7 +46,7 @@ public class UnionType extends Type implements NodeWithAnnotations<UnionType> {
     public UnionType() {
         this(null, new NodeList<>());
     }
-    
+
     public UnionType(Range range, NodeList<ReferenceType> elements) {
         super(range, new NodeList<>());
         setElements(elements);
@@ -82,4 +82,10 @@ public class UnionType extends Type implements NodeWithAnnotations<UnionType> {
     public <A> void accept(VoidVisitor<A> v, A arg) {
         v.visit(this, arg);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getElements(), getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -31,7 +31,6 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -26,7 +26,6 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -27,6 +26,9 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * An unknown parameter type object. It plays the role of a null object for
@@ -63,7 +65,12 @@ public final class UnknownType extends Type {
         if (annotations.size() > 0) {
             throw new IllegalStateException("Inferred lambda types cannot be annotated.");
         }
-
         return (UnknownType) super.setAnnotations(annotations);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -29,6 +28,9 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * The return type of a {@link com.github.javaparser.ast.body.MethodDeclaration}
  * when it returns void.
@@ -37,6 +39,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  * @author Julio Vilmar Gesser
  */
 public final class VoidType extends Type implements NodeWithAnnotations<VoidType> {
+
     @AllFieldsConstructor
     public VoidType() {
         this(null);
@@ -61,4 +64,9 @@ public final class VoidType extends Type implements NodeWithAnnotations<VoidType
         return (VoidType) super.setAnnotations(annotations);
     }
 
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -27,7 +27,6 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.type;
 
 import com.github.javaparser.Range;
@@ -30,6 +29,8 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -59,8 +60,7 @@ public final class WildcardType extends Type implements NodeWithAnnotations<Wild
         this(null, extendedTypes, superTypes);
     }
 
-    public WildcardType(final Range range,
-                        final ReferenceType extendedTypes, final ReferenceType superTypes) {
+    public WildcardType(final Range range, final ReferenceType extendedTypes, final ReferenceType superTypes) {
         super(range, new NodeList<>());
         setExtendedTypes(extendedTypes);
         setSuperTypes(superTypes);
@@ -114,4 +114,10 @@ public final class WildcardType extends Type implements NodeWithAnnotations<Wild
     public WildcardType setAnnotations(NodeList<AnnotationExpr> annotations) {
         return (WildcardType) super.setAnnotations(annotations);
     }
+
+    @Override
+    public List<NodeList<?>> getNodeLists() {
+        return Arrays.asList(getAnnotations());
+    }
 }
+

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -28,7 +28,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/javaparser-generator-utils/src/main/java/com/github/javaparser/generator/utils/SeparatedItemStringBuilder.java
+++ b/javaparser-generator-utils/src/main/java/com/github/javaparser/generator/utils/SeparatedItemStringBuilder.java
@@ -29,6 +29,10 @@ public class SeparatedItemStringBuilder {
         return this;
     }
 
+    public boolean hasItems() {
+        return hasItems;
+    }
+
     /**
      * Convert the builder into its final string representation.
      */

--- a/javaparser-metamodel/src/main/java/com/github/javaparser/metamodel/BaseNodeMetaModel.java
+++ b/javaparser-metamodel/src/main/java/com/github/javaparser/metamodel/BaseNodeMetaModel.java
@@ -77,6 +77,20 @@ public abstract class BaseNodeMetaModel {
     }
 
     /**
+     * @return a list of all properties in this node and its parents. Note that a new list is created every time this
+     * method is called.
+     */
+    public List<PropertyMetaModel> getAllPropertyMetaModels() {
+        List<PropertyMetaModel> allPropertyMetaModels = new ArrayList<>(getDeclaredPropertyMetaModels());
+        BaseNodeMetaModel walkNode = this;
+        while (walkNode.getSuperNodeMetaModel().isPresent()) {
+            walkNode = walkNode.getSuperNodeMetaModel().get();
+            allPropertyMetaModels.addAll(walkNode.getDeclaredPropertyMetaModels());
+        }
+        return allPropertyMetaModels;
+    }
+
+    /**
      * @return the class for this AST node type.
      */
     public Class<? extends Node> getType() {

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modules>
         <module>javaparser-core</module>
         <module>javaparser-testing</module>
-        <module>javaparser-visitor-generator</module>
+        <module>javaparser-core-generators</module>
         <module>javaparser-metamodel-generator</module>
         <module>javaparser-generator-utils</module>
         <module>javaparser-metamodel</module>


### PR DESCRIPTION
@ftomassetti - I would like you to check:
- if you could use the metamodel directly, so we can remove getNodeLists from the AST
- if you are taking typeArguments into account correctly. I had to add a null check in `registerForSubtree`
- the changes in nodelists - there seem to be a lot more now.

I'd like to have this in the next release because it renames one of the new modules. Releasing now would push one single version of that module, never to be updated again.