### PR TITLE
Fix modifyList(Optional) infinite recursion

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -1095,7 +1095,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     }
 
     private <N extends Node> NodeList<N> modifyList(Optional<NodeList<N>> list, A arg) {
-        return list.map( ns -> modifyList(list, arg)).orElse(null);
+        return list.map(ns -> modifyList(ns, arg)).orElse(null);
     }
 }
 


### PR DESCRIPTION
`modifyList(Optional)` calls `modifyList(Optional)` recursively, instead of `modifyList(NodeList)` as it should.