### PR TITLE
Issue 806 explicit receiver parameters

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ParseStart.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseStart.java
@@ -58,7 +58,7 @@ public interface ParseStart<R> {
     ParseStart<VariableDeclarationExpr> VARIABLE_DECLARATION_EXPR = GeneratedJavaParser::VariableDeclarationExpression;
     ParseStart<ExplicitConstructorInvocationStmt> EXPLICIT_CONSTRUCTOR_INVOCATION_STMT = GeneratedJavaParser::ExplicitConstructorInvocation;
     ParseStart<Name> NAME = GeneratedJavaParser::Name;
-    ParseStart<Parameter> PARAMETER = GeneratedJavaParser::FormalParameter;
+    ParseStart<Parameter> PARAMETER = GeneratedJavaParser::Parameter;
 
     R parse(GeneratedJavaParser parser) throws ParseException;
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1204,11 +1204,7 @@ NodeList<Parameter> Parameters():
 	Parameter par;
 }
 {
-  "(" [ 
-        par = Parameter() { ret = add(ret, par); } 
-        ( "," par = Parameter() { ret = add(ret, par); } )* 
-        ] ")"
-
+  "(" [ par = Parameter() { ret = add(ret, par); } ( "," par = Parameter() { ret = add(ret, par); } )* ] ")"
   { return ret; }
 }
 
@@ -1243,15 +1239,41 @@ Parameter Parameter():
 	Type partialType;
 	boolean isVarArg = false;
 	Pair<SimpleName, List<ArrayBracketPair>> id;
+	SimpleName receiverId;
 	NodeList<AnnotationExpr> varArgAnnotations = emptyList();
+	Parameter ret;
 }
 {
-  modifier = Modifiers() partialType = Type() [ varArgAnnotations = Annotations() "..." { isVarArg = true;} ] id = VariableDeclaratorId()
-  {
+  modifier = Modifiers() partialType = Type() [ varArgAnnotations = Annotations() "..." { isVarArg = true;} ] 
+  ( LOOKAHEAD(ReceiverParameterId())
+    receiverId = ReceiverParameterId()
+    {
         Position begin = modifier.begin.orIfInvalid(partialType.getBegin().get());
-        return new Parameter(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, juggleArrayType(partialType, id.b), isVarArg, varArgAnnotations, id.a);
-  }
+        ret = new Parameter(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, partialType, isVarArg, varArgAnnotations, receiverId);
+    }
+  |
+    id = VariableDeclaratorId()
+    {
+        Position begin = modifier.begin.orIfInvalid(partialType.getBegin().get());
+        ret = new Parameter(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, juggleArrayType(partialType, id.b), isVarArg, varArgAnnotations, id.a);
+    }
+  )
+  { return ret; }
 }
+
+SimpleName ReceiverParameterId():
+{
+    String id;
+	String ret ="";
+	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
+    Position begin = INVALID;
+}
+{
+  ( id = Identifier() "." { ret = ret + id + "."; begin = begin.orIfInvalid(tokenBegin()); } )*
+  "this" { begin = begin.orIfInvalid(tokenBegin()); }
+  { return new SimpleName(range(begin, tokenEnd()), ret + "this"); }
+}
+
 
 ConstructorDeclaration ConstructorDeclaration(ModifierHolder modifier):
 {

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1169,7 +1169,7 @@ MethodDeclaration MethodDeclaration(ModifierHolder modifier):
     [ typeParameters = TypeParameters() { begin = begin.orIfInvalid(typeParameters.range.begin); } ]
     annotations = Annotations() { modifier.annotations.addAll(annotations); begin = begin.orIfInvalid(nodeListBegin(annotations)); }
     type = ResultType() { begin = begin.orIfInvalid(type.getBegin().get()); }
-    name = SimpleName() parameters = FormalParameters() ( arrayBracketPair = ArrayBracketPair() { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
+    name = SimpleName() parameters = Parameters() ( arrayBracketPair = ArrayBracketPair() { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
     [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
       ("," throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); } )* ]
     ( body = Block() | ";" )
@@ -1198,25 +1198,28 @@ ReferenceType<?> ReferenceTypeWithAnnotations():
     }
 }
 
-NodeList<Parameter> FormalParameters():
+NodeList<Parameter> Parameters():
 {
 	NodeList<Parameter> ret = emptyList();
 	Parameter par;
 }
 {
-  "(" [ par = FormalParameter() { ret = add(ret, par); } ( "," par = FormalParameter() { ret = add(ret, par); } )* ] ")"
+  "(" [ 
+        par = Parameter() { ret = add(ret, par); } 
+        ( "," par = Parameter() { ret = add(ret, par); } )* 
+        ] ")"
 
   { return ret; }
 }
 
-NodeList<Parameter> FormalLambdaParameters():
+NodeList<Parameter> LambdaParameters():
 {
   NodeList<Parameter> ret = null;
   Parameter par;
 }
 {
    ","
-  	par = FormalParameter() {  ret = add(ret, par);  } ( "," par = FormalParameter() { ret = add(ret, par); } )*
+  	par = Parameter() {  ret = add(ret, par);  } ( "," par = Parameter() { ret = add(ret, par); } )*
   { return ret;  }
 }
 
@@ -1234,7 +1237,7 @@ NodeList<Parameter> InferredLambdaParameters():
     { return ret;  }
 }
 
