### PR TITLE
Support parsing generic type argument lists containing primitives

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java5Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java5Validator.java
@@ -3,6 +3,7 @@ package com.github.javaparser.ast.validator;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
+import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.Type;
 
 import java.util.Optional;
@@ -20,9 +21,23 @@ public class Java5Validator extends Java1_4Validator {
         }
     });
 
+    protected Validator noPrimitiveGenericArguments = new TreeVisitorValidator((node, reporter) -> {
+        if (node instanceof NodeWithTypeArguments) {
+            Optional<NodeList<Type>> typeArguments = ((NodeWithTypeArguments<? extends Node>) node).getTypeArguments();
+            if (typeArguments.isPresent()) {
+                typeArguments.get().forEach(ty -> {
+                    if (ty instanceof PrimitiveType) {
+                        reporter.report(node, "Type arguments may not be primitive.");
+                    }
+                });
+            }
+        }
+    });
+
     public Java5Validator() {
         super();
         replace(noGenerics, genericsWithoutDiamondOperator);
+        add(noPrimitiveGenericArguments);
         
         // TODO validate annotations on classes, fields and methods but nowhere else
         // The following is probably too simple.

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1476,7 +1476,7 @@ Type TypeArgument():
 {
  annotations = Annotations() 
  (
-   ret = ReferenceType()
+   ret = Type()
  |
    ret = Wildcard()
  )

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/type/TypeTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/type/TypeTest.java
@@ -1,9 +1,18 @@
 package com.github.javaparser.ast.type;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.validator.Java5Validator;
 import org.junit.Test;
 
 import static com.github.javaparser.JavaParser.parseVariableDeclarationExpr;
+import static com.github.javaparser.ParseStart.VARIABLE_DECLARATION_EXPR;
+import static com.github.javaparser.Providers.provider;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TypeTest {
     @Test
@@ -12,6 +21,26 @@ public class TypeTest {
         assertEquals("List<Long>", typeAsString("List<Long> x;"));
         assertEquals("String", typeAsString("@A String x;"));
         assertEquals("List<? extends Object>", typeAsString("List<? extends Object> x;"));
+    }
+
+    @Test(expected = ParseProblemException.class)
+    public void primitiveTypeArgumentDefaultValidator() {
+        typeAsString("List<long> x;");
+    }
+
+    @Test
+    public void primitiveTypeArgumentLenientValidator() {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setValidator(new Java5Validator() {{
+            remove(noPrimitiveGenericArguments);
+        }});
+
+        ParseResult<VariableDeclarationExpr> result = new JavaParser(config).parse(
+                VARIABLE_DECLARATION_EXPR, provider("List<long> x;"));
+        assertTrue(result.isSuccessful());
+
+        VariableDeclarationExpr decl = result.getResult().get();
+        assertEquals("List<long>", decl.getVariable(0).getType().asString());
     }
 
     private String typeAsString(String s) {

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java5ValidatorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java5ValidatorTest.java
@@ -139,4 +139,10 @@ public class Java5ValidatorTest {
         ParseResult<CompilationUnit> result = javaParser.parse(COMPILATION_UNIT, provider("import static x;import static x.*;import x.X;import x.*;"));
         assertNoProblems(result);
     }
+
+    @Test
+    public void noPrimitiveTypeArguments() {
+        ParseResult<CompilationUnit> result = javaParser.parse(COMPILATION_UNIT, provider("class X extends Y<int> {}"));
+        assertProblems(result, "(line 1,col 17) Type arguments may not be primitive.");
+    }
 }


### PR DESCRIPTION
Obviously these argument lists don't really have a meaning in current Java:

- They may be supported in the future
- Third party tools that extend Java in some way may be able to give this construct meaning so being able to parse it is useful for them
- JavaParser can already *write* source files that contain primitive types in type argument lists, it just can't *parse* the files that it writes