### PR TITLE
Add next and previous token links to JavaToken

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
@@ -21,22 +21,21 @@
 
 package com.github.javaparser;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * A token from a parsed source file.
  * (Awkwardly named "Java"Token since JavaCC already generates an internal class Token.)
  */
 public class JavaToken {
-    public final Range range;
-    public final int kind;
-    public final String text;
+    private final Range range;
+    private final int kind;
+    private final String text;
+    private final Optional<JavaToken> previousToken;
+    private Optional<JavaToken> nextToken = Optional.empty();
 
-    public JavaToken(Range range, int kind, String text) {
-        this.range = range;
-        this.kind = kind;
-        this.text = text;
-    }
-
-    public JavaToken(Token token) {
+    public JavaToken(Token token, List<JavaToken> tokens) {
         Range range = Range.range(token.beginLine, token.beginColumn, token.endLine, token.endColumn);
         String text = token.image;
 
@@ -82,6 +81,13 @@ public class JavaToken {
         this.range = range;
         this.kind = token.kind;
         this.text = text;
+        if (!tokens.isEmpty()) {
+            final JavaToken previousToken = tokens.get(tokens.size() - 1);
+            this.previousToken = Optional.of(previousToken);
+            previousToken.nextToken = Optional.of(this);
+        } else {
+            previousToken = Optional.empty();
+        }
     }
 
     public Range getRange() {
@@ -94,6 +100,14 @@ public class JavaToken {
 
     public String getText() {
         return text;
+    }
+
+    public Optional<JavaToken> getNextToken() {
+        return nextToken;
+    }
+
+    public Optional<JavaToken> getPreviousToken() {
+        return previousToken;
     }
 
     @Override

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -190,7 +190,7 @@ TOKEN_MGR_DECLS :
         if(token.specialToken!=null) {
             CommonTokenAction(token.specialToken);
         }
-        token.javaToken = new JavaToken(token);
+        token.javaToken = new JavaToken(token, tokens);
         tokens.add(token.javaToken);
 
         String commentText = token.image;

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaTokenTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaTokenTest.java
@@ -31,6 +31,7 @@ import static com.github.javaparser.GeneratedJavaParserConstants.*;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.Range.range;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class JavaTokenTest {
 
@@ -40,11 +41,11 @@ public class JavaTokenTest {
         List<JavaToken> tokens = result.getTokens().get();
         Iterator<JavaToken> iterator = tokens.iterator();
         assertToken("1", range(1, 1, 1, 1), INTEGER_LITERAL, iterator.next());
-        assertToken(" ", range(1, 2, 1, 2), 1, iterator.next());
+        assertToken(" ", range(1, 2, 1, 2), SPACE, iterator.next());
         assertToken("+", range(1, 3, 1, 3), PLUS, iterator.next());
         assertToken("/*2*/", range(1, 4, 1, 8), MULTI_LINE_COMMENT, iterator.next());
         assertToken("1", range(1, 9, 1, 9), INTEGER_LITERAL, iterator.next());
-        assertToken(" ", range(1, 10, 1, 10), 1, iterator.next());
+        assertToken(" ", range(1, 10, 1, 10), SPACE, iterator.next());
         assertToken("", range(1, 10, 1, 10), EOF, iterator.next());
         assertEquals(false, iterator.hasNext());
     }
@@ -53,5 +54,8 @@ public class JavaTokenTest {
         assertEquals(image, token.getText());
         assertEquals(range, token.getRange());
         assertEquals(kind, token.getKind());
+        token.getNextToken().ifPresent(nt -> assertEquals(token, nt.getPreviousToken().get()));
+        token.getPreviousToken().ifPresent(pt -> assertEquals(token, pt.getNextToken().get()));
+        assertTrue(token.getNextToken().isPresent() || token.getPreviousToken().isPresent());
     }
 }


### PR DESCRIPTION
This gives an alternative way to traverse the tokens. Before, finding the next or previous token would involve getting access to the token list, finding the position of the current token, then accessing that position minus or plus one, while checking for bounds. Now it's just asking for `nextToken` or `previousToken`.