### PR TITLE
Refine CSM

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -185,6 +185,5 @@ public final class VariableDeclarator extends Node implements NodeWithType<Varia
     public VariableDeclaratorMetaModel getMetaModel() {
         return JavaParserMetaModel.variableDeclaratorMetaModel;
     }
-
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.visitor.CloneVisitor;
-import com.github.javaparser.metamodel.DerivedProperty;
 import com.github.javaparser.metamodel.VariableDeclaratorMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.visitor.CloneVisitor;
+import com.github.javaparser.metamodel.DerivedProperty;
 import com.github.javaparser.metamodel.VariableDeclaratorMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 
@@ -184,5 +185,6 @@ public final class VariableDeclarator extends Node implements NodeWithType<Varia
     public VariableDeclaratorMetaModel getMetaModel() {
         return JavaParserMetaModel.variableDeclaratorMetaModel;
     }
+
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
@@ -26,12 +26,7 @@ import com.github.javaparser.utils.Utils;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Optional;
-import static com.github.javaparser.ast.observer.ObservableProperty.Type.*;
-import com.github.javaparser.utils.Utils;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.Optional;
-import static com.github.javaparser.utils.Utils.capitalize;
 
 /**
  * Properties considered by the AstObserver
@@ -58,6 +53,15 @@ public enum ObservableProperty {
 
     private boolean derived;
 
+    public static ObservableProperty fromCamelCaseName(String camelCaseName) {
+        Optional<ObservableProperty> observableProperty = Arrays.stream(values()).filter( v -> v.camelCaseName().equals(camelCaseName)).findFirst();
+        if (observableProperty.isPresent()) {
+            return observableProperty.get();
+        } else {
+            throw new IllegalArgumentException("No property found with the given camel case name: " + camelCaseName);
+        }
+    }
+
     ObservableProperty(Type type) {
         this.type = type;
         this.derived = false;
@@ -70,6 +74,10 @@ public enum ObservableProperty {
 
     ObservableProperty() {
         this(Type.SINGLE_REFERENCE, false);
+    }
+
+    public boolean isDerived() {
+        return derived;
     }
 
     public boolean isAboutNodes() {
@@ -92,27 +100,21 @@ public enum ObservableProperty {
         return Utils.toCamelCase(name());
     }
 
-    public Node singlePropertyFor(Node node) {
-        String getterName = "get" + Utils.capitalize(camelCaseName());
+    public Node getValueAsSingleReference(Node node) {
+        Object rawValue = getRawValue(node);
         try {
-            Object result = node.getClass().getMethod(getterName).invoke(node);
-            if (result == null) {
-                return null;
-            }
-            if (result instanceof Node) {
-                return (Node) result;
-            } else if (result instanceof Optional) {
-                Optional<Node> opt = (Optional<Node>) result;
+            if (rawValue instanceof Node) {
+                return (Node) rawValue;
+            } else if (rawValue instanceof Optional) {
+                Optional<Node> opt = (Optional<Node>) rawValue;
                 if (opt.isPresent()) {
                     return opt.get();
                 } else {
                     return null;
                 }
             } else {
-                throw new RuntimeException(String.format("Property %s returned %s (%s)", this.name(), result.toString(), result.getClass().getCanonicalName()));
+                throw new RuntimeException(String.format("Property %s returned %s (%s)", this.name(), rawValue.toString(), rawValue.getClass().getCanonicalName()));
             }
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException("Unable to get single value for " + this.name() + " from " + node, e);
         } catch (ClassCastException e) {
             throw new RuntimeException(e);
         }
@@ -127,154 +129,76 @@ public enum ObservableProperty {
         }
     }
 
-    public Object singleValueFor(Node node) {
+    public NodeList<? extends Node> getValueAsMultipleReference(Node node) {
+        Object rawValue = getRawValue(node);
+        try {
+            if (rawValue == null) {
+                return null;
+            }
+            if (rawValue instanceof NodeList) {
+                return (NodeList) rawValue;
+            } else {
+                Optional<NodeList> opt = (Optional<NodeList>) rawValue;
+                if (opt.isPresent()) {
+                    return opt.get();
+                } else {
+                    return null;
+                }
+            }
+        } catch (ClassCastException e) {
+            throw new RuntimeException("Unable to get list value for " + this.name() + " from " + node + " (class: " + node.getClass().getSimpleName() + ")", e);
+        }
+    }
+
+    public Collection<?> getValueAsCollection(Node node) {
+        Object rawValue = getRawValue(node);
+        try {
+            return (Collection) rawValue;
+        } catch (ClassCastException e) {
+            throw new RuntimeException("Unable to get list value for " + this.name() + " from " + node + " (class: " + node.getClass().getSimpleName() + ")", e);
+        }
+    }
+
+    public String getValueAsStringAttribute(Node node) {
+        return (String) getRawValue(node);
+    }
+
+    public Boolean getValueAsBooleanAttribute(Node node) {
+        return (Boolean) getRawValue(node);
+    }
+
+    public Object getRawValue(Node node) {
         String getterName = "get" + Utils.capitalize(camelCaseName());
         if (!hasMethod(node, getterName)) {
-            getterName = "has" + Utils.capitalize(camelCaseName());
+            getterName = "is" + Utils.capitalize(camelCaseName());
             if (!hasMethod(node, getterName)) {
-                if (camelCaseName().startsWith("is")) {
-                    getterName = camelCaseName();
-                } else {
-                    getterName = "is" + Utils.capitalize(camelCaseName());
-                }
+                getterName = "has" + Utils.capitalize(camelCaseName());
             }
         }
-        try {
-            Object result = node.getClass().getMethod(getterName).invoke(node);
-            if (result == null) {
-                return null;
-            }
-            if (result instanceof Optional) {
-                Optional<Node> opt = (Optional<Node>) result;
-                if (opt.isPresent()) {
-                    return opt.get();
-                } else {
-                    return null;
-                }
-            } else {
-                return result;
-            }
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException("Unable to get single value for " + this.name() + " from " + node + " (class: " + node.getClass().getSimpleName() + ")", e);
-        }
-    }
-
-    public NodeList<? extends Node> listValueFor(Node node) {
-        String getterName = "get" + Utils.capitalize(camelCaseName());
-        try {
-            Object result = node.getClass().getMethod(getterName).invoke(node);
-            if (result == null) {
-                return null;
-            }
-            if (result instanceof NodeList) {
-                return (NodeList) result;
-            } else {
-                Optional<NodeList> opt = (Optional<NodeList>) result;
-                if (opt.isPresent()) {
-                    return opt.get();
-                } else {
-                    return null;
-                }
-            }
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException("Unable to get list value for " + this.name() + " from " + node + " (class: " + node.getClass().getSimpleName() + ")", e);
-        }
-    }
-
-    public Collection<?> listPropertyFor(Node node) {
-        String getterName = "get" + Utils.capitalize(camelCaseName());
-        try {
-            Object result = node.getClass().getMethod(getterName).invoke(node);
-            if (result == null) {
-                return null;
-            }
-            return (Collection) result;
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException("Unable to get list value for " + this.name() + " from " + node + " (class: " + node.getClass().getSimpleName() + ")", e);
-        }
-    }
-
-    public String singleStringValueFor(Node node) {
-        return (String) getValue(node);
-    }
-
-    public Object getValue(Node node) {
-        String getterName = "get" + Utils.capitalize(camelCaseName());
         try {
             return node.getClass().getMethod(getterName).invoke(node);
-        } catch (NoSuchMethodException e1) {
-            getterName = "is" + Utils.capitalize(camelCaseName());
-            try {
-                return node.getClass().getMethod(getterName).invoke(node);
-            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e2) {
-                throw new RuntimeException("Unable to get value for " + this.name() + " from " + node + " (" + node.getClass().getSimpleName() + ")", e2);
-            }
-        } catch (IllegalAccessException | InvocationTargetException e) {
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException("Unable to get value for " + this.name() + " from " + node + " (" + node.getClass().getSimpleName() + ")", e);
         }
     }
 
     public boolean isNull(Node node) {
-        String getterName = "get" + Utils.capitalize(camelCaseName());
-        try {
-            return null == node.getClass().getMethod(getterName).invoke(node);
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException("Unable to get single value for " + this.name() + " from " + node, e);
-        }
+        return null == getRawValue(node);
     }
 
     public boolean isNullOrNotPresent(Node node) {
-        String getterName = "get" + Utils.capitalize(camelCaseName());
-        try {
-            Object result = node.getClass().getMethod(getterName).invoke(node);
-            if (result == null) {
-                return true;
-            }
-            if (result instanceof Optional) {
-                return !((Optional) result).isPresent();
-            }
-            return false;
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException("Unable to get single value for " + this.name() + " from " + node, e);
-        }
-    }
-
-    public static boolean valueIsNullOrEmpty(Object value) {
-        if (value == null) {
+        Object result = getRawValue(node);
+        if (result == null) {
             return true;
         }
-        if (value instanceof Optional) {
-            if (((Optional) value).isPresent()) {
-                value = ((Optional) value).get();
-            } else {
-                return true;
-            }
-        }
-        if (value instanceof Collection) {
-            if (((Collection) value).isEmpty()) {
-                return true;
-            }
+        if (result instanceof Optional) {
+            return !((Optional) result).isPresent();
         }
         return false;
     }
 
     public boolean isNullOrEmpty(Node node) {
-        String getterName = "get" + Utils.capitalize(camelCaseName());
-        try {
-            Object result = node.getClass().getMethod(getterName).invoke(node);
-            return valueIsNullOrEmpty(result);
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException("Unable to get single value for " + this.name() + " from " + node, e);
-        }
-    }
-
-    public static ObservableProperty fromCamelCaseName(String camelCaseName) {
-        Optional<ObservableProperty> observableProperty = Arrays.stream(values()).filter( v -> v.camelCaseName().equals(camelCaseName)).findFirst();
-        if (observableProperty.isPresent()) {
-            return observableProperty.get();
-        } else {
-            throw new IllegalArgumentException("No property found with the given camel case name: " + camelCaseName);
-        }
+        return Utils.valueIsNullOrEmpty(getRawValue(node));
     }
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -526,10 +526,10 @@ public final class JavaParserMetaModel {
         unaryExprMetaModel.getDeclaredPropertyMetaModels().add(unaryExprMetaModel.expressionPropertyMetaModel);
         unaryExprMetaModel.operatorPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "operator", com.github.javaparser.ast.expr.UnaryExpr.Operator.class, Optional.empty(), false, false, false, false, false);
         unaryExprMetaModel.getDeclaredPropertyMetaModels().add(unaryExprMetaModel.operatorPropertyMetaModel);
-        unaryExprMetaModel.prefixPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "prefix", boolean.class, Optional.empty(), false, true, false, false, false);
-        unaryExprMetaModel.getDerivedPropertyMetaModels().add(unaryExprMetaModel.prefixPropertyMetaModel);
         unaryExprMetaModel.postfixPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "postfix", boolean.class, Optional.empty(), false, true, false, false, false);
         unaryExprMetaModel.getDerivedPropertyMetaModels().add(unaryExprMetaModel.postfixPropertyMetaModel);
+        unaryExprMetaModel.prefixPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "prefix", boolean.class, Optional.empty(), false, true, false, false, false);
+        unaryExprMetaModel.getDerivedPropertyMetaModels().add(unaryExprMetaModel.prefixPropertyMetaModel);
         variableDeclarationExprMetaModel.annotationsPropertyMetaModel = new PropertyMetaModel(variableDeclarationExprMetaModel, "annotations", com.github.javaparser.ast.expr.AnnotationExpr.class, Optional.of(annotationExprMetaModel), false, false, true, false, false);
         variableDeclarationExprMetaModel.getDeclaredPropertyMetaModels().add(variableDeclarationExprMetaModel.annotationsPropertyMetaModel);
         variableDeclarationExprMetaModel.modifiersPropertyMetaModel = new PropertyMetaModel(variableDeclarationExprMetaModel, "modifiers", com.github.javaparser.ast.Modifier.class, Optional.empty(), false, false, false, true, false);

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -526,10 +526,10 @@ public final class JavaParserMetaModel {
         unaryExprMetaModel.getDeclaredPropertyMetaModels().add(unaryExprMetaModel.expressionPropertyMetaModel);
         unaryExprMetaModel.operatorPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "operator", com.github.javaparser.ast.expr.UnaryExpr.Operator.class, Optional.empty(), false, false, false, false, false);
         unaryExprMetaModel.getDeclaredPropertyMetaModels().add(unaryExprMetaModel.operatorPropertyMetaModel);
-        unaryExprMetaModel.postfixPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "postfix", boolean.class, Optional.empty(), false, true, false, false, false);
-        unaryExprMetaModel.getDerivedPropertyMetaModels().add(unaryExprMetaModel.postfixPropertyMetaModel);
         unaryExprMetaModel.prefixPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "prefix", boolean.class, Optional.empty(), false, true, false, false, false);
         unaryExprMetaModel.getDerivedPropertyMetaModels().add(unaryExprMetaModel.prefixPropertyMetaModel);
+        unaryExprMetaModel.postfixPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "postfix", boolean.class, Optional.empty(), false, true, false, false, false);
+        unaryExprMetaModel.getDerivedPropertyMetaModels().add(unaryExprMetaModel.postfixPropertyMetaModel);
         variableDeclarationExprMetaModel.annotationsPropertyMetaModel = new PropertyMetaModel(variableDeclarationExprMetaModel, "annotations", com.github.javaparser.ast.expr.AnnotationExpr.class, Optional.of(annotationExprMetaModel), false, false, true, false, false);
         variableDeclarationExprMetaModel.getDeclaredPropertyMetaModels().add(variableDeclarationExprMetaModel.annotationsPropertyMetaModel);
         variableDeclarationExprMetaModel.modifiersPropertyMetaModel = new PropertyMetaModel(variableDeclarationExprMetaModel, "modifiers", com.github.javaparser.ast.Modifier.class, Optional.empty(), false, false, false, true, false);

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/UnaryExprMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/UnaryExprMetaModel.java
@@ -12,8 +12,8 @@ public class UnaryExprMetaModel extends ExpressionMetaModel {
 
     public PropertyMetaModel operatorPropertyMetaModel;
 
-    public PropertyMetaModel postfixPropertyMetaModel;
-
     public PropertyMetaModel prefixPropertyMetaModel;
+
+    public PropertyMetaModel postfixPropertyMetaModel;
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/UnaryExprMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/UnaryExprMetaModel.java
@@ -12,8 +12,8 @@ public class UnaryExprMetaModel extends ExpressionMetaModel {
 
     public PropertyMetaModel operatorPropertyMetaModel;
 
-    public PropertyMetaModel prefixPropertyMetaModel;
-
     public PropertyMetaModel postfixPropertyMetaModel;
+
+    public PropertyMetaModel prefixPropertyMetaModel;
 }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -24,6 +24,7 @@ package com.github.javaparser.printer;
 import com.github.javaparser.ASTParserConstants;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.observer.*;
@@ -79,677 +80,8 @@ public class ConcreteSyntaxModel {
     static {
 
         ///
-        /// Comments
+        /// Body
         ///
-
-
-        ///
-        /// Top Level
-        ///
-
-        concreteSyntaxModelByClass.put(CompilationUnit.class, sequence(
-                    comment(),
-                    child(ObservableProperty.PACKAGE_DECLARATION),
-                    list(ObservableProperty.IMPORTS, none(), none(), newline()),
-                    list(TYPES, newline(), CsmElement.newline(), CsmElement.none(), CsmElement.newline()),
-                    orphanCommentsEnding()));
-
-        concreteSyntaxModelByClass.put(PackageDeclaration.class, sequence(
-                comment(),
-                list(ObservableProperty.ANNOTATIONS),
-                token(ASTParserConstants.PACKAGE),
-                space(),
-                child(ObservableProperty.NAME),
-                semicolon(),
-                newline(),
-                newline(),
-                orphanCommentsEnding()));
-
-        concreteSyntaxModelByClass.put(Name.class, sequence(
-                comment(),
-                conditional(ObservableProperty.QUALIFIER, IS_PRESENT, sequence(child(ObservableProperty.QUALIFIER), token(ASTParserConstants.DOT))),
-                attribute(ObservableProperty.IDENTIFIER),
-                orphanCommentsEnding()
-        ));
-
-        concreteSyntaxModelByClass.put(ImportDeclaration.class, sequence(
-                comment(),
-                token(ASTParserConstants.IMPORT),
-                space(),
-                conditional(ObservableProperty.STATIC, FLAG, sequence(token(ASTParserConstants.STATIC), space())),
-                child(ObservableProperty.NAME),
-                conditional(ASTERISK, FLAG, sequence(token(ASTParserConstants.DOT), token(ASTParserConstants.STAR))),
-                semicolon(),
-                newline(),
-                orphanCommentsEnding()
-        ));
-
-        concreteSyntaxModelByClass.put(SimpleName.class, attribute(ObservableProperty.IDENTIFIER));
-
-        concreteSyntaxModelByClass.put(ConstructorDeclaration.class, sequence(
-                comment(),
-                memberAnnotations(),
-                modifiers(),
-                typeParameters(),
-                child(ObservableProperty.NAME),
-                token(ASTParserConstants.LPAREN),
-                list(ObservableProperty.PARAMETERS, sequence(comma(), space()), none(), none()),
-                token(ASTParserConstants.RPAREN),
-                list(ObservableProperty.THROWN_EXCEPTIONS, sequence(comma(), space()), sequence(space(), token(ASTParserConstants.THROWS), space()), none()),
-                space(),
-                child(ObservableProperty.BODY)
-        ));
-
-        concreteSyntaxModelByClass.put(Parameter.class, sequence(
-                comment(),
-                list(ObservableProperty.ANNOTATIONS, CsmElement.space(), CsmElement.none(), CsmElement.space()),
-                modifiers(),
-                child(ObservableProperty.TYPE),
-                conditional(ObservableProperty.VAR_ARGS, FLAG, token(ASTParserConstants.ELLIPSIS)),
-                space(),
-                child(ObservableProperty.NAME)));
-
-        concreteSyntaxModelByClass.put(BlockStmt.class, sequence(
-                orphanCommentsBeforeThis(),
-                comment(),
-                token(ASTParserConstants.LBRACE),
-                newline(),
-                list(ObservableProperty.STATEMENTS, newline(), indent(), sequence(newline(), unindent())),
-                orphanCommentsEnding(),
-                token(RBRACE)
-        ));
-
-        concreteSyntaxModelByClass.put(ExpressionStmt.class, sequence(
-            orphanCommentsBeforeThis(),
-            comment(),
-            child(ObservableProperty.EXPRESSION),
-            semicolon()
-        ));
-
-        concreteSyntaxModelByClass.put(MethodDeclaration.class, sequence(
-                orphanCommentsBeforeThis(),
-                comment(),
-                memberAnnotations(),
-                modifiers(),
-                conditional(ObservableProperty.DEFAULT, FLAG, sequence(token(ASTParserConstants._DEFAULT), space())),
-                typeParameters(),
-                child(ObservableProperty.TYPE),
-                space(),
-                child(ObservableProperty.NAME),
-                token(ASTParserConstants.LPAREN),
-                list(ObservableProperty.PARAMETERS, sequence(comma(), space()), none(), none()),
-                token(ASTParserConstants.RPAREN),
-                list(ObservableProperty.THROWN_EXCEPTIONS, sequence(comma(), space()), sequence(space(), token(ASTParserConstants.THROWS), space()), none()),
-                conditional(ObservableProperty.BODY, IS_PRESENT, sequence(space(), child(ObservableProperty.BODY)), semicolon())
-        ));
-
-        concreteSyntaxModelByClass.put(ClassOrInterfaceDeclaration.class, sequence(
-                    comment(),
-                    list(ObservableProperty.ANNOTATIONS, newline(), none(), newline()),
-                    modifiers(),
-                    conditional(ObservableProperty.INTERFACE, FLAG, token(ASTParserConstants.INTERFACE), token(ASTParserConstants.CLASS)),
-                    space(),
-                    child(ObservableProperty.NAME),
-                    list(TYPE_PARAMETERS, sequence(comma(), space()), string(ASTParserConstants.LT), string(ASTParserConstants.GT)),
-                    list(ObservableProperty.EXTENDED_TYPES,
-                            sequence(string(ASTParserConstants.COMMA), space()),
-                            sequence(space(), token(ASTParserConstants.EXTENDS), space()),
-                            none()),
-                    list(ObservableProperty.IMPLEMENTED_TYPES, sequence(string(ASTParserConstants.COMMA), space()), sequence(
-                            space(),
-                            token(ASTParserConstants.IMPLEMENTS),
-                            space()), none()),
-                    space(),
-                    block(sequence(newline(), list(ObservableProperty.MEMBERS, sequence(newline(), newline()), CsmElement.newline(), newline())))
-                    ));
-
-        concreteSyntaxModelByClass.put(ClassOrInterfaceType.class, sequence(comment(),
-                    conditional(SCOPE, IS_PRESENT, sequence(child(SCOPE), string(ASTParserConstants.DOT))),
-                    list(ANNOTATIONS, space()),
-                    child(NAME),
-                    conditional(ObservableProperty.USING_DIAMOND_OPERATOR, FLAG,
-                            sequence(string(ASTParserConstants.LT), string(ASTParserConstants.GT)),
-                            list(TYPE_ARGUMENTS, sequence(comma(), space()), string(ASTParserConstants.LT), string(ASTParserConstants.GT)))));
-
-        concreteSyntaxModelByClass.put(PrimitiveType.class, sequence(
-                    comment(),
-                    list(ObservableProperty.ANNOTATIONS),
-                    attribute(ObservableProperty.TYPE)));
-
-        concreteSyntaxModelByClass.put(ArrayType.class, sequence(
-                    child(ObservableProperty.COMPONENT_TYPE),
-                    list(ObservableProperty.ANNOTATIONS),
-                    string(ASTParserConstants.LBRACKET),
-                    string(ASTParserConstants.RBRACKET)));
-
-        concreteSyntaxModelByClass.put(FieldDeclaration.class, sequence(
-                    orphanCommentsBeforeThis(),
-                    comment(),
-                    annotations(),
-                    modifiers(),
-                    conditional(ObservableProperty.VARIABLES, IS_NOT_EMPTY, child(ObservableProperty.MAXIMUM_COMMON_TYPE)),
-                    space(),
-                    list(ObservableProperty.VARIABLES, sequence(comma(), space())),
-                    semicolon()));
-
-        // FIXME array levels
-        concreteSyntaxModelByClass.put(VariableDeclarator.class, sequence(
-                    comment(),
-                    child(ObservableProperty.NAME),
-                    conditional(ObservableProperty.INITIALIZER, IS_PRESENT, sequence(space(), token(ASTParserConstants.ASSIGN), space(),
-                            child(ObservableProperty.INITIALIZER)))
-        ));
-
-        concreteSyntaxModelByClass.put(ClassExpr.class, sequence(
-                comment(), child(ObservableProperty.TYPE), token(ASTParserConstants.DOT), token(ASTParserConstants.CLASS)));
-
-        concreteSyntaxModelByClass.put(AssignExpr.class, sequence(
-            comment(),
-            child(ObservableProperty.TARGET),
-            space(),
-            attribute(ObservableProperty.OPERATOR),
-            space(),
-            child(ObservableProperty.VALUE)
-        ));
-
-        concreteSyntaxModelByClass.put(NameExpr.class, sequence(
-           comment(),
-           child(ObservableProperty.NAME),
-           orphanCommentsEnding()
-        ));
-
-        concreteSyntaxModelByClass.put(ObjectCreationExpr.class, sequence(
-            comment(),
-            conditional(ObservableProperty.SCOPE, IS_PRESENT, sequence(child(ObservableProperty.SCOPE), token(ASTParserConstants.DOT))),
-            token(ASTParserConstants.NEW),
-            space(),
-            list(ObservableProperty.TYPE_ARGUMENTS, CsmElement.sequence(CsmElement.comma(), CsmElement.space()), CsmElement.token(LT), CsmElement.token(GT)),
-            conditional(ObservableProperty.TYPE_ARGUMENTS, IS_NOT_EMPTY, space()),
-            child(ObservableProperty.TYPE),
-            token(ASTParserConstants.LPAREN),
-            list(ObservableProperty.ARGUMENTS, sequence(comma(), space()), none(), none()),
-            token(ASTParserConstants.RPAREN),
-            conditional(ObservableProperty.ANONYMOUS_CLASS_BODY, IS_PRESENT,
-                    CsmElement.sequence(
-                            CsmElement.space(), CsmElement.token(LBRACE), CsmElement.newline(), CsmElement.indent(),
-                            CsmElement.list(ObservableProperty.ANONYMOUS_CLASS_BODY,
-                                    CsmElement.newline(),
-                                    CsmElement.newline(),
-                                    CsmElement.newline(),
-                                    CsmElement.newline()),
-                            CsmElement.unindent(),
-                            CsmElement.token(RBRACE)
-                    ))
-        ));
-
-        concreteSyntaxModelByClass.put(MethodCallExpr.class, sequence(
-            comment(),
-            conditional(ObservableProperty.SCOPE, IS_PRESENT, sequence(child(ObservableProperty.SCOPE), token(ASTParserConstants.DOT))),
-            typeArguments(),
-            child(ObservableProperty.NAME),
-            token(ASTParserConstants.LPAREN),
-            list(ObservableProperty.ARGUMENTS, sequence(comma(), space()), none(), none()),
-            token(ASTParserConstants.RPAREN)
-        ));
-
-        concreteSyntaxModelByClass.put(VoidType.class, sequence(comment(), annotations(), token(ASTParserConstants.VOID)));
-
-        concreteSyntaxModelByClass.put(WildcardType.class, sequence(comment(), annotations(), token(ASTParserConstants.HOOK),
-                CsmElement.conditional(ObservableProperty.EXTENDED_TYPE, IS_PRESENT, CsmElement.sequence(space(), token(ASTParserConstants.EXTENDS), space(), CsmElement.child(EXTENDED_TYPE))),
-                CsmElement.conditional(ObservableProperty.SUPER_TYPE, IS_PRESENT, CsmElement.sequence(space(), token(ASTParserConstants.SUPER), space(), CsmElement.child(SUPER_TYPE)))));
-
-        concreteSyntaxModelByClass.put(MarkerAnnotationExpr.class, sequence(comment(), token(ASTParserConstants.AT), attribute(ObservableProperty.NAME)));
-
-        concreteSyntaxModelByClass.put(ReturnStmt.class, sequence(comment(), token(ASTParserConstants.RETURN),
-                conditional(ObservableProperty.EXPRESSION, IS_PRESENT, sequence(space(), child(ObservableProperty.EXPRESSION))),
-                semicolon()));
-
-        concreteSyntaxModelByClass.put(IfStmt.class, sequence(
-                comment(),
-                token(ASTParserConstants.IF),
-                space(),
-                token(ASTParserConstants.LPAREN),
-                child(ObservableProperty.CONDITION),
-                token(ASTParserConstants.RPAREN),
-                conditional(ObservableProperty.THEN_BLOCK, CsmConditional.Condition.FLAG,
-                        sequence(space(), child(ObservableProperty.THEN_STMT),
-                                conditional(ObservableProperty.ELSE_STMT, IS_PRESENT, space())),
-                        sequence(newline(), CsmElement.indent(), child(ObservableProperty.THEN_STMT),
-                                conditional(ObservableProperty.ELSE_STMT, IS_PRESENT, newline()),
-                                unindent())),
-                conditional(ObservableProperty.ELSE_STMT, IS_PRESENT,
-                        sequence(token(ASTParserConstants.ELSE),
-                            conditional(ObservableProperty.ELSE_BLOCK, CsmConditional.Condition.FLAG,
-                                    sequence(space(), child(ObservableProperty.ELSE_STMT)),
-                                    sequence(newline(), CsmElement.indent(), child(ObservableProperty.ELSE_STMT), unindent()))))
-        ));
-
-        concreteSyntaxModelByClass.put(ForeachStmt.class, sequence(
-                comment(),
-                token(ASTParserConstants.FOR),
-                space(),
-                token(ASTParserConstants.LPAREN),
-                child(ObservableProperty.VARIABLE),
-                space(),
-                token(ASTParserConstants.COLON),
-                space(),
-                child(ObservableProperty.ITERABLE),
-                token(ASTParserConstants.RPAREN),
-                space(),
-                child(ObservableProperty.BODY)
-        ));
-
-        concreteSyntaxModelByClass.put(VariableDeclarationExpr.class, sequence(
-                comment(),
-                list(ObservableProperty.ANNOTATIONS, CsmElement.space(), CsmElement.none(), CsmElement.space()),
-                modifiers(),
-                child(ObservableProperty.MAXIMUM_COMMON_TYPE),
-                space(),
-                list(ObservableProperty.VARIABLES, sequence(comma(), space()))
-        ));
-
-        concreteSyntaxModelByClass.put(StringLiteralExpr.class, sequence(
-                comment(),
-                stringToken(ObservableProperty.VALUE)
-        ));
-        concreteSyntaxModelByClass.put(ThisExpr.class, sequence(
-                comment(),
-                conditional(ObservableProperty.CLASS_EXPR, IS_PRESENT, sequence(child(CLASS_EXPR), token(ASTParserConstants.DOT))),
-                token(ASTParserConstants.THIS)
-        ));
-
-        concreteSyntaxModelByClass.put(ForStmt.class, sequence(
-                comment(),
-                token(ASTParserConstants.FOR),
-                space(),
-                token(ASTParserConstants.LPAREN),
-                list(ObservableProperty.INITIALIZATION, sequence(comma(), space())),
-                semicolon(),
-                space(),
-                child(ObservableProperty.COMPARE),
-                semicolon(),
-                space(),
-                list(ObservableProperty.UPDATE, sequence(comma(), space())),
-                token(ASTParserConstants.RPAREN),
-                space(),
-                child(ObservableProperty.BODY)
-        ));
-
-        concreteSyntaxModelByClass.put(BooleanLiteralExpr.class, sequence(
-                comment(), attribute(VALUE)
-        ));
-        concreteSyntaxModelByClass.put(WhileStmt.class, sequence(
-                comment(),
-                token(ASTParserConstants.WHILE),
-                space(),
-                token(ASTParserConstants.LPAREN),
-                child(ObservableProperty.CONDITION),
-                token(ASTParserConstants.RPAREN),
-                space(),
-                child(ObservableProperty.BODY)
-        ));
-
-        concreteSyntaxModelByClass.put(LambdaExpr.class, sequence(
-                comment(),
-                conditional(ObservableProperty.ENCLOSING_PARAMETERS, FLAG, token(ASTParserConstants.LPAREN)),
-                list(ObservableProperty.PARAMETERS, sequence(comma(), space())),
-                conditional(ObservableProperty.ENCLOSING_PARAMETERS, FLAG, token(ASTParserConstants.RPAREN)),
-                space(),
-                token(ASTParserConstants.ARROW),
-                space(),
-                conditional(ObservableProperty.EXPRESSION_BODY, IS_PRESENT, child(ObservableProperty.EXPRESSION_BODY), child(ObservableProperty.BODY))
-        ));
-
-        concreteSyntaxModelByClass.put(CharLiteralExpr.class, sequence(
-                comment(),
-                charToken(ObservableProperty.VALUE)
-        ));
-
-        concreteSyntaxModelByClass.put(BinaryExpr.class, sequence(
-                comment(),
-                child(ObservableProperty.LEFT),
-                space(),
-                attribute(ObservableProperty.OPERATOR),
-                space(),
-                child(ObservableProperty.RIGHT)
-        ));
-
-        concreteSyntaxModelByClass.put(UnaryExpr.class, sequence(
-                conditional(ObservableProperty.PREFIX, FLAG, attribute(ObservableProperty.OPERATOR)),
-                child(ObservableProperty.EXPRESSION),
-                conditional(ObservableProperty.POSTFIX, FLAG, attribute(ObservableProperty.OPERATOR))
-        ));
-
-        concreteSyntaxModelByClass.put(InstanceOfExpr.class, sequence(
-                comment(),
-                child(ObservableProperty.EXPRESSION),
-                space(),
-                token(ASTParserConstants.INSTANCEOF),
-                space(),
-                child(ObservableProperty.TYPE)
-        ));
-
-        concreteSyntaxModelByClass.put(EnclosedExpr.class, sequence(
-                comment(),
-                token(ASTParserConstants.LPAREN),
-                child(ObservableProperty.INNER),
-                token(ASTParserConstants.RPAREN)
-        ));
-
-        concreteSyntaxModelByClass.put(ThrowStmt.class, sequence(
-                comment(),
-                token(ASTParserConstants.THROW),
-                space(),
-                child(ObservableProperty.EXPRESSION),
-                semicolon()
-        ));
-        concreteSyntaxModelByClass.put(IntegerLiteralExpr.class, sequence(
-                comment(),
-                attribute(ObservableProperty.VALUE)
-        ));
-        concreteSyntaxModelByClass.put(LongLiteralExpr.class, sequence(
-                comment(),
-                attribute(ObservableProperty.VALUE)
-        ));
-        concreteSyntaxModelByClass.put(DoubleLiteralExpr.class, sequence(
-                comment(),
-                attribute(ObservableProperty.VALUE)
-        ));
-        concreteSyntaxModelByClass.put(MethodReferenceExpr.class, sequence(
-                comment(),
-                child(ObservableProperty.SCOPE),
-                token(ASTParserConstants.DOUBLECOLON),
-                typeArguments(),
-                attribute(ObservableProperty.IDENTIFIER)
-        ));
-
-        concreteSyntaxModelByClass.put(NullLiteralExpr.class, sequence(
-                comment(),
-                token(ASTParserConstants.NULL)
-        ));
-        concreteSyntaxModelByClass.put(TypeExpr.class, sequence(
-                comment(),
-                child(ObservableProperty.TYPE)
-        ));
-        concreteSyntaxModelByClass.put(CastExpr.class, sequence(
-                comment(),
-                token(ASTParserConstants.LPAREN),
-                child(ObservableProperty.TYPE),
-                token(ASTParserConstants.RPAREN),
-                space(),
-                child(ObservableProperty.EXPRESSION)
-        ));
-        concreteSyntaxModelByClass.put(UnknownType.class, none());
-
-        concreteSyntaxModelByClass.put(TypeParameter.class, sequence(
-                comment(),
-                annotations(),
-                child(ObservableProperty.NAME),
-                list(ObservableProperty.TYPE_BOUND,
-                        sequence(
-                            space(),
-                            token(ASTParserConstants.BIT_AND),
-                            space()),
-                        sequence(
-                                space(),
-                                token(ASTParserConstants.EXTENDS),
-                                space()),
-                        none())
-        ));
-
-        concreteSyntaxModelByClass.put(ArrayCreationExpr.class, sequence(
-                comment(),
-                token(ASTParserConstants.NEW),
-                space(),
-                CsmElement.child(ObservableProperty.ELEMENT_TYPE),
-                list(ObservableProperty.LEVELS),
-                conditional(ObservableProperty.INITIALIZER, IS_PRESENT, sequence(space(), child(ObservableProperty.INITIALIZER)))
-        ));
-
-        concreteSyntaxModelByClass.put(ArrayCreationLevel.class, sequence(
-                annotations(),
-                token(ASTParserConstants.LBRACKET),
-                child(ObservableProperty.DIMENSION),
-                token(ASTParserConstants.RBRACKET)
-        ));
-
-        concreteSyntaxModelByClass.put(EmptyMemberDeclaration.class, sequence(comment(), token(ASTParserConstants.SEMICOLON)));
-
-        concreteSyntaxModelByClass.put(InitializerDeclaration.class, sequence(
-                comment(),
-                conditional(ObservableProperty.STATIC, FLAG, sequence(token(ASTParserConstants.STATIC), space())),
-                child(ObservableProperty.BODY)));
-
-        concreteSyntaxModelByClass.put(NormalAnnotationExpr.class, sequence(
-                comment(),
-                token(ASTParserConstants.AT),
-                child(ObservableProperty.NAME),
-                token(ASTParserConstants.LPAREN),
-                list(ObservableProperty.PAIRS, sequence(comma(), space())),
-                token(ASTParserConstants.RPAREN)
-        ));
-
-        concreteSyntaxModelByClass.put(ArrayInitializerExpr.class, sequence(
-                comment(),
-                token(ASTParserConstants.LBRACE),
-                list(ObservableProperty.VALUES, sequence(comma(), space()), space(), space()),
-                token(RBRACE)));
-
-        concreteSyntaxModelByClass.put(EnumDeclaration.class, sequence(
-                comment(),
-                annotations(),
-                modifiers(),
-                token(ASTParserConstants.ENUM),
-                space(),
-                child(ObservableProperty.NAME),
-                list(ObservableProperty.IMPLEMENTED_TYPES,
-                        sequence(comma(), space()),
-                        sequence(space(), token(ASTParserConstants.IMPLEMENTS), space()),
-                        none()),
-                space(),
-                token(ASTParserConstants.LBRACE),
-                CsmElement.newline(),
-                CsmElement.indent(),
-                CsmElement.newline(),
-                list(ObservableProperty.ENTRIES,
-                        sequence(comma(), space()),
-                        CsmElement.none(),
-                        none()),
-                conditional(ObservableProperty.MEMBERS, IS_EMPTY,
-                        conditional(ObservableProperty.ENTRIES, IS_NOT_EMPTY, newline()),
-                        sequence(CsmElement.semicolon(), newline(), CsmElement.newline(), list(ObservableProperty.MEMBERS, newline(), newline(), none(), CsmElement.newline()))),
-                unindent(),
-                token(RBRACE)
-        ));
-
-        concreteSyntaxModelByClass.put(EnumConstantDeclaration.class, sequence(
-                comment(),
-                memberAnnotations(),
-                child(ObservableProperty.NAME),
-                list(ObservableProperty.ARGUMENTS, sequence(comma(), space()), token(ASTParserConstants.LPAREN), token(ASTParserConstants.RPAREN)),
-                conditional(CLASS_BODY, IS_NOT_EMPTY, sequence(space(), token(ASTParserConstants.LBRACE), CsmElement.newline(), CsmElement.indent(), CsmElement.newline(),
-                        list(ObservableProperty.CLASS_BODY, newline(), newline(), none(), CsmElement.newline()),
-                        unindent(),
-                        token(RBRACE), CsmElement.newline()))
-        ));
-
-        concreteSyntaxModelByClass.put(FieldAccessExpr.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.conditional(SCOPE, IS_PRESENT, CsmElement.sequence(CsmElement.child(SCOPE), CsmElement.token(ASTParserConstants.DOT))),
-                child(ObservableProperty.NAME)
-        ));
-
-        concreteSyntaxModelByClass.put(ArrayAccessExpr.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.child(ObservableProperty.NAME),
-                CsmElement.token(ASTParserConstants.LBRACKET),
-                CsmElement.child(ObservableProperty.INDEX),
-                CsmElement.token(ASTParserConstants.RBRACKET)
-        ));
-
-        concreteSyntaxModelByClass.put(SuperExpr.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.conditional(ObservableProperty.CLASS_EXPR, IS_PRESENT, CsmElement.sequence(CsmElement.child(ObservableProperty.CLASS_EXPR), CsmElement.token(ASTParserConstants.DOT))),
-                CsmElement.token(ASTParserConstants.SUPER)
-        ));
-
-        concreteSyntaxModelByClass.put(LocalClassDeclarationStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.child(ObservableProperty.CLASS_DECLARATION)
-        ));
-
-        concreteSyntaxModelByClass.put(ExplicitConstructorInvocationStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.conditional(ObservableProperty.THIS, FLAG,
-                        CsmElement.sequence(typeArguments(), CsmElement.token(ASTParserConstants.THIS)),
-                        CsmElement.sequence(
-                                CsmElement.conditional(ObservableProperty.EXPRESSION, IS_PRESENT, CsmElement.sequence(CsmElement.child(ObservableProperty.EXPRESSION), CsmElement.token(ASTParserConstants.DOT))),
-                                typeArguments(),
-                                CsmElement.token(ASTParserConstants.SUPER)
-                        )),
-                CsmElement.token(ASTParserConstants.LPAREN),
-                CsmElement.list(ObservableProperty.ARGUMENTS, CsmElement.sequence(CsmElement.comma(), CsmElement.space())),
-                CsmElement.token(ASTParserConstants.RPAREN),
-                CsmElement.semicolon()
-        ));
-
-
-        concreteSyntaxModelByClass.put(AssertStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.ASSERT),
-                CsmElement.space(),
-                CsmElement.child(ObservableProperty.CHECK),
-                CsmElement.conditional(ObservableProperty.MESSAGE, IS_PRESENT, CsmElement.sequence(
-                        CsmElement.space(),
-                        CsmElement.token(ASTParserConstants.COLON),
-                        CsmElement.space(),
-                        CsmElement.child(ObservableProperty.MESSAGE)
-                )),
-                CsmElement.semicolon()
-        ));
-
-
-        concreteSyntaxModelByClass.put(LabeledStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.child(ObservableProperty.LABEL),
-                CsmElement.token(ASTParserConstants.COLON),
-                CsmElement.space(),
-                child(ObservableProperty.STATEMENT)
-        ));
-
-
-        concreteSyntaxModelByClass.put(EmptyStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.SEMICOLON)
-        ));
-
-        concreteSyntaxModelByClass.put(SwitchStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.SWITCH),
-                CsmElement.token(ASTParserConstants.LPAREN),
-                CsmElement.child(ObservableProperty.SELECTOR),
-                CsmElement.token(ASTParserConstants.RPAREN),
-                CsmElement.space(),
-                CsmElement.token(ASTParserConstants.LBRACE),
-                CsmElement.newline(),
-                CsmElement.list(ObservableProperty.ENTRIES, CsmElement.none(), CsmElement.indent(), CsmElement.unindent()),
-                CsmElement.token(ASTParserConstants.RBRACE)
-        ));
-
-        concreteSyntaxModelByClass.put(SwitchEntryStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.conditional(ObservableProperty.LABEL, IS_PRESENT,
-                        CsmElement.sequence(CsmElement.token(ASTParserConstants.CASE), CsmElement.space(), CsmElement.child(ObservableProperty.LABEL), CsmElement.token(ASTParserConstants.COLON)),
-                        CsmElement.sequence(CsmElement.token(ASTParserConstants._DEFAULT), CsmElement.token(ASTParserConstants.COLON))),
-                CsmElement.newline(),
-                CsmElement.indent(),
-                CsmElement.list(ObservableProperty.STATEMENTS, CsmElement.newline(), CsmElement.none(), CsmElement.newline()),
-                CsmElement.unindent()
-        ));
-
-        concreteSyntaxModelByClass.put(BreakStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.BREAK),
-                CsmElement.conditional(ObservableProperty.LABEL, IS_PRESENT, CsmElement.sequence(CsmElement.space(), CsmElement.child(ObservableProperty.LABEL))),
-                CsmElement.semicolon()
-        ));
-
-        concreteSyntaxModelByClass.put(ConditionalExpr.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.child(ObservableProperty.CONDITION),
-                CsmElement.space(),
-                CsmElement.token(ASTParserConstants.HOOK),
-                CsmElement.space(),
-                CsmElement.child(ObservableProperty.THEN_EXPR),
-                CsmElement.space(),
-                CsmElement.token(ASTParserConstants.COLON),
-                CsmElement.space(),
-                CsmElement.child(ObservableProperty.ELSE_EXPR)
-        ));
-
-        concreteSyntaxModelByClass.put(ContinueStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.CONTINUE),
-                CsmElement.conditional(ObservableProperty.LABEL, IS_PRESENT, CsmElement.sequence(CsmElement.space(), CsmElement.child(ObservableProperty.LABEL))),
-                CsmElement.semicolon()
-        ));
-
-        concreteSyntaxModelByClass.put(DoStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.DO),
-                CsmElement.space(),
-                CsmElement.child(ObservableProperty.BODY),
-                CsmElement.space(),
-                CsmElement.token(ASTParserConstants.WHILE),
-                CsmElement.space(),
-                CsmElement.token(ASTParserConstants.LPAREN),
-                child(ObservableProperty.CONDITION),
-                CsmElement.token(ASTParserConstants.RPAREN),
-                CsmElement.semicolon()
-        ));
-
-        concreteSyntaxModelByClass.put(SynchronizedStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.SYNCHRONIZED),
-                CsmElement.space(),
-                CsmElement.token(LPAREN),
-                CsmElement.child(EXPRESSION),
-                CsmElement.token(RPAREN),
-                CsmElement.space(),
-                CsmElement.child(BODY)
-        ));
-
-        concreteSyntaxModelByClass.put(TryStmt.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.token(ASTParserConstants.TRY),
-                CsmElement.space(),
-                CsmElement.conditional(ObservableProperty.RESOURCES, CsmConditional.Condition.IS_NOT_EMPTY, CsmElement.sequence(
-                        CsmElement.token(LPAREN),
-                        list(ObservableProperty.RESOURCES, CsmElement.sequence(CsmElement.semicolon(), CsmElement.newline()), CsmElement.indent(), CsmElement.unindent()),
-                        CsmElement.token(RPAREN),
-                        CsmElement.space())),
-                CsmElement.child(ObservableProperty.TRY_BLOCK),
-                CsmElement.list(ObservableProperty.CATCH_CLAUSES),
-                CsmElement.conditional(ObservableProperty.FINALLY_BLOCK, IS_PRESENT, CsmElement.sequence(CsmElement.space(), CsmElement.token(ASTParserConstants.FINALLY), CsmElement.space(), CsmElement.child(ObservableProperty.FINALLY_BLOCK)))
-        ));
-
-        concreteSyntaxModelByClass.put(CatchClause.class, CsmElement.sequence(
-                CsmElement.comment(),
-                CsmElement.space(),
-                CsmElement.token(ASTParserConstants.CATCH),
-                CsmElement.space(),
-                CsmElement.token(LPAREN),
-                CsmElement.child(ObservableProperty.PARAMETER),
-                CsmElement.token(RPAREN),
-                CsmElement.space(),
-                CsmElement.child(BODY)
-        ));
-
-        concreteSyntaxModelByClass.put(UnionType.class, CsmElement.sequence(
-                CsmElement.comment(),
-                annotations(),
-                CsmElement.list(ObservableProperty.ELEMENTS, CsmElement.sequence(CsmElement.space(), CsmElement.token(ASTParserConstants.BIT_OR), CsmElement.space()))
-        ));
 
         concreteSyntaxModelByClass.put(AnnotationDeclaration.class, CsmElement.sequence(
                 CsmElement.comment(),
@@ -781,7 +113,717 @@ public class ConcreteSyntaxModel {
                 CsmElement.semicolon()
         ));
 
-        List<String> unsupportedNodeClassNames = JavaParserMetaModel.getNodeMetaModels().stream().filter(c -> !concreteSyntaxModelByClass.containsKey(c.getType())).map(nm -> nm.getType().getSimpleName()).collect(Collectors.toList());
+        concreteSyntaxModelByClass.put(ClassOrInterfaceDeclaration.class, sequence(
+                comment(),
+                list(ObservableProperty.ANNOTATIONS, newline(), none(), newline()),
+                modifiers(),
+                conditional(ObservableProperty.INTERFACE, FLAG, token(ASTParserConstants.INTERFACE), token(ASTParserConstants.CLASS)),
+                space(),
+                child(ObservableProperty.NAME),
+                list(TYPE_PARAMETERS, sequence(comma(), space()), string(ASTParserConstants.LT), string(ASTParserConstants.GT)),
+                list(ObservableProperty.EXTENDED_TYPES,
+                        sequence(string(ASTParserConstants.COMMA), space()),
+                        sequence(space(), token(ASTParserConstants.EXTENDS), space()),
+                        none()),
+                list(ObservableProperty.IMPLEMENTED_TYPES, sequence(string(ASTParserConstants.COMMA), space()), sequence(
+                        space(),
+                        token(ASTParserConstants.IMPLEMENTS),
+                        space()), none()),
+                space(),
+                block(sequence(newline(), list(ObservableProperty.MEMBERS, sequence(newline(), newline()), CsmElement.newline(), newline())))
+        ));
+
+        concreteSyntaxModelByClass.put(ConstructorDeclaration.class, sequence(
+                comment(),
+                memberAnnotations(),
+                modifiers(),
+                typeParameters(),
+                child(ObservableProperty.NAME),
+                token(ASTParserConstants.LPAREN),
+                list(ObservableProperty.PARAMETERS, sequence(comma(), space()), none(), none()),
+                token(ASTParserConstants.RPAREN),
+                list(ObservableProperty.THROWN_EXCEPTIONS, sequence(comma(), space()), sequence(space(), token(ASTParserConstants.THROWS), space()), none()),
+                space(),
+                child(ObservableProperty.BODY)
+        ));
+
+        concreteSyntaxModelByClass.put(EmptyMemberDeclaration.class, sequence(comment(), token(ASTParserConstants.SEMICOLON)));
+
+        concreteSyntaxModelByClass.put(EnumConstantDeclaration.class, sequence(
+                comment(),
+                memberAnnotations(),
+                child(ObservableProperty.NAME),
+                list(ObservableProperty.ARGUMENTS, sequence(comma(), space()), token(ASTParserConstants.LPAREN), token(ASTParserConstants.RPAREN)),
+                conditional(CLASS_BODY, IS_NOT_EMPTY, sequence(space(), token(ASTParserConstants.LBRACE), CsmElement.newline(), CsmElement.indent(), CsmElement.newline(),
+                        list(ObservableProperty.CLASS_BODY, newline(), newline(), none(), CsmElement.newline()),
+                        unindent(),
+                        token(RBRACE), CsmElement.newline()))
+        ));
+
+        concreteSyntaxModelByClass.put(EnumDeclaration.class, sequence(
+                comment(),
+                annotations(),
+                modifiers(),
+                token(ASTParserConstants.ENUM),
+                space(),
+                child(ObservableProperty.NAME),
+                list(ObservableProperty.IMPLEMENTED_TYPES,
+                        sequence(comma(), space()),
+                        sequence(space(), token(ASTParserConstants.IMPLEMENTS), space()),
+                        none()),
+                space(),
+                token(ASTParserConstants.LBRACE),
+                CsmElement.newline(),
+                CsmElement.indent(),
+                CsmElement.newline(),
+                list(ObservableProperty.ENTRIES,
+                        sequence(comma(), space()),
+                        CsmElement.none(),
+                        none()),
+                conditional(ObservableProperty.MEMBERS, IS_EMPTY,
+                        conditional(ObservableProperty.ENTRIES, IS_NOT_EMPTY, newline()),
+                        sequence(CsmElement.semicolon(), newline(), CsmElement.newline(), list(ObservableProperty.MEMBERS, newline(), newline(), none(), CsmElement.newline()))),
+                unindent(),
+                token(RBRACE)
+        ));
+
+        concreteSyntaxModelByClass.put(FieldDeclaration.class, sequence(
+                orphanCommentsBeforeThis(),
+                comment(),
+                annotations(),
+                modifiers(),
+                conditional(ObservableProperty.VARIABLES, IS_NOT_EMPTY, child(ObservableProperty.MAXIMUM_COMMON_TYPE)),
+                space(),
+                list(ObservableProperty.VARIABLES, sequence(comma(), space())),
+                semicolon()));
+
+        concreteSyntaxModelByClass.put(InitializerDeclaration.class, sequence(
+                comment(),
+                conditional(ObservableProperty.STATIC, FLAG, sequence(token(ASTParserConstants.STATIC), space())),
+                child(ObservableProperty.BODY)));
+
+        concreteSyntaxModelByClass.put(MethodDeclaration.class, sequence(
+                orphanCommentsBeforeThis(),
+                comment(),
+                memberAnnotations(),
+                modifiers(),
+                conditional(ObservableProperty.DEFAULT, FLAG, sequence(token(ASTParserConstants._DEFAULT), space())),
+                typeParameters(),
+                child(ObservableProperty.TYPE),
+                space(),
+                child(ObservableProperty.NAME),
+                token(ASTParserConstants.LPAREN),
+                list(ObservableProperty.PARAMETERS, sequence(comma(), space()), none(), none()),
+                token(ASTParserConstants.RPAREN),
+                list(ObservableProperty.THROWN_EXCEPTIONS, sequence(comma(), space()), sequence(space(), token(ASTParserConstants.THROWS), space()), none()),
+                conditional(ObservableProperty.BODY, IS_PRESENT, sequence(space(), child(ObservableProperty.BODY)), semicolon())
+        ));
+
+        concreteSyntaxModelByClass.put(Parameter.class, sequence(
+                comment(),
+                list(ObservableProperty.ANNOTATIONS, CsmElement.space(), CsmElement.none(), CsmElement.space()),
+                modifiers(),
+                child(ObservableProperty.TYPE),
+                conditional(ObservableProperty.VAR_ARGS, FLAG, token(ASTParserConstants.ELLIPSIS)),
+                space(),
+                child(ObservableProperty.NAME)));
+
+        concreteSyntaxModelByClass.put(VariableDeclarator.class, sequence(
+                comment(),
+                child(ObservableProperty.NAME),
+                // FIXME: we should introduce a derived property
+                // list(ObservableProperty.EXTRA_ARRAY_LEVELS),
+                conditional(ObservableProperty.INITIALIZER, IS_PRESENT, sequence(space(), token(ASTParserConstants.ASSIGN), space(),
+                        child(ObservableProperty.INITIALIZER)))
+        ));
+
+        ///
+        /// Expressions
+        ///
+
+        concreteSyntaxModelByClass.put(ArrayAccessExpr.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.child(ObservableProperty.NAME),
+                CsmElement.token(ASTParserConstants.LBRACKET),
+                CsmElement.child(ObservableProperty.INDEX),
+                CsmElement.token(ASTParserConstants.RBRACKET)
+        ));
+
+        concreteSyntaxModelByClass.put(ArrayCreationExpr.class, sequence(
+                comment(),
+                token(ASTParserConstants.NEW),
+                space(),
+                CsmElement.child(ObservableProperty.ELEMENT_TYPE),
+                list(ObservableProperty.LEVELS),
+                conditional(ObservableProperty.INITIALIZER, IS_PRESENT, sequence(space(), child(ObservableProperty.INITIALIZER)))
+        ));
+
+        concreteSyntaxModelByClass.put(ArrayInitializerExpr.class, sequence(
+                comment(),
+                token(ASTParserConstants.LBRACE),
+                list(ObservableProperty.VALUES, sequence(comma(), space()), space(), space()),
+                token(RBRACE)));
+
+        concreteSyntaxModelByClass.put(AssignExpr.class, sequence(
+                comment(),
+                child(ObservableProperty.TARGET),
+                space(),
+                attribute(ObservableProperty.OPERATOR),
+                space(),
+                child(ObservableProperty.VALUE)
+        ));
+
+        concreteSyntaxModelByClass.put(BinaryExpr.class, sequence(
+                comment(),
+                child(ObservableProperty.LEFT),
+                space(),
+                attribute(ObservableProperty.OPERATOR),
+                space(),
+                child(ObservableProperty.RIGHT)
+        ));
+
+        concreteSyntaxModelByClass.put(BooleanLiteralExpr.class, sequence(
+                comment(), attribute(VALUE)
+        ));
+
+        concreteSyntaxModelByClass.put(CastExpr.class, sequence(
+                comment(),
+                token(ASTParserConstants.LPAREN),
+                child(ObservableProperty.TYPE),
+                token(ASTParserConstants.RPAREN),
+                space(),
+                child(ObservableProperty.EXPRESSION)
+        ));
+
+        concreteSyntaxModelByClass.put(CharLiteralExpr.class, sequence(
+                comment(),
+                charToken(ObservableProperty.VALUE)
+        ));
+
+        concreteSyntaxModelByClass.put(ClassExpr.class, sequence(
+                comment(), child(ObservableProperty.TYPE), token(ASTParserConstants.DOT), token(ASTParserConstants.CLASS)));
+
+        concreteSyntaxModelByClass.put(ConditionalExpr.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.child(ObservableProperty.CONDITION),
+                CsmElement.space(),
+                CsmElement.token(ASTParserConstants.HOOK),
+                CsmElement.space(),
+                CsmElement.child(ObservableProperty.THEN_EXPR),
+                CsmElement.space(),
+                CsmElement.token(ASTParserConstants.COLON),
+                CsmElement.space(),
+                CsmElement.child(ObservableProperty.ELSE_EXPR)
+        ));
+
+        concreteSyntaxModelByClass.put(DoubleLiteralExpr.class, sequence(
+                comment(),
+                attribute(ObservableProperty.VALUE)
+        ));
+
+        concreteSyntaxModelByClass.put(EnclosedExpr.class, sequence(
+                comment(),
+                token(ASTParserConstants.LPAREN),
+                child(ObservableProperty.INNER),
+                token(ASTParserConstants.RPAREN)
+        ));
+
+        concreteSyntaxModelByClass.put(FieldAccessExpr.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.conditional(SCOPE, IS_PRESENT, CsmElement.sequence(CsmElement.child(SCOPE), CsmElement.token(ASTParserConstants.DOT))),
+                child(ObservableProperty.NAME)
+        ));
+
+        concreteSyntaxModelByClass.put(InstanceOfExpr.class, sequence(
+                comment(),
+                child(ObservableProperty.EXPRESSION),
+                space(),
+                token(ASTParserConstants.INSTANCEOF),
+                space(),
+                child(ObservableProperty.TYPE)
+        ));
+
+        concreteSyntaxModelByClass.put(IntegerLiteralExpr.class, sequence(
+                comment(),
+                attribute(ObservableProperty.VALUE)
+        ));
+
+        concreteSyntaxModelByClass.put(LambdaExpr.class, sequence(
+                comment(),
+                conditional(ObservableProperty.ENCLOSING_PARAMETERS, FLAG, token(ASTParserConstants.LPAREN)),
+                list(ObservableProperty.PARAMETERS, sequence(comma(), space())),
+                conditional(ObservableProperty.ENCLOSING_PARAMETERS, FLAG, token(ASTParserConstants.RPAREN)),
+                space(),
+                token(ASTParserConstants.ARROW),
+                space(),
+                conditional(ObservableProperty.EXPRESSION_BODY, IS_PRESENT, child(ObservableProperty.EXPRESSION_BODY), child(ObservableProperty.BODY))
+        ));
+
+        concreteSyntaxModelByClass.put(LongLiteralExpr.class, sequence(
+                comment(),
+                attribute(ObservableProperty.VALUE)
+        ));
+
+        concreteSyntaxModelByClass.put(MarkerAnnotationExpr.class, sequence(comment(), token(ASTParserConstants.AT), attribute(ObservableProperty.NAME)));
+
+        concreteSyntaxModelByClass.put(MemberValuePair.class, CsmElement.sequence(CsmElement.comment(),
+                CsmElement.child(ObservableProperty.NAME),
+                CsmElement.space(),
+                CsmElement.token(ASTParserConstants.ASSIGN),
+                CsmElement.space(),
+                CsmElement.child(ObservableProperty.VALUE)));
+
+        concreteSyntaxModelByClass.put(MethodCallExpr.class, sequence(
+                comment(),
+                conditional(ObservableProperty.SCOPE, IS_PRESENT, sequence(child(ObservableProperty.SCOPE), token(ASTParserConstants.DOT))),
+                typeArguments(),
+                child(ObservableProperty.NAME),
+                token(ASTParserConstants.LPAREN),
+                list(ObservableProperty.ARGUMENTS, sequence(comma(), space()), none(), none()),
+                token(ASTParserConstants.RPAREN)
+        ));
+
+        concreteSyntaxModelByClass.put(MethodReferenceExpr.class, sequence(
+                comment(),
+                child(ObservableProperty.SCOPE),
+                token(ASTParserConstants.DOUBLECOLON),
+                typeArguments(),
+                attribute(ObservableProperty.IDENTIFIER)
+        ));
+
+        concreteSyntaxModelByClass.put(Name.class, sequence(
+                comment(),
+                conditional(ObservableProperty.QUALIFIER, IS_PRESENT, sequence(child(ObservableProperty.QUALIFIER), token(ASTParserConstants.DOT))),
+                attribute(ObservableProperty.IDENTIFIER),
+                orphanCommentsEnding()
+        ));
+
+        concreteSyntaxModelByClass.put(NameExpr.class, sequence(
+                comment(),
+                child(ObservableProperty.NAME),
+                orphanCommentsEnding()
+        ));
+
+        concreteSyntaxModelByClass.put(NormalAnnotationExpr.class, sequence(
+                comment(),
+                token(ASTParserConstants.AT),
+                child(ObservableProperty.NAME),
+                token(ASTParserConstants.LPAREN),
+                list(ObservableProperty.PAIRS, sequence(comma(), space())),
+                token(ASTParserConstants.RPAREN)
+        ));
+
+        concreteSyntaxModelByClass.put(NullLiteralExpr.class, sequence(
+                comment(),
+                token(ASTParserConstants.NULL)
+        ));
+
+        concreteSyntaxModelByClass.put(ObjectCreationExpr.class, sequence(
+                comment(),
+                conditional(ObservableProperty.SCOPE, IS_PRESENT, sequence(child(ObservableProperty.SCOPE), token(ASTParserConstants.DOT))),
+                token(ASTParserConstants.NEW),
+                space(),
+                list(ObservableProperty.TYPE_ARGUMENTS, CsmElement.sequence(CsmElement.comma(), CsmElement.space()), CsmElement.token(LT), CsmElement.token(GT)),
+                conditional(ObservableProperty.TYPE_ARGUMENTS, IS_NOT_EMPTY, space()),
+                child(ObservableProperty.TYPE),
+                token(ASTParserConstants.LPAREN),
+                list(ObservableProperty.ARGUMENTS, sequence(comma(), space()), none(), none()),
+                token(ASTParserConstants.RPAREN),
+                conditional(ObservableProperty.ANONYMOUS_CLASS_BODY, IS_PRESENT,
+                        CsmElement.sequence(
+                                CsmElement.space(), CsmElement.token(LBRACE), CsmElement.newline(), CsmElement.indent(),
+                                CsmElement.list(ObservableProperty.ANONYMOUS_CLASS_BODY,
+                                        CsmElement.newline(),
+                                        CsmElement.newline(),
+                                        CsmElement.newline(),
+                                        CsmElement.newline()),
+                                CsmElement.unindent(),
+                                CsmElement.token(RBRACE)
+                        ))
+        ));
+
+        concreteSyntaxModelByClass.put(SimpleName.class, attribute(ObservableProperty.IDENTIFIER));
+
+        concreteSyntaxModelByClass.put(SingleMemberAnnotationExpr.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.AT),
+                CsmElement.child(ObservableProperty.NAME),
+                CsmElement.token(ASTParserConstants.LPAREN),
+                CsmElement.child(ObservableProperty.MEMBER_VALUE),
+                CsmElement.token(ASTParserConstants.RPAREN)));
+
+        concreteSyntaxModelByClass.put(StringLiteralExpr.class, sequence(
+                comment(),
+                stringToken(ObservableProperty.VALUE)
+        ));
+
+        concreteSyntaxModelByClass.put(SuperExpr.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.conditional(ObservableProperty.CLASS_EXPR, IS_PRESENT, CsmElement.sequence(CsmElement.child(ObservableProperty.CLASS_EXPR), CsmElement.token(ASTParserConstants.DOT))),
+                CsmElement.token(ASTParserConstants.SUPER)
+        ));
+
+        concreteSyntaxModelByClass.put(ThisExpr.class, sequence(
+                comment(),
+                conditional(ObservableProperty.CLASS_EXPR, IS_PRESENT, sequence(child(CLASS_EXPR), token(ASTParserConstants.DOT))),
+                token(ASTParserConstants.THIS)
+        ));
+
+        concreteSyntaxModelByClass.put(TypeExpr.class, sequence(
+                comment(),
+                child(ObservableProperty.TYPE)
+        ));
+
+        concreteSyntaxModelByClass.put(UnaryExpr.class, sequence(
+                conditional(ObservableProperty.PREFIX, FLAG, attribute(ObservableProperty.OPERATOR)),
+                child(ObservableProperty.EXPRESSION),
+                conditional(ObservableProperty.POSTFIX, FLAG, attribute(ObservableProperty.OPERATOR))
+        ));
+
+        concreteSyntaxModelByClass.put(VariableDeclarationExpr.class, sequence(
+                comment(),
+                list(ObservableProperty.ANNOTATIONS, CsmElement.space(), CsmElement.none(), CsmElement.space()),
+                modifiers(),
+                child(ObservableProperty.MAXIMUM_COMMON_TYPE),
+                space(),
+                list(ObservableProperty.VARIABLES, sequence(comma(), space()))
+        ));
+
+        ///
+        /// Statements
+        ///
+
+        concreteSyntaxModelByClass.put(AssertStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.ASSERT),
+                CsmElement.space(),
+                CsmElement.child(ObservableProperty.CHECK),
+                CsmElement.conditional(ObservableProperty.MESSAGE, IS_PRESENT, CsmElement.sequence(
+                        CsmElement.space(),
+                        CsmElement.token(ASTParserConstants.COLON),
+                        CsmElement.space(),
+                        CsmElement.child(ObservableProperty.MESSAGE)
+                )),
+                CsmElement.semicolon()
+        ));
+
+        concreteSyntaxModelByClass.put(BlockStmt.class, sequence(
+                orphanCommentsBeforeThis(),
+                comment(),
+                token(ASTParserConstants.LBRACE),
+                newline(),
+                list(ObservableProperty.STATEMENTS, newline(), indent(), sequence(newline(), unindent())),
+                orphanCommentsEnding(),
+                token(RBRACE)
+        ));
+
+        concreteSyntaxModelByClass.put(BreakStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.BREAK),
+                CsmElement.conditional(ObservableProperty.LABEL, IS_PRESENT, CsmElement.sequence(CsmElement.space(), CsmElement.child(ObservableProperty.LABEL))),
+                CsmElement.semicolon()
+        ));
+
+        concreteSyntaxModelByClass.put(CatchClause.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.space(),
+                CsmElement.token(ASTParserConstants.CATCH),
+                CsmElement.space(),
+                CsmElement.token(LPAREN),
+                CsmElement.child(ObservableProperty.PARAMETER),
+                CsmElement.token(RPAREN),
+                CsmElement.space(),
+                CsmElement.child(BODY)
+        ));
+
+        concreteSyntaxModelByClass.put(ContinueStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.CONTINUE),
+                CsmElement.conditional(ObservableProperty.LABEL, IS_PRESENT, CsmElement.sequence(CsmElement.space(), CsmElement.child(ObservableProperty.LABEL))),
+                CsmElement.semicolon()
+        ));
+
+        concreteSyntaxModelByClass.put(DoStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.DO),
+                CsmElement.space(),
+                CsmElement.child(ObservableProperty.BODY),
+                CsmElement.space(),
+                CsmElement.token(ASTParserConstants.WHILE),
+                CsmElement.space(),
+                CsmElement.token(ASTParserConstants.LPAREN),
+                child(ObservableProperty.CONDITION),
+                CsmElement.token(ASTParserConstants.RPAREN),
+                CsmElement.semicolon()
+        ));
+
+        concreteSyntaxModelByClass.put(EmptyStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.SEMICOLON)
+        ));
+
+        concreteSyntaxModelByClass.put(ExplicitConstructorInvocationStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.conditional(ObservableProperty.THIS, FLAG,
+                        CsmElement.sequence(typeArguments(), CsmElement.token(ASTParserConstants.THIS)),
+                        CsmElement.sequence(
+                                CsmElement.conditional(ObservableProperty.EXPRESSION, IS_PRESENT, CsmElement.sequence(CsmElement.child(ObservableProperty.EXPRESSION), CsmElement.token(ASTParserConstants.DOT))),
+                                typeArguments(),
+                                CsmElement.token(ASTParserConstants.SUPER)
+                        )),
+                CsmElement.token(ASTParserConstants.LPAREN),
+                CsmElement.list(ObservableProperty.ARGUMENTS, CsmElement.sequence(CsmElement.comma(), CsmElement.space())),
+                CsmElement.token(ASTParserConstants.RPAREN),
+                CsmElement.semicolon()
+        ));
+
+        concreteSyntaxModelByClass.put(ExpressionStmt.class, sequence(
+                orphanCommentsBeforeThis(),
+                comment(),
+                child(ObservableProperty.EXPRESSION),
+                semicolon()
+        ));
+
+        concreteSyntaxModelByClass.put(ForeachStmt.class, sequence(
+                comment(),
+                token(ASTParserConstants.FOR),
+                space(),
+                token(ASTParserConstants.LPAREN),
+                child(ObservableProperty.VARIABLE),
+                space(),
+                token(ASTParserConstants.COLON),
+                space(),
+                child(ObservableProperty.ITERABLE),
+                token(ASTParserConstants.RPAREN),
+                space(),
+                child(ObservableProperty.BODY)
+        ));
+
+        concreteSyntaxModelByClass.put(ForStmt.class, sequence(
+                comment(),
+                token(ASTParserConstants.FOR),
+                space(),
+                token(ASTParserConstants.LPAREN),
+                list(ObservableProperty.INITIALIZATION, sequence(comma(), space())),
+                semicolon(),
+                space(),
+                child(ObservableProperty.COMPARE),
+                semicolon(),
+                space(),
+                list(ObservableProperty.UPDATE, sequence(comma(), space())),
+                token(ASTParserConstants.RPAREN),
+                space(),
+                child(ObservableProperty.BODY)
+        ));
+
+        concreteSyntaxModelByClass.put(IfStmt.class, sequence(
+                comment(),
+                token(ASTParserConstants.IF),
+                space(),
+                token(ASTParserConstants.LPAREN),
+                child(ObservableProperty.CONDITION),
+                token(ASTParserConstants.RPAREN),
+                conditional(ObservableProperty.THEN_BLOCK, CsmConditional.Condition.FLAG,
+                        sequence(space(), child(ObservableProperty.THEN_STMT),
+                                conditional(ObservableProperty.ELSE_STMT, IS_PRESENT, space())),
+                        sequence(newline(), CsmElement.indent(), child(ObservableProperty.THEN_STMT),
+                                conditional(ObservableProperty.ELSE_STMT, IS_PRESENT, newline()),
+                                unindent())),
+                conditional(ObservableProperty.ELSE_STMT, IS_PRESENT,
+                        sequence(token(ASTParserConstants.ELSE),
+                                conditional(ObservableProperty.ELSE_BLOCK, CsmConditional.Condition.FLAG,
+                                        sequence(space(), child(ObservableProperty.ELSE_STMT)),
+                                        sequence(newline(), CsmElement.indent(), child(ObservableProperty.ELSE_STMT), unindent()))))
+        ));
+
+        concreteSyntaxModelByClass.put(LabeledStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.child(ObservableProperty.LABEL),
+                CsmElement.token(ASTParserConstants.COLON),
+                CsmElement.space(),
+                child(ObservableProperty.STATEMENT)
+        ));
+
+        concreteSyntaxModelByClass.put(LocalClassDeclarationStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.child(ObservableProperty.CLASS_DECLARATION)
+        ));
+
+        concreteSyntaxModelByClass.put(ReturnStmt.class, sequence(comment(), token(ASTParserConstants.RETURN),
+                conditional(ObservableProperty.EXPRESSION, IS_PRESENT, sequence(space(), child(ObservableProperty.EXPRESSION))),
+                semicolon()));
+
+        concreteSyntaxModelByClass.put(SwitchEntryStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.conditional(ObservableProperty.LABEL, IS_PRESENT,
+                        CsmElement.sequence(CsmElement.token(ASTParserConstants.CASE), CsmElement.space(), CsmElement.child(ObservableProperty.LABEL), CsmElement.token(ASTParserConstants.COLON)),
+                        CsmElement.sequence(CsmElement.token(ASTParserConstants._DEFAULT), CsmElement.token(ASTParserConstants.COLON))),
+                CsmElement.newline(),
+                CsmElement.indent(),
+                CsmElement.list(ObservableProperty.STATEMENTS, CsmElement.newline(), CsmElement.none(), CsmElement.newline()),
+                CsmElement.unindent()
+        ));
+
+        concreteSyntaxModelByClass.put(SwitchStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.SWITCH),
+                CsmElement.token(ASTParserConstants.LPAREN),
+                CsmElement.child(ObservableProperty.SELECTOR),
+                CsmElement.token(ASTParserConstants.RPAREN),
+                CsmElement.space(),
+                CsmElement.token(ASTParserConstants.LBRACE),
+                CsmElement.newline(),
+                CsmElement.list(ObservableProperty.ENTRIES, CsmElement.none(), CsmElement.indent(), CsmElement.unindent()),
+                CsmElement.token(ASTParserConstants.RBRACE)
+        ));
+
+        concreteSyntaxModelByClass.put(SynchronizedStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.SYNCHRONIZED),
+                CsmElement.space(),
+                CsmElement.token(LPAREN),
+                CsmElement.child(EXPRESSION),
+                CsmElement.token(RPAREN),
+                CsmElement.space(),
+                CsmElement.child(BODY)
+        ));
+
+        concreteSyntaxModelByClass.put(ThrowStmt.class, sequence(
+                comment(),
+                token(ASTParserConstants.THROW),
+                space(),
+                child(ObservableProperty.EXPRESSION),
+                semicolon()
+        ));
+
+        concreteSyntaxModelByClass.put(TryStmt.class, CsmElement.sequence(
+                CsmElement.comment(),
+                CsmElement.token(ASTParserConstants.TRY),
+                CsmElement.space(),
+                CsmElement.conditional(ObservableProperty.RESOURCES, CsmConditional.Condition.IS_NOT_EMPTY, CsmElement.sequence(
+                        CsmElement.token(LPAREN),
+                        list(ObservableProperty.RESOURCES, CsmElement.sequence(CsmElement.semicolon(), CsmElement.newline()), CsmElement.indent(), CsmElement.unindent()),
+                        CsmElement.token(RPAREN),
+                        CsmElement.space())),
+                CsmElement.child(ObservableProperty.TRY_BLOCK),
+                CsmElement.list(ObservableProperty.CATCH_CLAUSES),
+                CsmElement.conditional(ObservableProperty.FINALLY_BLOCK, IS_PRESENT, CsmElement.sequence(CsmElement.space(), CsmElement.token(ASTParserConstants.FINALLY), CsmElement.space(), CsmElement.child(ObservableProperty.FINALLY_BLOCK)))
+        ));
+
+        concreteSyntaxModelByClass.put(WhileStmt.class, sequence(
+                comment(),
+                token(ASTParserConstants.WHILE),
+                space(),
+                token(ASTParserConstants.LPAREN),
+                child(ObservableProperty.CONDITION),
+                token(ASTParserConstants.RPAREN),
+                space(),
+                child(ObservableProperty.BODY)
+        ));
+
+        ///
+        /// Types
+        ///
+
+        concreteSyntaxModelByClass.put(ArrayType.class, sequence(
+                child(ObservableProperty.COMPONENT_TYPE),
+                list(ObservableProperty.ANNOTATIONS),
+                string(ASTParserConstants.LBRACKET),
+                string(ASTParserConstants.RBRACKET)));
+
+        concreteSyntaxModelByClass.put(ClassOrInterfaceType.class, sequence(comment(),
+                conditional(SCOPE, IS_PRESENT, sequence(child(SCOPE), string(ASTParserConstants.DOT))),
+                list(ANNOTATIONS, space()),
+                child(NAME),
+                conditional(ObservableProperty.USING_DIAMOND_OPERATOR, FLAG,
+                        sequence(string(ASTParserConstants.LT), string(ASTParserConstants.GT)),
+                        list(TYPE_ARGUMENTS, sequence(comma(), space()), string(ASTParserConstants.LT), string(ASTParserConstants.GT)))));
+
+        concreteSyntaxModelByClass.put(IntersectionType.class, CsmElement.sequence(
+                CsmElement.comment(),
+                annotations(),
+                CsmElement.list(ObservableProperty.ELEMENTS, CsmElement.sequence(CsmElement.space(), CsmElement.token(ASTParserConstants.BIT_AND), CsmElement.space()))));
+
+        concreteSyntaxModelByClass.put(PrimitiveType.class, sequence(
+                comment(),
+                list(ObservableProperty.ANNOTATIONS),
+                attribute(ObservableProperty.TYPE)));
+
+        concreteSyntaxModelByClass.put(TypeParameter.class, sequence(
+                comment(),
+                annotations(),
+                child(ObservableProperty.NAME),
+                list(ObservableProperty.TYPE_BOUND,
+                        sequence(
+                                space(),
+                                token(ASTParserConstants.BIT_AND),
+                                space()),
+                        sequence(
+                                space(),
+                                token(ASTParserConstants.EXTENDS),
+                                space()),
+                        none())
+        ));
+
+        concreteSyntaxModelByClass.put(UnionType.class, CsmElement.sequence(
+                CsmElement.comment(),
+                annotations(),
+                CsmElement.list(ObservableProperty.ELEMENTS, CsmElement.sequence(CsmElement.space(), CsmElement.token(ASTParserConstants.BIT_OR), CsmElement.space()))
+        ));
+
+        concreteSyntaxModelByClass.put(UnknownType.class, none());
+
+        concreteSyntaxModelByClass.put(VoidType.class, sequence(comment(), annotations(), token(ASTParserConstants.VOID)));
+
+        concreteSyntaxModelByClass.put(WildcardType.class, sequence(comment(), annotations(), token(ASTParserConstants.HOOK),
+                CsmElement.conditional(ObservableProperty.EXTENDED_TYPE, IS_PRESENT, CsmElement.sequence(space(), token(ASTParserConstants.EXTENDS), space(), CsmElement.child(EXTENDED_TYPE))),
+                CsmElement.conditional(ObservableProperty.SUPER_TYPE, IS_PRESENT, CsmElement.sequence(space(), token(ASTParserConstants.SUPER), space(), CsmElement.child(SUPER_TYPE)))));
+
+        ///
+        /// Top Level
+        ///
+
+        concreteSyntaxModelByClass.put(ArrayCreationLevel.class, sequence(
+                annotations(),
+                token(ASTParserConstants.LBRACKET),
+                child(ObservableProperty.DIMENSION),
+                token(ASTParserConstants.RBRACKET)
+        ));
+
+        concreteSyntaxModelByClass.put(CompilationUnit.class, sequence(
+                    comment(),
+                    child(ObservableProperty.PACKAGE_DECLARATION),
+                    list(ObservableProperty.IMPORTS, none(), none(), newline()),
+                    list(TYPES, newline(), CsmElement.newline(), CsmElement.none(), CsmElement.newline()),
+                    orphanCommentsEnding()));
+
+        concreteSyntaxModelByClass.put(ImportDeclaration.class, sequence(
+                comment(),
+                token(ASTParserConstants.IMPORT),
+                space(),
+                conditional(ObservableProperty.STATIC, FLAG, sequence(token(ASTParserConstants.STATIC), space())),
+                child(ObservableProperty.NAME),
+                conditional(ASTERISK, FLAG, sequence(token(ASTParserConstants.DOT), token(ASTParserConstants.STAR))),
+                semicolon(),
+                newline(),
+                orphanCommentsEnding()
+        ));
+
+        concreteSyntaxModelByClass.put(PackageDeclaration.class, sequence(
+                comment(),
+                list(ObservableProperty.ANNOTATIONS),
+                token(ASTParserConstants.PACKAGE),
+                space(),
+                child(ObservableProperty.NAME),
+                semicolon(),
+                newline(),
+                newline(),
+                orphanCommentsEnding()));
+
+        List<String> unsupportedNodeClassNames = JavaParserMetaModel.getNodeMetaModels().stream()
+                .filter(c -> !c.isAbstract() && Comment.class.isAssignableFrom(c.getType()) && !concreteSyntaxModelByClass.containsKey(c.getType()))
+                .map(nm -> nm.getType().getSimpleName())
+                .collect(Collectors.toList());
         if (unsupportedNodeClassNames.isEmpty()) {
             initializationError = Optional.empty();
         } else {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -821,7 +821,7 @@ public class ConcreteSyntaxModel {
                 orphanCommentsEnding()));
 
         List<String> unsupportedNodeClassNames = JavaParserMetaModel.getNodeMetaModels().stream()
-                .filter(c -> !c.isAbstract() && Comment.class.isAssignableFrom(c.getType()) && !concreteSyntaxModelByClass.containsKey(c.getType()))
+                .filter(c -> !c.isAbstract() && !Comment.class.isAssignableFrom(c.getType()) && !concreteSyntaxModelByClass.containsKey(c.getType()))
                 .map(nm -> nm.getType().getSimpleName())
                 .collect(Collectors.toList());
         if (unsupportedNodeClassNames.isEmpty()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -24,6 +24,7 @@ package com.github.javaparser.printer;
 import com.github.javaparser.ASTParserConstants;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.observer.*;
 import com.github.javaparser.ast.observer.Observable;
@@ -166,7 +167,7 @@ public class ConcreteSyntaxModel {
                 comment(),
                 memberAnnotations(),
                 modifiers(),
-                conditional(ObservableProperty.DEFAULT, FLAG, sequence(token(ASTParserConstants.DEFAULT), space())),
+                conditional(ObservableProperty.DEFAULT, FLAG, sequence(token(ASTParserConstants._DEFAULT), space())),
                 typeParameters(),
                 child(ObservableProperty.TYPE),
                 space(),
@@ -745,6 +746,53 @@ public class ConcreteSyntaxModel {
                 annotations(),
                 CsmElement.list(ObservableProperty.ELEMENTS, CsmElement.sequence(CsmElement.space(), CsmElement.token(ASTParserConstants.BIT_OR), CsmElement.space()))
         ));
+
+        concreteSyntaxModelByClass.put(AnnotationDeclaration.class, CsmElement.sequence(
+                CsmElement.comment(),
+                memberAnnotations(),
+                modifiers(),
+                CsmElement.token(ASTParserConstants.AT),
+                CsmElement.token(ASTParserConstants.INTERFACE),
+                CsmElement.space(),
+                CsmElement.child(ObservableProperty.NAME),
+                CsmElement.space(),
+                CsmElement.token(LBRACE),
+                CsmElement.newline(),
+                CsmElement.indent(),
+                CsmElement.list(ObservableProperty.MEMBERS, CsmElement.newline(), CsmElement.none(), CsmElement.none(), CsmElement.newline()),
+                CsmElement.unindent(),
+                CsmElement.token(RBRACE)
+        ));
+
+        concreteSyntaxModelByClass.put(AnnotationMemberDeclaration.class, CsmElement.sequence(
+                CsmElement.comment(),
+                memberAnnotations(),
+                modifiers(),
+                CsmElement.child(ObservableProperty.TYPE),
+                CsmElement.space(),
+                CsmElement.child(ObservableProperty.NAME),
+                CsmElement.token(LPAREN),
+                CsmElement.token(RPAREN),
+                CsmElement.conditional(ObservableProperty.DEFAULT_VALUE, IS_PRESENT, CsmElement.sequence(CsmElement.space(), CsmElement.token(ASTParserConstants._DEFAULT), CsmElement.space(), CsmElement.child(DEFAULT_VALUE))),
+                CsmElement.semicolon()
+        ));
+    }
+
+    private static class JavadocContentTokenCalculator implements CsmToken.TokenContentCalculator {
+        @Override
+        public String calculate(Node node) {
+            return "/**" + ((JavadocComment)node).getContent() + "*";
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof JavadocContentTokenCalculator;
+        }
     }
 
     private ConcreteSyntaxModel() {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
@@ -40,7 +40,7 @@ public class CsmAttribute implements CsmElement {
 
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
-        Object value = property.singleValueFor(node);
+        Object value = property.getRawValue(node);
         printer.print(PrintingHelper.printToString(value));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
@@ -21,12 +21,17 @@
 
 package com.github.javaparser.printer.concretesyntaxmodel;
 
+import com.github.javaparser.ASTParserConstants;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.SourcePrinter;
 
 public class CsmAttribute implements CsmElement {
+    public ObservableProperty getProperty() {
+        return property;
+    }
+
     private ObservableProperty property;
 
     public CsmAttribute(ObservableProperty property) {
@@ -37,5 +42,19 @@ public class CsmAttribute implements CsmElement {
     public void prettyPrint(Node node, SourcePrinter printer) {
         Object value = property.singleValueFor(node);
         printer.print(PrintingHelper.printToString(value));
+    }
+
+    public int getTokenType(String text) {
+        if (property == ObservableProperty.IDENTIFIER) {
+            return ASTParserConstants.IDENTIFIER;
+        }
+        if (property == ObservableProperty.TYPE) {
+            for (int i=0;i<ASTParserConstants.tokenImage.length;i++) {
+                if (ASTParserConstants.tokenImage[i].equals("\"" + text.toLowerCase() + "\"")) {
+                    return i;
+                }
+            }
+        }
+        throw new UnsupportedOperationException(property.name()+ " " + text);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmChar.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmChar.java
@@ -35,7 +35,7 @@ public class CsmChar implements CsmElement {
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
         printer.print("'");
-        printer.print(property.singleStringValueFor(node));
+        printer.print(property.getValueAsStringAttribute(node));
         printer.print("'");
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
@@ -35,6 +35,22 @@ public class CsmConditional implements CsmElement {
     private CsmElement thenElement;
     private CsmElement elseElement;
 
+    public Condition getCondition() {
+        return condition;
+    }
+
+    public ObservableProperty getProperty() {
+        return property;
+    }
+
+    public CsmElement getThenElement() {
+        return thenElement;
+    }
+
+    public CsmElement getElseElement() {
+        return elseElement;
+    }
+
     public enum Condition {
         IS_EMPTY,
         IS_NOT_EMPTY,
@@ -43,7 +59,7 @@ public class CsmConditional implements CsmElement {
 
         boolean evaluate(Node node, ObservableProperty property){
             if (this == IS_PRESENT) {
-                return !property.isNullOrEmpty(node);
+                return !property.isNullOrNotPresent(node);
             }
             if (this == FLAG) {
                 return (Boolean)property.singleValueFor(node);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
@@ -24,10 +24,7 @@ package com.github.javaparser.printer.concretesyntaxmodel;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
-import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.SourcePrinter;
-
-import java.util.function.Predicate;
 
 public class CsmConditional implements CsmElement {
     private Condition condition;
@@ -62,13 +59,13 @@ public class CsmConditional implements CsmElement {
                 return !property.isNullOrNotPresent(node);
             }
             if (this == FLAG) {
-                return (Boolean)property.singleValueFor(node);
+                return property.getValueAsBooleanAttribute(node);
             }
             if (this == IS_EMPTY) {
-                return property.listValueFor(node).isEmpty();
+                return property.getValueAsMultipleReference(node).isEmpty();
             }
             if (this == IS_NOT_EMPTY) {
-                NodeList value = property.listValueFor(node);
+                NodeList value = property.getValueAsMultipleReference(node);
                 return value != null && !value.isEmpty();
             }
             throw new UnsupportedOperationException(name());

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmElement.java
@@ -67,6 +67,10 @@ public interface CsmElement {
         return new CsmToken(tokenType);
     }
 
+    static CsmElement token(int tokenType, CsmToken.TokenContentCalculator tokenContentCalculator) {
+        return new CsmToken(tokenType, tokenContentCalculator);
+    }
+
     static CsmElement conditional(ObservableProperty property, CsmConditional.Condition condition, CsmElement thenElement) {
         return new CsmConditional(property, condition, thenElement);
     }
@@ -76,7 +80,7 @@ public interface CsmElement {
     }
 
     static CsmElement space() {
-        return new CsmToken(32, " ");
+        return new CsmToken(1, " ");
     }
 
     static CsmElement semicolon() {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmList.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmList.java
@@ -37,14 +37,32 @@ public class CsmList implements CsmElement {
     private CsmElement preceeding;
     private CsmElement following;
 
+    public ObservableProperty getProperty() {
+        return property;
+    }
+
+    public CsmElement getSeparatorPost() {
+        return separatorPost;
+    }
+
+    public CsmElement getSeparatorPre() {
+        return separatorPre;
+    }
+
+    public CsmElement getPreceeding() {
+        return preceeding;
+    }
+
+    public CsmElement getFollowing() {
+        return following;
+    }
+
     public CsmList(ObservableProperty property, CsmElement separator) {
-        this.property = property;
-        this.separatorPost = separator;
+        this(property, new CsmNone(), separator, new CsmNone(), new CsmNone());
     }
 
     public CsmList(ObservableProperty property) {
-        this.property = property;
-        this.separatorPost = null;
+        this(property, new CsmNone(), new CsmNone(), new CsmNone(), new CsmNone());
     }
 
     public CsmList(ObservableProperty property, CsmElement separatorPre, CsmElement separatorPost, CsmElement preceeding, CsmElement following) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmList.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmList.java
@@ -76,7 +76,7 @@ public class CsmList implements CsmElement {
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
         if (property.isAboutNodes()) {
-            NodeList nodeList = property.listValueFor(node);
+            NodeList nodeList = property.getValueAsMultipleReference(node);
             if (nodeList == null) {
                 return;
             }
@@ -96,7 +96,7 @@ public class CsmList implements CsmElement {
                 following.prettyPrint(node, printer);
             }
         } else {
-            Collection<?> values = property.listPropertyFor(node);
+            Collection<?> values = property.getValueAsCollection(node);
             if (values == null) {
                 return;
             }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmSequence.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmSequence.java
@@ -39,6 +39,10 @@ public class CsmSequence implements CsmElement {
         this.elements = elements;
     }
 
+    public List<CsmElement> getElements() {
+        return elements;
+    }
+
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
         elements.forEach(e -> e.prettyPrint(node, printer));

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmSingleReference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmSingleReference.java
@@ -27,8 +27,12 @@ import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.SourcePrinter;
 
 
-class CsmSingleReference implements CsmElement {
+public class CsmSingleReference implements CsmElement {
     private ObservableProperty property;
+
+    public ObservableProperty getProperty() {
+        return property;
+    }
 
     public CsmSingleReference(ObservableProperty property) {
         this.property = property;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmSingleReference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmSingleReference.java
@@ -40,7 +40,7 @@ public class CsmSingleReference implements CsmElement {
 
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
-        Node child = property.singlePropertyFor(node);
+        Node child = property.getValueAsSingleReference(node);
         if (child != null) {
             ConcreteSyntaxModel.genericPrettyPrint(child, printer);
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmString.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmString.java
@@ -35,7 +35,7 @@ public class CsmString implements CsmElement {
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
         printer.print("\"");
-        printer.print(property.singleStringValueFor(node));
+        printer.print(property.getValueAsStringAttribute(node));
         printer.print("\"");
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
@@ -31,11 +31,34 @@ import com.github.javaparser.printer.SourcePrinter;
 public class CsmToken implements CsmElement {
     private int tokenType;
     private String content;
+    private TokenContentCalculator tokenContentCalculator;
+
+    public interface TokenContentCalculator {
+        String calculate(Node node);
+    }
+
+    public int getTokenType() {
+        return tokenType;
+    }
+
+    public String getContent(Node node) {
+        if (tokenContentCalculator != null) {
+            return tokenContentCalculator.calculate(node);
+        }
+        return content;
+    }
+
     public CsmToken(int tokenType) {
+
         this.tokenType = tokenType;
         this.content = ASTParserConstants.tokenImage[tokenType];
         if (content.startsWith("\"")) {
             content = content.substring(1, content.length() - 1);
+        }
+        if (tokenType == 3) {
+            content = "\n";
+        } else if (tokenType == 32) {
+            content = " ";
         }
     }
 
@@ -44,12 +67,46 @@ public class CsmToken implements CsmElement {
         this.content = content;
     }
 
+    public CsmToken(int tokenType, TokenContentCalculator tokenContentCalculator) {
+        this.tokenType = tokenType;
+        this.tokenContentCalculator = tokenContentCalculator;
+    }
+
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
         if (tokenType == 3) {
             printer.println();
         } else {
-            printer.print(content);
+            printer.print(getContent(node));
         }
+    }
+
+    @Override
+    public String toString() {
+        return "token(" + ASTParserConstants.tokenImage[tokenType]+ ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CsmToken csmToken = (CsmToken) o;
+
+        if (tokenType != csmToken.tokenType) return false;
+        if (content != null ? !content.equals(csmToken.content) : csmToken.content != null) return false;
+        return tokenContentCalculator != null ? tokenContentCalculator.equals(csmToken.tokenContentCalculator) : csmToken.tokenContentCalculator == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tokenType;
+        result = 31 * result + (content != null ? content.hashCode() : 0);
+        result = 31 * result + (tokenContentCalculator != null ? tokenContentCalculator.hashCode() : 0);
+        return result;
+    }
+
+    public boolean isWhiteSpace() {
+        return tokenType == 3 || tokenType == 1 || tokenType == 0 || tokenType == 31 || tokenType == 32;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
@@ -26,12 +26,19 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.SourcePrinter;
+import com.github.javaparser.utils.Utils;
 
 
 public class CsmToken implements CsmElement {
     private int tokenType;
     private String content;
     private TokenContentCalculator tokenContentCalculator;
+
+    public static int NEWLINE_TOKEN = 3;
+    public static int SPACE_TOKEN = 1;
+    public static int SPACE_TOKEN_ALT = 32;
+    public static int TAB_TOKEN = 31;
+    public static int EOF_TOKEN = 0;
 
     public interface TokenContentCalculator {
         String calculate(Node node);
@@ -55,9 +62,9 @@ public class CsmToken implements CsmElement {
         if (content.startsWith("\"")) {
             content = content.substring(1, content.length() - 1);
         }
-        if (tokenType == 3) {
-            content = "\n";
-        } else if (tokenType == 32) {
+        if (tokenType == NEWLINE_TOKEN) {
+            content = Utils.EOL;
+        } else if (tokenType == SPACE_TOKEN) {
             content = " ";
         }
     }
@@ -107,6 +114,6 @@ public class CsmToken implements CsmElement {
     }
 
     public boolean isWhiteSpace() {
-        return tokenType == 3 || tokenType == 1 || tokenType == 0 || tokenType == 31 || tokenType == 32;
+        return tokenType == NEWLINE_TOKEN || tokenType == SPACE_TOKEN || tokenType == EOF_TOKEN || tokenType == TAB_TOKEN || tokenType == SPACE_TOKEN_ALT;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -181,4 +181,28 @@ public class Utils {
         sb.append(s.substring(1));
         return sb.toString();
     }
+
+    /**
+     * Return true if the value is null, an empty Optional or an empty String.
+     * @param value
+     * @return
+     */
+    public static boolean valueIsNullOrEmpty(Object value) {
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof Optional) {
+            if (((Optional) value).isPresent()) {
+                value = ((Optional) value).get();
+            } else {
+                return true;
+            }
+        }
+        if (value instanceof Collection) {
+            if (((Collection) value).isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Refinements to CSM either suggested by @cal101 or emerged while working on lexical preservation.

Also:
* introduced check to verify all node classes are covered by the CSM (idea from @matozoid)
* reorganize ObservableProperty to make easier to get values using reflection