### PR TITLE
Check root argument of SourceRoot must be a directory

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -7,8 +7,6 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.printer.PrettyPrinter;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,13 +19,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
-import static com.github.javaparser.Providers.UTF8;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.CodeGenerationUtils.fileInPackageRelativePath;
 import static com.github.javaparser.utils.CodeGenerationUtils.packageAbsolutePath;
 import static com.github.javaparser.utils.SourceRoot.Callback.Result.SAVE;
-import static com.github.javaparser.utils.CodeGenerationUtils.fileInPackageRelativePath;
-import static com.github.javaparser.utils.CodeGenerationUtils.packageAbsolutePath;
 
 /**
  * A collection of Java source files located in one directory and its subdirectories on the file system.
@@ -50,6 +45,9 @@ public class SourceRoot {
     private JavaParser javaParser = new JavaParser();
 
     public SourceRoot(Path root) {
+        if (Files.isRegularFile(root)) {
+            throw new IllegalArgumentException("Only directories are allowed as root path!");
+        }
         this.root = root.normalize();
         Log.info("New source root at \"%s\"", this.root);
     }
@@ -128,14 +126,9 @@ public class SourceRoot {
     }
 
     private void save(CompilationUnit cu, Path path) throws IOException {
-        path.getParent().toFile().mkdirs();
-
+        Files.createDirectories(path.getParent());
         final String code = new PrettyPrinter().print(cu);
-        try (PrintWriter out = new PrintWriter(path.toFile(), UTF8.toString())) {
-            out.println(code);
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        Files.write(path, code.getBytes());
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -46,7 +46,7 @@ public class SourceRoot {
     private JavaParser javaParser = new JavaParser();
 
     public SourceRoot(Path root) {
-        if (Files.isRegularFile(root)) {
+        if (!Files.isDirectory(root)) {
             throw new IllegalArgumentException("Only directories are allowed as root path!");
         }
         this.root = root.normalize();

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
+import static com.github.javaparser.Providers.UTF8;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.CodeGenerationUtils.fileInPackageRelativePath;
 import static com.github.javaparser.utils.CodeGenerationUtils.packageAbsolutePath;
@@ -128,7 +129,7 @@ public class SourceRoot {
     private void save(CompilationUnit cu, Path path) throws IOException {
         Files.createDirectories(path.getParent());
         final String code = new PrettyPrinter().print(cu);
-        Files.write(path, code.getBytes());
+        Files.write(path, code.getBytes(UTF8));
     }
 
     /**

--- a/javaparser-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -27,4 +27,10 @@ public class SourceRootTest {
             }
         }
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fileAsRootIsNotAllowed() {
+        String path = SourceRootTest.class.getResource("/com/github/javaparser/utils/Bla.java").getPath();
+        new SourceRoot(Paths.get(path));
+    }
 }


### PR DESCRIPTION
Or else `tryToParse` will fail on strage paths like `/home/artur/HelloWorld.java/HelloWorld.java`.

Also cleaned up `save` method.