### PR TITLE
Generate the clone() method

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
@@ -1,6 +1,7 @@
 package com.github.javaparser.generator.core;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.generator.core.node.CloneGenerator;
 import com.github.javaparser.generator.core.node.GetNodeListsGenerator;
 import com.github.javaparser.generator.core.node.PropertyGenerator;
 import com.github.javaparser.generator.core.node.RemoveMethodGenerator;
@@ -34,6 +35,7 @@ public class CoreGenerator {
         new GetNodeListsGenerator(javaParser, sourceRoot).generate();
         new PropertyGenerator(javaParser, sourceRoot).generate();
         new RemoveMethodGenerator(javaParser, sourceRoot).generate();
+        new CloneGenerator(javaParser, sourceRoot).generate();
 
         sourceRoot.saveAll();
     }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/CloneGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/CloneGenerator.java
@@ -1,0 +1,31 @@
+package com.github.javaparser.generator.core.node;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.visitor.CloneVisitor;
+import com.github.javaparser.generator.NodeGenerator;
+import com.github.javaparser.generator.utils.SourceRoot;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
+
+import static com.github.javaparser.JavaParser.parseClassBodyDeclaration;
+import static com.github.javaparser.generator.utils.GeneratorUtils.f;
+
+public class CloneGenerator extends NodeGenerator {
+    public CloneGenerator(JavaParser javaParser, SourceRoot sourceRoot) {
+        super(javaParser, sourceRoot);
+    }
+
+    @Override
+    protected void generateNode(BaseNodeMetaModel nodeMetaModel, CompilationUnit nodeCu, ClassOrInterfaceDeclaration nodeCoid) {
+        nodeCoid.getMethodsByName("clone").forEach(Node::remove);
+
+        nodeCu.addImport(CloneVisitor.class);
+        nodeCoid.addMember(parseClassBodyDeclaration(f(
+                "@Override public %s clone() { return (%s) accept(new CloneVisitor(), null); }",
+                nodeMetaModel.getTypeNameGenerified(),
+                nodeMetaModel.getTypeNameGenerified()
+        )));
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * In <code>new int[1][2];</code> there are two ArrayCreationLevel objects,
@@ -139,6 +140,11 @@ public class ArrayCreationLevel extends Node implements NodeWithAnnotations<Arra
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public ArrayCreationLevel clone() {
+        return (ArrayCreationLevel) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * <p>
@@ -450,6 +451,11 @@ public final class CompilationUnit extends Node {
 
     public CompilationUnit removePackageDeclaration() {
         return setPackageDeclaration((PackageDeclaration) null);
+    }
+
+    @Override
+    public CompilationUnit clone() {
+        return (CompilationUnit) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An import declaration.
@@ -119,6 +120,11 @@ public final class ImportDeclaration extends Node implements NodeWithName<Import
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ImportDeclaration clone() {
+        return (ImportDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -258,11 +258,6 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
     }
 
     @Override
-    public Node clone() {
-        return (Node) accept(new CloneVisitor(), null);
-    }
-
-    @Override
     public Optional<Node> getParentNode() {
         return Optional.ofNullable(parentNode);
     }
@@ -533,6 +528,11 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable 
 
     public Node removeComment() {
         return setComment((Comment) null);
+    }
+
+    @Override
+    public Node clone() {
+        return (Node) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A package declaration.
@@ -142,6 +143,11 @@ public final class PackageDeclaration extends Node implements NodeWithAnnotation
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public PackageDeclaration clone() {
+        return (PackageDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationDeclaration.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An annotation type declaration.<br/><code>@interface X { ... }</code>
@@ -77,6 +78,11 @@ public final class AnnotationDeclaration extends TypeDeclaration<AnnotationDecla
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public AnnotationDeclaration clone() {
+        return (AnnotationDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The "int id();" in <code>@interface X { int id(); }</code>
@@ -179,6 +180,11 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public AnnotationMemberDeclaration clone() {
+        return (AnnotationMemberDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Any declaration that can appear between the { and } of a class, interface, or enum.
@@ -89,6 +90,11 @@ public abstract class BodyDeclaration<T extends Node> extends Node implements No
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public BodyDeclaration<?> clone() {
+        return (BodyDeclaration<?>) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Represents a declaration which is callable eg. a method or a constructor.
@@ -186,6 +187,11 @@ public abstract class CallableDeclaration<T extends Node> extends BodyDeclaratio
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public CallableDeclaration<?> clone() {
+        return (CallableDeclaration<?>) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
@@ -37,6 +37,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.*;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A definition of a class or interface.<br/><code>class X { ... }</code>
@@ -179,6 +180,11 @@ public final class ClassOrInterfaceDeclaration extends TypeDeclaration<ClassOrIn
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public ClassOrInterfaceDeclaration clone() {
+        return (ClassOrInterfaceDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -39,6 +39,7 @@ import java.util.EnumSet;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A constructor declaration: <code>class X { X() { } }</code> where X(){} is the constructor declaration.
@@ -168,6 +169,11 @@ public final class ConstructorDeclaration extends CallableDeclaration<Constructo
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ConstructorDeclaration clone() {
+        return (ConstructorDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EmptyMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EmptyMemberDeclaration.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Arrays;
 import java.util.List;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A loose ";" inside a body.<br/><code>class X { ; }</code>
@@ -68,6 +69,11 @@ public final class EmptyMemberDeclaration extends BodyDeclaration<EmptyMemberDec
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public EmptyMemberDeclaration clone() {
+        return (EmptyMemberDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * One of the values an enum can take. A(1) and B(2) in this example: <code>enum X { A(1), B(2) }</code>
@@ -146,6 +147,11 @@ public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantD
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public EnumConstantDeclaration clone() {
+        return (EnumConstantDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -37,6 +37,7 @@ import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The declaration of an enum.<br/><code>enum X { ... }</code>
@@ -151,6 +152,11 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public EnumDeclaration clone() {
+        return (EnumDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -43,6 +43,7 @@ import static com.github.javaparser.ast.Modifier.PUBLIC;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The declaration of a field in a class. "private static int a=15*15;" in this example: <code>class X { private static
@@ -206,6 +207,11 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public FieldDeclaration clone() {
+        return (FieldDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A (possibly static) initializer body. "static { a=3; }" in this example: <code>class X { static { a=3; }  } </code>
@@ -104,6 +105,11 @@ public final class InitializerDeclaration extends BodyDeclaration<InitializerDec
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public InitializerDeclaration clone() {
+        return (InitializerDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A method declaration. "public int abc() {return 1;}" in this example: <code>class X { public int abc() {return 1;}
@@ -241,6 +242,11 @@ public final class MethodDeclaration extends CallableDeclaration<MethodDeclarati
 
     public MethodDeclaration removeBody() {
         return setBody((BlockStmt) null);
+    }
+
+    @Override
+    public MethodDeclaration clone() {
+        return (MethodDeclaration) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The parameters to a method or lambda. Lambda parameters may have inferred types, in that case "type" is UnknownType.
@@ -207,6 +208,11 @@ public final class Parameter extends Node implements NodeWithType<Parameter, Typ
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public Parameter clone() {
+        return (Parameter) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -35,6 +35,7 @@ import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A base class for all types of type declarations.
@@ -151,6 +152,11 @@ public abstract class TypeDeclaration<T extends Node> extends BodyDeclaration<T>
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public TypeDeclaration<?> clone() {
+        return (TypeDeclaration<?>) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The declaration of a variable.<br/><code>int x = 14;</code>
@@ -170,6 +171,11 @@ public final class VariableDeclarator extends Node implements NodeWithType<Varia
 
     public VariableDeclarator removeInitializer() {
         return setInitializer((Expression) null);
+    }
+
+    @Override
+    public VariableDeclarator clone() {
+        return (VariableDeclarator) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * <p>
@@ -65,6 +66,11 @@ public final class BlockComment extends Comment {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public BlockComment clone() {
+        return (BlockComment) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Abstract class for all AST nodes that represent comments.
@@ -126,6 +127,11 @@ public abstract class Comment extends Node {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public Comment clone() {
+        return (Comment) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A Javadoc comment. <code>/&#42;&#42; a comment &#42;/</code>
@@ -67,6 +68,11 @@ public final class JavadocComment extends Comment {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public JavadocComment clone() {
+        return (JavadocComment) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * <p>
@@ -69,6 +70,11 @@ public final class LineComment extends Comment {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public LineComment clone() {
+        return (LineComment) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A base class for the different types of annotations.
@@ -69,6 +70,11 @@ public abstract class AnnotationExpr extends Expression implements NodeWithName<
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public AnnotationExpr clone() {
+        return (AnnotationExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Array brackets [] being used to get a value from an array.
@@ -98,6 +99,11 @@ public final class ArrayAccessExpr extends Expression {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ArrayAccessExpr clone() {
+        return (ArrayAccessExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * <code>new int[5][4][][]</code> or <code>new int[][]{{1},{2,3}}</code>.
@@ -187,6 +188,11 @@ public final class ArrayCreationExpr extends Expression {
 
     public ArrayCreationExpr removeInitializer() {
         return setInitializer((ArrayInitializerExpr) null);
+    }
+
+    @Override
+    public ArrayCreationExpr clone() {
+        return (ArrayCreationExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The initialization of an array. In the following sample, the outer { } is an ArrayInitializerExpr.
@@ -97,6 +98,11 @@ public final class ArrayInitializerExpr extends Expression {
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public ArrayInitializerExpr clone() {
+        return (ArrayInitializerExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An assignment expression. It supports the operators that are found the the AssignExpr.Operator enum.
@@ -128,6 +129,11 @@ public final class AssignExpr extends Expression {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public AssignExpr clone() {
+        return (AssignExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An expression with an expression on the left, an expression on the right, and an operator in the middle.
@@ -129,6 +130,11 @@ public final class BinaryExpr extends Expression {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public BinaryExpr clone() {
+        return (BinaryExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The boolean literals.
@@ -77,6 +78,11 @@ public final class BooleanLiteralExpr extends LiteralExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public BooleanLiteralExpr clone() {
+        return (BooleanLiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A typecast. The (long) in <code>(long)15</code>
@@ -105,6 +106,11 @@ public final class CastExpr extends Expression implements NodeWithType<CastExpr,
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public CastExpr clone() {
+        return (CastExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Utils;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A literal character.
@@ -74,6 +75,11 @@ public final class CharLiteralExpr extends StringLiteralExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public CharLiteralExpr clone() {
+        return (CharLiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Defines an expression that accesses the class of a type.
@@ -86,6 +87,11 @@ public final class ClassExpr extends Expression implements NodeWithType<ClassExp
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ClassExpr clone() {
+        return (ClassExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An if-then or if-then-else construct.
@@ -115,6 +116,11 @@ public final class ConditionalExpr extends Expression {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ConditionalExpr clone() {
+        return (ConditionalExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A float or a double constant. This value is stored exactly as found in the source.
@@ -64,6 +65,11 @@ public final class DoubleLiteralExpr extends StringLiteralExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public DoubleLiteralExpr clone() {
+        return (DoubleLiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An expression between ( ).
@@ -96,6 +97,11 @@ public final class EnclosedExpr extends Expression {
 
     public EnclosedExpr removeInner() {
         return setInner((Expression) null);
+    }
+
+    @Override
+    public EnclosedExpr clone() {
+        return (EnclosedExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A base class for all expressions.
@@ -39,6 +40,11 @@ public abstract class Expression extends Node {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public Expression clone() {
+        return (Expression) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Access of a field of an object.
@@ -191,6 +192,11 @@ public final class FieldAccessExpr extends Expression implements NodeWithSimpleN
 
     public FieldAccessExpr removeScope() {
         return setScope((Expression) null);
+    }
+
+    @Override
+    public FieldAccessExpr clone() {
+        return (FieldAccessExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Usage of the instanceof operator.
@@ -106,6 +107,11 @@ public final class InstanceOfExpr extends Expression implements NodeWithType<Ins
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public InstanceOfExpr clone() {
+        return (InstanceOfExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * All ways to specify an int literal.
@@ -66,6 +67,11 @@ public class IntegerLiteralExpr extends StringLiteralExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public IntegerLiteralExpr clone() {
+        return (IntegerLiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A lambda expression. The parameters are on the left side of the ->.
@@ -136,6 +137,11 @@ public class LambdaExpr extends Expression implements NodeWithParameters<LambdaE
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public LambdaExpr clone() {
+        return (LambdaExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralExpr.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A base class for all literal expressions.
@@ -39,6 +40,11 @@ public abstract class LiteralExpr extends Expression {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public LiteralExpr clone() {
+        return (LiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * All ways to specify a long literal.
@@ -66,6 +67,11 @@ public class LongLiteralExpr extends StringLiteralExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public LongLiteralExpr clone() {
+        return (LongLiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An annotation that uses only the annotation type name.
@@ -62,6 +63,11 @@ public final class MarkerAnnotationExpr extends AnnotationExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public MarkerAnnotationExpr clone() {
+        return (MarkerAnnotationExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A value for a member of an annotation.
@@ -105,6 +106,11 @@ public final class MemberValuePair extends Node implements NodeWithSimpleName<Me
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public MemberValuePair clone() {
+        return (MemberValuePair) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A method call on an object. <br/><code>circle.circumference()</code> <br/>In <code>a.&lt;String&gt;bb(15);</code> a
@@ -188,6 +189,11 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
 
     public MethodCallExpr removeScope() {
         return setScope((Expression) null);
+    }
+
+    @Override
+    public MethodCallExpr clone() {
+        return (MethodCallExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Method reference expressions introduced in Java 8 specifically designed to simplify lambda Expressions.
@@ -147,6 +148,11 @@ public class MethodReferenceExpr extends Expression implements NodeWithTypeArgum
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public MethodReferenceExpr clone() {
+        return (MethodReferenceExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A name that may consist of multiple identifiers.
@@ -145,6 +146,11 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
 
     public Name removeQualifier() {
         return setQualifier((Name) null);
+    }
+
+    @Override
+    public Name clone() {
+        return (Name) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Whenever a SimpleName is used in an expression, it is wrapped in NameExpr.
@@ -88,6 +89,11 @@ public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public NameExpr clone() {
+        return (NameExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An annotation that has zero or more key-value pairs.<br/><code>@Mapping(a=5, d=10)</code>
@@ -113,6 +114,11 @@ public final class NormalAnnotationExpr extends AnnotationExpr {
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public NormalAnnotationExpr clone() {
+        return (NormalAnnotationExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NullLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NullLiteralExpr.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A literal "null".
@@ -58,6 +59,11 @@ public final class NullLiteralExpr extends LiteralExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public NullLiteralExpr clone() {
+        return (NullLiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A constructor call. <br/>In <code>new HashMap.Entry<String, Long>(15) {public String getKey() {return null;}};</code>
@@ -240,6 +241,11 @@ public final class ObjectCreationExpr extends Expression implements NodeWithType
 
     public ObjectCreationExpr removeScope() {
         return setScope((Expression) null);
+    }
+
+    @Override
+    public ObjectCreationExpr clone() {
+        return (ObjectCreationExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A name that consists of a single identifier.
@@ -81,6 +82,11 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public SimpleName clone() {
+        return (SimpleName) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An annotation that has a single value. <br/><code>@Count(15)</code>
@@ -80,6 +81,11 @@ public final class SingleMemberAnnotationExpr extends AnnotationExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public SingleMemberAnnotationExpr clone() {
+        return (SingleMemberAnnotationExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.utils.Utils;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A literal string.
@@ -89,6 +90,11 @@ public class StringLiteralExpr extends LiteralExpr {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public StringLiteralExpr clone() {
+        return (StringLiteralExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An occurrence of the "super" keyword. <br/><code>World.super.greet()</code> is a MethodCallExpr of method name greet,
@@ -99,6 +100,11 @@ public final class SuperExpr extends Expression {
 
     public SuperExpr removeClassExpr() {
         return setClassExpr((Expression) null);
+    }
+
+    @Override
+    public SuperExpr clone() {
+        return (SuperExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An occurrence of the "this" keyword. <br/><code>World.this.greet()</code> is a MethodCallExpr of method name greet,
@@ -93,6 +94,11 @@ public final class ThisExpr extends Expression {
 
     public ThisExpr removeClassExpr() {
         return setClassExpr((Expression) null);
+    }
+
+    @Override
+    public ThisExpr clone() {
+        return (ThisExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * This class is just instantiated as scopes for MethodReferenceExpr nodes to encapsulate Types.
@@ -87,6 +88,11 @@ public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type>
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public TypeExpr clone() {
+        return (TypeExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An expression where an operator is applied to a single expression.
@@ -128,6 +129,11 @@ public final class UnaryExpr extends Expression implements NodeWithExpression<Un
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public UnaryExpr clone() {
+        return (UnaryExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A declaration of variables.
@@ -179,6 +180,11 @@ public final class VariableDeclarationExpr extends Expression implements NodeWit
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public VariableDeclarationExpr clone() {
+        return (VariableDeclarationExpr) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
@@ -103,7 +103,7 @@ public interface NodeWithStatements<N extends Node> {
     @SuppressWarnings("unchecked")
     default N copyStatements(NodeList<Statement> nodeList) {
         for (Statement n : nodeList) {
-            addStatement((Statement) n.clone());
+            addStatement(n.clone());
         }
         return (N) this;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A usage of the keyword "assert"
@@ -119,6 +120,11 @@ public final class AssertStmt extends Statement {
 
     public AssertStmt removeMessage() {
         return setMessage((Expression) null);
+    }
+
+    @Override
+    public AssertStmt clone() {
+        return (AssertStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BlockStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BlockStmt.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Statements in between { and }.
@@ -95,6 +96,11 @@ public final class BlockStmt extends Statement implements NodeWithStatements<Blo
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public BlockStmt clone() {
+        return (BlockStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A usage of the break keyword.
@@ -101,6 +102,11 @@ public final class BreakStmt extends Statement {
 
     public BreakStmt removeLabel() {
         return setLabel((SimpleName) null);
+    }
+
+    @Override
+    public BreakStmt clone() {
+        return (BreakStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.EnumSet;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The catch part of a try-catch-finally. <br/>In <code>try { ... } catch (Exception e) { ... }</code> the CatchClause
@@ -117,6 +118,11 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public CatchClause clone() {
+        return (CatchClause) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A continue statement with an optional label;
@@ -105,6 +106,11 @@ public final class ContinueStmt extends Statement implements NodeWithOptionalLab
 
     public ContinueStmt removeLabel() {
         return setLabel((SimpleName) null);
+    }
+
+    @Override
+    public ContinueStmt clone() {
+        return (ContinueStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A do-while.
@@ -103,6 +104,11 @@ public final class DoStmt extends Statement implements NodeWithBody<DoStmt> {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public DoStmt clone() {
+        return (DoStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/EmptyStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/EmptyStmt.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * @author Julio Vilmar Gesser
@@ -57,6 +58,11 @@ public final class EmptyStmt extends Statement {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public EmptyStmt clone() {
+        return (EmptyStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A call to super or this in a constructor or initializer.
@@ -197,6 +198,11 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
 
     public ExplicitConstructorInvocationStmt removeExpression() {
         return setExpression((Expression) null);
+    }
+
+    @Override
+    public ExplicitConstructorInvocationStmt clone() {
+        return (ExplicitConstructorInvocationStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Used to wrap an expression so that it can take the place of a statement.
@@ -85,6 +86,11 @@ public final class ExpressionStmt extends Statement implements NodeWithExpressio
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ExpressionStmt clone() {
+        return (ExpressionStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A classic for statement.
@@ -174,6 +175,11 @@ public final class ForStmt extends Statement implements NodeWithBody<ForStmt> {
 
     public ForStmt removeCompare() {
         return setCompare((Expression) null);
+    }
+
+    @Override
+    public ForStmt clone() {
+        return (ForStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A for-each statement.
@@ -125,6 +126,11 @@ public final class ForeachStmt extends Statement implements NodeWithBody<Foreach
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ForeachStmt clone() {
+        return (ForeachStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An if-then-else statement. The else is optional.
@@ -134,6 +135,11 @@ public final class IfStmt extends Statement {
 
     public IfStmt removeElseStmt() {
         return setElseStmt((Statement) null);
+    }
+
+    @Override
+    public IfStmt clone() {
+        return (IfStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A statement that is labeled, like <code>label123: println("continuing");</code>
@@ -102,6 +103,11 @@ public final class LabeledStmt extends Statement {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public LabeledStmt clone() {
+        return (LabeledStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A class declaration inside a method. 
@@ -84,6 +85,11 @@ public final class LocalClassDeclarationStmt extends Statement {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public LocalClassDeclarationStmt clone() {
+        return (LocalClassDeclarationStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Optional;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The return statement, with an optional expression to return.
@@ -104,6 +105,11 @@ public final class ReturnStmt extends Statement {
 
     public ReturnStmt removeExpression() {
         return setExpression((Expression) null);
+    }
+
+    @Override
+    public ReturnStmt clone() {
+        return (ReturnStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A base class for all statements.
@@ -39,6 +40,11 @@ public abstract class Statement extends Node {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public Statement clone() {
+        return (Statement) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * One case in a switch statement.
@@ -144,6 +145,11 @@ public final class SwitchEntryStmt extends Statement implements NodeWithStatemen
 
     public SwitchEntryStmt removeLabel() {
         return setLabel((Expression) null);
+    }
+
+    @Override
+    public SwitchEntryStmt clone() {
+        return (SwitchEntryStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A switch statement.
@@ -130,6 +131,11 @@ public final class SwitchStmt extends Statement {
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public SwitchStmt clone() {
+        return (SwitchStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Usage of the synchronized keyword.
@@ -104,6 +105,11 @@ public final class SynchronizedStmt extends Statement implements NodeWithBlockSt
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public SynchronizedStmt clone() {
+        return (SynchronizedStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Usage of the throw statement.
@@ -86,6 +87,11 @@ public final class ThrowStmt extends Statement implements NodeWithExpression<Thr
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ThrowStmt clone() {
+        return (ThrowStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The try statement.
@@ -188,6 +189,11 @@ public final class TryStmt extends Statement {
 
     public TryStmt removeTryBlock() {
         return setTryBlock((BlockStmt) null);
+    }
+
+    @Override
+    public TryStmt clone() {
+        return (TryStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A while statement.
@@ -103,6 +104,11 @@ public final class WhileStmt extends Statement implements NodeWithBody<WhileStmt
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public WhileStmt clone() {
+        return (WhileStmt) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * To indicate that a type is an array, it gets wrapped in an ArrayType for every array level it has.
@@ -170,6 +171,11 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ArrayType clone() {
+        return (ArrayType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A class or an interface type. <br/><code>Object</code> <br/><code>HashMap&lt;String, String></code>
@@ -191,6 +192,11 @@ public final class ClassOrInterfaceType extends ReferenceType implements NodeWit
 
     public ClassOrInterfaceType removeScope() {
         return setScope((ClassOrInterfaceType) null);
+    }
+
+    @Override
+    public ClassOrInterfaceType clone() {
+        return (ClassOrInterfaceType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Represents a set of types. A given value of this type has to be assignable to at all of the element types.
@@ -104,6 +105,11 @@ public class IntersectionType extends Type implements NodeWithAnnotations<Inters
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public IntersectionType clone() {
+        return (IntersectionType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A primitive type.
@@ -166,6 +167,11 @@ public final class PrimitiveType extends Type implements NodeWithAnnotations<Pri
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public PrimitiveType clone() {
+        return (PrimitiveType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.type;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Base class for reference types.
@@ -44,6 +45,11 @@ public abstract class ReferenceType<T extends ReferenceType> extends Type {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public ReferenceType<?> clone() {
+        return (ReferenceType<?>) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Base class for types.
@@ -90,6 +91,11 @@ public abstract class Type extends Node {
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public Type clone() {
+        return (Type) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A type parameter.
@@ -154,6 +155,11 @@ public final class TypeParameter extends ReferenceType<TypeParameter> implements
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public TypeParameter clone() {
+        return (TypeParameter) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * Represents a set of types. A given value of this type has to be assignable to at least one of the element types.
@@ -101,6 +102,11 @@ public class UnionType extends Type implements NodeWithAnnotations<UnionType> {
             }
         }
         return super.remove(node);
+    }
+
+    @Override
+    public UnionType clone() {
+        return (UnionType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Arrays;
 import java.util.List;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * An unknown parameter type object. It plays the role of a null object for
@@ -78,6 +79,11 @@ public final class UnknownType extends Type {
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public UnknownType clone() {
+        return (UnknownType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.Arrays;
 import java.util.List;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * The return type of a {@link com.github.javaparser.ast.body.MethodDeclaration}
@@ -74,6 +75,11 @@ public final class VoidType extends Type implements NodeWithAnnotations<VoidType
         if (node == null)
             return false;
         return super.remove(node);
+    }
+
+    @Override
+    public VoidType clone() {
+        return (VoidType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 
 /**
  * A wildcard type argument.
@@ -149,6 +150,11 @@ public final class WildcardType extends Type implements NodeWithAnnotations<Wild
 
     public WildcardType removeSuperTypes() {
         return setSuperTypes((ReferenceType) null);
+    }
+
+    @Override
+    public WildcardType clone() {
+        return (WildcardType) accept(new CloneVisitor(), null);
     }
 }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -53,7 +53,7 @@ public class JavaParserTest {
     @Test
     public void rangeOfArrayCreationLevelWithExpressionIsCorrect() {
         String code = "new int[123][456]";
-        ArrayCreationExpr expression = (ArrayCreationExpr)JavaParser.parseExpression(code);
+        ArrayCreationExpr expression = JavaParser.parseExpression(code);
         Optional<Range> range;
 
         range = expression.getLevels().get(0).getRange();
@@ -68,7 +68,7 @@ public class JavaParserTest {
     @Test
     public void rangeOfArrayCreationLevelWithoutExpressionIsCorrect() {
         String code = "new int[][]";
-        ArrayCreationExpr expression = (ArrayCreationExpr)JavaParser.parseExpression(code);
+        ArrayCreationExpr expression = JavaParser.parseExpression(code);
         Optional<Range> range;
 
         range = expression.getLevels().get(0).getRange();

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/stmt/BlockStmtTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/stmt/BlockStmtTest.java
@@ -13,7 +13,7 @@ public class BlockStmtTest {
         MethodCallExpr expression = new MethodCallExpr(exp, "y");
 
         blockStmt.addStatement(expression);
-        blockStmt.addStatement((Expression) expression.clone());
+        blockStmt.addStatement(expression.clone());
         // This fails when the issue exists:
         String s = blockStmt.toString();
     }


### PR DESCRIPTION
The advantage is that clone now returns the type of the node it is called on, not `Node`.

#687