### PR TITLE
Fix issue 866: LexicalPreservingPrinter: Unsupported operation - remove

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -60,6 +60,9 @@ public class ConcreteSyntaxModel {
         return list(ObservableProperty.MODIFIERS, space(), none(), space());
     }
 
+    /**
+     * Build a mix collecting all the elements specified.
+     */
     private static CsmElement mix(CsmElement... elements) {
         return new CsmMix(Arrays.asList(elements));
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -34,13 +34,11 @@ import com.github.javaparser.ast.type.*;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmConditional;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
+import com.github.javaparser.printer.concretesyntaxmodel.CsmMix;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmToken;
 import com.github.javaparser.utils.Utils;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.github.javaparser.GeneratedJavaParserConstants.*;
@@ -60,6 +58,10 @@ public class ConcreteSyntaxModel {
 
     private static CsmElement modifiers() {
         return list(ObservableProperty.MODIFIERS, space(), none(), space());
+    }
+
+    private static CsmElement mix(CsmElement... elements) {
+        return new CsmMix(Arrays.asList(elements));
     }
 
     private static CsmElement memberAnnotations() {
@@ -208,8 +210,7 @@ public class ConcreteSyntaxModel {
         concreteSyntaxModelByClass.put(MethodDeclaration.class, sequence(
                 orphanCommentsBeforeThis(),
                 comment(),
-                memberAnnotations(),
-                modifiers(),
+                mix(memberAnnotations(), modifiers()),
                 typeParameters(),
                 child(ObservableProperty.TYPE),
                 space(),

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
@@ -74,6 +74,8 @@ public class CsmAttribute implements CsmElement {
                 }
                 throw new UnsupportedOperationException("getTokenType does not know how to handle value for "
                         + node.getClass().getCanonicalName());
+            case NAME:
+                return GeneratedJavaParserConstants.IDENTIFIER;
             default:
                 throw new UnsupportedOperationException("getTokenType does not know how to handle property "
                         + property + " with text: " + text);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
@@ -72,13 +72,10 @@ public class CsmAttribute implements CsmElement {
                 if (node instanceof IntegerLiteralExpr) {
                     return GeneratedJavaParserConstants.INTEGER_LITERAL;
                 }
-                throw new UnsupportedOperationException("getTokenType does not know how to handle value for "
-                        + node.getClass().getCanonicalName());
             case NAME:
                 return GeneratedJavaParserConstants.IDENTIFIER;
-            default:
-                throw new UnsupportedOperationException("getTokenType does not know how to handle property "
-                        + property + " with text: " + text);
         }
+        throw new UnsupportedOperationException("getTokenType does not know how to handle property "
+                + property + " with text: " + text);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
@@ -23,6 +23,7 @@ package com.github.javaparser.printer.concretesyntaxmodel;
 
 import com.github.javaparser.GeneratedJavaParserConstants;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.printer.SourcePrinter;
 
@@ -43,7 +44,7 @@ public class CsmAttribute implements CsmElement {
         printer.print(PrintingHelper.printToString(value));
     }
 
-    public int getTokenType(String text) {
+    public int getTokenType(Node node, String text) {
         if (property == ObservableProperty.IDENTIFIER) {
             return GeneratedJavaParserConstants.IDENTIFIER;
         }
@@ -53,6 +54,20 @@ public class CsmAttribute implements CsmElement {
                     return i;
                 }
             }
+        }
+        if (property == ObservableProperty.OPERATOR) {
+            try {
+                return (Integer)(GeneratedJavaParserConstants.class.getDeclaredField(text).get(null));
+            } catch (IllegalAccessException|NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        if (property == ObservableProperty.VALUE) {
+            if (node instanceof IntegerLiteralExpr) {
+                return GeneratedJavaParserConstants.INTEGER_LITERAL;
+            }
+            throw new UnsupportedOperationException("getTokenType does not know how to handle value for "
+                    + node.getClass().getCanonicalName());
         }
         throw new UnsupportedOperationException(property.name()+ " " + text);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmIndent.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmIndent.java
@@ -30,4 +30,14 @@ public class CsmIndent implements CsmElement {
     public void prettyPrint(Node node, SourcePrinter printer) {
         printer.indent();
     }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof CsmIndent;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmMix.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmMix.java
@@ -4,6 +4,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.printer.SourcePrinter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A group of elements that could be in any order.
@@ -46,6 +47,6 @@ public class CsmMix implements CsmElement {private List<CsmElement> elements;
 
     @Override
     public String toString() {
-        return "CsmMix[" + String.join(", ",elements.stream().map(e -> elements.toString()).toString()) + "]";
+        return "CsmMix[" + String.join(", ",elements.stream().map(e -> elements.toString()).collect(Collectors.toList())) + "]";
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmMix.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmMix.java
@@ -1,0 +1,53 @@
+package com.github.javaparser.printer.concretesyntaxmodel;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.printer.SourcePrinter;
+
+import java.util.List;
+
+/**
+ * A group of elements that could be in any order.
+ */
+public class CsmMix implements CsmElement {private List<CsmElement> elements;
+
+    public CsmMix(List<CsmElement> elements) {
+        if (elements == null) {
+            throw new NullPointerException();
+        }
+        if (elements.stream().filter(e -> e == null).findAny().isPresent()) {
+            throw new IllegalArgumentException("Null element in the mix");
+        }
+        this.elements = elements;
+    }
+
+    public List<CsmElement> getElements() {
+        return elements;
+    }
+
+    @Override
+    public void prettyPrint(Node node, SourcePrinter printer) {
+        printer.print("mix[");
+        elements.forEach(e -> e.prettyPrint(node, printer));
+        printer.print("]");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CsmMix csmMix = (CsmMix) o;
+
+        return elements != null ? elements.equals(csmMix.elements) : csmMix.elements == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return elements != null ? elements.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "CsmMix[" + String.join(", ",elements.stream().map(e -> elements.toString()).toString()) + "]";
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmMix.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmMix.java
@@ -26,9 +26,7 @@ public class CsmMix implements CsmElement {private List<CsmElement> elements;
 
     @Override
     public void prettyPrint(Node node, SourcePrinter printer) {
-        printer.print("mix[");
         elements.forEach(e -> e.prettyPrint(node, printer));
-        printer.print("]");
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmString.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmString.java
@@ -38,4 +38,10 @@ public class CsmString implements CsmElement {
         printer.print(property.getValueAsStringAttribute(node));
         printer.print("\"");
     }
+
+    @Override
+    public String toString() {
+        return String.format("CsmString(property:%s)", property);
+    }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
@@ -111,4 +111,8 @@ public class CsmToken implements CsmElement {
     public boolean isWhiteSpace() {
         return TokenTypes.isWhitespace(tokenType);
     }
+
+    public boolean isNewLine() {
+        return TokenTypes.isEndOfLineCharacter(tokenType);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmUnindent.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmUnindent.java
@@ -30,4 +30,14 @@ public class CsmUnindent implements CsmElement {
     public void prettyPrint(Node node, SourcePrinter printer) {
         printer.unindent();
     }
+
+    @Override
+    public int hashCode() {
+        return 2;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof CsmUnindent;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
@@ -102,4 +102,8 @@ class ChildTextElement extends TextElement {
         return child instanceof Comment;
     }
 
+    @Override
+    public boolean isChild(Class<? extends Node> nodeClass) {
+        return nodeClass.isInstance(child);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
@@ -103,7 +103,7 @@ class ChildTextElement extends TextElement {
     }
 
     @Override
-    public boolean isChild(Class<? extends Node> nodeClass) {
+    public boolean isChildOfClass(Class<? extends Node> nodeClass) {
         return nodeClass.isInstance(child);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -830,6 +830,15 @@ public class Difference {
                         elements.add(diffElIterator++, new Added(elementToAdd));
                     }
 
+                    // Check if the last thing we added is a space
+                    //if (diffElIterator > startIndex
+                    //        && elements.get(diffElIterator - 1).isAdded()
+                    //        && elements.get(diffElIterator - 1).getElement() instanceof TokenTextElement
+                    //        && ((TokenTextElement)elements.get(diffElIterator - 1).getElement()).isWhiteSpace()) {
+                    //
+                    //}
+                    int v= 0;
+
                 } else {
                     throw new UnsupportedOperationException("" + diffEl + " vs " + nodeTextEl);
                 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -351,66 +351,12 @@ public class Difference {
                 CsmElement nextAfter = after.elements.get(afterIndex);
 
                 if ((nextOriginal instanceof CsmMix) && (nextAfter instanceof CsmMix)) {
-//                    List<CsmElement> elementsInOriginalMix = new LinkedList<>(((CsmMix) nextOriginal).getElements());
-//                    List<CsmElement> elementsInAfterMix = new LinkedList<>(((CsmMix) nextAfter).getElements());
-//
-//                    int[] indexOfCorrespondingAfterElementForOriginalElement = new int[elementsInOriginalMix.size()];
-//                    int[] indexOfCorrespondingOriginalElementForAfterElement = new int[elementsInAfterMix.size()];
-//
-//                    Arrays.fill(indexOfCorrespondingAfterElementForOriginalElement, -1);
-//                    Arrays.fill(indexOfCorrespondingOriginalElementForAfterElement, -1);
-//
-//                    for (int i=0;i<elementsInOriginalMix.size();i++) {
-//                        boolean found = false;
-//                        for (int j=0;j<elementsInAfterMix.size() && !found;j++) {
-//                            if (indexOfCorrespondingOriginalElementForAfterElement[j] == -1
-//                                    && matching(elementsInOriginalMix.get(i), elementsInAfterMix.get(j))) {
-//                                indexOfCorrespondingOriginalElementForAfterElement[j] = i;
-//                                indexOfCorrespondingAfterElementForOriginalElement[i] = j;
-//                            }
-//                        }
-//                    }
-//
-//                    int startingPointForMix = elements.size();
-//
-//                    for (CsmElement el : elementsInOriginalMix) {
-//                        // if we find a match in the after mix then it is kept
-//                        boolean found = false;
-//                        for (int i=0;i<elementsInAfterMix.size() && !found;i++) {
-//                            found = matching(el, elementsInAfterMix.get(i));
-//                        }
-//                        if (found) {
-//                            elements.add(new Kept(el));
-//                        } else {
-//                            elements.add(new Removed(el));
-//                        }
-//                    }
-//
-//                    for (int j=0;j<elementsInAfterMix.size();j++) {
-//                        if (indexOfCorrespondingOriginalElementForAfterElement[j] == -1) {
-//                            // if it is followed by any original element we will keep it just in front of it
-//                            int elementToPreceed = -1;
-//                            for (int k=j+1;k<elementsInAfterMix.size() && elementToPreceed == -1;k++) {
-//                                if (indexOfCorrespondingOriginalElementForAfterElement[k] != -1) {
-//                                    elementToPreceed = k;
-//                                    elements.add(startingPointForMix + indexOfCorrespondingOriginalElementForAfterElement[k], new Added(elementsInAfterMix.get(j)));
-//                                    // we need also to update all index refering to after this point
-//                                    for (int z=0;z<elementsInAfterMix.size();z++) {
-//                                        if (indexOfCorrespondingOriginalElementForAfterElement[z] >= indexOfCorrespondingOriginalElementForAfterElement[k]) {
-//                                            indexOfCorrespondingOriginalElementForAfterElement[z] += 1;
-//                                        }
-//                                    }
-//                                }
-//                            }
-//                            if (elementToPreceed == -1) {
-//                                elements.add(new Added(elementsInAfterMix.get(j)));
-//                            }
-//                        }
-//                    }
-//
-//                    originalIndex++;
-//                    afterIndex++;
-                    elements.add(new Reshuffled((CsmMix)nextOriginal, (CsmMix)nextAfter));
+                    if (((CsmMix) nextAfter).getElements().equals(((CsmMix) nextOriginal).getElements())) {
+                        // No reason to deal with a reshuffled, we are just going to keep everything as it is
+                        ((CsmMix) nextAfter).getElements().forEach(el -> elements.add(new Kept(el)));
+                    } else {
+                        elements.add(new Reshuffled((CsmMix)nextOriginal, (CsmMix)nextAfter));
+                    }
                     originalIndex++;
                     afterIndex++;
                 } else if (matching(nextOriginal, nextAfter)) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -693,6 +693,16 @@ public class Difference {
                             if (diffIndex + 1 >= this.getElements().size() || !(this.getElements().get(diffIndex + 1) instanceof Added)) {
                                 nodeTextIndex = considerEnforcingIndentation(nodeText, nodeTextIndex);
                             }
+                            // If in front we have one space and before also we had space let's drop one space
+                            if (nodeText.getElements().size() > nodeTextIndex && nodeTextIndex > 0) {
+                                if (nodeText.getElements().get(nodeTextIndex).isWhiteSpace()
+                                        && nodeText.getElements().get(nodeTextIndex - 1).isWhiteSpace()) {
+                                    // However we do not want to do that when we are doing a replacement
+                                    if ((diffIndex + 1 )== this.elements.size() || !(elements.get(diffIndex +1 ) instanceof Added)) {
+                                        nodeText.getElements().remove(nodeTextIndex--);
+                                    }
+                                }
+                            }
                         }
                         diffIndex++;
                     } else if ((removed.element instanceof CsmToken) && nodeTextEl instanceof TokenTextElement

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -19,7 +19,7 @@ import static com.github.javaparser.GeneratedJavaParserConstants.*;
  */
 public class Difference {
 
-    private int STANDARD_INDENTATION_SIZE = 4;
+    public static int STANDARD_INDENTATION_SIZE = 4;
 
     private List<DifferenceElement> elements;
 
@@ -373,10 +373,10 @@ public class Difference {
      * to the difference (adding and removing the elements provided).
      */
     void apply(NodeText nodeText, Node node) {
-        List<TokenTextElement> indentation = nodeText.getLexicalPreservingPrinter().findIndentation(node);
         if (nodeText == null) {
             throw new NullPointerException();
         }
+        List<TokenTextElement> indentation = nodeText.getLexicalPreservingPrinter().findIndentation(node);
         int diffIndex = 0;
         int nodeTextIndex = 0;
         do {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -637,8 +637,7 @@ public class Difference {
         List<TextElement> indentationAdj = processIndentation(indentation, nodeText.getElements().subList(0, nodeTextIndex - 1));
         if (nodeTextIndex < nodeText.getElements().size() && nodeText.getElements().get(nodeTextIndex).isToken(RBRACE)) {
             indentationAdj = indentationAdj.subList(0, indentationAdj.size() - Math.min(STANDARD_INDENTATION_SIZE, indentationAdj.size()));
-        }
-        if (followedByUnindent) {
+        } else if (followedByUnindent) {
             indentationAdj = indentationAdj.subList(0, Math.max(0, indentationAdj.size() - STANDARD_INDENTATION_SIZE));
         }
         for (TextElement e : indentationAdj) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -779,27 +779,6 @@ public class Difference {
                         }
                     }
 
-
-
-                    //Map<Integer, List<CsmElement>> elementsToAddBeforeGivenNodeTextIndex = new HashMap<>();
-                    //List<CsmElement> elementsToBeAddedAtTheEnd = new LinkedList<>();
-                    //Set<Integer> nodeTextElementsToKeep = new HashSet<>();
-
-                    // Let's figure out which ones of the existing tokens are going to be removed
-
-                    // Now I should translate all of this to a sequence of additions and deletions
-                    // and then just add these differences to the diff to be treated normally
-
-//                    // Now let's understand how the new elements are positioned w.r.t. to the kept elements
-//                    if (nodeTextIndexOfPreviousElements.isEmpty()) {
-//                        // They are all just following the sequence in the new mix
-//                        for (CsmElement csmElement : reshuffled.getElement().getElements()) {
-//                            nodeText.addElement(nodeTextIndex++, toTextElement());
-//                        }
-//                    } else {
-//                        throw new UnsupportedOperationException();
-//                    }
-
                     // We go over the original node text elements, in the order they appear in the NodeText.
                     // Considering an original node text element (ONE)
                     // * we verify if it corresponds to a CSM element. If it does not we just move on, otherwise

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -21,16 +21,12 @@ import static com.github.javaparser.GeneratedJavaParserConstants.*;
  */
 public class Difference {
 
-    public static int STANDARD_INDENTATION_SIZE = 4;
+    private static int STANDARD_INDENTATION_SIZE = 4;
 
     private List<DifferenceElement> elements;
 
     private Difference(List<DifferenceElement> elements) {
         this.elements = elements;
-    }
-
-    public void removeIndentationElements() {
-        elements.removeIf(el -> el.getElement() instanceof CsmIndent || el.getElement() instanceof CsmUnindent);
     }
 
     interface DifferenceElement {
@@ -46,6 +42,9 @@ public class Difference {
             return new Kept(element);
         }
 
+        /**
+         * Return the CsmElement considered in this DifferenceElement.
+         */
         CsmElement getElement();
 
         boolean isAdded();
@@ -309,22 +308,6 @@ public class Difference {
                 CsmElement nextOriginal = original.elements.get(originalIndex);
                 CsmElement nextAfter = after.elements.get(afterIndex);
 
-                // FIXME
-//                if (nextOriginal instanceof CsmIndent || nextOriginal instanceof CsmUnindent) {
-//                    originalIndex++;
-//                    continue;
-//                }
-//                if (nextAfter instanceof CsmIndent) {
-//                    for (int i=0;i<STANDARD_INDENTATION_SIZE;i++) {
-//                        elements.add(new Added(CsmElement.space()));
-//                    }
-//                    continue;
-//                }
-//                if (nextAfter instanceof CsmUnindent) {
-//                    afterIndex++;
-//                    continue;
-//                }
-
                 if (matching(nextOriginal, nextAfter)) {
                     elements.add(new Kept(nextOriginal));
                     originalIndex++;
@@ -584,10 +567,10 @@ public class Difference {
                     } else if ((kept.element instanceof CsmToken) && ((CsmToken) kept.element).isWhiteSpace()) {
                         diffIndex++;
                     } else if (kept.element instanceof CsmIndent) {
-                        // FIXME
+                        // Nothing to do
                         diffIndex++;
                     } else if (kept.element instanceof CsmUnindent) {
-                        // FIXME
+                        // Nothing to do
                         diffIndex++;
                     } else {
                         throw new UnsupportedOperationException("kept " + kept.element + " vs " + nodeTextEl);
@@ -681,5 +664,13 @@ public class Difference {
 
     public List<DifferenceElement> getElements() {
         return elements;
+    }
+
+    /**
+     * Remove from the difference all the elements related to indentation.
+     * This is mainly intended for test purposes.
+     */
+    void removeIndentationElements() {
+        elements.removeIf(el -> el.getElement() instanceof CsmIndent || el.getElement() instanceof CsmUnindent);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -87,6 +87,10 @@ public class Difference {
         }
     }
 
+    /**
+     * Elements in a CsmMix have been reshuffled. It could also mean that
+     * some new elements have been added or removed to the mix.
+     */
     private static class Reshuffled implements DifferenceElement {
         CsmMix previousOrder;
         CsmMix element;
@@ -621,7 +625,7 @@ public class Difference {
                         // Nothing to do
                         diffIndex++;
                     } else if (kept.element instanceof CsmUnindent) {
-                        // Nothing to do
+                        // Nothing to do, beside considering indentation
                         diffIndex++;
                         for (int i = 0; i < STANDARD_INDENTATION_SIZE && nodeTextIndex >= 1 && nodeText.getTextElement(nodeTextIndex - 1).isSpaceOrTab(); i++) {
                             nodeText.removeElement(--nodeTextIndex);
@@ -775,16 +779,6 @@ public class Difference {
                     for (CsmElement elementToAdd : elementsToBeAddedAtTheEnd) {
                         elements.add(diffElIterator++, new Added(elementToAdd));
                     }
-
-                    // Check if the last thing we added is a space
-                    //if (diffElIterator > startIndex
-                    //        && elements.get(diffElIterator - 1).isAdded()
-                    //        && elements.get(diffElIterator - 1).getElement() instanceof TokenTextElement
-                    //        && ((TokenTextElement)elements.get(diffElIterator - 1).getElement()).isWhiteSpace()) {
-                    //
-                    //}
-                    int v= 0;
-
                 } else {
                     throw new UnsupportedOperationException("" + diffEl + " vs " + nodeTextEl);
                 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -572,6 +572,9 @@ public class Difference {
                     } else if (kept.element instanceof CsmUnindent) {
                         // Nothing to do
                         diffIndex++;
+                        for (int i=0;i<STANDARD_INDENTATION_SIZE && nodeTextIndex>=1 && nodeText.getTextElement(nodeTextIndex-1).isSpaceOrTab();i++) {
+                            nodeText.removeElement(--nodeTextIndex);
+                        }
                     } else {
                         throw new UnsupportedOperationException("kept " + kept.element + " vs " + nodeTextEl);
                     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -542,7 +542,7 @@ public class Difference {
                         boolean followedByUnindent = (diffIndex + 1) < elements.size()
                                 && elements.get(diffIndex + 1).isAdded()
                                 && elements.get(diffIndex + 1).getElement() instanceof CsmUnindent;
-                        nodeTextIndex = adjustIndentation(indentation, nodeText, nodeTextIndex, followedByUnindent && !addedIndentation);
+                        nodeTextIndex = adjustIndentation(indentation, nodeText, nodeTextIndex, followedByUnindent/* && !addedIndentation*/);
                     }
                     diffIndex++;
                 } else if (diffEl instanceof Kept) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -643,8 +643,8 @@ public class Difference {
                             if (nodeText.getElements().size() > nodeTextIndex && nodeTextIndex > 0) {
                                 if (nodeText.getElements().get(nodeTextIndex).isWhiteSpace()
                                         && nodeText.getElements().get(nodeTextIndex - 1).isWhiteSpace()) {
-                                    // However we do not want to do that when we are doing a replacement
-                                    if ((diffIndex + 1 )== this.elements.size() || !(elements.get(diffIndex +1 ) instanceof Added)) {
+                                    // However we do not want to do that when we are about to adding or removing elements
+                                    if ((diffIndex + 1 )== this.elements.size() || (elements.get(diffIndex +1 ) instanceof Kept)) {
                                         nodeText.getElements().remove(nodeTextIndex--);
                                     }
                                 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -819,6 +819,7 @@ public class Difference {
                     for (CsmElement elementToAdd : elementsToBeAddedAtTheEnd) {
                         elements.add(diffElIterator++, new Added(elementToAdd));
                     }
+
                 } else {
                     throw new UnsupportedOperationException("" + diffEl + " vs " + nodeTextEl);
                 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.Printable;
@@ -223,15 +224,18 @@ class LexicalDifferenceCalculator {
         } else if (csm instanceof CsmUnindent) {
             elements.add(csm);
         } else if (csm instanceof CsmAttribute) {
-            CsmAttribute csmAttribute = (CsmAttribute)csm;
+            CsmAttribute csmAttribute = (CsmAttribute) csm;
             Object value = change.getValue(csmAttribute.getProperty(), node);
             String text = value.toString();
             if (value instanceof Printable) {
-                text = ((Printable)value).asString();
+                text = ((Printable) value).asString();
             }
             elements.add(new CsmToken(csmAttribute.getTokenType(node, value.toString()), text));
+        } else if ((csm instanceof CsmString) && (node instanceof StringLiteralExpr)) {
+            elements.add(new CsmToken(GeneratedJavaParserConstants.STRING_LITERAL,
+                    "\"" + ((StringLiteralExpr) node).getValue() + "\""));
         } else {
-            throw new UnsupportedOperationException(csm.getClass().getSimpleName());
+            throw new UnsupportedOperationException(csm.getClass().getSimpleName()+ " " + csm);
         }
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -154,8 +154,19 @@ class LexicalDifferenceCalculator {
         } else if (csm instanceof CsmList) {
             CsmList csmList = (CsmList) csm;
             if (csmList.getProperty().isAboutNodes()) {
-                NodeList nodeList = (NodeList)change.getValue(csmList.getProperty(), node);
-                if (!nodeList.isEmpty()) {
+                Object rawValue = change.getValue(csmList.getProperty(), node);
+                NodeList nodeList = null;
+                if (rawValue instanceof NodeList) {
+                    nodeList = (NodeList)rawValue;
+                } else if (rawValue instanceof Optional) {
+                    Optional optional = (Optional)rawValue;
+                    if (optional.isPresent()) {
+                        nodeList = (NodeList)optional.get();
+                    }
+                } else {
+                    throw new IllegalStateException("Expected Optional or NodeList, found " + rawValue);
+                }
+                if (nodeList != null && !nodeList.isEmpty()) {
                     calculatedSyntaxModelForNode(csmList.getPreceeding(), node, elements, change);
                     for (int i = 0; i < nodeList.size(); i++) {
                         if (i != 0) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
+import com.github.javaparser.printer.Printable;
 import com.github.javaparser.printer.SourcePrinter;
 import com.github.javaparser.printer.concretesyntaxmodel.*;
 import com.github.javaparser.printer.lexicalpreservation.changes.*;
@@ -220,7 +221,11 @@ class LexicalDifferenceCalculator {
         } else if (csm instanceof CsmAttribute) {
             CsmAttribute csmAttribute = (CsmAttribute)csm;
             Object value = change.getValue(csmAttribute.getProperty(), node);
-            elements.add(new CsmToken(csmAttribute.getTokenType(value.toString()), value.toString()));
+            String text = value.toString();
+            if (value instanceof Printable) {
+                text = ((Printable)value).asString();
+            }
+            elements.add(new CsmToken(csmAttribute.getTokenType(node, value.toString()), text));
         } else {
             throw new UnsupportedOperationException(csm.getClass().getSimpleName());
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -44,6 +44,10 @@ class LexicalDifferenceCalculator {
         public CalculatedSyntaxModel sub(int start, int end) {
             return new CalculatedSyntaxModel(elements.subList(start, end));
         }
+
+        public void removeIndentationElements() {
+            elements.removeIf(el -> el instanceof CsmIndent || el instanceof CsmUnindent);
+        }
     }
 
     static class CsmChild implements CsmElement {
@@ -215,9 +219,9 @@ class LexicalDifferenceCalculator {
                 calculatedSyntaxModelForNode(csmConditional.getElseElement(), node, elements, change);
             }
         } else if (csm instanceof CsmIndent) {
-            //elements.add(csm);
+            elements.add(csm);
         } else if (csm instanceof CsmUnindent) {
-            //elements.add(csm);
+            elements.add(csm);
         } else if (csm instanceof CsmAttribute) {
             CsmAttribute csmAttribute = (CsmAttribute)csm;
             Object value = change.getValue(csmAttribute.getProperty(), node);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -234,6 +234,11 @@ class LexicalDifferenceCalculator {
         } else if ((csm instanceof CsmString) && (node instanceof StringLiteralExpr)) {
             elements.add(new CsmToken(GeneratedJavaParserConstants.STRING_LITERAL,
                     "\"" + ((StringLiteralExpr) node).getValue() + "\""));
+        } else if (csm instanceof CsmMix) {
+            CsmMix csmMix = (CsmMix)csm;
+            List<CsmElement> mixElements = new LinkedList<>();
+            csmMix.getElements().forEach(e -> calculatedSyntaxModelForNode(e, node, mixElements, change));
+            elements.add(new CsmMix(mixElements));
         } else {
             throw new UnsupportedOperationException(csm.getClass().getSimpleName()+ " " + csm);
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -328,7 +328,6 @@ public class LexicalPreservingPrinter {
     private NodeText interpret(Node node, CsmElement csm) {
         LexicalDifferenceCalculator.CalculatedSyntaxModel calculatedSyntaxModel = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(csm, node);
 
-        // TODO inject indentation after newlines
         List<TokenTextElement> indentation = findIndentation(node);
 
         NodeText nodeText = new NodeText(this);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -24,6 +24,8 @@ package com.github.javaparser.printer.lexicalpreservation;
 import com.github.javaparser.*;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.observer.AstObserver;
@@ -333,6 +335,17 @@ public class LexicalPreservingPrinter {
                 nodeText.addToken(((CsmToken) element).getTokenType(), ((CsmToken) element).getContent(node));
             } else {
                 throw new UnsupportedOperationException(element.getClass().getSimpleName());
+            }
+        }
+        // Array brackets are a pain... we do not have a way to represent them explicitly in the AST
+        // so they have to be handled in a special way
+        if (node instanceof VariableDeclarator) {
+            VariableDeclarator variableDeclarator = (VariableDeclarator)node;
+            FieldDeclaration fieldDeclaration = (FieldDeclaration)variableDeclarator.getParentNode().get();
+            int extraArrayLevels = variableDeclarator.getType().getArrayLevel() - fieldDeclaration.getMaximumCommonType().getArrayLevel();
+            for (int i=0; i<extraArrayLevels; i++) {
+                nodeText.addElement(new TokenTextElement(GeneratedJavaParserConstants.LBRACKET));
+                nodeText.addElement(new TokenTextElement(GeneratedJavaParserConstants.RBRACKET));
             }
         }
         return nodeText;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -161,7 +161,7 @@ public class LexicalPreservingPrinter {
 
             @Override
             public void concreteListChange(NodeList changedList, ListChangeType type, int index, Node nodeAddedOrRemoved) {
-                NodeText nodeText = lpp.getTextForNode(changedList.getParentNodeForChildren());
+                NodeText nodeText = lpp.getOrCreateNodeText(changedList.getParentNodeForChildren());
                 if (type == ListChangeType.REMOVAL) {
                     new LexicalDifferenceCalculator().calculateListRemovalDifference(findNodeListName(changedList), changedList, index, nodeAddedOrRemoved).apply(nodeText, changedList.getParentNodeForChildren());
                 } else if (type == ListChangeType.ADDITION) {
@@ -327,6 +327,9 @@ public class LexicalPreservingPrinter {
 
     private NodeText interpret(Node node, CsmElement csm) {
         LexicalDifferenceCalculator.CalculatedSyntaxModel calculatedSyntaxModel = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(csm, node);
+
+        // TODO inject indentation after newlines
+
         NodeText nodeText = new NodeText(this);
         for (CsmElement element : calculatedSyntaxModel.elements) {
             if (element instanceof LexicalDifferenceCalculator.CsmChild) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -36,6 +36,7 @@ import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.visitor.TreeVisitor;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
+import com.github.javaparser.printer.concretesyntaxmodel.CsmMix;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmToken;
 import com.github.javaparser.utils.Pair;
 import com.github.javaparser.utils.Utils;
@@ -350,12 +351,15 @@ public class LexicalPreservingPrinter {
             pendingIndentation = false;
             if (element instanceof LexicalDifferenceCalculator.CsmChild) {
                 nodeText.addChild(((LexicalDifferenceCalculator.CsmChild) element).getChild());
-            } else if (element instanceof CsmToken){
-                CsmToken csmToken = (CsmToken)element;
+            } else if (element instanceof CsmToken) {
+                CsmToken csmToken = (CsmToken) element;
                 nodeText.addToken(csmToken.getTokenType(), csmToken.getContent(node));
                 if (csmToken.isNewLine()) {
                     pendingIndentation = true;
                 }
+            } else if (element instanceof CsmMix) {
+                CsmMix csmMix = (CsmMix)element;
+                csmMix.getElements().forEach(e -> interpret(node, e, nodeText));
             } else {
                 throw new UnsupportedOperationException(element.getClass().getSimpleName());
             }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -286,8 +286,29 @@ public class LexicalPreservingPrinter {
             NodeText nodeText = new NodeText(this);
             PrimitiveType primitiveType = (PrimitiveType)node;
             switch (primitiveType.getType()) {
+                case BOOLEAN:
+                    nodeText.addToken(GeneratedJavaParserConstants.BOOLEAN, node.toString());
+                    break;
+                case CHAR:
+                    nodeText.addToken(GeneratedJavaParserConstants.CHAR, node.toString());
+                    break;
+                case BYTE:
+                    nodeText.addToken(GeneratedJavaParserConstants.BYTE, node.toString());
+                    break;
+                case SHORT:
+                    nodeText.addToken(GeneratedJavaParserConstants.SHORT, node.toString());
+                    break;
                 case INT:
                     nodeText.addToken(GeneratedJavaParserConstants.INT, node.toString());
+                    break;
+                case LONG:
+                    nodeText.addToken(GeneratedJavaParserConstants.LONG, node.toString());
+                    break;
+                case FLOAT:
+                    nodeText.addToken(GeneratedJavaParserConstants.FLOAT, node.toString());
+                    break;
+                case DOUBLE:
+                    nodeText.addToken(GeneratedJavaParserConstants.DOUBLE, node.toString());
                     break;
                 default:
                     throw new IllegalArgumentException();

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -329,13 +329,23 @@ public class LexicalPreservingPrinter {
         LexicalDifferenceCalculator.CalculatedSyntaxModel calculatedSyntaxModel = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(csm, node);
 
         // TODO inject indentation after newlines
+        List<TokenTextElement> indentation = findIndentation(node);
 
         NodeText nodeText = new NodeText(this);
+        boolean pendingIndentation = false;
         for (CsmElement element : calculatedSyntaxModel.elements) {
+            if (pendingIndentation && !(element instanceof CsmToken && ((CsmToken)element).isNewLine())) {
+                indentation.forEach(el -> nodeText.addElement(el));
+            }
+            pendingIndentation = false;
             if (element instanceof LexicalDifferenceCalculator.CsmChild) {
                 nodeText.addChild(((LexicalDifferenceCalculator.CsmChild) element).getChild());
             } else if (element instanceof CsmToken){
-                nodeText.addToken(((CsmToken) element).getTokenType(), ((CsmToken) element).getContent(node));
+                CsmToken csmToken = (CsmToken)element;
+                nodeText.addToken(csmToken.getTokenType(), csmToken.getContent(node));
+                if (csmToken.isNewLine()) {
+                    pendingIndentation = true;
+                }
             } else {
                 throw new UnsupportedOperationException(element.getClass().getSimpleName());
             }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.nodeTypes.NodeWithVariables;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.observer.PropagatingAstObserver;
@@ -350,8 +351,8 @@ public class LexicalPreservingPrinter {
         // so they have to be handled in a special way
         if (node instanceof VariableDeclarator) {
             VariableDeclarator variableDeclarator = (VariableDeclarator)node;
-            FieldDeclaration fieldDeclaration = (FieldDeclaration)variableDeclarator.getParentNode().get();
-            int extraArrayLevels = variableDeclarator.getType().getArrayLevel() - fieldDeclaration.getMaximumCommonType().getArrayLevel();
+            NodeWithVariables<?> nodeWithVariables = (NodeWithVariables)variableDeclarator.getParentNode().get();
+            int extraArrayLevels = variableDeclarator.getType().getArrayLevel() - nodeWithVariables.getMaximumCommonType().getArrayLevel();
             for (int i=0; i<extraArrayLevels; i++) {
                 nodeText.addElement(new TokenTextElement(GeneratedJavaParserConstants.LBRACKET));
                 nodeText.addElement(new TokenTextElement(GeneratedJavaParserConstants.RBRACKET));

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -269,12 +269,11 @@ public class LexicalPreservingPrinter {
      * Print a Node into a Writer, preserving the lexical information.
      */
     public void print(Node node, Writer writer) throws IOException {
-        if (textForNodes.containsKey(node)) {
-            final NodeText text = textForNodes.get(node);
-            writer.append(text.expand());
-        } else {
-            writer.append(node.toString());
+        if (!textForNodes.containsKey(node)) {
+            getOrCreateNodeText(node);
         }
+        final NodeText text = textForNodes.get(node);
+        writer.append(text.expand());
     }
 
     //

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -282,9 +282,8 @@ public class LexicalPreservingPrinter {
     // Methods to handle transformations
     //
 
-    private NodeText prettyPrintingTextNode(Node node) {
+    private NodeText prettyPrintingTextNode(Node node, NodeText nodeText) {
         if (node instanceof PrimitiveType) {
-            NodeText nodeText = new NodeText(this);
             PrimitiveType primitiveType = (PrimitiveType)node;
             switch (primitiveType.getType()) {
                 case BOOLEAN:
@@ -317,20 +316,18 @@ public class LexicalPreservingPrinter {
             return nodeText;
         }
         if (node instanceof JavadocComment) {
-            NodeText nodeText = new NodeText(this);
             nodeText.addToken(GeneratedJavaParserConstants.JAVA_DOC_COMMENT, "/**"+((JavadocComment)node).getContent()+"*/");
             return nodeText;
         }
 
-        return interpret(node, ConcreteSyntaxModel.forClass(node.getClass()));
+        return interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
     }
 
-    private NodeText interpret(Node node, CsmElement csm) {
+    private NodeText interpret(Node node, CsmElement csm, NodeText nodeText) {
         LexicalDifferenceCalculator.CalculatedSyntaxModel calculatedSyntaxModel = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(csm, node);
 
         List<TokenTextElement> indentation = findIndentation(node);
 
-        NodeText nodeText = new NodeText(this);
         boolean pendingIndentation = false;
         for (CsmElement element : calculatedSyntaxModel.elements) {
             if (pendingIndentation && !(element instanceof CsmToken && ((CsmToken)element).isNewLine())) {
@@ -366,7 +363,9 @@ public class LexicalPreservingPrinter {
     // Visible for testing
     NodeText getOrCreateNodeText(Node node) {
         if (!textForNodes.containsKey(node)) {
-            textForNodes.put(node, prettyPrintingTextNode(node));
+            NodeText nodeText = new NodeText(this);
+            textForNodes.put(node, nodeText);
+            prettyPrintingTextNode(node, nodeText);
         }
         return textForNodes.get(node);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
@@ -34,6 +34,8 @@ class NodeText {
     private LexicalPreservingPrinter lexicalPreservingPrinter;
     private List<TextElement> elements;
 
+    public static int NOT_FOUND = -1;
+
     LexicalPreservingPrinter getLexicalPreservingPrinter() {
         return lexicalPreservingPrinter;
     }
@@ -103,13 +105,24 @@ class NodeText {
     }
 
     int findElement(TextElementMatcher matcher, int from) {
+        int res = tryToFindElement(matcher, from);
+        if (res == NOT_FOUND) {
+            throw new IllegalArgumentException(
+                    String.format("I could not find child '%s' from position %d. Elements: %s",
+                            matcher, from, elements));
+        } else {
+            return res;
+        }
+    }
+
+    int tryToFindElement(TextElementMatcher matcher, int from) {
         for (int i=from; i<elements.size(); i++) {
             TextElement element = elements.get(i);
             if (matcher.match(element)) {
                 return i;
             }
         }
-        throw new IllegalArgumentException(String.format("I could not find child '%s' from position %d", matcher, from));
+        return NOT_FOUND;
     }
 
     int findChild(Node child) {
@@ -118,6 +131,14 @@ class NodeText {
 
     int findChild(Node child, int from) {
         return findElement(TextElementMatchers.byNode(child), from);
+    }
+
+    int tryToFindChild(Node child) {
+        return tryToFindChild(child, 0);
+    }
+
+    int tryToFindChild(Node child, int from) {
+        return tryToFindElement(TextElementMatchers.byNode(child), from);
     }
 
     //

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElement.java
@@ -56,5 +56,8 @@ public abstract class TextElement implements TextElementMatcher {
         return isWhiteSpace() || isComment();
     }
 
-    public abstract boolean isChild(Class<? extends Node> nodeClass);
+    /**
+     * Is this TextElement representing a child of the given class?
+     */
+    public abstract boolean isChildOfClass(Class<? extends Node> nodeClass);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElement.java
@@ -23,6 +23,7 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import com.github.javaparser.GeneratedJavaParserConstants;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.type.VoidType;
 
 public abstract class TextElement implements TextElementMatcher {
 
@@ -55,4 +56,5 @@ public abstract class TextElement implements TextElementMatcher {
         return isWhiteSpace() || isComment();
     }
 
+    public abstract boolean isChild(Class<? extends Node> nodeClass);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementMatchers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementMatchers.java
@@ -29,7 +29,17 @@ class TextElementMatchers {
         return textElement -> textElement.isToken(tokenType);
     }
 
-    static TextElementMatcher byNode(Node node) {
-        return textElement -> textElement.isNode(node);
+    static TextElementMatcher byNode(final Node node) {
+        return new TextElementMatcher() {
+            @Override
+            public boolean match(TextElement textElement) {
+                return textElement.isNode(node);
+            }
+
+            @Override
+            public String toString() {
+                return "match node " + node;
+            }
+        };
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
@@ -128,4 +128,9 @@ class TokenTextElement extends TextElement {
     public boolean isNewline() {
         return TokenTypes.isEndOfLineCharacter(tokenKind);
     }
+
+    @Override
+    public boolean isChild(Class<? extends Node> nodeClass) {
+        return false;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
@@ -130,7 +130,7 @@ class TokenTextElement extends TextElement {
     }
 
     @Override
-    public boolean isChild(Class<? extends Node> nodeClass) {
+    public boolean isChildOfClass(Class<? extends Node> nodeClass) {
         return false;
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceTest.java
@@ -14,7 +14,9 @@ import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
+import com.github.javaparser.printer.concretesyntaxmodel.CsmIndent;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmToken;
+import com.github.javaparser.printer.concretesyntaxmodel.CsmUnindent;
 import com.github.javaparser.printer.lexicalpreservation.LexicalDifferenceCalculator.CsmChild;
 import org.junit.Test;
 
@@ -361,8 +363,10 @@ public class DifferenceTest extends AbstractLexicalPreservingTest {
         int i = 0;
         assertEquals(Difference.DifferenceElement.kept(new CsmToken(GeneratedJavaParserConstants.LBRACE)), diff.getElements().get(i++));
         assertEquals(Difference.DifferenceElement.kept(new CsmToken(eolToken())), diff.getElements().get(i++));
+        assertEquals(Difference.DifferenceElement.added(new CsmIndent()), diff.getElements().get(i++));
         assertEquals(Difference.DifferenceElement.added(new CsmChild(s)), diff.getElements().get(i++));
         assertEquals(Difference.DifferenceElement.added(new CsmToken(eolToken())), diff.getElements().get(i++));
+        assertEquals(Difference.DifferenceElement.added(new CsmUnindent()), diff.getElements().get(i++));
         assertEquals(Difference.DifferenceElement.kept(new CsmToken(GeneratedJavaParserConstants.RBRACE)), diff.getElements().get(i++));
         assertEquals(i, diff.getElements().size());
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceTest.java
@@ -104,6 +104,7 @@ public class DifferenceTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmOriginal = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(element, annotationDeclaration);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator().calculatedSyntaxModelAfterPropertyChange(element, annotationDeclaration, ObservableProperty.MODIFIERS, EnumSet.noneOf(Modifier.class), EnumSet.of(Modifier.PUBLIC));
         Difference diff = Difference.calculate(csmOriginal, csmChanged);
+        diff.removeIndentationElements();
         int i = 0;
         assertEquals(added(new CsmToken(GeneratedJavaParserConstants.PUBLIC)), diff.getElements().get(i++));
         assertEquals(added(new CsmToken(spaceToken())), diff.getElements().get(i++));
@@ -140,6 +141,7 @@ public class DifferenceTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator().calculatedSyntaxModelAfterPropertyChange(element, annotationDeclaration, ObservableProperty.NAME,
                 annotationDeclaration.getName(), newName);
         Difference diff = Difference.calculate(csmOriginal, csmChanged);
+        diff.removeIndentationElements();
         int i = 0;
         assertEquals(kept(new CsmToken(GeneratedJavaParserConstants.AT)), diff.getElements().get(i++));
         assertEquals(kept(new CsmToken(GeneratedJavaParserConstants.INTERFACE)), diff.getElements().get(i++));
@@ -174,6 +176,7 @@ public class DifferenceTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmOriginal = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(element, annotationDeclaration);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator().calculatedSyntaxModelAfterPropertyChange(element, annotationDeclaration, ObservableProperty.COMMENT, null, comment);
         Difference diff = Difference.calculate(csmOriginal, csmChanged);
+        diff.removeIndentationElements();
         int i = 0;
         assertEquals(kept(new CsmToken(GeneratedJavaParserConstants.PUBLIC)), diff.getElements().get(i++));
         assertEquals(kept(new CsmToken(spaceToken())), diff.getElements().get(i++));
@@ -208,6 +211,7 @@ public class DifferenceTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmOriginal = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(element, annotationDeclaration);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator().calculatedSyntaxModelAfterPropertyChange(element, annotationDeclaration, ObservableProperty.COMMENT, annotationDeclaration.getComment().get(), null);
         Difference diff = Difference.calculate(csmOriginal, csmChanged);
+        diff.removeIndentationElements();
         int i = 0;
         assertEquals(kept(new CsmToken(GeneratedJavaParserConstants.PUBLIC)), diff.getElements().get(i++));
         assertEquals(kept(new CsmToken(spaceToken())), diff.getElements().get(i++));
@@ -242,6 +246,7 @@ public class DifferenceTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmOriginal = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(element, annotationDeclaration);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator().calculatedSyntaxModelAfterPropertyChange(element, annotationDeclaration, ObservableProperty.MODIFIERS, EnumSet.of(Modifier.PUBLIC), EnumSet.noneOf(Modifier.class));
         Difference diff = Difference.calculate(csmOriginal, csmChanged);
+        diff.removeIndentationElements();
         int i = 0;
         assertEquals(removed(new CsmToken(GeneratedJavaParserConstants.PUBLIC)), diff.getElements().get(i++));
         assertEquals(removed(new CsmToken(spaceToken())), diff.getElements().get(i++));

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculatorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculatorTest.java
@@ -227,7 +227,7 @@ public class LexicalDifferenceCalculatorTest extends AbstractLexicalPreservingTe
     }
 
     @Test
-    public void addingStatementToEmptyBlock() throws IOException {
+    public void csmModelAfterAddingStatementToEmptyBlock() throws IOException {
         LexicalDifferenceCalculator ldc = new LexicalDifferenceCalculator();
         considerExample("ASimpleClassWithMoreFormatting_step3");
 
@@ -246,22 +246,48 @@ public class LexicalDifferenceCalculatorTest extends AbstractLexicalPreservingTe
                         setter.getBody().get().getStatements(),
                         0,
                         assignStatement);
-        calculatedSyntaxModel.removeIndentationElements();
         int index = 0;
         assertEquals(CsmElement.token(GeneratedJavaParserConstants.LBRACE), calculatedSyntaxModel.elements.get(index++));
         assertEquals(CsmElement.newline(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
-        assertEquals(CsmElement.space(), calculatedSyntaxModel.elements.get(index++));
+        assertEquals(CsmElement.indent(), calculatedSyntaxModel.elements.get(index++));
         assertTrue(isChild(calculatedSyntaxModel.elements.get(index++), ExpressionStmt.class));
         assertEquals(CsmElement.newline(), calculatedSyntaxModel.elements.get(index++));
+        assertEquals(CsmElement.unindent(), calculatedSyntaxModel.elements.get(index++));
         assertEquals(CsmElement.token(GeneratedJavaParserConstants.RBRACE), calculatedSyntaxModel.elements.get(index++));
         assertEquals(index, calculatedSyntaxModel.elements.size());
+    }
+
+    @Test
+    public void differenceAfterddingStatementToEmptyBlock() throws IOException {
+        LexicalDifferenceCalculator ldc = new LexicalDifferenceCalculator();
+        considerExample("ASimpleClassWithMoreFormatting_step3");
+
+        MethodDeclaration setter = cu.getClassByName("MyRenamedClass").get()
+                .getMethodsByName("setAField").get(0);
+        Statement assignStatement = new ExpressionStmt(
+                new AssignExpr(
+                        new FieldAccessExpr(new ThisExpr(),"aField"),
+                        new NameExpr("aField"),
+                        AssignExpr.Operator.ASSIGN
+                ));
+        Difference diff = ldc.calculateListAdditionDifference(
+                ObservableProperty.STATEMENTS,
+                setter.getBody().get().getStatements(),
+                0,
+                assignStatement);
+        int index = 0;
+        assertEquals(Difference.DifferenceElement.kept(CsmElement.token(GeneratedJavaParserConstants.LBRACE)), diff.getElements().get(index++));
+        assertEquals(Difference.DifferenceElement.kept(CsmElement.newline()), diff.getElements().get(index++));
+        assertEquals(Difference.DifferenceElement.added(CsmElement.indent()), diff.getElements().get(index++));
+        assertTrue(isAddedChild(diff.getElements().get(index++), ExpressionStmt.class));
+        assertEquals(Difference.DifferenceElement.added(CsmElement.newline()), diff.getElements().get(index++));
+        assertEquals(Difference.DifferenceElement.added(CsmElement.unindent()), diff.getElements().get(index++));
+        assertEquals(Difference.DifferenceElement.kept(CsmElement.token(GeneratedJavaParserConstants.RBRACE)), diff.getElements().get(index++));
+        assertEquals(index, diff.getElements().size());
+    }
+
+    private boolean isAddedChild(Difference.DifferenceElement element, Class<? extends Node> childClass) {
+        return element.isAdded() && isChild(element.getElement(), childClass);
     }
 
     private boolean isChild(CsmElement element, Class<? extends Node> childClass) {

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculatorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculatorTest.java
@@ -17,7 +17,6 @@ import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmToken;
-import com.sun.tools.javac.jvm.Gen;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -538,7 +538,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
                 "   protected void initializePage() {}" + EOL +
                 "}", result.b.print(cu));
     }
-    
+
     @Test
     public void preserveSpaceAsIsForASimpleClassWithMoreFormatting() throws IOException {
         considerExample("ASimpleClassWithMoreFormatting");

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -14,9 +14,7 @@ import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.utils.Pair;
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -546,28 +546,62 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
     }
 
     @Test
-    public void addingParameterToMethod() throws IOException {
+    public void preserveSpaceAsIsForASimpleClassWithMoreFormatting() throws IOException {
         considerExample("ASimpleClassWithMoreFormatting");
         assertEquals(readExample("ASimpleClassWithMoreFormatting"), lpp.print(cu));
+    }
+
+    @Test
+    public void renameASimpleClassWithMoreFormatting() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting");
 
         cu.getClassByName("ASimpleClass").get()
                 .setName("MyRenamedClass");
         assertEquals(readExample("ASimpleClassWithMoreFormatting_step1"), lpp.print(cu));
+    }
 
-        // Adding a method: we add a setter
+    @Test
+    public void addMethodToASimpleClassWithMoreFormatting() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting");
+
+        cu.getClassByName("ASimpleClass").get()
+                .setName("MyRenamedClass");
         MethodDeclaration setter = cu
                 .getClassByName("MyRenamedClass").get()
                 .addMethod("setAField", Modifier.PUBLIC);
         assertEquals(readExample("ASimpleClassWithMoreFormatting_step2"), lpp.print(cu));
-//        setter.addParameter("boolean", "aField");
-//        assertEquals(readExample("ASimpleClassWithMoreFormatting_step3"), lpp.print(cu));
-//        setter.getBody().get().getStatements().add(new ExpressionStmt(
-//                new AssignExpr(
-//                        new FieldAccessExpr(new ThisExpr(),"aField"),
-//                        new NameExpr("aField"),
-//                        AssignExpr.Operator.ASSIGN
-//                )));
-//        assertEquals(readExample("ASimpleClassWithMoreFormatting_step4"), lpp.print(cu));
+    }
+
+    @Test
+    public void addingParameterToAnAddedMethodInASimpleClassWithMoreFormatting() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting");
+
+        cu.getClassByName("ASimpleClass").get()
+                .setName("MyRenamedClass");
+        MethodDeclaration setter = cu
+                .getClassByName("MyRenamedClass").get()
+                .addMethod("setAField", Modifier.PUBLIC);
+        setter.addParameter("boolean", "aField");
+        assertEquals(readExample("ASimpleClassWithMoreFormatting_step3"), lpp.print(cu));
+    }
+
+    @Test
+    public void addingStatementToAnAddedMethodInASimpleClassWithMoreFormatting() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting");
+
+        cu.getClassByName("ASimpleClass").get()
+                .setName("MyRenamedClass");
+        MethodDeclaration setter = cu
+                .getClassByName("MyRenamedClass").get()
+                .addMethod("setAField", Modifier.PUBLIC);
+        setter.addParameter("boolean", "aField");
+        setter.getBody().get().getStatements().add(new ExpressionStmt(
+                new AssignExpr(
+                        new FieldAccessExpr(new ThisExpr(),"aField"),
+                        new NameExpr("aField"),
+                        AssignExpr.Operator.ASSIGN
+                )));
+        assertEquals(readExample("ASimpleClassWithMoreFormatting_step4"), lpp.print(cu));
     }
 
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -7,12 +7,10 @@ import com.github.javaparser.Providers;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
-import com.github.javaparser.ast.stmt.CatchClause;
-import com.github.javaparser.ast.stmt.ExpressionStmt;
-import com.github.javaparser.ast.stmt.Statement;
-import com.github.javaparser.ast.stmt.TryStmt;
+import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.UnionType;
+import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.utils.Pair;
 import org.junit.Test;
 
@@ -25,6 +23,7 @@ import java.util.stream.Collectors;
 
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
@@ -644,7 +643,6 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
 
         MethodDeclaration setter = cu.getClassByName("MyRenamedClass").get()
                 .getMethodsByName("setAField").get(0);
-        setter.addParameter("boolean", "aField");
         setter.getBody().get().getStatements().add(new ExpressionStmt(
                 new AssignExpr(
                         new FieldAccessExpr(new ThisExpr(),"aField"),
@@ -652,6 +650,112 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
                         AssignExpr.Operator.ASSIGN
                 )));
         assertEquals(readExample("ASimpleClassWithMoreFormatting_step4"), lpp.print(cu));
+    }
+
+    @Test
+    public void nodeTextForMethod() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting_step4");
+
+        MethodDeclaration setter = cu.getClassByName("MyRenamedClass").get()
+                .getMethodsByName("setAField").get(0);
+        NodeText nodeText;
+
+        nodeText = lpp.getTextForNode(setter);
+        int index = 0;
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.PUBLIC));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(VoidType.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(SimpleName.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LPAREN));
+        assertTrue(nodeText.getElements().get(index++).isChild(Parameter.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RPAREN));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(BlockStmt.class));
+        assertEquals(index, nodeText.getElements().size());
+
+        nodeText = lpp.getTextForNode(setter.getBody().get());
+        index = 0;
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LBRACE));
+        assertTrue(nodeText.getElements().get(index++).isNewline());
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(ExpressionStmt.class));
+        assertTrue(nodeText.getElements().get(index++).isNewline());
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RBRACE));
+        assertEquals(index, nodeText.getElements().size());
+
+        nodeText = lpp.getTextForNode(setter.getBody().get().getStatement(0));
+        index = 0;
+        assertTrue(nodeText.getElements().get(index++).isChild(AssignExpr.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SEMICOLON));
+        assertEquals(index, nodeText.getElements().size());
+    }
+
+    @Test
+    public void nodeTextForModifiedMethod() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting_step3");
+
+        MethodDeclaration setter = cu.getClassByName("MyRenamedClass").get()
+                .getMethodsByName("setAField").get(0);
+        setter.getBody().get().getStatements().add(new ExpressionStmt(
+                new AssignExpr(
+                        new FieldAccessExpr(new ThisExpr(),"aField"),
+                        new NameExpr("aField"),
+                        AssignExpr.Operator.ASSIGN
+                )));
+        NodeText nodeText;
+
+        nodeText = lpp.getTextForNode(setter);
+        int index = 0;
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.PUBLIC));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(VoidType.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(SimpleName.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LPAREN));
+        assertTrue(nodeText.getElements().get(index++).isChild(Parameter.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RPAREN));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(BlockStmt.class));
+        assertEquals(index, nodeText.getElements().size());
+
+        nodeText = lpp.getTextForNode(setter.getBody().get());
+        index = 0;
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LBRACE));
+        assertTrue(nodeText.getElements().get(index++).isNewline());
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isChild(ExpressionStmt.class));
+        assertTrue(nodeText.getElements().get(index++).isNewline());
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RBRACE));
+        assertEquals(index, nodeText.getElements().size());
+
+        nodeText = lpp.getTextForNode(setter.getBody().get().getStatement(0));
+        index = 0;
+        assertTrue(nodeText.getElements().get(index++).isChild(AssignExpr.class));
+        assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SEMICOLON));
+        assertEquals(index, nodeText.getElements().size());
     }
 
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -6,9 +6,7 @@ import com.github.javaparser.ParseStart;
 import com.github.javaparser.Providers;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
-import com.github.javaparser.ast.expr.ArrayCreationExpr;
-import com.github.javaparser.ast.expr.BinaryExpr;
-import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
@@ -528,17 +526,15 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         CompilationUnit cu = result.a.getResult().get();
 
         cu.getTypes().stream()
-                .forEach(type -> {
-                    type.getMembers().stream()
-                            .forEach(member -> {
-                                if (member instanceof MethodDeclaration) {
-                                    MethodDeclaration methodDeclaration = (MethodDeclaration) member;
-                                    if (!methodDeclaration.getAnnotationByName("Override").isPresent()) {
-                                        methodDeclaration.addAnnotation("Override");
-                                    }
+                .forEach(type -> type.getMembers().stream()
+                        .forEach(member -> {
+                            if (member instanceof MethodDeclaration) {
+                                MethodDeclaration methodDeclaration = (MethodDeclaration) member;
+                                if (!methodDeclaration.getAnnotationByName("Override").isPresent()) {
+                                    methodDeclaration.addAnnotation("Override");
                                 }
-                            });
-                });
+                            }
+                        }));
         assertEquals("public class TestPage extends Page {" + EOL +
                 EOL +
                 "   @Override()" + EOL +
@@ -547,6 +543,31 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
                 "   @Override" + EOL +
                 "   protected void initializePage() {}" + EOL +
                 "}", result.b.print(cu));
+    }
+
+    @Test
+    public void addingParameterToMethod() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting");
+        assertEquals(readExample("ASimpleClassWithMoreFormatting"), lpp.print(cu));
+
+        cu.getClassByName("ASimpleClass").get()
+                .setName("MyRenamedClass");
+        assertEquals(readExample("ASimpleClassWithMoreFormatting_step1"), lpp.print(cu));
+
+        // Adding a method: we add a setter
+        MethodDeclaration setter = cu
+                .getClassByName("MyRenamedClass").get()
+                .addMethod("setAField", Modifier.PUBLIC);
+        assertEquals(readExample("ASimpleClassWithMoreFormatting_step2"), lpp.print(cu));
+//        setter.addParameter("boolean", "aField");
+//        assertEquals(readExample("ASimpleClassWithMoreFormatting_step3"), lpp.print(cu));
+//        setter.getBody().get().getStatements().add(new ExpressionStmt(
+//                new AssignExpr(
+//                        new FieldAccessExpr(new ThisExpr(),"aField"),
+//                        new NameExpr("aField"),
+//                        AssignExpr.Operator.ASSIGN
+//                )));
+//        assertEquals(readExample("ASimpleClassWithMoreFormatting_step4"), lpp.print(cu));
     }
 
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -794,8 +794,11 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
                                 if (member instanceof MethodDeclaration) {
                                     MethodDeclaration methodDeclaration = (MethodDeclaration) member;
                                     if (methodDeclaration.getAnnotationByName("Override").isPresent()) {
-                                        methodDeclaration.getAnnotations().stream()
-                                                .forEach(anno -> anno.remove());
+
+                                        while (methodDeclaration.getAnnotations().isNonEmpty()) {
+                                            AnnotationExpr annotationExpr = methodDeclaration.getAnnotations().get(0);
+                                            annotationExpr.remove();
+                                        }
 
                                         methodDeclaration.addMarkerAnnotation("Override");
                                     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -662,14 +662,14 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         int index = 0;
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.PUBLIC));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(VoidType.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(VoidType.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(SimpleName.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(SimpleName.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LPAREN));
-        assertTrue(nodeText.getElements().get(index++).isChild(Parameter.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(Parameter.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RPAREN));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(BlockStmt.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(BlockStmt.class));
         assertEquals(index, nodeText.getElements().size());
 
         nodeText = lpp.getTextForNode(setter.getBody().get());
@@ -684,7 +684,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(ExpressionStmt.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(ExpressionStmt.class));
         assertTrue(nodeText.getElements().get(index++).isNewline());
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
@@ -695,7 +695,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
 
         nodeText = lpp.getTextForNode(setter.getBody().get().getStatement(0));
         index = 0;
-        assertTrue(nodeText.getElements().get(index++).isChild(AssignExpr.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(AssignExpr.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SEMICOLON));
         assertEquals(index, nodeText.getElements().size());
     }
@@ -718,14 +718,14 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         int index = 0;
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.PUBLIC));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(VoidType.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(VoidType.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(SimpleName.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(SimpleName.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LPAREN));
-        assertTrue(nodeText.getElements().get(index++).isChild(Parameter.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(Parameter.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RPAREN));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(BlockStmt.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(BlockStmt.class));
         assertEquals(index, nodeText.getElements().size());
 
         nodeText = lpp.getTextForNode(setter.getBody().get());
@@ -740,7 +740,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
-        assertTrue(nodeText.getElements().get(index++).isChild(ExpressionStmt.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(ExpressionStmt.class));
         assertTrue(nodeText.getElements().get(index++).isNewline());
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
@@ -751,7 +751,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
 
         nodeText = lpp.getOrCreateNodeText(setter.getBody().get().getStatement(0));
         index = 0;
-        assertTrue(nodeText.getElements().get(index++).isChild(AssignExpr.class));
+        assertTrue(nodeText.getElements().get(index++).isChildOfClass(AssignExpr.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SEMICOLON));
         assertEquals(index, nodeText.getElements().size());
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -749,7 +749,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RBRACE));
         assertEquals(index, nodeText.getElements().size());
 
-        nodeText = lpp.getTextForNode(setter.getBody().get().getStatement(0));
+        nodeText = lpp.getOrCreateNodeText(setter.getBody().get().getStatement(0));
         index = 0;
         assertTrue(nodeText.getElements().get(index++).isChild(AssignExpr.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SEMICOLON));

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -561,6 +561,19 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
     }
 
     @Test
+    public void theLexicalPreservationStringForAnAddedMethodShouldBeIndented() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting");
+
+        cu.getClassByName("ASimpleClass").get()
+                .setName("MyRenamedClass");
+        MethodDeclaration setter = cu
+                .getClassByName("MyRenamedClass").get()
+                .addMethod("setAField", Modifier.PUBLIC);
+        assertEquals("public void setAField() {" + EOL +
+                "    }", lpp.print(setter));
+    }
+
+    @Test
     public void addMethodToASimpleClassWithMoreFormatting() throws IOException {
         considerExample("ASimpleClassWithMoreFormatting");
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -599,6 +599,27 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
     }
 
     @Test
+    public void findIndentationOfEmptyMethod() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting_step3");
+
+        MethodDeclaration setter = cu.getClassByName("MyRenamedClass").get()
+                .getMethodsByName("setAField").get(0);
+        assertEquals(4, lpp.findIndentation(setter).size());
+        assertEquals(4, lpp.findIndentation(setter.getBody().get()).size());
+    }
+
+    @Test
+    public void findIndentationOfMethodWithStatements() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting_step4");
+
+        MethodDeclaration setter = cu.getClassByName("MyRenamedClass").get()
+                .getMethodsByName("setAField").get(0);
+        assertEquals(4, lpp.findIndentation(setter).size());
+        assertEquals(4, lpp.findIndentation(setter.getBody().get()).size());
+        assertEquals(8, lpp.findIndentation(setter.getBody().get().getStatement(0)).size());
+    }
+
+    @Test
     public void addingStatementToAnAddedMethodInASimpleClassWithMoreFormatting() throws IOException {
         considerExample("ASimpleClassWithMoreFormatting");
 
@@ -607,6 +628,22 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         MethodDeclaration setter = cu
                 .getClassByName("MyRenamedClass").get()
                 .addMethod("setAField", Modifier.PUBLIC);
+        setter.addParameter("boolean", "aField");
+        setter.getBody().get().getStatements().add(new ExpressionStmt(
+                new AssignExpr(
+                        new FieldAccessExpr(new ThisExpr(),"aField"),
+                        new NameExpr("aField"),
+                        AssignExpr.Operator.ASSIGN
+                )));
+        assertEquals(readExample("ASimpleClassWithMoreFormatting_step4"), lpp.print(cu));
+    }
+
+    @Test
+    public void addingStatementToAnAddedMethodInASimpleClassWithMoreFormattingFromStep3() throws IOException {
+        considerExample("ASimpleClassWithMoreFormatting_step3");
+
+        MethodDeclaration setter = cu.getClassByName("MyRenamedClass").get()
+                .getMethodsByName("setAField").get(0);
         setter.addParameter("boolean", "aField");
         setter.getBody().get().getStatements().add(new ExpressionStmt(
                 new AssignExpr(

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1,9 +1,6 @@
 package com.github.javaparser.printer.lexicalpreservation;
 
-import com.github.javaparser.GeneratedJavaParserConstants;
-import com.github.javaparser.ParseResult;
-import com.github.javaparser.ParseStart;
-import com.github.javaparser.Providers;
+import com.github.javaparser.*;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
@@ -754,6 +751,25 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         assertTrue(nodeText.getElements().get(index++).isChildOfClass(AssignExpr.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SEMICOLON));
         assertEquals(index, nodeText.getElements().size());
+    }
+
+    // See issue #926
+    @Test
+    public void addASecondStatementToExistingMethod() throws IOException {
+        considerExample("MethodWithOneStatement");
+
+        MethodDeclaration methodDeclaration = cu.getType(0).getMethodsByName("someMethod").get(0);
+        methodDeclaration.getBody().get().getStatements().add(new ExpressionStmt(
+                new VariableDeclarationExpr(
+                        new VariableDeclarator(
+                                JavaParser.parseClassOrInterfaceType("String"),
+                                "test2",
+                                new StringLiteralExpr("")))
+        ));
+        assertEquals("public void someMethod() {" + EOL
+                + "        String test = \"\";" + EOL
+                + "        String test2 = \"\";" + EOL
+                + "    }", lpp.print(methodDeclaration));
     }
 
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.printer.lexicalpreservation;
 
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -15,8 +14,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.EnumSet;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * These tests are more "high level" than the ones in LexicalPreservingPrinterTest.

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
@@ -183,7 +183,7 @@ public class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexi
     public void removingField() throws IOException {
         ClassOrInterfaceDeclaration cid = consider("public class A { int foo; }");
         cid.getMembers().remove(0);
-        assertTransformedToString("public class A {  }", cid);
+        assertTransformedToString("public class A {}", cid);
     }
 
     @Test

--- a/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting.java.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting.java.txt
@@ -1,0 +1,26 @@
+package com.github.javaparser.examples;
+
+
+/**
+ * A class with some uncommon formatting, to check the lexical preservation
+ */
+public class
+ASimpleClass
+{
+
+    boolean aField;
+
+    public ASimpleClass(boolean aField)
+    {
+        this.aField = aField;
+    }
+
+
+    // Some empty lines
+
+
+    public boolean getAField()
+    {
+        return aField;
+    }
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step1.java.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step1.java.txt
@@ -1,0 +1,26 @@
+package com.github.javaparser.examples;
+
+
+/**
+ * A class with some uncommon formatting, to check the lexical preservation
+ */
+public class
+MyRenamedClass
+{
+
+    boolean aField;
+
+    public ASimpleClass(boolean aField)
+    {
+        this.aField = aField;
+    }
+
+
+    // Some empty lines
+
+
+    public boolean getAField()
+    {
+        return aField;
+    }
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step2.java.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step2.java.txt
@@ -1,0 +1,29 @@
+package com.github.javaparser.examples;
+
+
+/**
+ * A class with some uncommon formatting, to check the lexical preservation
+ */
+public class
+MyRenamedClass
+{
+
+    boolean aField;
+
+    public ASimpleClass(boolean aField)
+    {
+        this.aField = aField;
+    }
+
+
+    // Some empty lines
+
+
+    public boolean getAField()
+    {
+        return aField;
+    }
+    
+    public void setAField() {
+    }
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step3.java.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step3.java.txt
@@ -1,0 +1,29 @@
+package com.github.javaparser.examples;
+
+
+/**
+ * A class with some uncommon formatting, to check the lexical preservation
+ */
+public class
+MyRenamedClass
+{
+
+    boolean aField;
+
+    public ASimpleClass(boolean aField)
+    {
+        this.aField = aField;
+    }
+
+
+    // Some empty lines
+
+
+    public boolean getAField()
+    {
+        return aField;
+    }
+    
+    public void setAField(boolean aField) {
+    }
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step4.java.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step4.java.txt
@@ -1,0 +1,30 @@
+package com.github.javaparser.examples;
+
+
+/**
+ * A class with some uncommon formatting, to check the lexical preservation
+ */
+public class
+MyRenamedClass
+{
+
+    boolean aField;
+
+    public ASimpleClass(boolean aField)
+    {
+        this.aField = aField;
+    }
+
+
+    // Some empty lines
+
+
+    public boolean getAField()
+    {
+        return aField;
+    }
+    
+    public void setAField(boolean aField) {
+        this.aField = aField;
+    }    
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step4.java.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/ASimpleClassWithMoreFormatting_step4.java.txt
@@ -26,5 +26,5 @@ MyRenamedClass
     
     public void setAField(boolean aField) {
         this.aField = aField;
-    }    
+    }
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/MethodWithOneStatement.java.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/MethodWithOneStatement.java.txt
@@ -1,0 +1,5 @@
+class A {
+    public void someMethod() {
+        String test = "";
+    }
+}


### PR DESCRIPTION
This fix #866. 
The PR is built on top of #929 and #930 

We introduce a new CsmElement named CsmMix to represent elements that can have any order. They require a specific handling in Difference.apply. We basically considere the CsmMix before the change, after the change and the order of elements in the text trying to figure out the most natural way to change the text.

Additionally we need also to adapt space around in certain cases.

These three PRs combines should fix a few things in the lexical preservation. It is probably not 100% perfect but the number of tests is growing (203) and it should eventually stabilize. There are hard things related to indentation and space reconciliation.

In the long term I hope we root out all bugs, we grow our test base and then in 4.0 we can improve the whole design.