### PR TITLE
Add pre-in-post-order visiting to TreeVisitor #751

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
@@ -37,7 +37,18 @@ public class JavaToken {
     }
 
     public JavaToken(Token token) {
-        this(Range.range(token.beginLine, token.beginColumn, token.endLine, token.endColumn), token.kind, token.image);
+        Range range = Range.range(token.beginLine, token.beginColumn, token.endLine, token.endColumn);
+        String text = token.image;
+        if (token.kind == ASTParserConstants.GT) {
+            range = Range.range(token.beginLine, token.beginColumn, token.endLine, token.beginColumn);
+            text = ">";
+        } else if (token.kind == ASTParserConstants.RSIGNEDSHIFT) {
+            range = Range.range(token.beginLine, token.beginColumn, token.endLine, token.beginColumn + 1);
+            text = ">>";
+        }
+        this.range = range;
+        this.kind = token.kind;
+        this.text = text;
     }
 
     public Range getRange() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/TreeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/TreeVisitor.java
@@ -34,10 +34,42 @@ import java.util.Queue;
 public abstract class TreeVisitor {
 
     /**
-     * https://en.wikipedia.org/wiki/Depth-first_search
+     * Performs a pre-order node traversal starting with a given node. When each node is visited,
+     * {@link #process(Node)} is called for further processing.
      *
-     * @param node the start node, and the first one that is passed to process(node).
+     * @param node The node at which the traversal begins.
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Pre-order">Pre-order traversal</a>
      */
+    public void visitPreOrder(Node node) {
+        process(node);
+        new ArrayList<>(node.getChildNodes()).forEach(child -> visitPreOrder(child));
+    }
+
+    /**
+     * Performs a post-order node traversal starting with a given node. When each node is visited,
+     * {@link #process(Node)} is called for further processing.
+     *
+     * @param node The node at which the traversal begins.
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Post-order">Post-order traversal</a>
+     */
+    public void visitPostOrder(Node node) {
+        new ArrayList<>(node.getChildNodes()).forEach(child -> visitPostOrder(child));
+        process(node);
+    }
+
+    /**
+     * Performs a pre-order node traversal starting with a given node. When each node is visited,
+     * {@link #process(Node)} is called for further processing.
+     *
+     * @deprecated As of release 3.1.0, replaced by {@link #visitPreOrder(Node)}
+     *
+     * @param node The node at which the traversal begins.
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Pre-order">Pre-order traversal</a>
+     */
+    @Deprecated
     public void visitDepthFirst(Node node) {
         process(node);
         final List<Node> copy = new ArrayList<>(node.getChildNodes());
@@ -63,5 +95,10 @@ public abstract class TreeVisitor {
         }
     }
 
+    /**
+     * Process the given node.
+     *
+     * @param node The current node to process.
+     */
     public abstract void process(Node node);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/TreeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/TreeVisitor.java
@@ -33,6 +33,13 @@ import java.util.Queue;
  */
 public abstract class TreeVisitor {
 
+    public void visitLeavesFirst(Node node) {
+        for (Node child : node.getChildNodes()) {
+            visitLeavesFirst(child);
+        }
+        process(node);
+    }
+
     /**
      * Performs a pre-order node traversal starting with a given node. When each node is visited,
      * {@link #process(Node)} is called for further processing.

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/visitor/TreeVisitorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/visitor/TreeVisitorTest.java
@@ -74,12 +74,67 @@ public class TreeVisitorTest {
             @Override
             public void process(Node node) {
                 if (node instanceof IntegerLiteralExpr) {
-                    node.getParentNode().ifPresent(parent -> ((ArrayInitializerExpr) parent).getValues().add(new IntegerLiteralExpr("1")));
+                    node.getParentNode().ifPresent(
+                            parent -> ((ArrayInitializerExpr) parent).getValues().add(new IntegerLiteralExpr("1")));
                 }
                 result.append("<").append(node).append("> ");
             }
         };
         visitor.visitDepthFirst(expression);
         System.out.println(result);
+    }
+
+    @Test
+    public void isValidPreOrderTraversal() {
+        StringBuilder result = new StringBuilder();
+        new TreeVisitor() {
+            @Override
+            public void process(Node node) {
+                result.append("<").append(node).append("> ");
+            }
+        }.visitPreOrder(JavaParser.parseExpression("(2+3)+(4+5)"));
+        assertEquals("<(2 + 3) + (4 + 5)> <(2 + 3)> <2 + 3> <2> <3> <(4 + 5)> <4 + 5> <4> <5> ", result.toString());
+    }
+
+    @Test
+    public void isValidPostOrderTraversal() {
+        StringBuilder result = new StringBuilder();
+        new TreeVisitor() {
+            @Override
+            public void process(Node node) {
+                result.append("<").append(node).append("> ");
+            }
+        }.visitPostOrder(JavaParser.parseExpression("(2+3)+(4+5)"));
+        assertEquals("<2> <3> <2 + 3> <(2 + 3)> <4> <5> <4 + 5> <(4 + 5)> <(2 + 3) + (4 + 5)> ", result.toString());
+    }
+
+    @Test
+    public void preOrderConcurrentModificationIsOk() {
+        StringBuilder result = new StringBuilder();
+        new TreeVisitor() {
+            @Override
+            public void process(Node node) {
+                if (node instanceof IntegerLiteralExpr) {
+                    node.getParentNode().ifPresent(
+                            parent -> ((ArrayInitializerExpr) parent).getValues().add(new IntegerLiteralExpr("1")));
+                }
+                result.append("<").append(node).append("> ");
+            }
+        }.visitPreOrder(JavaParser.parseExpression("new int[]{1,2,3,4}"));
+    }
+
+    @Test
+    public void postOrderConcurrentModificationIsOk() {
+        StringBuilder result = new StringBuilder();
+        new TreeVisitor() {
+            @Override
+            public void process(Node node) {
+                if (node instanceof IntegerLiteralExpr) {
+                    node.getParentNode().ifPresent(
+                            parent -> ((ArrayInitializerExpr) parent).getValues().add(new IntegerLiteralExpr("1")));
+                }
+                result.append("<").append(node).append("> ");
+            }
+        }.visitPostOrder(JavaParser.parseExpression("new int[]{1,2,3,4}"));
     }
 }


### PR DESCRIPTION
This is my first time ever issuing a pull request, and it appears that I've got some unrelated commits from @ftomassetti that shouldn't be. If this so, please let me know, and I'll try to fix it. Otherwise, please review and comment. Let me know what you think about deprecating visitDepthFirst().