### PR TITLE
Fix getJavadocComment to not  throw ClassCastException 

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
@@ -40,7 +40,7 @@ public interface NodeWithJavadoc<N extends Node> {
      * Gets the JavadocComment for this node. You can set the JavadocComment by calling setJavadocComment passing a
      * JavadocComment.
      *
-     * @return The JavadocComment for this node wrapped in an optional as it maybe absent.
+     * @return The JavadocComment for this node wrapped in an optional as it may be absent.
      */
     default Optional<JavadocComment> getJavadocComment() {
         return getComment()
@@ -51,7 +51,7 @@ public interface NodeWithJavadoc<N extends Node> {
     /**
      * Gets the Javadoc for this node. You can set the Javadoc by calling setJavadocComment passing a Javadoc.
      *
-     * @return The Javadoc for this node wrapped in an optional as it maybe absent.
+     * @return The Javadoc for this node wrapped in an optional as it may be absent.
      */
     default Optional<Javadoc> getJavadoc() {
         return getJavadocComment().map(JavadocComment::parse);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
@@ -40,19 +40,21 @@ public interface NodeWithJavadoc<N extends Node> {
      * Gets the JavadocComment for this node. You can set the JavadocComment by calling setJavadocComment passing a
      * JavadocComment.
      *
-     * @return The JavadocComment for this node if it exists, null if it doesn't.
+     * @return The JavadocComment for this node wrapped in an optional as it maybe absent.
      */
     default Optional<JavadocComment> getJavadocComment() {
-        return getComment().flatMap(c -> Optional.of((JavadocComment) c));
+        return getComment()
+                .filter(comment -> comment instanceof JavadocComment)
+                .map(comment -> (JavadocComment) comment);
     }
 
     /**
      * Gets the Javadoc for this node. You can set the Javadoc by calling setJavadocComment passing a Javadoc.
      *
-     * @return The Javadoc for this node if it exists, null if it doesn't.
+     * @return The Javadoc for this node wrapped in an optional as it maybe absent.
      */
     default Optional<Javadoc> getJavadoc() {
-        return getJavadocComment().flatMap(c -> Optional.of(c.parse()));
+        return getJavadocComment().map(JavadocComment::parse);
     }
 
     /**

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadocTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadocTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
- * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ * Copyright (C) 2011, 2013-2017 The JavaParser Team.
  *
  * This file is part of JavaParser.
  *
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.nodeTypes;
 
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 import org.junit.Test;
@@ -58,6 +59,15 @@ public class NodeWithJavadocTest {
         decl.setComment(new JavadocComment("A comment"));
         assertEquals(true, decl.removeJavaDocComment());
         assertFalse(decl.getComment().isPresent());
+    }
+
+    @Test
+    public void getJavadocOnMethodWithLineCommentShouldReturnEmptyOptional() {
+        MethodDeclaration method = new MethodDeclaration();
+        method.setLineComment("Lorem Ipsum.");
+
+        assertFalse(method.getJavadocComment().isPresent());
+        assertFalse(method.getJavadoc().isPresent());
     }
 
 }


### PR DESCRIPTION
if a comment but not a javadoc comment is present. Also removing unnecessary optional wrapping.