### PR TITLE
Fixes #907 allowing javadoc block parsing over multiple lines.

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -26,10 +26,10 @@ import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.utils.Utils;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.github.javaparser.utils.Utils.nextWord;
@@ -38,6 +38,9 @@ import static com.github.javaparser.utils.Utils.nextWord;
  * The class responsible for parsing the content of JavadocComments and produce JavadocDocuments.
  */
 class JavadocParser {
+
+    private static String BLOCK_TAG_PREFIX = "@";
+    private static Pattern BLOCK_PATTERN = Pattern.compile("^" + BLOCK_TAG_PREFIX, Pattern.MULTILINE);
 
     public static Javadoc parse(JavadocComment comment) {
         return parse(comment.getContent());
@@ -57,9 +60,15 @@ class JavadocParser {
             blockLines = Collections.emptyList();
         } else {
             descriptionText = trimRight(String.join("\n", cleanLines.subList(0, indexOfFirstBlockTag)));
-            blockLines = cleanLines.subList(indexOfFirstBlockTag, cleanLines.size()).stream()
-                    .filter(Utils.STRING_NOT_EMPTY)
-                    .collect(Collectors.toList());
+            String tagBlock = cleanLines.subList(indexOfFirstBlockTag, cleanLines.size())
+                .stream()
+                .collect(Collectors.joining("\n"));
+
+            blockLines = BLOCK_PATTERN
+                .splitAsStream(tagBlock)
+                .filter(Utils.STRING_NOT_EMPTY)
+                .map(s -> BLOCK_TAG_PREFIX + s.replace("\n", " ").trim())
+                .collect(Collectors.toList());
         }
         Javadoc document = new Javadoc(JavadocDescription.parseText(descriptionText));
         blockLines.forEach(l -> document.addBlockTag(parseBlockTag(l)));
@@ -74,7 +83,7 @@ class JavadocParser {
     }
 
     private static boolean isABlockLine(String line) {
-        return line.trim().startsWith("@");
+        return line.trim().startsWith(BLOCK_TAG_PREFIX);
     }
 
     private static String trimRight(String string) {

--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -60,10 +60,16 @@ class JavadocParser {
             blockLines = Collections.emptyList();
         } else {
             descriptionText = trimRight(String.join("\n", cleanLines.subList(0, indexOfFirstBlockTag)));
+
+            //Combine cleaned lines, but only starting with the first block tag till the end
+            //In this combined string it is easier to handle multiple lines which actually belong together
             String tagBlock = cleanLines.subList(indexOfFirstBlockTag, cleanLines.size())
                 .stream()
                 .collect(Collectors.joining("\n"));
 
+            //Split up the entire tag black again, considering now that some lines belong to the same block tag.
+            //The pattern used splits the block at each new line starting with the '@' symbol, thus the symbol
+            //then needs to be added again so that the block parsers handles everything correctly.
             blockLines = BLOCK_PATTERN
                 .splitAsStream(tagBlock)
                 .filter(Utils.STRING_NOT_EMPTY)

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
@@ -111,6 +111,26 @@ public class JavadocParserTest {
     }
 
     @Test
+    public void parseMultilineParamBlockTags() {
+        String text = "\n" +
+                "     * Add a field to this and automatically add the import of the type if needed\n" +
+                "     *\n" +
+                "     * @param typeClass the type of the field\n" +
+                "     * continued in a second line\n" +
+                "     * @param name the name of the field\n" +
+                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}\n" +
+                "     * @return the {@link FieldDeclaration} created\n" +
+                "     ";
+        Javadoc res = JavadocParser.parse(text);
+        assertEquals(new Javadoc(JavadocDescription.parseText("Add a field to this and automatically add the import of the type if needed"))
+                             .addBlockTag(JavadocBlockTag.createParamBlockTag("typeClass", "the type of the field continued in a second line"))
+                             .addBlockTag(JavadocBlockTag.createParamBlockTag("name", "the name of the field"))
+                             .addBlockTag(JavadocBlockTag.createParamBlockTag("modifiers", "the modifiers like {@link Modifier#PUBLIC}"))
+                             .addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.RETURN, "the {@link FieldDeclaration} created")), res);
+    }
+
+
+    @Test
     public void startsWithAsteriskEmpty() {
         assertEquals(-1, JavadocParser.startsWithAsterisk(""));
     }


### PR DESCRIPTION
Allows javadoc blocks to extend over multiple lines and parse them correctly as one block.