### PR TITLE
The generators are now run during the build

### DIFF
--- a/javaparser-core-generators/pom.xml
+++ b/javaparser-core-generators/pom.xml
@@ -27,4 +27,30 @@
             <version>1.7.22</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-javaparser-core</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <classpathScope>test</classpathScope>
+                    <mainClass>com.github.javaparser.generator.core.CoreGenerator</mainClass>
+                    <arguments>
+                        <argument>${project.basedir}</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
@@ -5,7 +5,6 @@ import com.github.javaparser.generator.core.node.GetNodeListsGenerator;
 import com.github.javaparser.generator.core.node.PropertyGenerator;
 import com.github.javaparser.generator.core.node.RemoveMethodGenerator;
 import com.github.javaparser.generator.core.visitor.*;
-import com.github.javaparser.generator.utils.GeneratorUtils;
 import com.github.javaparser.generator.utils.SourceRoot;
 
 import java.nio.file.Path;
@@ -16,11 +15,19 @@ import java.nio.file.Paths;
  */
 public class CoreGenerator {
     public static void main(String[] args) throws Exception {
-        Path root = GeneratorUtils.getJavaParserBasePath().resolve(Paths.get("javaparser-core", "src", "main", "java"));
-
-        final JavaParser javaParser = new JavaParser();
-
+        if (args.length != 1) {
+            throw new RuntimeException("Need 1 parameter: the JavaParser source checkout root directory.");
+        }
+        final Path root = Paths.get(args[0], "..", "javaparser-core", "src", "main", "java");
         final SourceRoot sourceRoot = new SourceRoot(root);
+
+        new CoreGenerator().run(sourceRoot);
+
+        sourceRoot.saveAll();
+    }
+
+    private void run(SourceRoot sourceRoot) throws Exception {
+        final JavaParser javaParser = new JavaParser();
 
         new GenericVisitorAdapterGenerator(javaParser, sourceRoot).generate();
         new EqualsVisitorGenerator(javaParser, sourceRoot).generate();
@@ -35,7 +42,5 @@ public class CoreGenerator {
         new GetNodeListsGenerator(javaParser, sourceRoot).generate();
         new PropertyGenerator(javaParser, sourceRoot).generate();
         new RemoveMethodGenerator(javaParser, sourceRoot).generate();
-
-        sourceRoot.saveAll();
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -611,20 +611,20 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     @Override
     public Visitable visit(final MethodDeclaration n, final A arg) {
         BlockStmt body = n.getBody().map( s -> (BlockStmt) s.accept(this, arg)).orElse(null);
+        Type type = (Type) n.getType().accept(this, arg);
         SimpleName name = (SimpleName) n.getName().accept(this, arg);
         NodeList<Parameter> parameters = modifyList(n.getParameters(), arg);
         NodeList<ReferenceType> thrownExceptions = modifyList(n.getThrownExceptions(), arg);
-        Type type = (Type) n.getType().accept(this, arg);
         NodeList<TypeParameter> typeParameters = modifyList(n.getTypeParameters(), arg);
         NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         Comment comment = n.getComment().map( s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || type == null)
+        if (type == null || name == null)
             return null;
         n.setBody(body);
+        n.setType(type);
         n.setName(name);
         n.setParameters(parameters);
         n.setThrownExceptions(thrownExceptions);
-        n.setType(type);
         n.setTypeParameters(typeParameters);
         n.setAnnotations(annotations);
         n.setComment(comment);

--- a/javaparser-generator-utils/src/main/java/com/github/javaparser/generator/utils/GeneratorUtils.java
+++ b/javaparser-generator-utils/src/main/java/com/github/javaparser/generator/utils/GeneratorUtils.java
@@ -107,18 +107,6 @@ public final class GeneratorUtils {
     }
 
     /**
-     * For generators that are inside the JavaParser project, this will get the root path of the project.
-     */
-    public static Path getJavaParserBasePath() {
-        String path = GeneratorUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-        // Silly Windows fix
-        if (path.charAt(2) == ':') {
-            path = path.substring(1);
-        }
-        return Paths.get(path, "..", "..", "..");
-    }
-
-    /**
      * @param input "aCamelCaseString"
      * @return "A_CAMEL_CASE_STRING"
      */

--- a/javaparser-metamodel-generator/pom.xml
+++ b/javaparser-metamodel-generator/pom.xml
@@ -28,4 +28,30 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-javaparser-metamodel</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <classpathScope>test</classpathScope>
+                    <mainClass>com.github.javaparser.generator.metamodel.MetaModelGenerator</mainClass>
+                    <arguments>
+                        <argument>${project.basedir}</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/javaparser-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
+++ b/javaparser-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
@@ -21,7 +21,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import static com.github.javaparser.generator.utils.GeneratorUtils.decapitalize;
-import static com.github.javaparser.generator.utils.GeneratorUtils.getJavaParserBasePath;
 
 public class MetaModelGenerator {
     static final String NODE_META_MODEL = "BaseNodeMetaModel";
@@ -138,21 +137,23 @@ public class MetaModelGenerator {
     static String METAMODEL_PACKAGE = "com.github.javaparser.metamodel";
 
     public static void main(String[] args) throws IOException, NoSuchMethodException {
-        new MetaModelGenerator().run();
-    }
+        if (args.length != 1) {
+            throw new RuntimeException("Need 1 parameter: the JavaParser source checkout root directory.");
+        }
+        final Path root = Paths.get(args[0], "..", "javaparser-metamodel", "src", "main", "java");
+        final SourceRoot sourceRoot = new SourceRoot(root);
 
-    private void run() throws IOException, NoSuchMethodException {
-        final Path root = getJavaParserBasePath().resolve(Paths.get("javaparser-metamodel", "src", "main", "java"));
-
-        JavaParser javaParser = new JavaParser();
-
-        SourceRoot sourceRoot = new SourceRoot(root);
-
-        CompilationUnit javaParserMetaModel = sourceRoot.parse(METAMODEL_PACKAGE, "JavaParserMetaModel.java", javaParser).get();
-
-        generateNodeMetaModels(javaParserMetaModel, sourceRoot);
+        new MetaModelGenerator().run(sourceRoot);
 
         sourceRoot.saveAll();
+    }
+
+    private void run(SourceRoot sourceRoot) throws IOException, NoSuchMethodException {
+        final JavaParser javaParser = new JavaParser();
+
+        final CompilationUnit javaParserMetaModel = sourceRoot.parse(METAMODEL_PACKAGE, "JavaParserMetaModel.java", javaParser).get();
+
+        generateNodeMetaModels(javaParserMetaModel, sourceRoot);
     }
 
     private void generateNodeMetaModels(CompilationUnit javaParserMetaModelCu, SourceRoot sourceRoot) throws NoSuchMethodException {


### PR DESCRIPTION
It shows a funny dependency issue:
- to generate the metamodel, we need to compile and introspect core.
- to generate the core classes, we need the metamodel.

So we end up with core classes as they were before code generation, and core java file with the new generated code :(

Can't be helped, I think. It's good advice to run the build two times before making a PR though.