### PR TITLE
Make sure files are always generated with a unix end of line character.

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -35,6 +35,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmConditional;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmToken;
+import com.github.javaparser.utils.Utils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +47,7 @@ import static com.github.javaparser.GeneratedJavaParserConstants.*;
 import static com.github.javaparser.ast.observer.ObservableProperty.*;
 import static com.github.javaparser.printer.concretesyntaxmodel.CsmConditional.Condition.*;
 import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.*;
+import static com.github.javaparser.utils.Utils.*;
 
 /**
  * The Concrete Syntax Model for a single node type. It knows the syntax used to represent a certain element in Java
@@ -934,7 +936,7 @@ public class ConcreteSyntaxModel {
     }
 
     public static String genericPrettyPrint(Node node) {
-        SourcePrinter sourcePrinter = new SourcePrinter("    ");
+        SourcePrinter sourcePrinter = new SourcePrinter("    ", EOL);
         forClass(node.getClass()).prettyPrint(node, sourcePrinter);
         return sourcePrinter.getSource();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -53,7 +53,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
 
     public PrettyPrintVisitor(PrettyPrinterConfiguration prettyPrinterConfiguration) {
         configuration = prettyPrinterConfiguration;
-        printer = new SourcePrinter(configuration.getIndent());
+        printer = new SourcePrinter(configuration.getIndent(), configuration.getEndOfLineCharacter());
     }
 
     public String getSource() {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
@@ -23,9 +23,13 @@ package com.github.javaparser.printer;
 
 import java.util.function.Function;
 
+import static com.github.javaparser.utils.Utils.EOL;
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
 public class PrettyPrinterConfiguration {
     private boolean printComments = true;
     private String indent = "    ";
+    private String endOfLineCharacter = EOL;
     private Function<PrettyPrinterConfiguration, PrettyPrintVisitor> visitorFactory = PrettyPrintVisitor::new;
 
     public String getIndent() {
@@ -33,7 +37,7 @@ public class PrettyPrinterConfiguration {
     }
 
     public PrettyPrinterConfiguration setIndent(String indent) {
-        this.indent = indent;
+        this.indent = assertNotNull(indent);
         return this;
     }
 
@@ -51,7 +55,16 @@ public class PrettyPrinterConfiguration {
     }
 
     public PrettyPrinterConfiguration setVisitorFactory(Function<PrettyPrinterConfiguration, PrettyPrintVisitor> visitorFactory) {
-        this.visitorFactory = visitorFactory;
+        this.visitorFactory = assertNotNull(visitorFactory);
+        return this;
+    }
+
+    public String getEndOfLineCharacter() {
+        return endOfLineCharacter;
+    }
+
+    public PrettyPrinterConfiguration setEndOfLineCharacter(String endOfLineCharacter) {
+        this.endOfLineCharacter = assertNotNull(endOfLineCharacter);
         return this;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
@@ -21,16 +21,16 @@
 
 package com.github.javaparser.printer;
 
-import static com.github.javaparser.utils.Utils.EOL;
-
 public class SourcePrinter {
     private final String indentation;
+    private final String endOfLineCharacter;
     private int level = 0;
     private boolean indented = false;
     private final StringBuilder buf = new StringBuilder();
 
-    SourcePrinter(final String indentation) {
+    SourcePrinter(final String indentation, final String endOfLineCharacter) {
         this.indentation = indentation;
+        this.endOfLineCharacter = endOfLineCharacter;
     }
 
     public SourcePrinter indent() {
@@ -65,7 +65,7 @@ public class SourcePrinter {
     }
 
     public SourcePrinter println() {
-        buf.append(EOL);
+        buf.append(endOfLineCharacter);
         indented = false;
         return this;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.printer.PrettyPrinter;
+import com.github.javaparser.printer.PrettyPrinterConfiguration;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -129,7 +130,7 @@ public class SourceRoot {
 
     private void save(CompilationUnit cu, Path path) throws IOException {
         Files.createDirectories(path.getParent());
-        final String code = new PrettyPrinter().print(cu);
+        final String code = new PrettyPrinter(new PrettyPrinterConfiguration().setEndOfLineCharacter("\n")).print(cu);
         Files.write(path, code.getBytes(UTF8));
     }
 


### PR DESCRIPTION
Adds an option to the pretty printer to set the end of line character, and makes `SourceRoot` always use `\n`. This way files should always be generated with the same EOL character.

The other PR will change this code around again.