### PR TITLE
Add maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,18 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <maven-jacoco-plugin.version>0.7.7.201606060606</maven-jacoco-plugin.version>
         <maven-coveralls-plugin.version>4.2.0</maven-coveralls-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <bnd-maven-plugin.version>3.2.0</bnd-maven-plugin.version>
     </properties>
 
@@ -205,6 +206,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven-release-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION
Useful for third party users, enables viewing generated source when debugging, regardless of build system etc.

Will cause a `...-sources.jar` file to be generated next to the binary jar.