-Parameter FormalParameter():
+Parameter Parameter():
 {
 	ModifierHolder modifier;
 	Type partialType;
@@ -1265,7 +1268,7 @@ ConstructorDeclaration ConstructorDeclaration(ModifierHolder modifier):
 {
   [ typeParameters = TypeParameters() { begin = begin.orIfInvalid(typeParameters.range.begin); } ]
   // Modifiers matched in the caller
-  name = SimpleName() { begin = begin.orIfInvalid(typeParameters.range.begin); begin = begin.orIfInvalid(tokenBegin()); } parameters = FormalParameters() [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
+  name = SimpleName() { begin = begin.orIfInvalid(typeParameters.range.begin); begin = begin.orIfInvalid(tokenBegin()); } parameters = Parameters() [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
   ("," throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); })* ]
   "{" { blockBegin=tokenBegin(); }
     [ LOOKAHEAD(ExplicitConstructorInvocation()) exConsInv = ExplicitConstructorInvocation() ]
@@ -1969,7 +1972,7 @@ Expression PrimaryPrefix():
 	|
 	  "(" {begin=tokenBegin();}
 	  	[
-	  	( LOOKAHEAD(FormalParameter()) p = FormalParameter() { isLambda = true;} [params = FormalLambdaParameters()]
+	  	( LOOKAHEAD(Parameter()) p = Parameter() { isLambda = true;} [params = LambdaParameters()]
 	  	| ret = Expression() [params = InferredLambdaParameters() { isLambda = true;} ]
 	  	)
 	  	]

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
@@ -1,9 +1,9 @@
 package com.github.javaparser.ast.body;
 
-import com.github.javaparser.JavaParser;
 import org.junit.Test;
 
-import static com.github.javaparser.JavaParser.*;
+import static com.github.javaparser.JavaParser.parseClassBodyDeclaration;
+import static org.junit.Assert.assertEquals;
 
 public class MethodDeclarationTest {
     @Test
@@ -17,8 +17,14 @@ public class MethodDeclarationTest {
     }
     
     @Test
-    public void explicitReceiverParameters() {
-//        MethodDeclaration method = (MethodDeclaration) parseClassBodyDeclaration("void InnerInner(@mypackage.Anno Source.@mypackage.Anno Inner Source.Inner.this) { }");
-//        assertEquals(true, method.getParameter(0).isExplicitReceiverParameter());
+    public void explicitReceiverParameters1() {
+        MethodDeclaration method = (MethodDeclaration) parseClassBodyDeclaration("void InnerInner(@mypackage.Anno Source.@mypackage.Anno Inner Source.Inner.this) { }");
+        assertEquals("Source.Inner.this", method.getParameter(0).getNameAsString());
+    }
+
+    @Test
+    public void explicitReceiverParameters2() {
+        MethodDeclaration method = (MethodDeclaration) parseClassBodyDeclaration("void x(A this) { }");
+        assertEquals("this", method.getParameter(0).getNameAsString());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
@@ -3,14 +3,22 @@ package com.github.javaparser.ast.body;
 import com.github.javaparser.JavaParser;
 import org.junit.Test;
 
+import static com.github.javaparser.JavaParser.*;
+
 public class MethodDeclarationTest {
     @Test
     public void annotationsAllowedAfterGenericsAndBeforeReturnType() {
-        JavaParser.parseClassBodyDeclaration("public <T> @Abc String method() {return null;}");
+        parseClassBodyDeclaration("public <T> @Abc String method() {return null;}");
     }
 
     @Test
     public void annotationsAllowedBeforeGenerics() {
-        JavaParser.parseClassBodyDeclaration("public @Abc <T> String method() {return null;}");
+        parseClassBodyDeclaration("public @Abc <T> String method() {return null;}");
+    }
+    
+    @Test
+    public void explicitReceiverParameters() {
+//        MethodDeclaration method = (MethodDeclaration) parseClassBodyDeclaration("void InnerInner(@mypackage.Anno Source.@mypackage.Anno Inner Source.Inner.this) { }");
+//        assertEquals(true, method.getParameter(0).isExplicitReceiverParameter());
     }
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_test_results.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_test_results.txt
@@ -1,17 +1,5 @@
-openjdk/jdk/test/java/lang/annotation/typeAnnotations/ConstructorReceiverTest.java
-(line 111,col 69) Parse error. Found ".", expected one of  ")" "," "@" "["
-
-openjdk/jdk/test/java/lang/annotation/typeAnnotations/GetAnnotatedReceiverType.java
-(line 34,col 25) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
 openjdk/jdk/test/java/util/WeakHashMap/GCDuringIteration.java
 (line 118,col 39) Parse error. Found  "equal" <IDENTIFIER>, expected one of  "%=" "&=" "*=" "++" "+=" "--" "-=" "->" "/=" "::" ";" "<<=" "=" ">>=" ">>>=" "^=" "|="
-
-openjdk/jdk/test/tools/pack200/typeannos/TargetTypes.java
-(line 93,col 19) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/jdk/test/tools/pack200/typeannos/TypeUseTarget.java
-(line 39,col 36) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
 
 openjdk/langtools/test/com/sun/javadoc/testSourceTab/DoubleTab/C.java
 Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
@@ -19,14 +7,8 @@ Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
 openjdk/langtools/test/com/sun/javadoc/testSourceTab/SingleTab/C.java
 Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
 
-openjdk/langtools/test/com/sun/javadoc/testTypeAnnotations/typeannos/Receivers.java
-(line 32,col 23) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
 openjdk/langtools/test/com/sun/javadoc/testUnnamedPackage/BadSource.java
 (line 0,col 0) Parse error. Found  "Just" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
-
-openjdk/langtools/test/com/sun/javadoc/typeAnnotations/smoke/pkg/TargetTypes.java
-(line 97,col 23) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
 
 openjdk/langtools/test/tools/javac/6302184/T6302184.java
 Lexical error at line 29, column 9.  Encountered: "\ufffd" (65533), after : ""
@@ -101,38 +83,8 @@ openjdk/langtools/test/tools/javac/annotations/neg/Z9.java
 openjdk/langtools/test/tools/javac/annotations/typeAnnotations/6967002/T6967002.java
 (line 33,col 16) Parse error. Found "...", expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" ")" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/attribution/Scopes.java
-(line 37,col 23) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/classfile/TestNewCastArray.java
-(line 238,col 56) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
 openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/BadCast.java
 (line 12,col 16) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/DeclarationAnnotation.java
-(line 14,col 18) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/DuplicateAnnotationValue.java
-(line 10,col 38) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/DuplicateTypeAnnotation.java
-(line 10,col 19) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/InvalidLocation.java
-(line 10,col 16) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/MissingAnnotationValue.java
-(line 9,col 16) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/Nesting.java
-(line 39,col 17) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/StaticThings.java
-(line 33,col 21) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/common/receiver/WrongType.java
-(line 41,col 17) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
 
 openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/IncompleteArray.java
 (line 11,col 11) Parse error. Found "@", expected one of  "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
@@ -145,18 +97,6 @@ openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/OldArray
 
 openjdk/langtools/test/tools/javac/annotations/typeAnnotations/failures/StaticFields.java
 (line 13,col 10) Parse error. Found "@", expected one of  "(" "++" "--" ";" "assert" "boolean" "break" "byte" "char" "continue" "do" "double" "exports" "false" "float" "for" "if" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "return" "short" "super" "switch" "synchronized" "this" "throw" "to" "transitive" "true" "try" "uses" "void" "while" "with" "{" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/newlocations/BasicTest.java
-(line 70,col 33) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/newlocations/Receivers.java
-(line 34,col 17) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/TargetTypes.java
-(line 94,col 19) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/annotations/typeAnnotations/TypeUseTarget.java
-(line 39,col 36) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
 
 openjdk/langtools/test/tools/javac/api/T6265137a.java
 (line 24,col 1) Parse error. Found <EOF>, expected one of  "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
@@ -177,7 +117,7 @@ openjdk/langtools/test/tools/javac/diags/examples/AnnotationMustBeNameValue.java
 (line 31,col 15) Parse error. Found ",", expected one of  "!=" "%" "&" "&&" ")" "*" "+" "-" "/" "<" "<=" "==" ">" ">=" "?" "^" "instanceof" "|" "||"
 
 openjdk/langtools/test/tools/javac/diags/examples/ArrayAndReceiver.java
-(line 30,col 12) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 30,col 29) Parse error. Found "[", expected one of  ")" ","
 
 openjdk/langtools/test/tools/javac/diags/examples/AssertAsIdentifier.java
 (line 28,col 5) Parse error. Found "assert", expected one of  "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
@@ -257,18 +197,6 @@ openjdk/langtools/test/tools/javac/diags/examples/IllegalUnderscore.java
 openjdk/langtools/test/tools/javac/diags/examples/IllegalUnicodeEscape.java
 (line 27,col 11) Parse error. Found <EOF>, expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-openjdk/langtools/test/tools/javac/diags/examples/IncorrectConstructorReceiverName.java
-(line 28,col 15) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-openjdk/langtools/test/tools/javac/diags/examples/IncorrectConstructorReceiverType.java
-(line 28,col 22) Parse error. Found ".", expected one of  ")" "," "@" "["
-
-openjdk/langtools/test/tools/javac/diags/examples/IncorrectReceiverName.java
-(line 28,col 22) Parse error. Found ".", expected one of  ")" "," "@" "["
-
-openjdk/langtools/test/tools/javac/diags/examples/IncorrectReceiverType.java
-(line 27,col 12) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
 openjdk/langtools/test/tools/javac/diags/examples/InterfaceNotAllowed.java
 (line 28,col 9) There is no such thing as a local interface.
 
@@ -317,9 +245,6 @@ openjdk/langtools/test/tools/javac/diags/examples/PrematureEOF.java
 openjdk/langtools/test/tools/javac/diags/examples/ProcessorWrongType/ProcessorWrongType.java
 (line 0,col 0) Parse error. Found  "clas" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-openjdk/langtools/test/tools/javac/diags/examples/ReceiverParameterNotApplicableConstructor.java
-(line 27,col 47) Parse error. Found "this", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
-
 openjdk/langtools/test/tools/javac/diags/examples/RepeatedModifier.java
 (line 27,col 12) Duplicated modifier
 
@@ -346,9 +271,6 @@ Lexical error at line 31, column 0.  Encountered: <EOF> after : ""
 
 openjdk/langtools/test/tools/javac/diags/examples/UnclosedStringLiteral.java
 Lexical error at line 27, column 21.  Encountered: "\n" (10), after : "\"abc;"
-
-openjdk/langtools/test/tools/javac/diags/examples/VarargsAndReceiver.java
-(line 27,col 30) Parse error. Found "this", expected one of  "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
 
 openjdk/langtools/test/tools/javac/Digits.java
 Lexical error at line 11, column 43.  Encountered: "\u0663" (1635), after : ""
@@ -464,9 +386,6 @@ openjdk/langtools/test/tools/javac/policy/test3/A.java
 openjdk/langtools/test/tools/javac/processing/6994946/SyntaxErrorTest.java
 (line 12,col 9) Parse error. Found "}", expected "("
 
-openjdk/langtools/test/tools/javac/processing/errors/CrashOnNonExistingAnnotation/Source.java
-(line 39,col 102) Parse error. Found ".", expected one of  ")" "," "@" "["
-
 openjdk/langtools/test/tools/javac/processing/errors/TestParseErrors/ParseErrors.java
 (line 37,col 36) Parse error. Found ",", expected one of  "..." "@" "exports" "module" "open" "opens" "provides" "requires" "to" "transitive" "uses" "with" <IDENTIFIER>
 
@@ -531,4 +450,4 @@ openjdk/langtools/test/tools/javadoc/sourceOption/p/A.java
 openjdk/langtools/test/tools/javadoc/T4994049/FileWithTabs.java
 Lexical error at line 25, column 1.  Encountered: "\\" (92), after : ""
 
-191 problems in 171 files
+164 problems in 144 files


### PR DESCRIPTION
Does not fix #806, but it's better than nothing.

Really lame implementation that simply accepts a parameter name like "A.B.this" and creates a parameter with a `SimpleName` of literally "A.B.this".

Why? Because doing it correctly would mean putting another node next to `Parameter` and that's too intrusive to do right now. It will be scheduled for 4.0.0. This PR simply makes JavaParser not fail on receiver parameters.