### PR TITLE
Issue 812 begin end token

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/NodeGenerator.java
@@ -56,7 +56,7 @@ public abstract class NodeGenerator extends Generator {
                     throw new AssertionError(f("Wanted to regenerate a method with signature %s in %s, but it wasn't there.", callable.getSignature(), containingClassOrInterface.getNameAsString()));
                 });
     }
-
+    
     private void addMethod(
             ClassOrInterfaceDeclaration containingClassOrInterface,
             CallableDeclaration<?> callable,

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/MainConstructorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/MainConstructorGenerator.java
@@ -1,8 +1,10 @@
 package com.github.javaparser.generator.core.node;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -11,6 +13,8 @@ import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.utils.SourceRoot;
+
+import java.util.List;
 
 import static com.github.javaparser.JavaParser.parseExplicitConstructorInvocationStmt;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
@@ -28,13 +32,13 @@ public class MainConstructorGenerator extends NodeGenerator {
         ConstructorDeclaration constructor = new ConstructorDeclaration()
                 .setPublic(true)
                 .setName(nodeCoid.getNameAsString())
-                .addParameter(Range.class, "range")
+                .addParameter(TokenRange.class, "tokenRange")
                 .setJavadocComment("This constructor is used by the parser and is considered private.");
-        
+
         BlockStmt body = constructor.getBody();
 
         SeparatedItemStringBuilder superCall = new SeparatedItemStringBuilder("super(", ", ", ");");
-        superCall.append("range");
+        superCall.append("tokenRange");
         for (PropertyMetaModel parameter : nodeMetaModel.getConstructorParameters()) {
             constructor.addParameter(parameter.getTypeNameForSetter(), parameter.getName());
             if (nodeMetaModel.getDeclaredPropertyMetaModels().contains(parameter)) {
@@ -45,11 +49,27 @@ public class MainConstructorGenerator extends NodeGenerator {
         }
 
         body.getStatements().add(0, parseExplicitConstructorInvocationStmt(superCall.toString()));
-        
+
         body.addStatement("customInitialization();");
 
-        replaceWhenSameSignature(nodeCoid, constructor);
-        nodeCu.addImport(Range.class);
+        ConstructorDeclaration rangeConstructor = constructor.clone();
+        rangeConstructor.getParameter(0).setType(Range.class);
+
+        replaceWhenSameSignature(nodeCoid, rangeConstructor, constructor);
+        nodeCu.addImport(TokenRange.class);
         annotateGenerated(constructor);
+    }
+
+    protected void replaceWhenSameSignature(ClassOrInterfaceDeclaration containingClassOrInterface, CallableDeclaration<?> callableWithSignature, CallableDeclaration<?> callableToReplaceWith) {
+        final List<CallableDeclaration<?>> existingCallables = containingClassOrInterface.getCallablesWithSignature(callableWithSignature.getSignature());
+        if (existingCallables.isEmpty()) {
+            throw new AssertionError(f("Wanted to regenerate a method with signature %s in %s, but it wasn't there.", callableWithSignature.getSignature(), containingClassOrInterface.getNameAsString()));
+        }
+        if (existingCallables.size() > 1) {
+            throw new AssertionError(f("Wanted to regenerate a method with signature %s in %s, but found more than one.", callableWithSignature.getSignature(), containingClassOrInterface.getNameAsString()));
+        }
+        final CallableDeclaration<?> existingCallable = existingCallables.get(0);
+        callableToReplaceWith.setJavadocComment(callableToReplaceWith.getJavadocComment().orElse(existingCallable.getJavadocComment().orElse(null)));
+        containingClassOrInterface.getMembers().replace(existingCallable, callableToReplaceWith);
     }
 }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/MainConstructorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/MainConstructorGenerator.java
@@ -52,24 +52,8 @@ public class MainConstructorGenerator extends NodeGenerator {
 
         body.addStatement("customInitialization();");
 
-        ConstructorDeclaration rangeConstructor = constructor.clone();
-        rangeConstructor.getParameter(0).setType(Range.class);
-
-        replaceWhenSameSignature(nodeCoid, rangeConstructor, constructor);
+        replaceWhenSameSignature(nodeCoid, constructor);
         nodeCu.addImport(TokenRange.class);
         annotateGenerated(constructor);
-    }
-
-    protected void replaceWhenSameSignature(ClassOrInterfaceDeclaration containingClassOrInterface, CallableDeclaration<?> callableWithSignature, CallableDeclaration<?> callableToReplaceWith) {
-        final List<CallableDeclaration<?>> existingCallables = containingClassOrInterface.getCallablesWithSignature(callableWithSignature.getSignature());
-        if (existingCallables.isEmpty()) {
-            throw new AssertionError(f("Wanted to regenerate a method with signature %s in %s, but it wasn't there.", callableWithSignature.getSignature(), containingClassOrInterface.getNameAsString()));
-        }
-        if (existingCallables.size() > 1) {
-            throw new AssertionError(f("Wanted to regenerate a method with signature %s in %s, but found more than one.", callableWithSignature.getSignature(), containingClassOrInterface.getNameAsString()));
-        }
-        final CallableDeclaration<?> existingCallable = existingCallables.get(0);
-        callableToReplaceWith.setJavadocComment(callableToReplaceWith.getJavadocComment().orElse(existingCallable.getJavadocComment().orElse(null)));
-        containingClassOrInterface.getMembers().replace(existingCallable, callableToReplaceWith);
     }
 }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
@@ -39,7 +39,7 @@ public class CloneVisitorGenerator extends VisitorGenerator {
         }
 
         SeparatedItemStringBuilder builder = new SeparatedItemStringBuilder(f("%s r = new %s(", node.getTypeNameGenerified(), node.getTypeNameGenerified()), ",", ");");
-        builder.append("n.getRange().orElse(null)");
+        builder.append("n.getTokenRange().orElse(null)");
         for (PropertyMetaModel field : node.getConstructorParameters()) {
             if (field.getName().equals("comment")) {
                 continue;

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -47,7 +47,6 @@ import java.util.TreeSet;
 import static com.github.javaparser.ParseStart.*;
 import static com.github.javaparser.Problem.PROBLEM_BY_BEGIN_POSITION;
 import static com.github.javaparser.Providers.*;
-import static com.github.javaparser.Range.range;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -112,8 +111,7 @@ public final class JavaParser {
      * The start indicates what can be found in the source code (compilation unit, block, import...)
      *
      * @param start refer to the constants in ParseStart to see what can be parsed.
-     * @param provider refer to Providers to see how you can read source.
-     * The provider will be closed after parsing.
+     * @param provider refer to Providers to see how you can read source. The provider will be closed after parsing.
      * @param <N> the subclass of Node that is the result of parsing in the start.
      * @return the parse result, a collection of encountered problems, and some extra data.
      */
@@ -134,9 +132,14 @@ public final class JavaParser {
             return new ParseResult<>(resultNode, parser.problems, parser.getTokens(),
                     parser.getCommentsCollection());
         } catch (ParseException p) {
-            final Token token = p.currentToken;
-            final Range range = range(token.beginLine, token.beginColumn, token.endLine, token.endColumn);
-            parser.problems.add(new Problem(makeMessageForParseException(p), range, p));
+            TokenRange tokenRange = null;
+            if (p.currentToken != null) {
+                if (p.currentToken instanceof GeneratedJavaParser.CustomToken) {
+                    final JavaToken token = ((GeneratedJavaParser.CustomToken) p.currentToken).javaToken;
+                    tokenRange = new TokenRange(token, token);
+                }
+            }
+            parser.problems.add(new Problem(makeMessageForParseException(p), tokenRange, p));
             return new ParseResult<>(null, parser.problems, parser.getTokens(), parser.getCommentsCollection());
         } catch (Exception e) {
             final String message = e.getMessage() == null ? "Unknown error" : e.getMessage();
@@ -213,8 +216,7 @@ public final class JavaParser {
      * Parses the Java code contained in the {@link InputStream} and returns a
      * {@link CompilationUnit} that represents it.
      *
-     * @param in {@link InputStream} containing Java source code.
-     * It will be closed after parsing.
+     * @param in {@link InputStream} containing Java source code. It will be closed after parsing.
      * @param encoding encoding of the source code
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
@@ -228,8 +230,7 @@ public final class JavaParser {
      * {@link CompilationUnit} that represents it.<br>
      * Note: Uses UTF-8 encoding
      *
-     * @param in {@link InputStream} containing Java source code.
-     * It will be closed after parsing.
+     * @param in {@link InputStream} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      */
@@ -241,8 +242,7 @@ public final class JavaParser {
      * Parses the Java code contained in a {@link File} and returns a
      * {@link CompilationUnit} that represents it.
      *
-     * @param file {@link File} containing Java source code.
-     * It will be closed after parsing.
+     * @param file {@link File} containing Java source code. It will be closed after parsing.
      * @param encoding encoding of the source code
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
@@ -257,8 +257,7 @@ public final class JavaParser {
      * {@link CompilationUnit} that represents it.<br>
      * Note: Uses UTF-8 encoding
      *
-     * @param file {@link File} containing Java source code.
-     * It will be closed after parsing.
+     * @param file {@link File} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      * @throws FileNotFoundException the file was not found
@@ -344,8 +343,7 @@ public final class JavaParser {
      * Parses Java code from a Reader and returns a
      * {@link CompilationUnit} that represents it.<br>
      *
-     * @param reader the reader containing Java source code.
-     * It will be closed after parsing.
+     * @param reader the reader containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
@@ -24,16 +24,28 @@ package com.github.javaparser;
 import java.util.List;
 import java.util.Optional;
 
+import static com.github.javaparser.Position.*;
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
 /**
  * A token from a parsed source file.
  * (Awkwardly named "Java"Token since JavaCC already generates an internal class Token.)
  */
 public class JavaToken {
+    public static final JavaToken INVALID = new JavaToken();
+
     private final Range range;
     private final int kind;
     private final String text;
     private final Optional<JavaToken> previousToken;
     private Optional<JavaToken> nextToken = Optional.empty();
+
+    private JavaToken() {
+        range = new Range(pos(-1,-1), pos(-1,-1));
+        kind = 0;
+        text = "INVALID";
+        previousToken = Optional.empty();
+    }
 
     public JavaToken(Token token, List<JavaToken> tokens) {
         Range range = Range.range(token.beginLine, token.beginColumn, token.endLine, token.endColumn);
@@ -114,4 +126,26 @@ public class JavaToken {
     public String toString() {
         return text;
     }
+
+    /**
+     * Check if the position is usable. Does not know what it is pointing at, so it can't check if the position is after
+     * the end of the source.
+     */
+    public boolean valid() {
+        return !invalid();
+    }
+
+    public boolean invalid() {
+        return this == INVALID;
+    }
+
+    public JavaToken orIfInvalid(JavaToken anotherToken) {
+        assertNotNull(anotherToken);
+        if (valid() || anotherToken.invalid()) {
+            return this;
+        }
+        return anotherToken;
+    }
+
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/Problem.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Problem.java
@@ -32,10 +32,10 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  */
 public class Problem {
     private final String message;
-    private final Range location;
+    private final TokenRange location;
     private final Throwable cause;
 
-    public Problem(String message, Range location, Throwable cause) {
+    public Problem(String message, TokenRange location, Throwable cause) {
         assertNotNull(message);
 
         this.message = message;
@@ -69,13 +69,13 @@ public class Problem {
      * @return the message plus location information.
      */
     public String getVerboseMessage() {
-        return getLocation().map(l -> l.begin + " " + message).orElse(message);
+        return getLocation().map(l -> l.getBegin().getRange().begin + " " + message).orElse(message);
     }
 
     /**
      * @return the location that was passed into the constructor.
      */
-    public Optional<Range> getLocation() {
+    public Optional<TokenRange> getLocation() {
         return Optional.ofNullable(location);
     }
 
@@ -83,7 +83,7 @@ public class Problem {
      * @deprecated use getLocation()
      */
     @Deprecated
-    public Optional<Range> getRange() {
+    public Optional<TokenRange> getRange() {
         return getLocation();
     }
 
@@ -99,7 +99,7 @@ public class Problem {
      */
     public static Comparator<Problem> PROBLEM_BY_BEGIN_POSITION = (a, b) -> {
         if (a.getLocation().isPresent() && b.getLocation().isPresent()) {
-            return a.getLocation().get().begin.compareTo(b.getLocation().get().begin);
+            return a.getLocation().get().getBegin().getRange().begin.compareTo(b.getLocation().get().getBegin().getRange().begin);
         }
         if (a.getLocation().isPresent() || b.getLocation().isPresent()) {
             if (a.getLocation().isPresent()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
@@ -1,15 +1,19 @@
 package com.github.javaparser;
 
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
 /**
  * The range of tokens covered by this node.
  */
 public class TokenRange {
+    public static final TokenRange INVALID = new TokenRange(JavaToken.INVALID, JavaToken.INVALID);
+    
     private final JavaToken begin;
     private final JavaToken end;
 
     public TokenRange(JavaToken begin, JavaToken end) {
-        this.begin = begin;
-        this.end = end;
+        this.begin = assertNotNull(begin);
+        this.end = assertNotNull(end);
     }
 
     public JavaToken getBegin() {
@@ -22,5 +26,13 @@ public class TokenRange {
 
     public Range getRange() {
         return new Range(begin.getRange().begin, end.getRange().end);
+    }
+
+    public TokenRange withBegin(JavaToken begin) {
+        return new TokenRange(assertNotNull(begin), end);
+    }
+
+    public TokenRange withEnd(JavaToken end) {
+        return new TokenRange(begin, assertNotNull(end));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
@@ -1,0 +1,22 @@
+package com.github.javaparser;
+
+/**
+ * The range of tokens covered by this node.
+ */
+public class TokenRange {
+    private final JavaToken begin;
+    private final JavaToken end;
+    
+    public TokenRange(JavaToken begin, JavaToken end){
+        this.begin = begin;
+        this.end = end;
+    }
+
+    public JavaToken getBegin() {
+        return begin;
+    }
+
+    public JavaToken getEnd() {
+        return end;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
@@ -6,8 +6,8 @@ package com.github.javaparser;
 public class TokenRange {
     private final JavaToken begin;
     private final JavaToken end;
-    
-    public TokenRange(JavaToken begin, JavaToken end){
+
+    public TokenRange(JavaToken begin, JavaToken end) {
         this.begin = begin;
         this.end = end;
     }
@@ -18,5 +18,9 @@ public class TokenRange {
 
     public JavaToken getEnd() {
         return end;
+    }
+
+    public Range getRange() {
+        return new Range(begin.getRange().begin, end.getRange().end);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
@@ -37,6 +37,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ArrayCreationLevelMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * In <code>new int[1][2];</code> there are two ArrayCreationLevel objects,
@@ -68,8 +69,8 @@ public class ArrayCreationLevel extends Node implements NodeWithAnnotations<Arra
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ArrayCreationLevel(Range range, Expression dimension, NodeList<AnnotationExpr> annotations) {
-        super(range);
+    public ArrayCreationLevel(TokenRange tokenRange, Expression dimension, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange);
         setDimension(dimension);
         setAnnotations(annotations);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -47,6 +47,7 @@ import static com.github.javaparser.JavaParser.parseName;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.TokenRange;
 
 /**
  * <p>
@@ -87,8 +88,8 @@ public final class CompilationUnit extends Node {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public CompilationUnit(Range range, PackageDeclaration packageDeclaration, NodeList<ImportDeclaration> imports, NodeList<TypeDeclaration<?>> types, ModuleDeclaration module) {
-        super(range);
+    public CompilationUnit(TokenRange tokenRange, PackageDeclaration packageDeclaration, NodeList<ImportDeclaration> imports, NodeList<TypeDeclaration<?>> types, ModuleDeclaration module) {
+        super(tokenRange);
         setPackageDeclaration(packageDeclaration);
         setImports(imports);
         setTypes(types);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ImportDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An import declaration.
@@ -63,8 +64,8 @@ public final class ImportDeclaration extends Node implements NodeWithName<Import
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ImportDeclaration(Range range, Name name, boolean isStatic, boolean isAsterisk) {
-        super(range);
+    public ImportDeclaration(TokenRange tokenRange, Name name, boolean isStatic, boolean isAsterisk) {
+        super(tokenRange);
         setName(name);
         setStatic(isStatic);
         setAsterisk(isAsterisk);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast;
 
 import com.github.javaparser.HasParentNode;
 import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.LineComment;
@@ -132,6 +133,9 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     private Range range;
 
     @InternalProperty
+    private final TokenRange tokenRange;
+
+    @InternalProperty
     private Node parentNode;
 
     @InternalProperty
@@ -148,8 +152,9 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     @InternalProperty
     private List<AstObserver> observers = new ArrayList<>();
 
-    public Node(Range range) {
-        this.range = range;
+    protected Node(TokenRange tokenRange) {
+        this.range = new Range(tokenRange.getBegin().getRange().begin, tokenRange.getEnd().getRange().end);
+        this.tokenRange = tokenRange;
     }
 
     /**
@@ -175,6 +180,13 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      */
     public Optional<Range> getRange() {
         return Optional.ofNullable(range);
+    }
+
+    /**
+     * @return the range of tokens that this node covers.
+     */
+    public Optional<TokenRange> getTokenRange() {
+        return Optional.ofNullable(tokenRange);
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.nodeTypes.NodeWithRange;
+import com.github.javaparser.ast.nodeTypes.NodeWithTokenRange;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.observer.PropagatingAstObserver;
@@ -39,9 +40,9 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.NodeMetaModel;
 import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
+import javax.annotation.Generated;
 import java.util.*;
 import static java.util.Collections.unmodifiableList;
-import javax.annotation.Generated;
 import com.github.javaparser.ast.Node;
 
 /**
@@ -87,7 +88,7 @@ import com.github.javaparser.ast.Node;
  *
  * @author Julio Vilmar Gesser
  */
-public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable, NodeWithRange<Node> {
+public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable, NodeWithRange<Node>, NodeWithTokenRange<Node> {
 
     /**
      * Different registration mode for observers on nodes.
@@ -133,7 +134,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     private Range range;
 
     @InternalProperty
-    private final TokenRange tokenRange;
+    private TokenRange tokenRange;
 
     @InternalProperty
     private Node parentNode;
@@ -153,8 +154,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     private List<AstObserver> observers = new ArrayList<>();
 
     protected Node(TokenRange tokenRange) {
-        this.range = new Range(tokenRange.getBegin().getRange().begin, tokenRange.getEnd().getRange().end);
-        this.tokenRange = tokenRange;
+        setTokenRange(tokenRange);
     }
 
     /**
@@ -187,6 +187,16 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      */
     public Optional<TokenRange> getTokenRange() {
         return Optional.ofNullable(tokenRange);
+    }
+
+    public Node setTokenRange(TokenRange tokenRange) {
+        this.tokenRange = tokenRange;
+        if (tokenRange == null) {
+            range = null;
+        } else {
+            range = new Range(tokenRange.getBegin().getRange().begin, tokenRange.getEnd().getRange().end);
+        }
+        return this;
     }
 
     /**
@@ -449,7 +459,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      * it will try to remove its parent instead,
      * until it finds a node that can be removed,
      * or no parent can be found.
-     * 
+     * <p>
      * Since everything at CompilationUnit level is removable,
      * this method will only (silently) fail when the node is in a detached AST fragment.
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
@@ -36,6 +36,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.PackageDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A package declaration.
@@ -65,8 +66,8 @@ public final class PackageDeclaration extends Node implements NodeWithAnnotation
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public PackageDeclaration(Range range, NodeList<AnnotationExpr> annotations, Name name) {
-        super(range);
+    public PackageDeclaration(TokenRange tokenRange, NodeList<AnnotationExpr> annotations, Name name) {
+        super(tokenRange);
         setAnnotations(annotations);
         setName(name);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationDeclaration.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An annotation type declaration.<br/><code>@interface X { ... }</code>
@@ -60,8 +61,8 @@ public final class AnnotationDeclaration extends TypeDeclaration<AnnotationDecla
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public AnnotationDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<BodyDeclaration<?>> members) {
-        super(range, modifiers, annotations, name, members);
+    public AnnotationDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<BodyDeclaration<?>> members) {
+        super(tokenRange, modifiers, annotations, name, members);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The "int id();" in <code>@interface X { int id(); }</code>
@@ -78,8 +79,8 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public AnnotationMemberDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, SimpleName name, Expression defaultValue) {
-        super(range, annotations);
+    public AnnotationMemberDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, SimpleName name, Expression defaultValue) {
+        super(tokenRange, annotations);
         setModifiers(modifiers);
         setType(type);
         setName(name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/BodyDeclaration.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.BodyDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Any declaration that can appear between the { and } of a class, interface, or enum.
@@ -55,8 +56,8 @@ public abstract class BodyDeclaration<T extends BodyDeclaration<?>> extends Node
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public BodyDeclaration(Range range, NodeList<AnnotationExpr> annotations) {
-        super(range);
+    public BodyDeclaration(TokenRange tokenRange, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange);
         setAnnotations(annotations);
         customInitialization();
     }
@@ -64,7 +65,7 @@ public abstract class BodyDeclaration<T extends BodyDeclaration<?>> extends Node
     /**
      * This supports {@link EmptyMemberDeclaration}.
      */
-    protected BodyDeclaration(Range range) {
+    protected BodyDeclaration(TokenRange range) {
         this(range, new NodeList<>());
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
@@ -44,6 +44,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Represents a declaration which is callable eg. a method or a constructor.
@@ -67,8 +68,8 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public CallableDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions) {
-        super(range, annotations);
+    public CallableDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions) {
+        super(tokenRange, annotations);
         setModifiers(modifiers);
         setTypeParameters(typeParameters);
         setName(name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
@@ -46,6 +46,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ClassOrInterfaceDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A definition of a class or interface.<br/><code>class X { ... }</code>
@@ -78,8 +79,8 @@ public final class ClassOrInterfaceDeclaration extends TypeDeclaration<ClassOrIn
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ClassOrInterfaceDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, boolean isInterface, SimpleName name, NodeList<TypeParameter> typeParameters, NodeList<ClassOrInterfaceType> extendedTypes, NodeList<ClassOrInterfaceType> implementedTypes, NodeList<BodyDeclaration<?>> members) {
-        super(range, modifiers, annotations, name, members);
+    public ClassOrInterfaceDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, boolean isInterface, SimpleName name, NodeList<TypeParameter> typeParameters, NodeList<ClassOrInterfaceType> extendedTypes, NodeList<ClassOrInterfaceType> implementedTypes, NodeList<BodyDeclaration<?>> members) {
+        super(tokenRange, modifiers, annotations, name, members);
         setInterface(isInterface);
         setTypeParameters(typeParameters);
         setExtendedTypes(extendedTypes);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -44,6 +44,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ConstructorDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A constructor declaration: <code>class X { X() { } }</code> where X(){} is the constructor declaration.
@@ -69,8 +70,8 @@ public final class ConstructorDeclaration extends CallableDeclaration<Constructo
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ConstructorDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt body) {
-        super(range, modifiers, annotations, typeParameters, name, parameters, thrownExceptions);
+    public ConstructorDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt body) {
+        super(tokenRange, modifiers, annotations, typeParameters, name, parameters, thrownExceptions);
         setBody(body);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EmptyMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EmptyMemberDeclaration.java
@@ -33,6 +33,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.EmptyMemberDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A loose ";" inside a body.<br/><code>class X { ; }</code>
@@ -50,8 +51,8 @@ public final class EmptyMemberDeclaration extends BodyDeclaration<EmptyMemberDec
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public EmptyMemberDeclaration(Range range) {
-        super(range);
+    public EmptyMemberDeclaration(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
@@ -40,6 +40,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.EnumConstantDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * One of the values an enum can take. A(1) and B(2) in this example: <code>enum X { A(1), B(2) }</code>
@@ -69,8 +70,8 @@ public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantD
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public EnumConstantDeclaration(Range range, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<Expression> arguments, NodeList<BodyDeclaration<?>> classBody) {
-        super(range, annotations);
+    public EnumConstantDeclaration(TokenRange tokenRange, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<Expression> arguments, NodeList<BodyDeclaration<?>> classBody) {
+        super(tokenRange, annotations);
         setName(name);
         setArguments(arguments);
         setClassBody(classBody);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -41,6 +41,7 @@ import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The declaration of an enum.<br/><code>enum X { ... }</code>
@@ -68,8 +69,8 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration> impl
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public EnumDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<ClassOrInterfaceType> implementedTypes, NodeList<EnumConstantDeclaration> entries, NodeList<BodyDeclaration<?>> members) {
-        super(range, modifiers, annotations, name, members);
+    public EnumDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<ClassOrInterfaceType> implementedTypes, NodeList<EnumConstantDeclaration> entries, NodeList<BodyDeclaration<?>> members) {
+        super(tokenRange, modifiers, annotations, name, members);
         setImplementedTypes(implementedTypes);
         setEntries(entries);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -53,6 +53,7 @@ import static com.github.javaparser.ast.Modifier.*;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The declaration of a field in a class. "private static int a=15*15;" in this example: <code>class X { private static
@@ -86,8 +87,8 @@ public final class FieldDeclaration extends BodyDeclaration<FieldDeclaration> im
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public FieldDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<VariableDeclarator> variables) {
-        super(range, annotations);
+    public FieldDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<VariableDeclarator> variables) {
+        super(tokenRange, annotations);
         setModifiers(modifiers);
         setVariables(variables);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
@@ -37,6 +37,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.InitializerDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A (possibly static) initializer body. "static { a=3; }" in this example: <code>class X { static { a=3; }  } </code>
@@ -60,8 +61,8 @@ public final class InitializerDeclaration extends BodyDeclaration<InitializerDec
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public InitializerDeclaration(Range range, boolean isStatic, BlockStmt body) {
-        super(range);
+    public InitializerDeclaration(TokenRange tokenRange, boolean isStatic, BlockStmt body) {
+        super(tokenRange);
         setStatic(isStatic);
         setBody(body);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -51,6 +51,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.MethodDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A method declaration. "public int abc() {return 1;}" in this example: <code>class X { public int abc() {return 1;}
@@ -90,8 +91,8 @@ public final class MethodDeclaration extends CallableDeclaration<MethodDeclarati
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public MethodDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, Type type, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt body) {
-        super(range, modifiers, annotations, typeParameters, name, parameters, thrownExceptions);
+    public MethodDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<TypeParameter> typeParameters, Type type, SimpleName name, NodeList<Parameter> parameters, NodeList<ReferenceType> thrownExceptions, BlockStmt body) {
+        super(tokenRange, modifiers, annotations, typeParameters, name, parameters, thrownExceptions);
         setType(type);
         setBody(body);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -44,6 +44,7 @@ import java.util.EnumSet;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The parameters to a method or lambda. Lambda parameters may have inferred types, in that case "type" is UnknownType.
@@ -96,8 +97,8 @@ public final class Parameter extends Node implements NodeWithType<Parameter, Typ
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public Parameter(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, boolean isVarArgs, NodeList<AnnotationExpr> varArgsAnnotations, SimpleName name) {
-        super(range);
+    public Parameter(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, Type type, boolean isVarArgs, NodeList<AnnotationExpr> varArgsAnnotations, SimpleName name) {
+        super(tokenRange);
         setModifiers(modifiers);
         setAnnotations(annotations);
         setType(type);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -41,6 +41,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 import static java.util.stream.Collectors.toList;
 import javax.annotation.Generated;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.TokenRange;
 
 /**
  * A base class for all types of type declarations.
@@ -70,8 +71,8 @@ public abstract class TypeDeclaration<T extends TypeDeclaration<?>> extends Body
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public TypeDeclaration(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<BodyDeclaration<?>> members) {
-        super(range, annotations);
+    public TypeDeclaration(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, SimpleName name, NodeList<BodyDeclaration<?>> members) {
+        super(tokenRange, annotations);
         setModifiers(modifiers);
         setName(name);
         setMembers(members);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The declaration of a variable.<br/>In <code>int x = 14, y = 3;</code> "x = 14"  and " y = 3"  are
@@ -90,8 +91,8 @@ public final class VariableDeclarator extends Node implements NodeWithType<Varia
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public VariableDeclarator(Range range, Type type, SimpleName name, Expression initializer) {
-        super(range);
+    public VariableDeclarator(TokenRange tokenRange, Type type, SimpleName name, Expression initializer) {
+        super(tokenRange);
         setType(type);
         setName(name);
         setInitializer(initializer);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.BlockCommentMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * <p>
@@ -52,8 +53,8 @@ public final class BlockComment extends Comment {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public BlockComment(Range range, String content) {
-        super(range, content);
+    public BlockComment(TokenRange tokenRange, String content) {
+        super(tokenRange, content);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -31,6 +31,7 @@ import com.github.javaparser.metamodel.CommentMetaModel;
 import com.github.javaparser.metamodel.InternalProperty;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Abstract class for all AST nodes that represent comments.
@@ -54,8 +55,8 @@ public abstract class Comment extends Node {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public Comment(Range range, String content) {
-        super(range);
+    public Comment(TokenRange tokenRange, String content) {
+        super(tokenRange);
         setContent(content);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.JavadocCommentMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A Javadoc comment. <code>/&#42;&#42; a comment &#42;/</code>
@@ -50,8 +51,8 @@ public final class JavadocComment extends Comment {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public JavadocComment(Range range, String content) {
-        super(range, content);
+    public JavadocComment(TokenRange tokenRange, String content) {
+        super(tokenRange, content);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.LineCommentMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * <p>
@@ -51,8 +52,8 @@ public final class LineComment extends Comment {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public LineComment(Range range, String content) {
-        super(range, content);
+    public LineComment(TokenRange tokenRange, String content) {
+        super(tokenRange, content);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.AnnotationExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A base class for the different types of annotations.
@@ -51,8 +52,8 @@ public abstract class AnnotationExpr extends Expression implements NodeWithName<
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public AnnotationExpr(Range range, Name name) {
-        super(range);
+    public AnnotationExpr(TokenRange tokenRange, Name name) {
+        super(tokenRange);
         setName(name);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ArrayAccessExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Array brackets [] being used to get a value from an array.
@@ -55,8 +56,8 @@ public final class ArrayAccessExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ArrayAccessExpr(Range range, Expression name, Expression index) {
-        super(range);
+    public ArrayAccessExpr(TokenRange tokenRange, Expression name, Expression index) {
+        super(tokenRange);
         setName(name);
         setIndex(index);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -39,6 +39,7 @@ import static com.github.javaparser.JavaParser.parseType;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.TokenRange;
 
 /**
  * <code>new int[5][4][][]</code> or <code>new int[][]{{1},{2,3}}</code>.
@@ -70,14 +71,19 @@ public final class ArrayCreationExpr extends Expression {
         this(null, elementType, new NodeList<>(), new ArrayInitializerExpr());
     }
 
+    /**
+     * @deprecated range shouldn't be in utility constructors.
+     */
+    @Deprecated
     public ArrayCreationExpr(Range range, Type elementType) {
-        this(range, elementType, new NodeList<>(), new ArrayInitializerExpr());
+        this(null, elementType, new NodeList<>(), new ArrayInitializerExpr());
+        setRange(range);
     }
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ArrayCreationExpr(Range range, Type elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
-        super(range);
+    public ArrayCreationExpr(TokenRange tokenRange, Type elementType, NodeList<ArrayCreationLevel> levels, ArrayInitializerExpr initializer) {
+        super(tokenRange);
         setElementType(elementType);
         setLevels(levels);
         setInitializer(initializer);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ArrayInitializerExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The initialization of an array. In the following sample, the outer { } is an ArrayInitializerExpr.
@@ -58,8 +59,8 @@ public final class ArrayInitializerExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ArrayInitializerExpr(Range range, NodeList<Expression> values) {
-        super(range);
+    public ArrayInitializerExpr(TokenRange tokenRange, NodeList<Expression> values) {
+        super(tokenRange);
         setValues(values);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
@@ -32,6 +32,7 @@ import com.github.javaparser.metamodel.AssignExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.printer.Printable;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An assignment expression. It supports the operators that are found the the AssignExpr.Operator enum.
@@ -74,8 +75,8 @@ public final class AssignExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public AssignExpr(Range range, Expression target, Expression value, Operator operator) {
-        super(range);
+    public AssignExpr(TokenRange tokenRange, Expression target, Expression value, Operator operator) {
+        super(tokenRange);
         setTarget(target);
         setValue(value);
         setOperator(operator);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -32,6 +32,7 @@ import com.github.javaparser.metamodel.BinaryExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.printer.Printable;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An expression with an expression on the left, an expression on the right, and an operator in the middle.
@@ -75,8 +76,8 @@ public final class BinaryExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public BinaryExpr(Range range, Expression left, Expression right, Operator operator) {
-        super(range);
+    public BinaryExpr(TokenRange tokenRange, Expression left, Expression right, Operator operator) {
+        super(tokenRange);
         setLeft(left);
         setRight(right);
         setOperator(operator);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.BooleanLiteralExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The boolean literals.
@@ -53,8 +54,8 @@ public final class BooleanLiteralExpr extends LiteralExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public BooleanLiteralExpr(Range range, boolean value) {
-        super(range);
+    public BooleanLiteralExpr(TokenRange tokenRange, boolean value) {
+        super(tokenRange);
         setValue(value);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.CastExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A typecast. The (long) in <code>(long)15</code>
@@ -58,8 +59,8 @@ public final class CastExpr extends Expression implements NodeWithType<CastExpr,
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public CastExpr(Range range, Type type, Expression expression) {
-        super(range);
+    public CastExpr(TokenRange tokenRange, Type type, Expression expression) {
+        super(tokenRange);
         setType(type);
         setExpression(expression);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CharLiteralExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.utils.StringEscapeUtils;
 import com.github.javaparser.utils.Utils;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A literal character.
@@ -64,8 +65,8 @@ public final class CharLiteralExpr extends LiteralStringValueExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public CharLiteralExpr(Range range, String value) {
-        super(range, value);
+    public CharLiteralExpr(TokenRange tokenRange, String value) {
+        super(tokenRange, value);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ClassExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Defines an expression that accesses the class of a type.
@@ -56,8 +57,8 @@ public final class ClassExpr extends Expression implements NodeWithType<ClassExp
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ClassExpr(Range range, Type type) {
-        super(range);
+    public ClassExpr(TokenRange tokenRange, Type type) {
+        super(tokenRange);
         setType(type);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ConditionalExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An if-then or if-then-else construct.
@@ -57,8 +58,8 @@ public final class ConditionalExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ConditionalExpr(Range range, Expression condition, Expression thenExpr, Expression elseExpr) {
-        super(range);
+    public ConditionalExpr(TokenRange tokenRange, Expression condition, Expression thenExpr, Expression elseExpr) {
+        super(tokenRange);
         setCondition(condition);
         setThenExpr(thenExpr);
         setElseExpr(elseExpr);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.DoubleLiteralExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A float or a double constant. This value is stored exactly as found in the source.
@@ -51,8 +52,8 @@ public final class DoubleLiteralExpr extends LiteralStringValueExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public DoubleLiteralExpr(Range range, String value) {
-        super(range, value);
+    public DoubleLiteralExpr(TokenRange tokenRange, String value) {
+        super(tokenRange, value);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.EnclosedExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An expression between ( ).
@@ -53,8 +54,8 @@ public final class EnclosedExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public EnclosedExpr(Range range, Expression inner) {
-        super(range);
+    public EnclosedExpr(TokenRange tokenRange, Expression inner) {
+        super(tokenRange);
         setInner(inner);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ExpressionMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A base class for all expressions.
@@ -42,8 +43,8 @@ public abstract class Expression extends Node {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public Expression(Range range) {
-        super(range);
+    public Expression(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -38,6 +38,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.FieldAccessExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Access of a field of an object.
@@ -68,8 +69,8 @@ public final class FieldAccessExpr extends Expression implements NodeWithSimpleN
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public FieldAccessExpr(Range range, Expression scope, NodeList<Type> typeArguments, SimpleName name) {
-        super(range);
+    public FieldAccessExpr(TokenRange tokenRange, Expression scope, NodeList<Type> typeArguments, SimpleName name) {
+        super(tokenRange);
         setScope(scope);
         setTypeArguments(typeArguments);
         setName(name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.InstanceOfExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Usage of the instanceof operator.
@@ -59,8 +60,8 @@ public final class InstanceOfExpr extends Expression implements NodeWithType<Ins
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public InstanceOfExpr(Range range, Expression expression, ReferenceType type) {
-        super(range);
+    public InstanceOfExpr(TokenRange tokenRange, Expression expression, ReferenceType type) {
+        super(tokenRange);
         setExpression(expression);
         setType(type);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.IntegerLiteralExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * All ways to specify an int literal.
@@ -53,8 +54,8 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public IntegerLiteralExpr(Range range, String value) {
-        super(range, value);
+    public IntegerLiteralExpr(TokenRange tokenRange, String value) {
+        super(tokenRange, value);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -41,6 +41,7 @@ import com.github.javaparser.metamodel.DerivedProperty;
 import com.github.javaparser.metamodel.LambdaExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A lambda expression. The parameters are on the left side of the ->.
@@ -72,8 +73,8 @@ public class LambdaExpr extends Expression implements NodeWithParameters<LambdaE
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public LambdaExpr(Range range, NodeList<Parameter> parameters, Statement body, boolean isEnclosingParameters) {
-        super(range);
+    public LambdaExpr(TokenRange tokenRange, NodeList<Parameter> parameters, Statement body, boolean isEnclosingParameters) {
+        super(tokenRange);
         setParameters(parameters);
         setBody(body);
         setEnclosingParameters(isEnclosingParameters);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LiteralExprMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A base class for all literal expressions.
@@ -42,8 +43,8 @@ public abstract class LiteralExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public LiteralExpr(Range range) {
-        super(range);
+    public LiteralExpr(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralStringValueExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LiteralStringValueExpr.java
@@ -29,6 +29,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LiteralStringValueExprMetaModel;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Any literal value that is stored internally as a String.
@@ -44,8 +45,8 @@ public abstract class LiteralStringValueExpr extends LiteralExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public LiteralStringValueExpr(Range range, String value) {
-        super(range);
+    public LiteralStringValueExpr(TokenRange tokenRange, String value) {
+        super(tokenRange);
         setValue(value);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LongLiteralExprMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * All ways to specify a long literal.
@@ -53,8 +54,8 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public LongLiteralExpr(Range range, String value) {
-        super(range, value);
+    public LongLiteralExpr(TokenRange tokenRange, String value) {
+        super(tokenRange, value);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import static com.github.javaparser.JavaParser.parseName;
 import static com.github.javaparser.JavaParser.parseName;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An annotation that uses only the annotation type name.
@@ -55,8 +56,8 @@ public final class MarkerAnnotationExpr extends AnnotationExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public MarkerAnnotationExpr(Range range, Name name) {
-        super(range, name);
+    public MarkerAnnotationExpr(TokenRange tokenRange, Name name) {
+        super(tokenRange, name);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.MemberValuePairMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A value for a member of an annotation.
@@ -60,8 +61,8 @@ public final class MemberValuePair extends Node implements NodeWithSimpleName<Me
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public MemberValuePair(Range range, SimpleName name, Expression value) {
-        super(range);
+    public MemberValuePair(TokenRange tokenRange, SimpleName name, Expression value) {
+        super(tokenRange);
         setName(name);
         setValue(value);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -40,6 +40,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.MethodCallExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A method call on an object. <br/><code>circle.circumference()</code> <br/>In <code>a.&lt;String&gt;bb(15);</code> a
@@ -84,8 +85,8 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public MethodCallExpr(Range range, Expression scope, NodeList<Type> typeArguments, SimpleName name, NodeList<Expression> arguments) {
-        super(range);
+    public MethodCallExpr(TokenRange tokenRange, Expression scope, NodeList<Type> typeArguments, SimpleName name, NodeList<Expression> arguments) {
+        super(tokenRange);
         setScope(scope);
         setTypeArguments(typeArguments);
         setName(name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
@@ -40,6 +40,7 @@ import com.github.javaparser.metamodel.MethodReferenceExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.NonEmptyProperty;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Method reference expressions introduced in Java 8 specifically designed to simplify lambda Expressions.
@@ -72,8 +73,8 @@ public class MethodReferenceExpr extends Expression implements NodeWithTypeArgum
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public MethodReferenceExpr(Range range, Expression scope, NodeList<Type> typeArguments, String identifier) {
-        super(range);
+    public MethodReferenceExpr(TokenRange tokenRange, Expression scope, NodeList<Type> typeArguments, String identifier) {
+        super(tokenRange);
         setScope(scope);
         setTypeArguments(typeArguments);
         setIdentifier(identifier);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A name that may consist of multiple identifiers.
@@ -81,8 +82,8 @@ public class Name extends Node implements NodeWithIdentifier<Name>, NodeWithAnno
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public Name(Range range, Name qualifier, String identifier, NodeList<AnnotationExpr> annotations) {
-        super(range);
+    public Name(TokenRange tokenRange, Name qualifier, String identifier, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange);
         setQualifier(qualifier);
         setIdentifier(identifier);
         setAnnotations(annotations);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.NameExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Whenever a SimpleName is used in an expression, it is wrapped in NameExpr.
@@ -53,13 +54,14 @@ public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>
 
     @AllFieldsConstructor
     public NameExpr(final SimpleName name) {
-        this(name.getRange().orElse(null), name);
+        this(name.getTokenRange().orElse(null), name);
+        setRange(name.getRange().orElse(null));
     }
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public NameExpr(Range range, SimpleName name) {
-        super(range);
+    public NameExpr(TokenRange tokenRange, SimpleName name) {
+        super(tokenRange);
         setName(name);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.NormalAnnotationExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An annotation that has zero or more key-value pairs.<br/><code>@Mapping(a=5, d=10)</code>
@@ -54,8 +55,8 @@ public final class NormalAnnotationExpr extends AnnotationExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public NormalAnnotationExpr(Range range, Name name, NodeList<MemberValuePair> pairs) {
-        super(range, name);
+    public NormalAnnotationExpr(TokenRange tokenRange, Name name, NodeList<MemberValuePair> pairs) {
+        super(tokenRange, name);
         setPairs(pairs);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NullLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NullLiteralExpr.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.NullLiteralExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A literal "null".
@@ -45,8 +46,8 @@ public final class NullLiteralExpr extends LiteralExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public NullLiteralExpr(Range range) {
-        super(range);
+    public NullLiteralExpr(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -42,6 +42,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ObjectCreationExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A constructor call. <br/>In <code>new HashMap.Entry<String, Long>(15) {public String getKey() {return null;}};</code>
@@ -84,8 +85,8 @@ public final class ObjectCreationExpr extends Expression implements NodeWithType
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ObjectCreationExpr(Range range, Expression scope, ClassOrInterfaceType type, NodeList<Type> typeArguments, NodeList<Expression> arguments, NodeList<BodyDeclaration<?>> anonymousClassBody) {
-        super(range);
+    public ObjectCreationExpr(TokenRange tokenRange, Expression scope, ClassOrInterfaceType type, NodeList<Type> typeArguments, NodeList<Expression> arguments, NodeList<BodyDeclaration<?>> anonymousClassBody) {
+        super(tokenRange);
         setScope(scope);
         setType(type);
         setTypeArguments(typeArguments);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
@@ -33,6 +33,7 @@ import com.github.javaparser.metamodel.NonEmptyProperty;
 import com.github.javaparser.metamodel.SimpleNameMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A name that consists of a single identifier.
@@ -56,8 +57,8 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public SimpleName(Range range, String identifier) {
-        super(range);
+    public SimpleName(TokenRange tokenRange, String identifier) {
+        super(tokenRange);
         setIdentifier(identifier);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.SingleMemberAnnotationExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An annotation that has a single value. <br/><code>@Count(15)</code>
@@ -52,8 +53,8 @@ public final class SingleMemberAnnotationExpr extends AnnotationExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public SingleMemberAnnotationExpr(Range range, Name name, Expression memberValue) {
-        super(range, name);
+    public SingleMemberAnnotationExpr(TokenRange tokenRange, Name name, Expression memberValue) {
+        super(tokenRange, name);
         setMemberValue(memberValue);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.metamodel.StringLiteralExprMetaModel;
 import com.github.javaparser.utils.StringEscapeUtils;
 import com.github.javaparser.utils.Utils;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A literal string.
@@ -69,8 +70,8 @@ public class StringLiteralExpr extends LiteralStringValueExpr {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public StringLiteralExpr(Range range, String value) {
-        super(range, value);
+    public StringLiteralExpr(TokenRange tokenRange, String value) {
+        super(tokenRange, value);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.SuperExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An occurrence of the "super" keyword. <br/><code>World.super.greet()</code> is a MethodCallExpr of method name greet,
@@ -56,8 +57,8 @@ public final class SuperExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public SuperExpr(Range range, Expression classExpr) {
-        super(range);
+    public SuperExpr(TokenRange tokenRange, Expression classExpr) {
+        super(tokenRange);
         setClassExpr(classExpr);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ThisExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An occurrence of the "this" keyword. <br/><code>World.this.greet()</code> is a MethodCallExpr of method name greet,
@@ -56,8 +57,8 @@ public final class ThisExpr extends Expression {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ThisExpr(Range range, Expression classExpr) {
-        super(range);
+    public ThisExpr(TokenRange tokenRange, Expression classExpr) {
+        super(tokenRange);
         setClassExpr(classExpr);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.TypeExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * This class is just instantiated as scopes for MethodReferenceExpr nodes to encapsulate Types.
@@ -57,8 +58,8 @@ public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type>
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public TypeExpr(Range range, Type type) {
-        super(range);
+    public TypeExpr(TokenRange tokenRange, Type type) {
+        super(tokenRange);
         setType(type);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
@@ -34,6 +34,7 @@ import com.github.javaparser.metamodel.UnaryExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.printer.Printable;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An expression where an operator is applied to a single expression.
@@ -88,8 +89,8 @@ public final class UnaryExpr extends Expression implements NodeWithExpression<Un
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public UnaryExpr(Range range, Expression expression, Operator operator) {
-        super(range);
+    public UnaryExpr(TokenRange tokenRange, Expression expression, Operator operator) {
+        super(tokenRange);
         setExpression(expression);
         setOperator(operator);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A declaration of variables.
@@ -97,8 +98,8 @@ public final class VariableDeclarationExpr extends Expression implements NodeWit
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public VariableDeclarationExpr(Range range, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<VariableDeclarator> variables) {
-        super(range);
+    public VariableDeclarationExpr(TokenRange tokenRange, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations, NodeList<VariableDeclarator> variables) {
+        super(tokenRange);
         setModifiers(modifiers);
         setAnnotations(annotations);
         setVariables(variables);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleDeclaration.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A Java 9 Jigsaw module declaration. <code>@Foo module com.github.abc { requires a.B; }</code>
@@ -47,8 +48,8 @@ public class ModuleDeclaration extends Node implements NodeWithName<ModuleDeclar
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ModuleDeclaration(Range range, NodeList<AnnotationExpr> annotations, Name name, boolean isOpen, NodeList<ModuleStmt> moduleStmts) {
-        super(range);
+    public ModuleDeclaration(TokenRange tokenRange, NodeList<AnnotationExpr> annotations, Name name, boolean isOpen, NodeList<ModuleStmt> moduleStmts) {
+        super(tokenRange);
         setAnnotations(annotations);
         setName(name);
         setOpen(isOpen);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleExportsStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleExportsStmt.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 public class ModuleExportsStmt extends ModuleStmt implements NodeWithName<ModuleExportsStmt> {
 
@@ -34,8 +35,8 @@ public class ModuleExportsStmt extends ModuleStmt implements NodeWithName<Module
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ModuleExportsStmt(Range range, Name name, NodeList<Name> moduleNames) {
-        super(range);
+    public ModuleExportsStmt(TokenRange tokenRange, Name name, NodeList<Name> moduleNames) {
+        super(tokenRange);
         setName(name);
         setModuleNames(moduleNames);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleOpensStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleOpensStmt.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 public class ModuleOpensStmt extends ModuleStmt implements NodeWithName<ModuleOpensStmt> {
 
@@ -34,8 +35,8 @@ public class ModuleOpensStmt extends ModuleStmt implements NodeWithName<ModuleOp
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ModuleOpensStmt(Range range, Name name, NodeList<Name> moduleNames) {
-        super(range);
+    public ModuleOpensStmt(TokenRange tokenRange, Name name, NodeList<Name> moduleNames) {
+        super(tokenRange);
         setName(name);
         setModuleNames(moduleNames);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleProvidesStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleProvidesStmt.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 public class ModuleProvidesStmt extends ModuleStmt implements NodeWithType<ModuleProvidesStmt, Type> {
 
@@ -35,8 +36,8 @@ public class ModuleProvidesStmt extends ModuleStmt implements NodeWithType<Modul
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ModuleProvidesStmt(Range range, Type type, NodeList<Type> withTypes) {
-        super(range);
+    public ModuleProvidesStmt(TokenRange tokenRange, Type type, NodeList<Type> withTypes) {
+        super(tokenRange);
         setType(type);
         setWithTypes(withTypes);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleRequiresStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleRequiresStmt.java
@@ -17,6 +17,7 @@ import java.util.EnumSet;
 import static com.github.javaparser.ast.Modifier.TRANSITIVE;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A require statement in module-info.java. <code>require a.b.C;</code>
@@ -38,8 +39,8 @@ public class ModuleRequiresStmt extends ModuleStmt implements NodeWithStaticModi
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ModuleRequiresStmt(Range range, EnumSet<Modifier> modifiers, Name name) {
-        super(range);
+    public ModuleRequiresStmt(TokenRange tokenRange, EnumSet<Modifier> modifiers, Name name) {
+        super(tokenRange);
         setModifiers(modifiers);
         setName(name);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleStmt.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.ModuleStmtMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 public abstract class ModuleStmt extends Node {
 
@@ -17,8 +18,8 @@ public abstract class ModuleStmt extends Node {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ModuleStmt(Range range) {
-        super(range);
+    public ModuleStmt(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleUsesStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleUsesStmt.java
@@ -13,6 +13,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.ModuleUsesStmtMetaModel;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 public class ModuleUsesStmt extends ModuleStmt implements NodeWithType<ModuleUsesStmt, Type> {
 
@@ -29,8 +30,8 @@ public class ModuleUsesStmt extends ModuleStmt implements NodeWithType<ModuleUse
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ModuleUsesStmt(Range range, Type type) {
-        super(range);
+    public ModuleUsesStmt(TokenRange tokenRange, Type type) {
+        super(tokenRange);
         setType(type);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTokenRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTokenRange.java
@@ -1,0 +1,18 @@
+package com.github.javaparser.ast.nodeTypes;
+
+import com.github.javaparser.Position;
+import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
+import com.github.javaparser.ast.Node;
+
+import java.util.Optional;
+
+/**
+ * A node that has a Range, which is every Node.
+ * 
+ */
+public interface NodeWithTokenRange<N> {
+    Optional<TokenRange> getTokenRange();
+
+    N setTokenRange(TokenRange range);
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.AssertStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A usage of the keyword "assert"
@@ -61,8 +62,8 @@ public final class AssertStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public AssertStmt(Range range, Expression check, Expression message) {
-        super(range);
+    public AssertStmt(TokenRange tokenRange, Expression check, Expression message) {
+        super(tokenRange);
         setCheck(check);
         setMessage(message);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BlockStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BlockStmt.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.BlockStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Statements in between { and }.
@@ -56,8 +57,8 @@ public final class BlockStmt extends Statement implements NodeWithStatements<Blo
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public BlockStmt(Range range, NodeList<Statement> statements) {
-        super(range);
+    public BlockStmt(TokenRange tokenRange, NodeList<Statement> statements) {
+        super(tokenRange);
         setStatements(statements);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.BreakStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A usage of the break keyword.
@@ -58,8 +59,8 @@ public final class BreakStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public BreakStmt(Range range, SimpleName label) {
-        super(range);
+    public BreakStmt(TokenRange tokenRange, SimpleName label) {
+        super(tokenRange);
         setLabel(label);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
@@ -39,6 +39,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.CatchClauseMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The catch part of a try-catch-finally. <br/>In <code>try { ... } catch (Exception e) { ... }</code> the CatchClause
@@ -67,8 +68,8 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public CatchClause(Range range, Parameter parameter, BlockStmt body) {
-        super(range);
+    public CatchClause(TokenRange tokenRange, Parameter parameter, BlockStmt body) {
+        super(tokenRange);
         setParameter(parameter);
         setBody(body);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
@@ -33,6 +33,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ContinueStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A continue statement with an optional label;
@@ -60,8 +61,8 @@ public final class ContinueStmt extends Statement implements NodeWithOptionalLab
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ContinueStmt(Range range, SimpleName label) {
-        super(range);
+    public ContinueStmt(TokenRange tokenRange, SimpleName label) {
+        super(tokenRange);
         setLabel(label);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.DoStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A do-while.
@@ -58,8 +59,8 @@ public final class DoStmt extends Statement implements NodeWithBody<DoStmt> {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public DoStmt(Range range, Statement body, Expression condition) {
-        super(range);
+    public DoStmt(TokenRange tokenRange, Statement body, Expression condition) {
+        super(tokenRange);
         setBody(body);
         setCondition(condition);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/EmptyStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/EmptyStmt.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.EmptyStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * @author Julio Vilmar Gesser
@@ -44,8 +45,8 @@ public final class EmptyStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public EmptyStmt(Range range) {
-        super(range);
+    public EmptyStmt(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -38,6 +38,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ExplicitConstructorInvocationStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A call to super or this in a constructor or initializer.
@@ -73,8 +74,8 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ExplicitConstructorInvocationStmt(Range range, NodeList<Type> typeArguments, boolean isThis, Expression expression, NodeList<Expression> arguments) {
-        super(range);
+    public ExplicitConstructorInvocationStmt(TokenRange tokenRange, NodeList<Type> typeArguments, boolean isThis, Expression expression, NodeList<Expression> arguments) {
+        super(tokenRange);
         setTypeArguments(typeArguments);
         setThis(isThis);
         setExpression(expression);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ExpressionStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Used to wrap an expression so that it can take the place of a statement.
@@ -55,8 +56,8 @@ public final class ExpressionStmt extends Statement implements NodeWithExpressio
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ExpressionStmt(Range range, Expression expression) {
-        super(range);
+    public ExpressionStmt(TokenRange tokenRange, Expression expression) {
+        super(tokenRange);
         setExpression(expression);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
@@ -39,6 +39,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ForStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A classic for statement.
@@ -68,8 +69,8 @@ public final class ForStmt extends Statement implements NodeWithBody<ForStmt> {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ForStmt(Range range, NodeList<Expression> initialization, Expression compare, NodeList<Expression> update, Statement body) {
-        super(range);
+    public ForStmt(TokenRange tokenRange, NodeList<Expression> initialization, Expression compare, NodeList<Expression> update, Statement body) {
+        super(tokenRange);
         setInitialization(initialization);
         setCompare(compare);
         setUpdate(update);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ForeachStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A for-each statement.
@@ -61,8 +62,8 @@ public final class ForeachStmt extends Statement implements NodeWithBody<Foreach
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ForeachStmt(Range range, VariableDeclarationExpr variable, Expression iterable, Statement body) {
-        super(range);
+    public ForeachStmt(TokenRange tokenRange, VariableDeclarationExpr variable, Expression iterable, Statement body) {
+        super(tokenRange);
         setVariable(variable);
         setIterable(iterable);
         setBody(body);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
@@ -35,6 +35,7 @@ import com.github.javaparser.metamodel.DerivedProperty;
 import com.github.javaparser.metamodel.IfStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An if-then-else statement. The else is optional.
@@ -62,8 +63,8 @@ public final class IfStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public IfStmt(Range range, Expression condition, Statement thenStmt, Statement elseStmt) {
-        super(range);
+    public IfStmt(TokenRange tokenRange, Expression condition, Statement thenStmt, Statement elseStmt) {
+        super(tokenRange);
         setCondition(condition);
         setThenStmt(thenStmt);
         setElseStmt(elseStmt);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.LabeledStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A statement that is labeled, like <code>label123: println("continuing");</code>
@@ -59,8 +60,8 @@ public final class LabeledStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public LabeledStmt(Range range, SimpleName label, Statement statement) {
-        super(range);
+    public LabeledStmt(TokenRange tokenRange, SimpleName label, Statement statement) {
+        super(tokenRange);
         setLabel(label);
         setStatement(statement);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.LocalClassDeclarationStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A class declaration inside a method. 
@@ -56,8 +57,8 @@ public final class LocalClassDeclarationStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public LocalClassDeclarationStmt(Range range, ClassOrInterfaceDeclaration classDeclaration) {
-        super(range);
+    public LocalClassDeclarationStmt(TokenRange tokenRange, ClassOrInterfaceDeclaration classDeclaration) {
+        super(tokenRange);
         setClassDeclaration(classDeclaration);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
@@ -33,6 +33,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ReturnStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The return statement, with an optional expression to return.
@@ -54,8 +55,8 @@ public final class ReturnStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ReturnStmt(Range range, Expression expression) {
-        super(range);
+    public ReturnStmt(TokenRange tokenRange, Expression expression) {
+        super(tokenRange);
         setExpression(expression);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.StatementMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A base class for all statements.
@@ -42,8 +43,8 @@ public abstract class Statement extends Node {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public Statement(Range range) {
-        super(range);
+    public Statement(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -37,6 +37,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.SwitchEntryStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * One case in a switch statement.
@@ -75,8 +76,8 @@ public final class SwitchEntryStmt extends Statement implements NodeWithStatemen
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public SwitchEntryStmt(Range range, Expression label, NodeList<Statement> statements) {
-        super(range);
+    public SwitchEntryStmt(TokenRange tokenRange, Expression label, NodeList<Statement> statements) {
+        super(tokenRange);
         setLabel(label);
         setStatements(statements);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
@@ -36,6 +36,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.SwitchStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A switch statement.
@@ -62,8 +63,8 @@ public final class SwitchStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public SwitchStmt(Range range, Expression selector, NodeList<SwitchEntryStmt> entries) {
-        super(range);
+    public SwitchStmt(TokenRange tokenRange, Expression selector, NodeList<SwitchEntryStmt> entries) {
+        super(tokenRange);
         setSelector(selector);
         setEntries(entries);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.SynchronizedStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Usage of the synchronized keyword.
@@ -59,8 +60,8 @@ public final class SynchronizedStmt extends Statement implements NodeWithBlockSt
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public SynchronizedStmt(Range range, Expression expression, BlockStmt body) {
-        super(range);
+    public SynchronizedStmt(TokenRange tokenRange, Expression expression, BlockStmt body) {
+        super(tokenRange);
         setExpression(expression);
         setBody(body);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ThrowStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Usage of the throw statement.
@@ -56,8 +57,8 @@ public final class ThrowStmt extends Statement implements NodeWithExpression<Thr
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ThrowStmt(Range range, Expression expression) {
-        super(range);
+    public ThrowStmt(TokenRange tokenRange, Expression expression) {
+        super(tokenRange);
         setExpression(expression);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
@@ -36,6 +36,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.TryStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The try statement.
@@ -80,8 +81,8 @@ public final class TryStmt extends Statement {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public TryStmt(Range range, NodeList<VariableDeclarationExpr> resources, BlockStmt tryBlock, NodeList<CatchClause> catchClauses, BlockStmt finallyBlock) {
-        super(range);
+    public TryStmt(TokenRange tokenRange, NodeList<VariableDeclarationExpr> resources, BlockStmt tryBlock, NodeList<CatchClause> catchClauses, BlockStmt finallyBlock) {
+        super(tokenRange);
         setResources(resources);
         setTryBlock(tryBlock);
         setCatchClauses(catchClauses);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.WhileStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A while statement.
@@ -58,8 +59,8 @@ public final class WhileStmt extends Statement implements NodeWithBody<WhileStmt
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public WhileStmt(Range range, Expression condition, Statement body) {
-        super(range);
+    public WhileStmt(TokenRange tokenRange, Expression condition, Statement body) {
+        super(tokenRange);
         setCondition(condition);
         setBody(body);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -33,13 +33,11 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.ArrayTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.utils.Pair;
-
 import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
@@ -60,9 +58,7 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
         this(type, nodeList(annotations));
     }
 
-    /**
-     * This constructor is used by the parser and is considered private.
-     */
+    /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
     public ArrayType(TokenRange tokenRange, Type componentType, NodeList<AnnotationExpr> annotations) {
         super(tokenRange, annotations);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -20,7 +20,7 @@
  */
 package com.github.javaparser.ast.type;
 
-import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
@@ -33,13 +33,15 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.ArrayTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.utils.Pair;
+
+import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.utils.Utils.assertNotNull;
-import javax.annotation.Generated;
 
 /**
  * To indicate that a type is an array, it gets wrapped in an ArrayType for every array level it has.
@@ -58,10 +60,12 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
         this(type, nodeList(annotations));
     }
 
-    /**This constructor is used by the parser and is considered private.*/
+    /**
+     * This constructor is used by the parser and is considered private.
+     */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ArrayType(Range range, Type componentType, NodeList<AnnotationExpr> annotations) {
-        super(range, annotations);
+    public ArrayType(TokenRange tokenRange, Type componentType, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange, annotations);
         setComponentType(componentType);
         customInitialization();
     }
@@ -107,11 +111,14 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
             if (arrayBracketPairList != null) {
                 for (int j = arrayBracketPairList.size() - 1; j >= 0; j--) {
                     ArrayBracketPair pair = arrayBracketPairList.get(j);
-                    Range range = null;
-                    if (type.getRange().isPresent() && pair.getRange().isPresent()) {
-                        range = new Range(type.getBegin().get(), pair.getRange().get().end);
+                    TokenRange tokenRange = null;
+                    if (type.getTokenRange().isPresent() && pair.getTokenRange().isPresent()) {
+                        tokenRange = new TokenRange(type.getTokenRange().get().getBegin(), pair.getTokenRange().get().getEnd());
                     }
-                    type = new ArrayType(range, type, pair.getAnnotations());
+                    type = new ArrayType(tokenRange, type, pair.getAnnotations());
+                    if (tokenRange != null) {
+                        type.setRange(tokenRange.getRange());
+                    }
                 }
             }
         }
@@ -127,7 +134,7 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
         final List<ArrayBracketPair> arrayBracketPairs = new ArrayList<>(0);
         while (type instanceof ArrayType) {
             ArrayType arrayType = (ArrayType) type;
-            arrayBracketPairs.add(new ArrayBracketPair(type.getRange().orElse(null), arrayType.getAnnotations()));
+            arrayBracketPairs.add(new ArrayBracketPair(type.getTokenRange().orElse(null), arrayType.getAnnotations()));
             type = arrayType.getComponentType();
         }
         return new Pair<>(type, arrayBracketPairs);
@@ -138,12 +145,12 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
      */
     public static class ArrayBracketPair {
 
-        private Range range;
+        private TokenRange tokenRange;
 
         private NodeList<AnnotationExpr> annotations = new NodeList<>();
 
-        public ArrayBracketPair(Range range, NodeList<AnnotationExpr> annotations) {
-            setRange(range);
+        public ArrayBracketPair(TokenRange tokenRange, NodeList<AnnotationExpr> annotations) {
+            setTokenRange(tokenRange);
             setAnnotations(annotations);
         }
 
@@ -156,13 +163,13 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
             return this;
         }
 
-        public ArrayBracketPair setRange(Range range) {
-            this.range = range;
+        public ArrayBracketPair setTokenRange(TokenRange range) {
+            this.tokenRange = range;
             return this;
         }
 
-        public Optional<Range> getRange() {
-            return Optional.ofNullable(range);
+        public Optional<TokenRange> getTokenRange() {
+            return Optional.ofNullable(tokenRange);
         }
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import static java.util.stream.Collectors.joining;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A class or an interface type. <br/><code>Object</code> <br/><code>HashMap&lt;String, String></code>
@@ -88,8 +89,8 @@ public final class ClassOrInterfaceType extends ReferenceType implements NodeWit
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ClassOrInterfaceType(Range range, ClassOrInterfaceType scope, SimpleName name, NodeList<Type> typeArguments, NodeList<AnnotationExpr> annotations) {
-        super(range, annotations);
+    public ClassOrInterfaceType(TokenRange tokenRange, ClassOrInterfaceType scope, SimpleName name, NodeList<Type> typeArguments, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange, annotations);
         setScope(scope);
         setName(name);
         setTypeArguments(typeArguments);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -38,6 +38,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 import static java.util.stream.Collectors.joining;
 import com.github.javaparser.metamodel.NonEmptyProperty;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Represents a set of types. A given value of this type has to be assignable to at all of the element types.
@@ -63,8 +64,8 @@ public class IntersectionType extends Type implements NodeWithAnnotations<Inters
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public IntersectionType(Range range, NodeList<ReferenceType> elements) {
-        super(range);
+    public IntersectionType(TokenRange tokenRange, NodeList<ReferenceType> elements) {
+        super(tokenRange);
         setElements(elements);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -38,6 +38,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.PrimitiveTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A primitive type.
@@ -124,8 +125,8 @@ public final class PrimitiveType extends Type implements NodeWithAnnotations<Pri
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public PrimitiveType(Range range, Primitive type) {
-        super(range);
+    public PrimitiveType(TokenRange tokenRange, Primitive type) {
+        super(tokenRange);
         setType(type);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ReferenceTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Base class for reference types.
@@ -48,8 +49,8 @@ public abstract class ReferenceType extends Type {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public ReferenceType(Range range, NodeList<AnnotationExpr> annotations) {
-        super(range, annotations);
+    public ReferenceType(TokenRange tokenRange, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange, annotations);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -31,6 +31,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.TypeMetaModel;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Base class for types.
@@ -45,7 +46,7 @@ public abstract class Type extends Node {
      * Several sub classes do not support annotations.
      * This is a support constructor for them.
       */
-    protected Type(Range range) {
+    protected Type(TokenRange range) {
         this(range, new NodeList<>());
     }
 
@@ -56,8 +57,8 @@ public abstract class Type extends Node {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public Type(Range range, NodeList<AnnotationExpr> annotations) {
-        super(range);
+    public Type(TokenRange tokenRange, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange);
         setAnnotations(annotations);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
@@ -41,6 +41,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.TypeParameterMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A type parameter.
@@ -72,8 +73,13 @@ public final class TypeParameter extends ReferenceType implements NodeWithSimple
         this(null, new SimpleName(name), typeBound, new NodeList<>());
     }
 
+    /**
+     * @deprecated range shouldn't be in utility constructors.
+     */
+    @Deprecated
     public TypeParameter(Range range, final SimpleName name, final NodeList<ClassOrInterfaceType> typeBound) {
-        this(range, name, typeBound, new NodeList<>());
+        this(null, name, typeBound, new NodeList<>());
+        setRange(range);
     }
 
     @AllFieldsConstructor
@@ -83,8 +89,8 @@ public final class TypeParameter extends ReferenceType implements NodeWithSimple
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public TypeParameter(Range range, SimpleName name, NodeList<ClassOrInterfaceType> typeBound, NodeList<AnnotationExpr> annotations) {
-        super(range, annotations);
+    public TypeParameter(TokenRange tokenRange, SimpleName name, NodeList<ClassOrInterfaceType> typeBound, NodeList<AnnotationExpr> annotations) {
+        super(tokenRange, annotations);
         setName(name);
         setTypeBound(typeBound);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -38,6 +38,7 @@ import com.github.javaparser.metamodel.NonEmptyProperty;
 import com.github.javaparser.metamodel.UnionTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * Represents a set of types. A given value of this type has to be assignable to at least one of the element types.
@@ -55,8 +56,8 @@ public class UnionType extends Type implements NodeWithAnnotations<UnionType> {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public UnionType(Range range, NodeList<ReferenceType> elements) {
-        super(range);
+    public UnionType(TokenRange tokenRange, NodeList<ReferenceType> elements) {
+        super(tokenRange);
         setElements(elements);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -33,6 +33,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.UnknownTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * An unknown parameter type object. It plays the role of a null object for
@@ -52,8 +53,8 @@ public final class UnknownType extends Type {
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public UnknownType(Range range) {
-        super(range);
+    public UnknownType(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.VoidTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * The return type of a {@link com.github.javaparser.ast.body.MethodDeclaration}
@@ -51,8 +52,8 @@ public final class VoidType extends Type implements NodeWithAnnotations<VoidType
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public VoidType(Range range) {
-        super(range);
+    public VoidType(TokenRange tokenRange) {
+        super(tokenRange);
         customInitialization();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Generated;
+import com.github.javaparser.TokenRange;
 
 /**
  * A wildcard type argument.
@@ -66,8 +67,8 @@ public final class WildcardType extends Type implements NodeWithAnnotations<Wild
 
     /**This constructor is used by the parser and is considered private.*/
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public WildcardType(Range range, ReferenceType extendedType, ReferenceType superType) {
-        super(range);
+    public WildcardType(TokenRange tokenRange, ReferenceType extendedType, ReferenceType superType) {
+        super(tokenRange);
         setExtendedType(extendedType);
         setSuperType(superType);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/ProblemReporter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/ProblemReporter.java
@@ -1,8 +1,8 @@
 package com.github.javaparser.ast.validator;
 
 import com.github.javaparser.Problem;
-import com.github.javaparser.Range;
-import com.github.javaparser.ast.nodeTypes.NodeWithRange;
+import com.github.javaparser.TokenRange;
+import com.github.javaparser.ast.nodeTypes.NodeWithTokenRange;
 
 import java.util.List;
 
@@ -24,11 +24,11 @@ public class ProblemReporter {
      * @param message description of the problem
      * @param node the node in which the problem occurred, used to find the Range of the problem.
      */
-    public void report(NodeWithRange<?> node, String message, Object... args) {
-        report(node.getRange().orElse(null), message, args);
+    public void report(NodeWithTokenRange<?> node, String message, Object... args) {
+        report(node.getTokenRange().orElse(null), message, args);
     }
 
-    public void report(Range range, String message, Object... args) {
+    public void report(TokenRange range, String message, Object... args) {
         problems.add(new Problem(f(message, args), range, null));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/chunks/ModifierValidator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/chunks/ModifierValidator.java
@@ -6,7 +6,7 @@ import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.modules.ModuleRequiresStmt;
 import com.github.javaparser.ast.nodeTypes.NodeWithModifiers;
-import com.github.javaparser.ast.nodeTypes.NodeWithRange;
+import com.github.javaparser.ast.nodeTypes.NodeWithTokenRange;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.validator.ProblemReporter;
 import com.github.javaparser.ast.validator.VisitorValidator;
@@ -161,7 +161,7 @@ public class ModifierValidator extends VisitorValidator {
         super.visit(n, reporter);
     }
 
-    private <T extends NodeWithModifiers<?> & NodeWithRange<?>> void validateModifiers(T n, ProblemReporter reporter, Modifier... allowedModifiers) {
+    private <T extends NodeWithModifiers<?> & NodeWithTokenRange<?>> void validateModifiers(T n, ProblemReporter reporter, Modifier... allowedModifiers) {
         validateAtMostOneOf(n, reporter, PUBLIC, PROTECTED, PRIVATE);
         validateAtMostOneOf(n, reporter, FINAL, ABSTRACT);
         if (hasStrictfp) {
@@ -192,7 +192,7 @@ public class ModifierValidator extends VisitorValidator {
         return false;
     }
 
-    private <T extends NodeWithModifiers<?> & NodeWithRange<?>> void validateAtMostOneOf(T t, ProblemReporter reporter, Modifier... modifiers) {
+    private <T extends NodeWithModifiers<?> & NodeWithTokenRange<?>> void validateAtMostOneOf(T t, ProblemReporter reporter, Modifier... modifiers) {
         List<Modifier> foundModifiers = new ArrayList<>();
         for (Modifier m : modifiers) {
             if (t.getModifiers().contains(m)) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -43,7 +43,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         PackageDeclaration packageDeclaration = cloneNode(n.getPackageDeclaration(), arg);
         NodeList<TypeDeclaration<?>> types = cloneList(n.getTypes(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        CompilationUnit r = new CompilationUnit(n.getRange().orElse(null), packageDeclaration, imports, types, module);
+        CompilationUnit r = new CompilationUnit(n.getTokenRange().orElse(null), packageDeclaration, imports, types, module);
         r.setComment(comment);
         return r;
     }
@@ -54,7 +54,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        PackageDeclaration r = new PackageDeclaration(n.getRange().orElse(null), annotations, name);
+        PackageDeclaration r = new PackageDeclaration(n.getTokenRange().orElse(null), annotations, name);
         r.setComment(comment);
         return r;
     }
@@ -66,7 +66,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<ClassOrInterfaceType> typeBound = cloneList(n.getTypeBound(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        TypeParameter r = new TypeParameter(n.getRange().orElse(null), name, typeBound, annotations);
+        TypeParameter r = new TypeParameter(n.getTokenRange().orElse(null), name, typeBound, annotations);
         r.setComment(comment);
         return r;
     }
@@ -75,7 +75,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(LineComment n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        LineComment r = new LineComment(n.getRange().orElse(null), n.getContent());
+        LineComment r = new LineComment(n.getTokenRange().orElse(null), n.getContent());
         r.setComment(comment);
         return r;
     }
@@ -84,7 +84,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(BlockComment n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        BlockComment r = new BlockComment(n.getRange().orElse(null), n.getContent());
+        BlockComment r = new BlockComment(n.getTokenRange().orElse(null), n.getContent());
         r.setComment(comment);
         return r;
     }
@@ -99,7 +99,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName name = cloneNode(n.getName(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ClassOrInterfaceDeclaration r = new ClassOrInterfaceDeclaration(n.getRange().orElse(null), n.getModifiers(), annotations, n.isInterface(), name, typeParameters, extendedTypes, implementedTypes, members);
+        ClassOrInterfaceDeclaration r = new ClassOrInterfaceDeclaration(n.getTokenRange().orElse(null), n.getModifiers(), annotations, n.isInterface(), name, typeParameters, extendedTypes, implementedTypes, members);
         r.setComment(comment);
         return r;
     }
@@ -113,7 +113,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName name = cloneNode(n.getName(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        EnumDeclaration r = new EnumDeclaration(n.getRange().orElse(null), n.getModifiers(), annotations, name, implementedTypes, entries, members);
+        EnumDeclaration r = new EnumDeclaration(n.getTokenRange().orElse(null), n.getModifiers(), annotations, name, implementedTypes, entries, members);
         r.setComment(comment);
         return r;
     }
@@ -126,7 +126,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName name = cloneNode(n.getName(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        EnumConstantDeclaration r = new EnumConstantDeclaration(n.getRange().orElse(null), annotations, name, arguments, classBody);
+        EnumConstantDeclaration r = new EnumConstantDeclaration(n.getTokenRange().orElse(null), annotations, name, arguments, classBody);
         r.setComment(comment);
         return r;
     }
@@ -138,7 +138,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName name = cloneNode(n.getName(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        AnnotationDeclaration r = new AnnotationDeclaration(n.getRange().orElse(null), n.getModifiers(), annotations, name, members);
+        AnnotationDeclaration r = new AnnotationDeclaration(n.getTokenRange().orElse(null), n.getModifiers(), annotations, name, members);
         r.setComment(comment);
         return r;
     }
@@ -151,7 +151,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Type type = cloneNode(n.getType(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        AnnotationMemberDeclaration r = new AnnotationMemberDeclaration(n.getRange().orElse(null), n.getModifiers(), annotations, type, name, defaultValue);
+        AnnotationMemberDeclaration r = new AnnotationMemberDeclaration(n.getTokenRange().orElse(null), n.getModifiers(), annotations, type, name, defaultValue);
         r.setComment(comment);
         return r;
     }
@@ -162,7 +162,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<VariableDeclarator> variables = cloneList(n.getVariables(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        FieldDeclaration r = new FieldDeclaration(n.getRange().orElse(null), n.getModifiers(), annotations, variables);
+        FieldDeclaration r = new FieldDeclaration(n.getTokenRange().orElse(null), n.getModifiers(), annotations, variables);
         r.setComment(comment);
         return r;
     }
@@ -174,7 +174,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName name = cloneNode(n.getName(), arg);
         Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        VariableDeclarator r = new VariableDeclarator(n.getRange().orElse(null), type, name, initializer);
+        VariableDeclarator r = new VariableDeclarator(n.getTokenRange().orElse(null), type, name, initializer);
         r.setComment(comment);
         return r;
     }
@@ -189,7 +189,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ConstructorDeclaration r = new ConstructorDeclaration(n.getRange().orElse(null), n.getModifiers(), annotations, typeParameters, name, parameters, thrownExceptions, body);
+        ConstructorDeclaration r = new ConstructorDeclaration(n.getTokenRange().orElse(null), n.getModifiers(), annotations, typeParameters, name, parameters, thrownExceptions, body);
         r.setComment(comment);
         return r;
     }
@@ -205,7 +205,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        MethodDeclaration r = new MethodDeclaration(n.getRange().orElse(null), n.getModifiers(), annotations, typeParameters, type, name, parameters, thrownExceptions, body);
+        MethodDeclaration r = new MethodDeclaration(n.getTokenRange().orElse(null), n.getModifiers(), annotations, typeParameters, type, name, parameters, thrownExceptions, body);
         r.setComment(comment);
         return r;
     }
@@ -218,7 +218,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Type type = cloneNode(n.getType(), arg);
         NodeList<AnnotationExpr> varArgsAnnotations = cloneList(n.getVarArgsAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        Parameter r = new Parameter(n.getRange().orElse(null), n.getModifiers(), annotations, type, n.isVarArgs(), varArgsAnnotations, name);
+        Parameter r = new Parameter(n.getTokenRange().orElse(null), n.getModifiers(), annotations, type, n.isVarArgs(), varArgsAnnotations, name);
         r.setComment(comment);
         return r;
     }
@@ -228,7 +228,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(EmptyMemberDeclaration n, Object arg) {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        EmptyMemberDeclaration r = new EmptyMemberDeclaration(n.getRange().orElse(null));
+        EmptyMemberDeclaration r = new EmptyMemberDeclaration(n.getTokenRange().orElse(null));
         r.setComment(comment);
         return r;
     }
@@ -239,7 +239,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         BlockStmt body = cloneNode(n.getBody(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        InitializerDeclaration r = new InitializerDeclaration(n.getRange().orElse(null), n.isStatic(), body);
+        InitializerDeclaration r = new InitializerDeclaration(n.getTokenRange().orElse(null), n.isStatic(), body);
         r.setComment(comment);
         return r;
     }
@@ -248,7 +248,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(JavadocComment n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        JavadocComment r = new JavadocComment(n.getRange().orElse(null), n.getContent());
+        JavadocComment r = new JavadocComment(n.getTokenRange().orElse(null), n.getContent());
         r.setComment(comment);
         return r;
     }
@@ -261,7 +261,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ClassOrInterfaceType r = new ClassOrInterfaceType(n.getRange().orElse(null), scope, name, typeArguments, annotations);
+        ClassOrInterfaceType r = new ClassOrInterfaceType(n.getTokenRange().orElse(null), scope, name, typeArguments, annotations);
         r.setComment(comment);
         return r;
     }
@@ -271,7 +271,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(PrimitiveType n, Object arg) {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        PrimitiveType r = new PrimitiveType(n.getRange().orElse(null), n.getType());
+        PrimitiveType r = new PrimitiveType(n.getTokenRange().orElse(null), n.getType());
         r.setComment(comment);
         return r;
     }
@@ -282,7 +282,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Type componentType = cloneNode(n.getComponentType(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ArrayType r = new ArrayType(n.getRange().orElse(null), componentType, annotations);
+        ArrayType r = new ArrayType(n.getTokenRange().orElse(null), componentType, annotations);
         r.setComment(comment);
         return r;
     }
@@ -293,7 +293,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Expression dimension = cloneNode(n.getDimension(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ArrayCreationLevel r = new ArrayCreationLevel(n.getRange().orElse(null), dimension, annotations);
+        ArrayCreationLevel r = new ArrayCreationLevel(n.getTokenRange().orElse(null), dimension, annotations);
         r.setComment(comment);
         return r;
     }
@@ -304,7 +304,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        IntersectionType r = new IntersectionType(n.getRange().orElse(null), elements);
+        IntersectionType r = new IntersectionType(n.getTokenRange().orElse(null), elements);
         r.setComment(comment);
         return r;
     }
@@ -315,7 +315,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        UnionType r = new UnionType(n.getRange().orElse(null), elements);
+        UnionType r = new UnionType(n.getTokenRange().orElse(null), elements);
         r.setComment(comment);
         return r;
     }
@@ -325,7 +325,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(VoidType n, Object arg) {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        VoidType r = new VoidType(n.getRange().orElse(null));
+        VoidType r = new VoidType(n.getTokenRange().orElse(null));
         r.setComment(comment);
         return r;
     }
@@ -337,7 +337,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         ReferenceType superType = cloneNode(n.getSuperType(), arg);
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        WildcardType r = new WildcardType(n.getRange().orElse(null), extendedType, superType);
+        WildcardType r = new WildcardType(n.getTokenRange().orElse(null), extendedType, superType);
         r.setComment(comment);
         return r;
     }
@@ -347,7 +347,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(UnknownType n, Object arg) {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        UnknownType r = new UnknownType(n.getRange().orElse(null));
+        UnknownType r = new UnknownType(n.getTokenRange().orElse(null));
         r.setComment(comment);
         return r;
     }
@@ -358,7 +358,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression index = cloneNode(n.getIndex(), arg);
         Expression name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ArrayAccessExpr r = new ArrayAccessExpr(n.getRange().orElse(null), name, index);
+        ArrayAccessExpr r = new ArrayAccessExpr(n.getTokenRange().orElse(null), name, index);
         r.setComment(comment);
         return r;
     }
@@ -370,7 +370,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         ArrayInitializerExpr initializer = cloneNode(n.getInitializer(), arg);
         NodeList<ArrayCreationLevel> levels = cloneList(n.getLevels(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ArrayCreationExpr r = new ArrayCreationExpr(n.getRange().orElse(null), elementType, levels, initializer);
+        ArrayCreationExpr r = new ArrayCreationExpr(n.getTokenRange().orElse(null), elementType, levels, initializer);
         r.setComment(comment);
         return r;
     }
@@ -380,7 +380,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ArrayInitializerExpr n, Object arg) {
         NodeList<Expression> values = cloneList(n.getValues(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ArrayInitializerExpr r = new ArrayInitializerExpr(n.getRange().orElse(null), values);
+        ArrayInitializerExpr r = new ArrayInitializerExpr(n.getTokenRange().orElse(null), values);
         r.setComment(comment);
         return r;
     }
@@ -391,7 +391,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression target = cloneNode(n.getTarget(), arg);
         Expression value = cloneNode(n.getValue(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        AssignExpr r = new AssignExpr(n.getRange().orElse(null), target, value, n.getOperator());
+        AssignExpr r = new AssignExpr(n.getTokenRange().orElse(null), target, value, n.getOperator());
         r.setComment(comment);
         return r;
     }
@@ -402,7 +402,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression left = cloneNode(n.getLeft(), arg);
         Expression right = cloneNode(n.getRight(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        BinaryExpr r = new BinaryExpr(n.getRange().orElse(null), left, right, n.getOperator());
+        BinaryExpr r = new BinaryExpr(n.getTokenRange().orElse(null), left, right, n.getOperator());
         r.setComment(comment);
         return r;
     }
@@ -413,7 +413,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression expression = cloneNode(n.getExpression(), arg);
         Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        CastExpr r = new CastExpr(n.getRange().orElse(null), type, expression);
+        CastExpr r = new CastExpr(n.getTokenRange().orElse(null), type, expression);
         r.setComment(comment);
         return r;
     }
@@ -423,7 +423,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ClassExpr n, Object arg) {
         Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ClassExpr r = new ClassExpr(n.getRange().orElse(null), type);
+        ClassExpr r = new ClassExpr(n.getTokenRange().orElse(null), type);
         r.setComment(comment);
         return r;
     }
@@ -435,7 +435,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression elseExpr = cloneNode(n.getElseExpr(), arg);
         Expression thenExpr = cloneNode(n.getThenExpr(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ConditionalExpr r = new ConditionalExpr(n.getRange().orElse(null), condition, thenExpr, elseExpr);
+        ConditionalExpr r = new ConditionalExpr(n.getTokenRange().orElse(null), condition, thenExpr, elseExpr);
         r.setComment(comment);
         return r;
     }
@@ -445,7 +445,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(EnclosedExpr n, Object arg) {
         Expression inner = cloneNode(n.getInner(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        EnclosedExpr r = new EnclosedExpr(n.getRange().orElse(null), inner);
+        EnclosedExpr r = new EnclosedExpr(n.getTokenRange().orElse(null), inner);
         r.setComment(comment);
         return r;
     }
@@ -457,7 +457,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression scope = cloneNode(n.getScope(), arg);
         NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        FieldAccessExpr r = new FieldAccessExpr(n.getRange().orElse(null), scope, typeArguments, name);
+        FieldAccessExpr r = new FieldAccessExpr(n.getTokenRange().orElse(null), scope, typeArguments, name);
         r.setComment(comment);
         return r;
     }
@@ -468,7 +468,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression expression = cloneNode(n.getExpression(), arg);
         ReferenceType type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        InstanceOfExpr r = new InstanceOfExpr(n.getRange().orElse(null), expression, type);
+        InstanceOfExpr r = new InstanceOfExpr(n.getTokenRange().orElse(null), expression, type);
         r.setComment(comment);
         return r;
     }
@@ -477,7 +477,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(StringLiteralExpr n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        StringLiteralExpr r = new StringLiteralExpr(n.getRange().orElse(null), n.getValue());
+        StringLiteralExpr r = new StringLiteralExpr(n.getTokenRange().orElse(null), n.getValue());
         r.setComment(comment);
         return r;
     }
@@ -486,7 +486,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(IntegerLiteralExpr n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        IntegerLiteralExpr r = new IntegerLiteralExpr(n.getRange().orElse(null), n.getValue());
+        IntegerLiteralExpr r = new IntegerLiteralExpr(n.getTokenRange().orElse(null), n.getValue());
         r.setComment(comment);
         return r;
     }
@@ -495,7 +495,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(LongLiteralExpr n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        LongLiteralExpr r = new LongLiteralExpr(n.getRange().orElse(null), n.getValue());
+        LongLiteralExpr r = new LongLiteralExpr(n.getTokenRange().orElse(null), n.getValue());
         r.setComment(comment);
         return r;
     }
@@ -504,7 +504,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(CharLiteralExpr n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        CharLiteralExpr r = new CharLiteralExpr(n.getRange().orElse(null), n.getValue());
+        CharLiteralExpr r = new CharLiteralExpr(n.getTokenRange().orElse(null), n.getValue());
         r.setComment(comment);
         return r;
     }
@@ -513,7 +513,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(DoubleLiteralExpr n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        DoubleLiteralExpr r = new DoubleLiteralExpr(n.getRange().orElse(null), n.getValue());
+        DoubleLiteralExpr r = new DoubleLiteralExpr(n.getTokenRange().orElse(null), n.getValue());
         r.setComment(comment);
         return r;
     }
@@ -522,7 +522,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(BooleanLiteralExpr n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        BooleanLiteralExpr r = new BooleanLiteralExpr(n.getRange().orElse(null), n.getValue());
+        BooleanLiteralExpr r = new BooleanLiteralExpr(n.getTokenRange().orElse(null), n.getValue());
         r.setComment(comment);
         return r;
     }
@@ -531,7 +531,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(NullLiteralExpr n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        NullLiteralExpr r = new NullLiteralExpr(n.getRange().orElse(null));
+        NullLiteralExpr r = new NullLiteralExpr(n.getTokenRange().orElse(null));
         r.setComment(comment);
         return r;
     }
@@ -544,7 +544,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression scope = cloneNode(n.getScope(), arg);
         NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        MethodCallExpr r = new MethodCallExpr(n.getRange().orElse(null), scope, typeArguments, name, arguments);
+        MethodCallExpr r = new MethodCallExpr(n.getTokenRange().orElse(null), scope, typeArguments, name, arguments);
         r.setComment(comment);
         return r;
     }
@@ -554,7 +554,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(NameExpr n, Object arg) {
         SimpleName name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        NameExpr r = new NameExpr(n.getRange().orElse(null), name);
+        NameExpr r = new NameExpr(n.getTokenRange().orElse(null), name);
         r.setComment(comment);
         return r;
     }
@@ -568,7 +568,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         ClassOrInterfaceType type = cloneNode(n.getType(), arg);
         NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ObjectCreationExpr r = new ObjectCreationExpr(n.getRange().orElse(null), scope, type, typeArguments, arguments, anonymousClassBody);
+        ObjectCreationExpr r = new ObjectCreationExpr(n.getTokenRange().orElse(null), scope, type, typeArguments, arguments, anonymousClassBody);
         r.setComment(comment);
         return r;
     }
@@ -579,7 +579,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Name qualifier = cloneNode(n.getQualifier(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        Name r = new Name(n.getRange().orElse(null), qualifier, n.getIdentifier(), annotations);
+        Name r = new Name(n.getTokenRange().orElse(null), qualifier, n.getIdentifier(), annotations);
         r.setComment(comment);
         return r;
     }
@@ -588,7 +588,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(SimpleName n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        SimpleName r = new SimpleName(n.getRange().orElse(null), n.getIdentifier());
+        SimpleName r = new SimpleName(n.getTokenRange().orElse(null), n.getIdentifier());
         r.setComment(comment);
         return r;
     }
@@ -598,7 +598,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ThisExpr n, Object arg) {
         Expression classExpr = cloneNode(n.getClassExpr(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ThisExpr r = new ThisExpr(n.getRange().orElse(null), classExpr);
+        ThisExpr r = new ThisExpr(n.getTokenRange().orElse(null), classExpr);
         r.setComment(comment);
         return r;
     }
@@ -608,7 +608,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(SuperExpr n, Object arg) {
         Expression classExpr = cloneNode(n.getClassExpr(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        SuperExpr r = new SuperExpr(n.getRange().orElse(null), classExpr);
+        SuperExpr r = new SuperExpr(n.getTokenRange().orElse(null), classExpr);
         r.setComment(comment);
         return r;
     }
@@ -618,7 +618,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(UnaryExpr n, Object arg) {
         Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        UnaryExpr r = new UnaryExpr(n.getRange().orElse(null), expression, n.getOperator());
+        UnaryExpr r = new UnaryExpr(n.getTokenRange().orElse(null), expression, n.getOperator());
         r.setComment(comment);
         return r;
     }
@@ -629,7 +629,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         NodeList<VariableDeclarator> variables = cloneList(n.getVariables(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        VariableDeclarationExpr r = new VariableDeclarationExpr(n.getRange().orElse(null), n.getModifiers(), annotations, variables);
+        VariableDeclarationExpr r = new VariableDeclarationExpr(n.getTokenRange().orElse(null), n.getModifiers(), annotations, variables);
         r.setComment(comment);
         return r;
     }
@@ -639,7 +639,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(MarkerAnnotationExpr n, Object arg) {
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        MarkerAnnotationExpr r = new MarkerAnnotationExpr(n.getRange().orElse(null), name);
+        MarkerAnnotationExpr r = new MarkerAnnotationExpr(n.getTokenRange().orElse(null), name);
         r.setComment(comment);
         return r;
     }
@@ -650,7 +650,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression memberValue = cloneNode(n.getMemberValue(), arg);
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        SingleMemberAnnotationExpr r = new SingleMemberAnnotationExpr(n.getRange().orElse(null), name, memberValue);
+        SingleMemberAnnotationExpr r = new SingleMemberAnnotationExpr(n.getTokenRange().orElse(null), name, memberValue);
         r.setComment(comment);
         return r;
     }
@@ -661,7 +661,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<MemberValuePair> pairs = cloneList(n.getPairs(), arg);
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        NormalAnnotationExpr r = new NormalAnnotationExpr(n.getRange().orElse(null), name, pairs);
+        NormalAnnotationExpr r = new NormalAnnotationExpr(n.getTokenRange().orElse(null), name, pairs);
         r.setComment(comment);
         return r;
     }
@@ -672,7 +672,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName name = cloneNode(n.getName(), arg);
         Expression value = cloneNode(n.getValue(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        MemberValuePair r = new MemberValuePair(n.getRange().orElse(null), name, value);
+        MemberValuePair r = new MemberValuePair(n.getTokenRange().orElse(null), name, value);
         r.setComment(comment);
         return r;
     }
@@ -684,7 +684,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression expression = cloneNode(n.getExpression(), arg);
         NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ExplicitConstructorInvocationStmt r = new ExplicitConstructorInvocationStmt(n.getRange().orElse(null), typeArguments, n.isThis(), expression, arguments);
+        ExplicitConstructorInvocationStmt r = new ExplicitConstructorInvocationStmt(n.getTokenRange().orElse(null), typeArguments, n.isThis(), expression, arguments);
         r.setComment(comment);
         return r;
     }
@@ -694,7 +694,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(LocalClassDeclarationStmt n, Object arg) {
         ClassOrInterfaceDeclaration classDeclaration = cloneNode(n.getClassDeclaration(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        LocalClassDeclarationStmt r = new LocalClassDeclarationStmt(n.getRange().orElse(null), classDeclaration);
+        LocalClassDeclarationStmt r = new LocalClassDeclarationStmt(n.getTokenRange().orElse(null), classDeclaration);
         r.setComment(comment);
         return r;
     }
@@ -705,7 +705,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression check = cloneNode(n.getCheck(), arg);
         Expression message = cloneNode(n.getMessage(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        AssertStmt r = new AssertStmt(n.getRange().orElse(null), check, message);
+        AssertStmt r = new AssertStmt(n.getTokenRange().orElse(null), check, message);
         r.setComment(comment);
         return r;
     }
@@ -715,7 +715,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(BlockStmt n, Object arg) {
         NodeList<Statement> statements = cloneList(n.getStatements(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        BlockStmt r = new BlockStmt(n.getRange().orElse(null), statements);
+        BlockStmt r = new BlockStmt(n.getTokenRange().orElse(null), statements);
         r.setComment(comment);
         return r;
     }
@@ -726,7 +726,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         SimpleName label = cloneNode(n.getLabel(), arg);
         Statement statement = cloneNode(n.getStatement(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        LabeledStmt r = new LabeledStmt(n.getRange().orElse(null), label, statement);
+        LabeledStmt r = new LabeledStmt(n.getTokenRange().orElse(null), label, statement);
         r.setComment(comment);
         return r;
     }
@@ -735,7 +735,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(EmptyStmt n, Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        EmptyStmt r = new EmptyStmt(n.getRange().orElse(null));
+        EmptyStmt r = new EmptyStmt(n.getTokenRange().orElse(null));
         r.setComment(comment);
         return r;
     }
@@ -745,7 +745,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ExpressionStmt n, Object arg) {
         Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ExpressionStmt r = new ExpressionStmt(n.getRange().orElse(null), expression);
+        ExpressionStmt r = new ExpressionStmt(n.getTokenRange().orElse(null), expression);
         r.setComment(comment);
         return r;
     }
@@ -756,7 +756,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<SwitchEntryStmt> entries = cloneList(n.getEntries(), arg);
         Expression selector = cloneNode(n.getSelector(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        SwitchStmt r = new SwitchStmt(n.getRange().orElse(null), selector, entries);
+        SwitchStmt r = new SwitchStmt(n.getTokenRange().orElse(null), selector, entries);
         r.setComment(comment);
         return r;
     }
@@ -767,7 +767,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression label = cloneNode(n.getLabel(), arg);
         NodeList<Statement> statements = cloneList(n.getStatements(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        SwitchEntryStmt r = new SwitchEntryStmt(n.getRange().orElse(null), label, statements);
+        SwitchEntryStmt r = new SwitchEntryStmt(n.getTokenRange().orElse(null), label, statements);
         r.setComment(comment);
         return r;
     }
@@ -777,7 +777,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(BreakStmt n, Object arg) {
         SimpleName label = cloneNode(n.getLabel(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        BreakStmt r = new BreakStmt(n.getRange().orElse(null), label);
+        BreakStmt r = new BreakStmt(n.getTokenRange().orElse(null), label);
         r.setComment(comment);
         return r;
     }
@@ -787,7 +787,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ReturnStmt n, Object arg) {
         Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ReturnStmt r = new ReturnStmt(n.getRange().orElse(null), expression);
+        ReturnStmt r = new ReturnStmt(n.getTokenRange().orElse(null), expression);
         r.setComment(comment);
         return r;
     }
@@ -799,7 +799,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Statement elseStmt = cloneNode(n.getElseStmt(), arg);
         Statement thenStmt = cloneNode(n.getThenStmt(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        IfStmt r = new IfStmt(n.getRange().orElse(null), condition, thenStmt, elseStmt);
+        IfStmt r = new IfStmt(n.getTokenRange().orElse(null), condition, thenStmt, elseStmt);
         r.setComment(comment);
         return r;
     }
@@ -810,7 +810,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Statement body = cloneNode(n.getBody(), arg);
         Expression condition = cloneNode(n.getCondition(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        WhileStmt r = new WhileStmt(n.getRange().orElse(null), condition, body);
+        WhileStmt r = new WhileStmt(n.getTokenRange().orElse(null), condition, body);
         r.setComment(comment);
         return r;
     }
@@ -820,7 +820,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ContinueStmt n, Object arg) {
         SimpleName label = cloneNode(n.getLabel(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ContinueStmt r = new ContinueStmt(n.getRange().orElse(null), label);
+        ContinueStmt r = new ContinueStmt(n.getTokenRange().orElse(null), label);
         r.setComment(comment);
         return r;
     }
@@ -831,7 +831,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Statement body = cloneNode(n.getBody(), arg);
         Expression condition = cloneNode(n.getCondition(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        DoStmt r = new DoStmt(n.getRange().orElse(null), body, condition);
+        DoStmt r = new DoStmt(n.getTokenRange().orElse(null), body, condition);
         r.setComment(comment);
         return r;
     }
@@ -843,7 +843,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression iterable = cloneNode(n.getIterable(), arg);
         VariableDeclarationExpr variable = cloneNode(n.getVariable(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ForeachStmt r = new ForeachStmt(n.getRange().orElse(null), variable, iterable, body);
+        ForeachStmt r = new ForeachStmt(n.getTokenRange().orElse(null), variable, iterable, body);
         r.setComment(comment);
         return r;
     }
@@ -856,7 +856,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<Expression> initialization = cloneList(n.getInitialization(), arg);
         NodeList<Expression> update = cloneList(n.getUpdate(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ForStmt r = new ForStmt(n.getRange().orElse(null), initialization, compare, update, body);
+        ForStmt r = new ForStmt(n.getTokenRange().orElse(null), initialization, compare, update, body);
         r.setComment(comment);
         return r;
     }
@@ -866,7 +866,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ThrowStmt n, Object arg) {
         Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ThrowStmt r = new ThrowStmt(n.getRange().orElse(null), expression);
+        ThrowStmt r = new ThrowStmt(n.getTokenRange().orElse(null), expression);
         r.setComment(comment);
         return r;
     }
@@ -877,7 +877,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         BlockStmt body = cloneNode(n.getBody(), arg);
         Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        SynchronizedStmt r = new SynchronizedStmt(n.getRange().orElse(null), expression, body);
+        SynchronizedStmt r = new SynchronizedStmt(n.getTokenRange().orElse(null), expression, body);
         r.setComment(comment);
         return r;
     }
@@ -890,7 +890,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<VariableDeclarationExpr> resources = cloneList(n.getResources(), arg);
         BlockStmt tryBlock = cloneNode(n.getTryBlock(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        TryStmt r = new TryStmt(n.getRange().orElse(null), resources, tryBlock, catchClauses, finallyBlock);
+        TryStmt r = new TryStmt(n.getTokenRange().orElse(null), resources, tryBlock, catchClauses, finallyBlock);
         r.setComment(comment);
         return r;
     }
@@ -901,7 +901,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         BlockStmt body = cloneNode(n.getBody(), arg);
         Parameter parameter = cloneNode(n.getParameter(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        CatchClause r = new CatchClause(n.getRange().orElse(null), parameter, body);
+        CatchClause r = new CatchClause(n.getTokenRange().orElse(null), parameter, body);
         r.setComment(comment);
         return r;
     }
@@ -912,7 +912,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Statement body = cloneNode(n.getBody(), arg);
         NodeList<Parameter> parameters = cloneList(n.getParameters(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        LambdaExpr r = new LambdaExpr(n.getRange().orElse(null), parameters, body, n.isEnclosingParameters());
+        LambdaExpr r = new LambdaExpr(n.getTokenRange().orElse(null), parameters, body, n.isEnclosingParameters());
         r.setComment(comment);
         return r;
     }
@@ -923,7 +923,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Expression scope = cloneNode(n.getScope(), arg);
         NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        MethodReferenceExpr r = new MethodReferenceExpr(n.getRange().orElse(null), scope, typeArguments, n.getIdentifier());
+        MethodReferenceExpr r = new MethodReferenceExpr(n.getTokenRange().orElse(null), scope, typeArguments, n.getIdentifier());
         r.setComment(comment);
         return r;
     }
@@ -933,7 +933,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(TypeExpr n, Object arg) {
         Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        TypeExpr r = new TypeExpr(n.getRange().orElse(null), type);
+        TypeExpr r = new TypeExpr(n.getTokenRange().orElse(null), type);
         r.setComment(comment);
         return r;
     }
@@ -955,7 +955,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Node visit(ImportDeclaration n, Object arg) {
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ImportDeclaration r = new ImportDeclaration(n.getRange().orElse(null), name, n.isStatic(), n.isAsterisk());
+        ImportDeclaration r = new ImportDeclaration(n.getTokenRange().orElse(null), name, n.isStatic(), n.isAsterisk());
         r.setComment(comment);
         return r;
     }
@@ -967,7 +967,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<ModuleStmt> moduleStmts = cloneList(n.getModuleStmts(), arg);
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ModuleDeclaration r = new ModuleDeclaration(n.getRange().orElse(null), annotations, name, n.isOpen(), moduleStmts);
+        ModuleDeclaration r = new ModuleDeclaration(n.getTokenRange().orElse(null), annotations, name, n.isOpen(), moduleStmts);
         r.setComment(comment);
         return r;
     }
@@ -977,7 +977,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ModuleRequiresStmt n, Object arg) {
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ModuleRequiresStmt r = new ModuleRequiresStmt(n.getRange().orElse(null), n.getModifiers(), name);
+        ModuleRequiresStmt r = new ModuleRequiresStmt(n.getTokenRange().orElse(null), n.getModifiers(), name);
         r.setComment(comment);
         return r;
     }
@@ -1019,7 +1019,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<Name> moduleNames = cloneList(n.getModuleNames(), arg);
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ModuleExportsStmt r = new ModuleExportsStmt(n.getRange().orElse(null), name, moduleNames);
+        ModuleExportsStmt r = new ModuleExportsStmt(n.getTokenRange().orElse(null), name, moduleNames);
         r.setComment(comment);
         return r;
     }
@@ -1030,7 +1030,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         Type type = cloneNode(n.getType(), arg);
         NodeList<Type> withTypes = cloneList(n.getWithTypes(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ModuleProvidesStmt r = new ModuleProvidesStmt(n.getRange().orElse(null), type, withTypes);
+        ModuleProvidesStmt r = new ModuleProvidesStmt(n.getTokenRange().orElse(null), type, withTypes);
         r.setComment(comment);
         return r;
     }
@@ -1040,7 +1040,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(ModuleUsesStmt n, Object arg) {
         Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ModuleUsesStmt r = new ModuleUsesStmt(n.getRange().orElse(null), type);
+        ModuleUsesStmt r = new ModuleUsesStmt(n.getTokenRange().orElse(null), type);
         r.setComment(comment);
         return r;
     }
@@ -1051,7 +1051,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<Name> moduleNames = cloneList(n.getModuleNames(), arg);
         Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        ModuleOpensStmt r = new ModuleOpensStmt(n.getRange().orElse(null), name, moduleNames);
+        ModuleOpensStmt r = new ModuleOpensStmt(n.getTokenRange().orElse(null), name, moduleNames);
         r.setComment(comment);
         return r;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -47,8 +47,7 @@ public class Utils {
     public static <E> boolean isNullOrEmpty(Collection<E> collection) {
         return collection == null || collection.isEmpty();
     }
-
-
+    
     public static <T> T assertNotNull(T o) {
         if (o == null) {
             throw new AssertionError("A reference was unexpectedly null.");

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -54,6 +54,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
 import com.github.javaparser.utils.*;
+import static com.github.javaparser.JavaToken.INVALID;
 import static com.github.javaparser.utils.Utils.*;
 import static com.github.javaparser.ast.NodeList.*;
 import static com.github.javaparser.GeneratedJavaParser.*;
@@ -111,16 +112,8 @@ final class GeneratedJavaParser {
         return ((CustomToken)token).javaToken;
     }
 
-    private Position tokenBegin() {
-        return token().getRange().begin;
-    }
-
-    private Position tokenEnd() {
-        return token().getRange().end;
-    }
-
-    private Range tokenRange() {
-        return token().getRange();
+    private TokenRange tokenRange() {
+        return new TokenRange(token(), token());
     }
 
     public void setTabSize(int size) {
@@ -171,6 +164,7 @@ TOKEN_MGR_DECLS :
 {
     private List<JavaToken> tokens = new ArrayList<JavaToken>();
     private CommentsCollection commentsCollection = new CommentsCollection();
+    private JavaToken homeToken;
 
     void reset() {
         tokens = new ArrayList<JavaToken>();
@@ -185,6 +179,10 @@ TOKEN_MGR_DECLS :
         return commentsCollection;
     }
 
+    JavaToken getHomeToken() {
+        return homeToken;
+    }
+
     private void CommonTokenAction(Token rawToken) {
         CustomToken token = (CustomToken) rawToken;
         if(token.specialToken!=null) {
@@ -192,6 +190,9 @@ TOKEN_MGR_DECLS :
         }
         token.javaToken = new JavaToken(token, tokens);
         tokens.add(token.javaToken);
+        if (homeToken == null) {
+            homeToken = token.javaToken;
+        }
 
         String commentText = token.image;
         if (token.kind == JAVA_DOC_COMMENT) {
@@ -202,12 +203,13 @@ TOKEN_MGR_DECLS :
             commentsCollection.addComment(comment);
         } else if (token.kind == SINGLE_LINE_COMMENT) {
             // line comments have their end of line character(s) included, and we don't want that.
-            Range range = tokenRange(token);
+            Range range = new Range(pos(token.beginLine, token.beginColumn), pos(token.endLine, token.endColumn));
             while (commentText.endsWith("\r") || commentText.endsWith("\n")) {
                 commentText = commentText.substring(0, commentText.length() - 1);
             }
             range = range.withEnd(pos(range.begin.line, range.begin.column + commentText.length()));
-            LineComment comment = new LineComment(range, commentText.substring(2));
+            LineComment comment = new LineComment(tokenRange(token), commentText.substring(2));
+            comment.setRange(range);
             commentsCollection.addComment(comment);
         }
     }
@@ -675,19 +677,19 @@ CompilationUnit CompilationUnit():
         )
     )*
     (<EOF> | "\u001A" /** ctrl+z char **/)
-    { return new CompilationUnit(range(Position.HOME, tokenEnd()), pakage, imports, types, module); }
+    { return new CompilationUnit(range(token_source.getHomeToken(), token()), pakage, imports, types, module); }
 }
 
 PackageDeclaration PackageDeclaration():
 {
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 	Name name;
-	Position begin;
+	JavaToken begin;
 }
 {
   annotations = Annotations() 
-  "package" {begin = tokenBegin();}  name = Name() ";"
-  { return new PackageDeclaration(range(begin, tokenEnd()), annotations, name); }
+  "package" {begin = token();}  name = Name() ";"
+  { return new PackageDeclaration(range(begin, token()), annotations, name); }
 }
 
 
@@ -696,14 +698,14 @@ ImportDeclaration ImportDeclaration():
     Name name;
     boolean isStatic = false;
     boolean isAsterisk = false;
-    Position begin;
+    JavaToken begin;
 }
 {
-    "import" {begin = tokenBegin();} 
+    "import" {begin = token();} 
     [ "static" { isStatic = true; } ] 
     name = Name() 
     [ "." "*" { isAsterisk = true; } ] ";"
-    { return new ImportDeclaration(range(begin, tokenEnd()), name, isStatic, isAsterisk); }
+    { return new ImportDeclaration(range(begin, token()), name, isStatic, isAsterisk); }
 }
 
 /*
@@ -714,7 +716,7 @@ ImportDeclaration ImportDeclaration():
 
 ModifierHolder Modifiers():
 {
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
     EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
     AnnotationExpr ann;
@@ -723,33 +725,33 @@ ModifierHolder Modifiers():
  (
   LOOKAHEAD(2)
   (
-   "public" { addModifier(this, modifiers, Modifier.PUBLIC); begin = begin.orIfInvalid(tokenBegin()); }
+   "public" { addModifier(this, modifiers, Modifier.PUBLIC); begin = begin.orIfInvalid(token()); }
   |
-   "static" { addModifier(this, modifiers, Modifier.STATIC); begin = begin.orIfInvalid(tokenBegin()); }
+   "static" { addModifier(this, modifiers, Modifier.STATIC); begin = begin.orIfInvalid(token()); }
   |
-   "protected" {  addModifier(this, modifiers, Modifier.PROTECTED); begin = begin.orIfInvalid(tokenBegin()); }
+   "protected" {  addModifier(this, modifiers, Modifier.PROTECTED); begin = begin.orIfInvalid(token()); }
   |
-   "private" { addModifier(this, modifiers, Modifier.PRIVATE); begin = begin.orIfInvalid(tokenBegin()); }
+   "private" { addModifier(this, modifiers, Modifier.PRIVATE); begin = begin.orIfInvalid(token()); }
   |
-   "final" { addModifier(this, modifiers, Modifier.FINAL); begin = begin.orIfInvalid(tokenBegin()); }
+   "final" { addModifier(this, modifiers, Modifier.FINAL); begin = begin.orIfInvalid(token()); }
   |
-   "abstract" { addModifier(this, modifiers, Modifier.ABSTRACT); begin = begin.orIfInvalid(tokenBegin()); }
+   "abstract" { addModifier(this, modifiers, Modifier.ABSTRACT); begin = begin.orIfInvalid(token()); }
   |
-   "synchronized" { addModifier(this, modifiers, Modifier.SYNCHRONIZED); begin = begin.orIfInvalid(tokenBegin()); }
+   "synchronized" { addModifier(this, modifiers, Modifier.SYNCHRONIZED); begin = begin.orIfInvalid(token()); }
   |
-   "native" { addModifier(this, modifiers, Modifier.NATIVE); begin = begin.orIfInvalid(tokenBegin()); }
+   "native" { addModifier(this, modifiers, Modifier.NATIVE); begin = begin.orIfInvalid(token()); }
   |
-   "transient" { addModifier(this, modifiers, Modifier.TRANSIENT); begin = begin.orIfInvalid(tokenBegin()); }
+   "transient" { addModifier(this, modifiers, Modifier.TRANSIENT); begin = begin.orIfInvalid(token()); }
   |
-   "volatile" { addModifier(this, modifiers, Modifier.VOLATILE); begin = begin.orIfInvalid(tokenBegin()); }
+   "volatile" { addModifier(this, modifiers, Modifier.VOLATILE); begin = begin.orIfInvalid(token()); }
   |
-   "strictfp" { addModifier(this, modifiers, Modifier.STRICTFP);  begin = begin.orIfInvalid(tokenBegin()); }
+   "strictfp" { addModifier(this, modifiers, Modifier.STRICTFP);  begin = begin.orIfInvalid(token()); }
   |
-   "transitive" { addModifier(this, modifiers, Modifier.TRANSITIVE);  begin = begin.orIfInvalid(tokenBegin()); }
+   "transitive" { addModifier(this, modifiers, Modifier.TRANSITIVE);  begin = begin.orIfInvalid(token()); }
   |
-   "default" { addModifier(this, modifiers, Modifier.DEFAULT);  begin = begin.orIfInvalid(tokenBegin()); }
+   "default" { addModifier(this, modifiers, Modifier.DEFAULT);  begin = begin.orIfInvalid(token()); }
   |
-   ann = Annotation() { annotations = add(annotations, ann); begin = begin.orIfInvalid(ann.getBegin().get()); }
+   ann = Annotation() { annotations = add(annotations, ann); begin = begin.orIfInvalid(ann.getTokenRange().get().getBegin()); }
   )
  )*
 
@@ -770,17 +772,17 @@ ClassOrInterfaceDeclaration ClassOrInterfaceDeclaration(ModifierHolder modifier)
     NodeList<ClassOrInterfaceType> extList = emptyList();
     NodeList<ClassOrInterfaceType> impList = emptyList();
     NodeList<BodyDeclaration<?>> members = emptyList();
-    Position begin = modifier.begin;
+    JavaToken begin = modifier.begin;
 }
 {
-  ( "class" | "interface" { isInterface = true; } ) { begin = begin.orIfInvalid(tokenBegin()); }
+  ( "class" | "interface" { isInterface = true; } ) { begin = begin.orIfInvalid(token()); }
   name = SimpleName()
   [ typePar = TypeParameters() ]
   [ extList = ExtendsList(isInterface) ]
   [ impList = ImplementsList(isInterface) ]
   members = ClassOrInterfaceBody(isInterface)
 
-	{ return new ClassOrInterfaceDeclaration(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, isInterface, name, typePar.list, extList, impList, members); }
+	{ return new ClassOrInterfaceDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, isInterface, name, typePar.list, extList, impList, members); }
 }
 
 NodeList<ClassOrInterfaceType> ExtendsList(boolean isInterface):
@@ -814,10 +816,10 @@ EnumDeclaration EnumDeclaration(ModifierHolder modifier):
 	NodeList<EnumConstantDeclaration> entries = emptyList();
 	BodyDeclaration<?> member;
     NodeList<BodyDeclaration<?>> members = emptyList();
-	Position begin = modifier.begin;
+	JavaToken begin = modifier.begin;
 }
 {
-  "enum" { begin = begin.orIfInvalid(tokenBegin()); }
+  "enum" { begin = begin.orIfInvalid(token()); }
   name = SimpleName()
   [ impList = ImplementsList(false) ]
   "{"
@@ -830,7 +832,7 @@ EnumDeclaration EnumDeclaration(ModifierHolder modifier):
  	]
   "}"
 
-  { return new EnumDeclaration(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, name, impList, entries, members); }
+  { return new EnumDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, name, impList, entries, members); }
 }
 
 
@@ -841,15 +843,15 @@ EnumConstantDeclaration EnumConstantDeclaration():
 	SimpleName name;
 	NodeList<Expression> args = emptyList();
 	NodeList<BodyDeclaration<?>> classBody = emptyList();
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
 }
 {
   {  }
-  ( ann = Annotation() { annotations = add(annotations, ann); begin = begin.orIfInvalid(ann.getBegin().get()); } )*
-  name = SimpleName() { begin = begin.orIfInvalid(tokenBegin()); } 
+  ( ann = Annotation() { annotations = add(annotations, ann); begin = begin.orIfInvalid(ann.getTokenRange().get().getBegin()); } )*
+  name = SimpleName() { begin = begin.orIfInvalid(token()); } 
   [ args = Arguments() ] [ classBody = ClassOrInterfaceBody(false) ]
   { 
-      return new EnumConstantDeclaration(range(begin, tokenEnd()), annotations, name, args, classBody);  
+      return new EnumConstantDeclaration(range(begin, token()), annotations, name, args, classBody);  
   }
 }
 
@@ -865,12 +867,12 @@ RangedList<TypeParameter> TypeParameters():
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 }
 {
-   "<" { ret.beginAt(tokenBegin()); }
+   "<" { ret.beginAt(token()); }
    annotations = Annotations() 
    tp = TypeParameter() { ret.add(tp); tp.setAnnotations(annotations); annotations = null; }
    ( "," 
    annotations = Annotations() tp = TypeParameter() { ret.add(tp); tp.setAnnotations(annotations); annotations = null; } )*
-   ">" { ret.endAt(tokenEnd()); }
+   ">" { ret.endAt(token()); }
    { return ret; }
 }
 
@@ -878,11 +880,11 @@ TypeParameter TypeParameter():
 {
 	SimpleName name;
 	NodeList<ClassOrInterfaceType> typeBound  = emptyList();
-	Position begin;
+	JavaToken begin;
 }
 {
-   name = SimpleName() { begin=tokenBegin(); } [ typeBound = TypeBound() ]
-   { return new TypeParameter(range(begin, tokenEnd()),name, typeBound); }
+   name = SimpleName() { begin=token(); } [ typeBound = TypeBound() ]
+   { return new TypeParameter(range(begin, token()), name, typeBound, new NodeList()); }
 }
 
 NodeList<ClassOrInterfaceType> TypeBound():
@@ -954,8 +956,8 @@ FieldDeclaration FieldDeclaration(ModifierHolder modifier):
   ( "," val = VariableDeclarator(partialType) { variables.add(val); } )* ";"
 
     { 
-        Position begin = modifier.begin.orIfInvalid(partialType.getBegin().get());
-        return new FieldDeclaration(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, variables);
+        JavaToken begin = modifier.begin.orIfInvalid(partialType.getTokenRange().get().getBegin());
+        return new FieldDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, variables);
     }
 }
 
@@ -966,20 +968,20 @@ VariableDeclarator VariableDeclarator(Type partialType):
 }
 {
     id = VariableDeclaratorId() [ "=" init = VariableInitializer() ]
-    { return new VariableDeclarator(range(id.a.getBegin().get(), tokenEnd()), juggleArrayType(partialType, id.b), id.a, init); }
+    { return new VariableDeclarator(range(id.a.getTokenRange().get().getBegin(), token()), juggleArrayType(partialType, id.b), id.a, init); }
 }
 
 Pair<SimpleName, List<ArrayBracketPair>> VariableDeclaratorId():
 {
 	SimpleName name;
-	Position begin;
+	JavaToken begin;
 	ArrayBracketPair arrayBracketPair;
 	List<ArrayBracketPair> arrayBracketPairs = new ArrayList(0);
 }
 {
-    name = SimpleName() { begin=tokenBegin();}  ( arrayBracketPair = ArrayBracketPair() { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
+    name = SimpleName() { begin=token();}  ( arrayBracketPair = ArrayBracketPair() { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
     {
-        name.setRange(name.getRange().get().withEnd(tokenEnd()));    
+        name.setTokenRange(name.getTokenRange().get().withEnd(token()));    
         return new Pair(name, arrayBracketPairs);
     }
 }
@@ -1001,11 +1003,11 @@ ArrayInitializerExpr ArrayInitializer():
 {
 	NodeList<Expression> values = emptyList();
 	Expression val;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "{" {begin=tokenBegin();} [ val = VariableInitializer() { values = add(values, val); } ( LOOKAHEAD(2) "," val = VariableInitializer() { values = add(values, val); } )* ] [ "," ] "}"
-  { return new ArrayInitializerExpr(range(begin, tokenEnd()), values); }
+  "{" {begin=token();} [ val = VariableInitializer() { values = add(values, val); } ( LOOKAHEAD(2) "," val = VariableInitializer() { values = add(values, val); } )* ] [ "," ] "}"
+  { return new ArrayInitializerExpr(range(begin, token()), values); }
 }
 
 MethodDeclaration MethodDeclaration(ModifierHolder modifier):
@@ -1019,21 +1021,21 @@ MethodDeclaration MethodDeclaration(ModifierHolder modifier):
 	NodeList<ReferenceType> throws_ = emptyList();
 	BlockStmt body = null;
 	NodeList<AnnotationExpr> annotations;
-	Position begin = modifier.begin;
+	JavaToken begin = modifier.begin;
 	ReferenceType throwType;
 }
 {
     // Modifiers already matched in the caller!
-    [ typeParameters = TypeParameters() { begin = begin.orIfInvalid(typeParameters.range.begin); } ]
+    [ typeParameters = TypeParameters() { begin = begin.orIfInvalid(typeParameters.range.getBegin()); } ]
     annotations = Annotations() { modifier.annotations.addAll(annotations); begin = begin.orIfInvalid(nodeListBegin(annotations)); }
-    type = ResultType() { begin = begin.orIfInvalid(type.getBegin().get()); }
+    type = ResultType() { begin = begin.orIfInvalid(type.getTokenRange().get().getBegin()); }
     name = SimpleName() parameters = Parameters() ( arrayBracketPair = ArrayBracketPair() { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
     [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
       ("," throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); } )* ]
     ( body = Block() | ";" )
     { 
         type = juggleArrayType(type, arrayBracketPairs);
-        return new MethodDeclaration(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, typeParameters.list, type, name, parameters, throws_, body);
+        return new MethodDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, typeParameters.list, type, name, parameters, throws_, body);
     }
 }
 
@@ -1084,9 +1086,9 @@ NodeList<Parameter> InferredLambdaParameters():
 }
 {
     ","
-    id = VariableDeclaratorId() 	{ ret = add(ret, new Parameter(range(id.a.getBegin().get(), id.a.getEnd().get()), EnumSet.noneOf(Modifier.class), emptyList(), new UnknownType(), false, emptyList(), id.a));}
+    id = VariableDeclaratorId() 	{ ret = add(ret, new Parameter(range(id.a.getTokenRange().get().getBegin(), id.a.getTokenRange().get().getEnd()), EnumSet.noneOf(Modifier.class), emptyList(), new UnknownType(), false, emptyList(), id.a));}
     (
-        "," id = VariableDeclaratorId()  { ret = add(ret, new Parameter(range(id.a.getBegin().get(), id.a.getEnd().get()), EnumSet.noneOf(Modifier.class), emptyList(), new UnknownType(), false, emptyList(), id.a)); }
+        "," id = VariableDeclaratorId()  { ret = add(ret, new Parameter(range(id.a.getTokenRange().get().getBegin(), id.a.getTokenRange().get().getEnd()), EnumSet.noneOf(Modifier.class), emptyList(), new UnknownType(), false, emptyList(), id.a)); }
     )*
     { return ret;  }
 }
@@ -1106,14 +1108,14 @@ Parameter Parameter():
   ( LOOKAHEAD(ReceiverParameterId())
     receiverId = ReceiverParameterId()
     {
-        Position begin = modifier.begin.orIfInvalid(partialType.getBegin().get());
-        ret = new Parameter(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, partialType, isVarArg, varArgAnnotations, receiverId);
+        JavaToken begin = modifier.begin.orIfInvalid(partialType.getTokenRange().get().getBegin());
+        ret = new Parameter(range(begin, token()), modifier.modifiers, modifier.annotations, partialType, isVarArg, varArgAnnotations, receiverId);
     }
   |
     id = VariableDeclaratorId()
     {
-        Position begin = modifier.begin.orIfInvalid(partialType.getBegin().get());
-        ret = new Parameter(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, juggleArrayType(partialType, id.b), isVarArg, varArgAnnotations, id.a);
+        JavaToken begin = modifier.begin.orIfInvalid(partialType.getTokenRange().get().getBegin());
+        ret = new Parameter(range(begin, token()), modifier.modifiers, modifier.annotations, juggleArrayType(partialType, id.b), isVarArg, varArgAnnotations, id.a);
     }
   )
   { return ret; }
@@ -1124,12 +1126,12 @@ SimpleName ReceiverParameterId():
     String id;
 	String ret ="";
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
-    Position begin = INVALID;
+    JavaToken begin = INVALID;
 }
 {
-  ( id = Identifier() "." { ret = ret + id + "."; begin = begin.orIfInvalid(tokenBegin()); } )*
-  "this" { begin = begin.orIfInvalid(tokenBegin()); }
-  { return new SimpleName(range(begin, tokenEnd()), ret + "this"); }
+  ( id = Identifier() "." { ret = ret + id + "."; begin = begin.orIfInvalid(token()); } )*
+  "this" { begin = begin.orIfInvalid(token()); }
+  { return new SimpleName(range(begin, token()), ret + "this"); }
 }
 
 
@@ -1141,16 +1143,16 @@ ConstructorDeclaration ConstructorDeclaration(ModifierHolder modifier):
 	NodeList<ReferenceType> throws_ = emptyList();
 	ExplicitConstructorInvocationStmt exConsInv = null;
 	NodeList<Statement> stmts = emptyList();
-    Position begin = modifier.begin;
-	Position blockBegin = INVALID;
+    JavaToken begin = modifier.begin;
+	JavaToken blockBegin = INVALID;
 	ReferenceType throwType;
 }
 {
-  [ typeParameters = TypeParameters() { begin = begin.orIfInvalid(typeParameters.range.begin); } ]
+  [ typeParameters = TypeParameters() { begin = begin.orIfInvalid(typeParameters.range.getBegin()); } ]
   // Modifiers matched in the caller
-  name = SimpleName() { begin = begin.orIfInvalid(typeParameters.range.begin); begin = begin.orIfInvalid(tokenBegin()); } parameters = Parameters() [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
+  name = SimpleName() { begin = begin.orIfInvalid(typeParameters.range.getBegin()); begin = begin.orIfInvalid(token()); } parameters = Parameters() [ "throws" throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); }
   ("," throwType = ReferenceTypeWithAnnotations() { throws_ = add(throws_, throwType); })* ]
-  "{" { blockBegin=tokenBegin(); }
+  "{" { blockBegin=token(); }
     [ LOOKAHEAD(ExplicitConstructorInvocation()) exConsInv = ExplicitConstructorInvocation() ]
     stmts = Statements()
   "}"
@@ -1159,7 +1161,7 @@ ConstructorDeclaration ConstructorDeclaration(ModifierHolder modifier):
   	if (exConsInv != null) {
   		stmts = add(0, stmts, exConsInv);
   	}
-  	return new ConstructorDeclaration(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, typeParameters.list, name, parameters, throws_, new BlockStmt(range(blockBegin, tokenEnd()), stmts));
+  	return new ConstructorDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, typeParameters.list, name, parameters, throws_, new BlockStmt(range(blockBegin, token()), stmts));
   }
 }
 
@@ -1169,25 +1171,25 @@ ExplicitConstructorInvocationStmt ExplicitConstructorInvocation():
 	NodeList<Expression> args;
 	Expression expr = null;
 	RangedList<Type> typeArgs = new RangedList<Type>(null);
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
 }
 {
   (
 	  LOOKAHEAD([ TypeArguments() ] <THIS> "(")
-	  [ typeArgs = TypeArguments() { begin=typeArgs.range.begin; } ]
-	  <THIS> { begin = begin.orIfInvalid(tokenBegin()); isThis = true; }
+	  [ typeArgs = TypeArguments() { begin=typeArgs.range.getBegin(); } ]
+	  <THIS> { begin = begin.orIfInvalid(token()); isThis = true; }
 	  args = Arguments() ";"
 	|
 	  [
 	    LOOKAHEAD( PrimaryExpressionWithoutSuperSuffix() "." )
 	  	expr = PrimaryExpressionWithoutSuperSuffix() "."
-	  	{ begin=expr.getBegin().get(); }
+	  	{ begin=expr.getTokenRange().get().getBegin(); }
 	  ]
-	  [ typeArgs = TypeArguments() { begin = begin.orIfInvalid(typeArgs.range.begin); } ]
-	  <SUPER> {begin = begin.orIfInvalid(tokenBegin());}
+	  [ typeArgs = TypeArguments() { begin = begin.orIfInvalid(typeArgs.range.getBegin()); } ]
+	  <SUPER> {begin = begin.orIfInvalid(token());}
 	  args = Arguments() ";"
   )
-  { return new ExplicitConstructorInvocationStmt(range(begin, tokenEnd()),typeArgs.list, isThis, expr, args); }
+  { return new ExplicitConstructorInvocationStmt(range(begin, token()),typeArgs.list, isThis, expr, args); }
 }
 
 NodeList<Statement> Statements():
@@ -1203,13 +1205,13 @@ NodeList<Statement> Statements():
 InitializerDeclaration InitializerDeclaration():
 {
 	BlockStmt body;
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
 	boolean isStatic = false;
 }
 {
-  [ "static" { isStatic = true; begin=tokenBegin();} ] 
-  body = Block() {begin = begin.orIfInvalid(body.getBegin().get());}
-  { return new InitializerDeclaration(range(begin, tokenEnd()), isStatic, body); }
+  [ "static" { isStatic = true; begin=token();} ] 
+  body = Block() {begin = begin.orIfInvalid(body.getTokenRange().get().getBegin());}
+  { return new InitializerDeclaration(range(begin, token()), isStatic, body); }
 }
 
 
@@ -1248,24 +1250,24 @@ ReferenceType ReferenceType():
 ArrayBracketPair ArrayBracketPair():
 {
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
-    Position begin = INVALID;
+    JavaToken begin = INVALID;
 }
 {
     annotations = Annotations()
-    "[" { begin = begin.orIfInvalid(tokenBegin()); } "]"
-    { return new ArrayBracketPair(range(begin, tokenEnd()), annotations); }
+    "[" { begin = begin.orIfInvalid(token()); } "]"
+    { return new ArrayBracketPair(range(begin, token()), annotations); }
 }
 
 IntersectionType IntersectionType():
 {
-	Position begin;
+	JavaToken begin;
 	ReferenceType elementType;
 	NodeList<ReferenceType> elements = emptyList();
 }
 {
-    elementType=ReferenceType() { begin=elementType.getBegin().get(); elements = add(elements, elementType); }
+    elementType=ReferenceType() { begin=elementType.getTokenRange().get().getBegin(); elements = add(elements, elementType); }
     "&" (elementType=ReferenceType() { elements = add(elements, elementType); } )+
-    { return new IntersectionType(range(begin, tokenEnd()), elements); }
+    { return new IntersectionType(range(begin, token()), elements); }
 }
 
 ClassOrInterfaceType AnnotatedClassOrInterfaceType():
@@ -1291,20 +1293,20 @@ ClassOrInterfaceType ClassOrInterfaceType():
 	ClassOrInterfaceType ret;
 	SimpleName name;
 	RangedList<Type> typeArgs = new RangedList<Type>(null);
-	Position begin;
+	JavaToken begin;
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 }
 {
-  name = SimpleName() {begin=tokenBegin();}
+  name = SimpleName() {begin=token();}
   [ LOOKAHEAD(2) typeArgs = TypeArguments() ]
   {
-      ret = new ClassOrInterfaceType(range(begin, tokenEnd()), null, name, typeArgs.list, annotations);
+      ret = new ClassOrInterfaceType(range(begin, token()), null, name, typeArgs.list, annotations);
   }
   (
 	  LOOKAHEAD(2) "." annotations = Annotations()  name = SimpleName()
 	  [ LOOKAHEAD(2) typeArgs = TypeArguments() ]
 	  {
-	    ret = new ClassOrInterfaceType(range(begin, tokenEnd()), ret, name, typeArgs.list, annotations);
+	    ret = new ClassOrInterfaceType(range(begin, token()), ret, name, typeArgs.list, annotations);
 	    annotations = null;
       }
   )*
@@ -1318,9 +1320,9 @@ RangedList<Type> TypeArguments():
 }
 {
    (
-     "<" { ret.beginAt(tokenBegin()); }
+     "<" { ret.beginAt(token()); }
      (type = TypeArgument() { ret.add(type); } ( "," type = TypeArgument() { ret.add(type); } )*)?
-     ">" { ret.endAt(tokenEnd()); }
+     ">" { ret.endAt(token()); }
    )
    { return ret; }
 }
@@ -1344,11 +1346,11 @@ WildcardType Wildcard():
 {
 	ReferenceType ext = null;
 	ReferenceType sup = null;
-	Position begin;
+	JavaToken begin;
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 }
 {
-   "?" {begin=tokenBegin();}
+   "?" {begin=token();}
    [
 		"extends" annotations = Annotations() ext = ReferenceType()
 		{
@@ -1361,7 +1363,7 @@ WildcardType Wildcard():
 		}
    ]
    { 
-     return new WildcardType(range(begin, tokenEnd()),ext, sup);
+     return new WildcardType(range(begin, token()),ext, sup);
    }
 }
 
@@ -1415,7 +1417,7 @@ Name Name():
 {
   annotations=Annotations() Identifier() { ret = new Name(tokenRange(), null, token.image, annotations); }
   ( LOOKAHEAD("." Annotations() Identifier()) 
-  "." annotations=Annotations() Identifier() { ret = new Name(range(ret.getBegin().get(), tokenEnd()), ret, token.image, annotations); } )*
+  "." annotations=Annotations() Identifier() { ret = new Name(range(ret.getTokenRange().get().getBegin(), token()), ret, token.image, annotations); } )*
   { return ret; }
 }
 
@@ -1466,7 +1468,7 @@ Expression Expression():
   [
     (
        LOOKAHEAD(2)
-    op = AssignmentOperator() value = Expression() { ret = new AssignExpr(range(ret.getBegin().get(), tokenEnd()), ret, value, op); }
+    op = AssignmentOperator() value = Expression() { ret = new AssignExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, value, op); }
   |
    "->" lambdaBody = LambdaBody()
    {
@@ -1487,7 +1489,7 @@ Expression Expression():
    }
  |  "::"  [typeArgs = TypeArguments() ] (Identifier() | "new")
  {
-   ret = new MethodReferenceExpr(range(ret.getBegin().get(), tokenEnd()), ret, typeArgs.list, token.image);
+   ret = new MethodReferenceExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, typeArgs.list, token.image);
  }
    )
   ]
@@ -1525,7 +1527,7 @@ Expression ConditionalExpression():
 }
 {
   ret = ConditionalOrExpression()
-  [ "?" left = Expression() ":" right = ConditionalExpression() { ret = new ConditionalExpr(range(ret.getBegin().get(), tokenEnd()), ret, left, right); } ]
+  [ "?" left = Expression() ":" right = ConditionalExpression() { ret = new ConditionalExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, left, right); } ]
   { return ret; }
 }
 
@@ -1535,7 +1537,7 @@ Expression ConditionalOrExpression():
 	Expression right;
 }
 {
-  ret = ConditionalAndExpression() ( "||" right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, BinaryExpr.Operator.OR); } )*
+  ret = ConditionalAndExpression() ( "||" right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
   { return ret; }
 }
 
@@ -1545,7 +1547,7 @@ Expression ConditionalAndExpression():
 	Expression right;
 }
 {
-  ret = InclusiveOrExpression() ( "&&" right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, BinaryExpr.Operator.AND); } )*
+  ret = InclusiveOrExpression() ( "&&" right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
   { return ret; }
 }
 
@@ -1555,7 +1557,7 @@ Expression InclusiveOrExpression():
 	Expression right;
 }
 {
-  ret = ExclusiveOrExpression() ( "|" right = ExclusiveOrExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, BinaryExpr.Operator.BINARY_OR); } )*
+  ret = ExclusiveOrExpression() ( "|" right = ExclusiveOrExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.BINARY_OR); } )*
   { return ret; }
 }
 
@@ -1565,7 +1567,7 @@ Expression ExclusiveOrExpression():
 	Expression right;
 }
 {
-  ret = AndExpression() ( "^" right = AndExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, BinaryExpr.Operator.XOR); } )*
+  ret = AndExpression() ( "^" right = AndExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.XOR); } )*
   { return ret; }
 }
 
@@ -1575,7 +1577,7 @@ Expression AndExpression():
 	Expression right;
 }
 {
-  ret = EqualityExpression() ( "&" right = EqualityExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, BinaryExpr.Operator.BINARY_AND); } )*
+  ret = EqualityExpression() ( "&" right = EqualityExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.BINARY_AND); } )*
   { return ret; }
 }
 
@@ -1590,7 +1592,7 @@ Expression EqualityExpression():
   (
     ( "==" { op = BinaryExpr.Operator.EQUALS; } |
       "!=" { op = BinaryExpr.Operator.NOT_EQUALS; }
-    ) right = InstanceOfExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, op); }
+    ) right = InstanceOfExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, op); }
   )*
   { return ret; }
 }
@@ -1604,7 +1606,7 @@ Expression InstanceOfExpression():
 {
     ret = RelationalExpression() [ "instanceof" annotations = Annotations() type = ReferenceType() {
         type.getAnnotations().addAll(annotations);
-        ret = new InstanceOfExpr(range(ret.getBegin().get(), tokenEnd()), ret, type); 
+        ret = new InstanceOfExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, type); 
     } ]
     { return ret; }
 }
@@ -1622,7 +1624,7 @@ Expression RelationalExpression():
   	  ">"  { op = BinaryExpr.Operator.GREATER; } |
   	  "<=" { op = BinaryExpr.Operator.LESS_EQUALS; } |
   	  ">=" { op = BinaryExpr.Operator.GREATER_EQUALS; }
-  	) right = ShiftExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, op); }
+  	) right = ShiftExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, op); }
   )*
   { return ret; }
 }
@@ -1639,7 +1641,7 @@ Expression ShiftExpression():
   	( "<<"             { op = BinaryExpr.Operator.LEFT_SHIFT; } |
   	  RSIGNEDSHIFT()   { op = BinaryExpr.Operator.SIGNED_RIGHT_SHIFT; } |
   	  RUNSIGNEDSHIFT() { op = BinaryExpr.Operator.UNSIGNED_RIGHT_SHIFT; }
-  	) right = AdditiveExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, op); }
+  	) right = AdditiveExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, op); }
   )*
   { return ret; }
 }
@@ -1655,7 +1657,7 @@ Expression AdditiveExpression():
   (
   	( "+" { op = BinaryExpr.Operator.PLUS; } |
   	  "-" { op = BinaryExpr.Operator.MINUS; }
-  	) right = MultiplicativeExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, op); }
+  	) right = MultiplicativeExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, op); }
   )*
   { return ret; }
 }
@@ -1672,7 +1674,7 @@ Expression MultiplicativeExpression():
   	( "*" { op = BinaryExpr.Operator.MULTIPLY; } |
   	  "/" { op = BinaryExpr.Operator.DIVIDE; } |
   	  "%" { op = BinaryExpr.Operator.REMAINDER; }
-  	) right = UnaryExpression() { ret = new BinaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, right, op); }
+  	) right = UnaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, op); }
   )*
   { return ret; }
 }
@@ -1681,7 +1683,7 @@ Expression UnaryExpression():
 {
 	Expression ret;
 	UnaryExpr.Operator op;
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
 }
 {
   (
@@ -1689,11 +1691,11 @@ Expression UnaryExpression():
 	|
 	  ret = PreDecrementExpression()
 	|
-	  ( "+" { op = UnaryExpr.Operator.PLUS; begin=tokenBegin();} |
-	    "-" { op = UnaryExpr.Operator.MINUS; begin=tokenBegin();}
+	  ( "+" { op = UnaryExpr.Operator.PLUS; begin=token();} |
+	    "-" { op = UnaryExpr.Operator.MINUS; begin=token();}
 	  ) ret = UnaryExpression()
 	  {
-        ret = new UnaryExpr(range(begin, tokenEnd()), ret, op);
+        ret = new UnaryExpr(range(begin, token()), ret, op);
 	  }
 	|
 	  ret = UnaryExpressionNotPlusMinus()
@@ -1704,20 +1706,20 @@ Expression UnaryExpression():
 Expression PreIncrementExpression():
 {
 	Expression ret;
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
 }
 {
-  "++" {begin=tokenBegin();} ret = UnaryExpression() { ret = new UnaryExpr(range(begin, tokenEnd()), ret, UnaryExpr.Operator.PREFIX_INCREMENT); }
+  "++" {begin=token();} ret = UnaryExpression() { ret = new UnaryExpr(range(begin, token()), ret, UnaryExpr.Operator.PREFIX_INCREMENT); }
   { return ret; }
 }
 
 Expression PreDecrementExpression():
 {
 	Expression ret;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "--" {begin=tokenBegin();} ret = UnaryExpression() { ret = new UnaryExpr(range(begin, tokenEnd()), ret, UnaryExpr.Operator.PREFIX_DECREMENT); }
+  "--" {begin=token();} ret = UnaryExpression() { ret = new UnaryExpr(range(begin, token()), ret, UnaryExpr.Operator.PREFIX_DECREMENT); }
   { return ret; }
 }
 
@@ -1725,13 +1727,13 @@ Expression UnaryExpressionNotPlusMinus():
 {
 	Expression ret;
 	UnaryExpr.Operator op;
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
 }
 {
   (
-	  ( "~" { op = UnaryExpr.Operator.BITWISE_COMPLEMENT; begin=tokenBegin(); } |
-	    "!" { op = UnaryExpr.Operator.LOGICAL_COMPLEMENT;     begin=tokenBegin(); }
-	  ) ret = UnaryExpression() { ret = new UnaryExpr(range(begin, tokenEnd()), ret, op); }
+	  ( "~" { op = UnaryExpr.Operator.BITWISE_COMPLEMENT; begin=token(); } |
+	    "!" { op = UnaryExpr.Operator.LOGICAL_COMPLEMENT;     begin=token(); }
+	  ) ret = UnaryExpression() { ret = new UnaryExpr(range(begin, token()), ret, op); }
 	|
 	  LOOKAHEAD( CastExpression() )
 	  ret = CastExpression()
@@ -1752,7 +1754,7 @@ Expression PostfixExpression():
   	LOOKAHEAD(2)
     ( "++" { op = UnaryExpr.Operator.POSTFIX_INCREMENT; } |
       "--" { op = UnaryExpr.Operator.POSTFIX_DECREMENT; }
-    ) { ret = new UnaryExpr(range(ret.getBegin().get(), tokenEnd()), ret, op); }
+    ) { ret = new UnaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, op); }
   ]
   { return ret; }
 }
@@ -1762,16 +1764,16 @@ Expression CastExpression():
 	Expression ret;
 	ReferenceType referenceType;
 	PrimitiveType primitiveType;
-	Position begin = INVALID;
+	JavaToken begin = INVALID;
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 	NodeList<ReferenceType> typesOfMultiCast = emptyList();
 }
 {
-  "(" {begin=tokenBegin();}
+  "(" {begin=token();}
   annotations = Annotations() 
   (
   	  LOOKAHEAD(2)
-  	  primitiveType = PrimitiveType() ")" ret = UnaryExpression() { primitiveType.setAnnotations(annotations); ret = new CastExpr(range(begin, tokenEnd()), primitiveType, ret); }
+  	  primitiveType = PrimitiveType() ")" ret = UnaryExpression() { primitiveType.setAnnotations(annotations); ret = new CastExpr(range(begin, token()), primitiveType, ret); }
   	|
   	  referenceType = ReferenceType() { typesOfMultiCast = add(typesOfMultiCast, referenceType); referenceType.setAnnotations(annotations); }
   	  ( "&" referenceType = ReferenceType() {
@@ -1780,9 +1782,9 @@ Expression CastExpression():
   	  )*
   	  ")" ret = UnaryExpressionNotPlusMinus() {
   	    if (typesOfMultiCast.size() > 1) {
-  	        ret = new CastExpr(range(begin, tokenEnd()), new IntersectionType(range(begin, tokenEnd()), typesOfMultiCast), ret);
+  	        ret = new CastExpr(range(begin, token()), new IntersectionType(range(begin, token()), typesOfMultiCast), ret);
   	    } else {
-  	        ret = new CastExpr(range(begin, tokenEnd()), referenceType, ret);
+  	        ret = new CastExpr(range(begin, token()), referenceType, ret);
   	    }
   	  }
  )
@@ -1819,7 +1821,7 @@ Expression PrimaryPrefix():
 	boolean hasArgs = false;
 	boolean isLambda = false;
 	Type type;
-	Position begin;
+	JavaToken begin;
 	Parameter p = null;
 	SimpleName id = null;
 }
@@ -1837,19 +1839,19 @@ Expression PrimaryPrefix():
 	  [ args = Arguments() {hasArgs=true;} ]
 	  	{
 			if (hasArgs) {
-	  			ret = new MethodCallExpr(range(ret.getBegin().get(), tokenEnd()), ret, typeArgs.list, name, args);
+	  			ret = new MethodCallExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, typeArgs.list, name, args);
 			} else {
-	  			ret = new FieldAccessExpr(range(ret.getBegin().get(), tokenEnd()), ret, emptyList(), name);
+	  			ret = new FieldAccessExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, emptyList(), name);
 			}
 	  	}
 	 |
 		"::" [typeArgs = TypeArguments() ] (Identifier() | "new")
 		{
-		  ret = new MethodReferenceExpr(range(ret.getBegin().get(), tokenEnd()), ret, typeArgs.list, token.image);
+		  ret = new MethodReferenceExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, typeArgs.list, token.image);
 		}
 	  )
 	|
-	  "(" {begin=tokenBegin();}
+	  "(" {begin=token();}
 	  	[
 	  	( LOOKAHEAD(Parameter()) p = Parameter() { isLambda = true;} [params = LambdaParameters()]
 	  	| ret = Expression() [params = InferredLambdaParameters() { isLambda = true;} ]
@@ -1857,19 +1859,19 @@ Expression PrimaryPrefix():
 	  	]
 	  	")"
 	  	{
-	  		   if(!isLambda) { ret = new EnclosedExpr(range(begin, tokenEnd()), ret);}
+	  		   if(!isLambda) { ret = new EnclosedExpr(range(begin, token()), ret);}
 	  		   else{
 	  		 	  if(ret != null){
 	  		  		  if(ret instanceof NameExpr)
 	  		  		  {
 	  		  		    id = ((NameExpr)ret).getName();
-	  		  		    p = new Parameter(range(ret.getBegin().get(), ret.getEnd().get()), EnumSet.noneOf(Modifier.class), emptyList(), new UnknownType(), false, emptyList(), id);
+	  		  		    p = new Parameter(range(ret.getTokenRange().get().getBegin(), ret.getTokenRange().get().getEnd()), EnumSet.noneOf(Modifier.class), emptyList(), new UnknownType(), false, emptyList(), id);
 	  		  		  }
 
 	  		  		}
 	  		  		params = add(0, params, p);
 	  		  		// TODO p may be null here
-	  		  		ret = new LambdaExpr(range(p.getBegin().get(), tokenEnd()), params, new BlockStmt(), true);
+	  		  		ret = new LambdaExpr(range(p.getTokenRange().get().getBegin(), token()), params, new BlockStmt(), true);
 	  		 	}
 
 	  		 }
@@ -1877,21 +1879,21 @@ Expression PrimaryPrefix():
 	  ret = AllocationExpression(null)
 	|
 	  LOOKAHEAD( ResultType() "." "class" )
-	  type = ResultType()  "." "class" { ret = new ClassExpr(range(type.getBegin().get(), tokenEnd()), type); }
+	  type = ResultType()  "." "class" { ret = new ClassExpr(range(type.getTokenRange().get().getBegin(), token()), type); }
 
 	| LOOKAHEAD (ResultType() "::" )
 	  type = ResultType() "::" [typeArgs = TypeArguments() ] (Identifier() | "new")
 		{
-		  ret = new TypeExpr(type.getRange().get(), type);
-		  ret = new MethodReferenceExpr(ret.getRange().get(), ret, typeArgs.list, token.image);
+		  ret = new TypeExpr(type.getTokenRange().get(), type);
+		  ret = new MethodReferenceExpr(ret.getTokenRange().get(), ret, typeArgs.list, token.image);
 		}
 
 	|
-	  	name = SimpleName() { begin=tokenBegin(); }
+	  	name = SimpleName() { begin=token(); }
 	  	[ args = Arguments() { hasArgs=true; } ]
 	  	{
 	  		if (hasArgs) {
-	  			ret = new MethodCallExpr(range(begin, tokenEnd()), null, emptyList(), name, args);
+	  			ret = new MethodCallExpr(range(begin, token()), null, emptyList(), name, args);
 			} else {
 	  			ret = new NameExpr(name);
 			}
@@ -1909,7 +1911,7 @@ Expression PrimarySuffix(Expression scope):
   	LOOKAHEAD(2)
 	ret = PrimarySuffixWithoutSuper(scope)
 	|
-  	"." "super" { ret = new SuperExpr(range(scope.getBegin().get(), tokenEnd()), scope); }
+  	"." "super" { ret = new SuperExpr(range(scope.getTokenRange().get().getBegin(), token()), scope); }
   )
   { return ret; }
 }
@@ -1926,7 +1928,7 @@ Expression PrimarySuffixWithoutSuper(Expression scope):
   (
   	"."
   	(
-		"this" { ret = new ThisExpr(range(scope.getBegin().get(), tokenEnd()), scope); }
+		"this" { ret = new ThisExpr(range(scope.getTokenRange().get().getBegin(), token()), scope); }
 	  |
 	  	ret = AllocationExpression(scope)
 	  |
@@ -1936,14 +1938,14 @@ Expression PrimarySuffixWithoutSuper(Expression scope):
 	  	[ args = Arguments() {hasArgs=true;} ]
 	  	{
 			if (hasArgs) {
-	  			ret = new MethodCallExpr(range(scope.getBegin().get(), tokenEnd()), scope, typeArgs.list, name, args);
+	  			ret = new MethodCallExpr(range(scope.getTokenRange().get().getBegin(), token()), scope, typeArgs.list, name, args);
 			} else {
-	  			ret =  new FieldAccessExpr(range(scope.getBegin().get(), tokenEnd()), scope, typeArgs.list, name);
+	  			ret =  new FieldAccessExpr(range(scope.getTokenRange().get().getBegin(), token()), scope, typeArgs.list, name);
 			}
 	  	}
 	)
 	|
-	  "["ret = Expression() "]" { ret = new ArrayAccessExpr(range(scope.getBegin().get(), tokenEnd()), scope, ret); }
+	  "["ret = Expression() "]" { ret = new ArrayAccessExpr(range(scope.getTokenRange().get().getBegin(), token()), scope, ret); }
   )
   { return ret; }
 }
@@ -2027,11 +2029,11 @@ Expression AllocationExpression(Expression scope):
 	RangedList<Type> typeArgs = new RangedList<Type>(null);
 	NodeList<BodyDeclaration<?>> anonymousBody = null;
 	NodeList<Expression> args;
-	Position begin;
+	JavaToken begin;
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
 }
 {
-    "new" { if(scope==null) {begin=tokenBegin();} else {begin=scope.getBegin().get();} }
+    "new" { if(scope==null) {begin=token();} else {begin=scope.getTokenRange().get().getBegin();} }
     
     annotations = Annotations() 
     (
@@ -2044,32 +2046,32 @@ Expression AllocationExpression(Expression scope):
             ret = ArrayCreation(begin, type)
         |
             args = Arguments() [ LOOKAHEAD(2) anonymousBody = ClassOrInterfaceBody(false) ]
-            { ret = new ObjectCreationExpr(range(begin, tokenEnd()), scope, (ClassOrInterfaceType) type, typeArgs.list, args, anonymousBody); }
+            { ret = new ObjectCreationExpr(range(begin, token()), scope, (ClassOrInterfaceType) type, typeArgs.list, args, anonymousBody); }
         )
     )
     { return ret; }
 }
 
-ArrayCreationExpr ArrayCreation(Position begin, Type type):
+ArrayCreationExpr ArrayCreation(JavaToken begin, Type type):
 {
 	Expression expr = null;
 	ArrayInitializerExpr arrayInitializerExpr = null;
 	NodeList<Expression> inits = emptyList();
 	List<NodeList<AnnotationExpr>> accum = new ArrayList<NodeList<AnnotationExpr>>();
 	NodeList<AnnotationExpr> annotations = new NodeList<AnnotationExpr>();
-	Position arrayCreationLevelStart = null;
-	List<Range> levelRanges = new ArrayList<Range>();
+	JavaToken arrayCreationLevelStart = null;
+	List<TokenRange> levelRanges = new ArrayList<TokenRange>();
 }
 { 
     ( LOOKAHEAD(2)
         annotations = Annotations()
-        "[" { arrayCreationLevelStart = annotations.isEmpty() ? tokenBegin() : annotations.get(0).getRange().get().begin; }
+        "[" { arrayCreationLevelStart = annotations.isEmpty() ? token() : annotations.get(0).getTokenRange().get().getBegin(); }
         (expr = Expression())? { accum = add(accum, annotations); inits = add(inits, expr); annotations=null; expr=null; } 
-        "]" { levelRanges.add(new Range(arrayCreationLevelStart,tokenEnd())); }
+        "]" { levelRanges.add(new TokenRange(arrayCreationLevelStart, token())); }
     )+ 
     (arrayInitializerExpr = ArrayInitializer())? 
     {  
-        return juggleArrayCreation(range(begin, tokenEnd()), levelRanges, type, inits, accum, arrayInitializerExpr);
+        return juggleArrayCreation(range(begin, token()), levelRanges, type, inits, accum, arrayInitializerExpr);
     }
 }
 
@@ -2123,34 +2125,34 @@ AssertStmt AssertStatement():
 {
 	Expression check;
 	Expression msg = null;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "assert" {begin=tokenBegin();} check = Expression() [ ":" msg = Expression() ] ";"
-  { return new AssertStmt(range(begin, tokenEnd()), check, msg);  }
+  "assert" {begin=token();} check = Expression() [ ":" msg = Expression() ] ";"
+  { return new AssertStmt(range(begin, token()), check, msg);  }
 }
 
 LabeledStmt LabeledStatement():
 {
 	SimpleName label;
 	Statement stmt;
-	Position begin;
+	JavaToken begin;
 }
 {
-  label = SimpleName() {begin=tokenBegin();} ":" stmt = Statement()
-  { return new LabeledStmt(range(begin, tokenEnd()), label, stmt); }
+  label = SimpleName() {begin=token();} ":" stmt = Statement()
+  { return new LabeledStmt(range(begin, token()), label, stmt); }
 }
 
 BlockStmt Block():
 {
 	NodeList<Statement> stmts = emptyList();
-	Position begin;
+	JavaToken begin;
 }
 {
-  "{" {begin=tokenBegin();}
+  "{" {begin=token();}
   	stmts = Statements()
   "}"
-  { return new BlockStmt(range(begin, tokenEnd()), stmts); }
+  { return new BlockStmt(range(begin, token()), stmts); }
 }
 
 /*
@@ -2167,11 +2169,11 @@ Statement BlockStatement():
   (
 	  LOOKAHEAD( Modifiers() ("class" | "interface") )
 	  modifier = Modifiers()
-	  typeDecl = ClassOrInterfaceDeclaration(modifier) { ret = new LocalClassDeclarationStmt(range(typeDecl.getBegin().get(), tokenEnd()), typeDecl); }
+	  typeDecl = ClassOrInterfaceDeclaration(modifier) { ret = new LocalClassDeclarationStmt(range(typeDecl.getTokenRange().get().getBegin(), token()), typeDecl); }
 	|
   	  LOOKAHEAD(VariableDeclarationExpression() )
 	  expr = VariableDeclarationExpression() ";"
-	  { ret = new ExpressionStmt(range(expr.getBegin().get(), tokenEnd()), expr); } 
+	  { ret = new ExpressionStmt(range(expr.getTokenRange().get().getBegin(), token()), expr); } 
     |
 	  ret = Statement()
   )
@@ -2188,8 +2190,8 @@ VariableDeclarationExpr VariableDeclarationExpression():
 {
   modifier = Modifiers() partialType = Type() var = VariableDeclarator(partialType) { variables.add(var); } ( "," var = VariableDeclarator(partialType) { variables.add(var); } )*
   {
-        Position begin=modifier.begin.orIfInvalid(partialType.getBegin().get());
-        return new VariableDeclarationExpr(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, variables);
+        JavaToken begin=modifier.begin.orIfInvalid(partialType.getTokenRange().get().getBegin());
+        return new VariableDeclarationExpr(range(begin, token()), modifier.modifiers, modifier.annotations, variables);
   }
 }
 
@@ -2209,7 +2211,7 @@ Statement LambdaBody():
   (
   	expr = Expression()
   	{
-  	  n = new ExpressionStmt(range(expr.getBegin().get(), tokenEnd()), expr);
+  	  n = new ExpressionStmt(range(expr.getTokenRange().get().getBegin(), token()), expr);
   	}
  	|  n = Block()
   )
@@ -2240,13 +2242,13 @@ ExpressionStmt StatementExpression():
 	|
 	  expr = PrimaryExpression()
 	  [
-	    "++" { expr = new UnaryExpr(range(expr.getBegin().get(), tokenEnd()), expr, UnaryExpr.Operator.POSTFIX_INCREMENT);  }
+	    "++" { expr = new UnaryExpr(range(expr.getTokenRange().get().getBegin(), token()), expr, UnaryExpr.Operator.POSTFIX_INCREMENT);  }
 	  |
-	    "--" { expr = new UnaryExpr(range(expr.getBegin().get(), tokenEnd()), expr, UnaryExpr.Operator.POSTFIX_DECREMENT);  }
+	    "--" { expr = new UnaryExpr(range(expr.getTokenRange().get().getBegin(), token()), expr, UnaryExpr.Operator.POSTFIX_DECREMENT);  }
 	  |
-	    op = AssignmentOperator() value = Expression() { expr = new AssignExpr(range(expr.getBegin().get(), tokenEnd()), expr, value, op); }
+	    op = AssignmentOperator() value = Expression() { expr = new AssignExpr(range(expr.getTokenRange().get().getBegin(), token()), expr, value, op); }
 	  |
-	    "::"  [typeArgs = TypeArguments() ] (Identifier() | "new"){expr = new MethodReferenceExpr(range(expr.getBegin().get(), tokenEnd()), expr, typeArgs.list, token.image); 	  }
+	    "::"  [typeArgs = TypeArguments() ] (Identifier() | "new"){expr = new MethodReferenceExpr(range(expr.getTokenRange().get().getBegin(), token()), expr, typeArgs.list, token.image); 	  }
 	 |
 	   "->" lambdaBody = LambdaBody()
 	   {
@@ -2255,7 +2257,7 @@ ExpressionStmt StatementExpression():
 	  ]
   )
   ";"
-  { return new ExpressionStmt(range(expr.getBegin().get(), tokenEnd()), expr); }
+  { return new ExpressionStmt(range(expr.getTokenRange().get().getBegin(), token()), expr); }
 }
 
 SwitchStmt SwitchStatement():
@@ -2263,31 +2265,31 @@ SwitchStmt SwitchStatement():
 	Expression selector;
 	SwitchEntryStmt entry;
 	NodeList<SwitchEntryStmt> entries = emptyList();
-	Position begin;
+	JavaToken begin;
 }
 {
-  "switch" {begin=tokenBegin();} "(" selector = Expression() ")" "{"
+  "switch" {begin=token();} "(" selector = Expression() ")" "{"
     ( entry = SwitchEntry() { entries = add(entries, entry); } )*
   "}"
 
-  { return new SwitchStmt(range(begin, tokenEnd()), selector, entries); }
+  { return new SwitchStmt(range(begin, token()), selector, entries); }
 }
 
 SwitchEntryStmt SwitchEntry():
 {
 	Expression label = null;
 	NodeList<Statement> stmts;
-	Position begin;
+	JavaToken begin;
 }
 {
   (
-	  "case" {begin=tokenBegin();} label = Expression()
+	  "case" {begin=token();} label = Expression()
 	|
-	  "default" {begin=tokenBegin();}
+	  "default" {begin=token();}
   )
   ":" stmts = Statements()
 
-  { return new SwitchEntryStmt(range(begin, tokenEnd()),label, stmts); }
+  { return new SwitchEntryStmt(range(begin, token()),label, stmts); }
 }
 
 IfStmt IfStatement():
@@ -2300,12 +2302,12 @@ IfStmt IfStatement():
 	Expression condition;
 	Statement thenStmt;
 	Statement elseStmt = null;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "if" {begin=tokenBegin();} "(" condition = Expression() ")" {} thenStmt = Statement() [ LOOKAHEAD(1) "else" {} elseStmt = Statement() ]
+  "if" {begin=token();} "(" condition = Expression() ")" {} thenStmt = Statement() [ LOOKAHEAD(1) "else" {} elseStmt = Statement() ]
   { 
-      return new IfStmt(range(begin, tokenEnd()), condition, thenStmt, elseStmt);
+      return new IfStmt(range(begin, token()), condition, thenStmt, elseStmt);
   }
 }
 
@@ -2313,22 +2315,22 @@ WhileStmt WhileStatement():
 {
 	Expression condition;
 	Statement body;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "while" {begin=tokenBegin();} "(" condition = Expression() ")" body = Statement()
-  { return new WhileStmt(range(begin, tokenEnd()),condition, body); }
+  "while" {begin=token();} "(" condition = Expression() ")" body = Statement()
+  { return new WhileStmt(range(begin, token()),condition, body); }
 }
 
 DoStmt DoStatement():
 {
 	Expression condition;
 	Statement body;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "do" {begin=tokenBegin();} body = Statement() "while" "(" condition = Expression() ")" ";"
-  { return new DoStmt(range(begin, tokenEnd()),body, condition); }
+  "do" {begin=token();} body = Statement() "while" "(" condition = Expression() ")" ";"
+  { return new DoStmt(range(begin, token()),body, condition); }
 }
 
 Statement ForStatement():
@@ -2338,10 +2340,10 @@ Statement ForStatement():
 	NodeList<Expression> init = emptyList();
 	NodeList<Expression> update = emptyList();
 	Statement body;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "for" {begin=tokenBegin();} "("
+  "for" {begin=token();} "("
 
   (
       LOOKAHEAD(VariableDeclarationExpression() ":")
@@ -2354,9 +2356,9 @@ Statement ForStatement():
 
   {
   	if (varExpr != null) {
-  		return new ForeachStmt(range(begin, tokenEnd()),varExpr, expr, body);
+  		return new ForeachStmt(range(begin, token()),varExpr, expr, body);
   	}
-	return new ForStmt(range(begin, tokenEnd()),init, expr, update, body);
+	return new ForStmt(range(begin, token()),init, expr, update, body);
   }
 }
 
@@ -2399,52 +2401,52 @@ NodeList<Expression> ForUpdate():
 BreakStmt BreakStatement():
 {
 	SimpleName label = null;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "break" {begin=tokenBegin();} [ label = SimpleName() ] ";"
-  { return new BreakStmt(range(begin, tokenEnd()), label); }
+  "break" {begin=token();} [ label = SimpleName() ] ";"
+  { return new BreakStmt(range(begin, token()), label); }
 }
 
 ContinueStmt ContinueStatement():
 {
 	SimpleName label = null;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "continue" {begin=tokenBegin();} [ label = SimpleName() ] ";"
-  { return new ContinueStmt(range(begin, tokenEnd()), label); }
+  "continue" {begin=token();} [ label = SimpleName() ] ";"
+  { return new ContinueStmt(range(begin, token()), label); }
 }
 
 ReturnStmt ReturnStatement():
 {
 	Expression expr = null;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "return" {begin=tokenBegin();} [ expr = Expression() ] ";"
-  { return new ReturnStmt(range(begin, tokenEnd()),expr); }
+  "return" {begin=token();} [ expr = Expression() ] ";"
+  { return new ReturnStmt(range(begin, token()),expr); }
 }
 
 ThrowStmt ThrowStatement():
 {
 	Expression expr;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "throw" {begin=tokenBegin();} expr = Expression() ";"
-  { return new ThrowStmt(range(begin, tokenEnd()),expr); }
+  "throw" {begin=token();} expr = Expression() ";"
+  { return new ThrowStmt(range(begin, token()),expr); }
 }
 
 SynchronizedStmt SynchronizedStatement():
 {
 	Expression expr;
 	BlockStmt body;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "synchronized" {begin=tokenBegin();} "(" expr = Expression() ")" body = Block()
-  { return new SynchronizedStmt(range(begin, tokenEnd()),expr, body); }
+  "synchronized" {begin=token();} "(" expr = Expression() ")" body = Block()
+  { return new SynchronizedStmt(range(begin, token()),expr, body); }
 }
 
 TryStmt TryStatement():
@@ -2458,42 +2460,42 @@ TryStmt TryStatement():
 	ReferenceType exceptionType;
 	NodeList<ReferenceType> exceptionTypes = emptyList();
 	Pair<SimpleName, List<ArrayBracketPair>> exceptId;
-	Position begin;
-	Position catchBegin;
-	Position typesBegin;
-	Position paramEnd;
+	JavaToken begin;
+	JavaToken catchBegin;
+	JavaToken typesBegin;
+	JavaToken paramEnd;
 	Type type;
 }
 {
-  "try" {begin=tokenBegin();}
+  "try" {begin=token();}
   (resources = ResourceSpecification())?
   tryBlock = Block()
   (
         LOOKAHEAD(2)
   		(
-  			"catch" {catchBegin=tokenBegin();}
-  			"(" { typesBegin=tokenBegin(); }
+  			"catch" {catchBegin=token();}
+  			"(" { typesBegin=token(); }
   			exceptModifier = Modifiers() exceptionType = ReferenceType() { exceptionTypes.add(exceptionType); }
   			( "|" exceptionType = ReferenceTypeWithAnnotations() { exceptionTypes.add(exceptionType); } )*
-  			exceptId = VariableDeclaratorId() { paramEnd = tokenEnd(); }
+  			exceptId = VariableDeclaratorId() { paramEnd = token(); }
   			")"
   			 
   			catchBlock = Block()
   			{
   			    if (exceptionTypes.size() > 1) {
-  			        type = new UnionType(range(exceptionTypes.get(0).getRange().get().begin, exceptionTypes.get(exceptionTypes.size() - 1).getRange().get().end), exceptionTypes);
+  			        type = new UnionType(range(exceptionTypes.get(0), exceptionTypes.get(exceptionTypes.size() - 1)), exceptionTypes);
   			    } else {
   			        type = (Type)exceptionTypes.get(0);
   			    }
-				Parameter catchType = new Parameter(range(type.getRange().get().begin, paramEnd), exceptModifier.modifiers, exceptModifier.annotations, type, false, emptyList(), exceptId.a);
-  			    catchs = add(catchs, new CatchClause(range(catchBegin, tokenEnd()), catchType, catchBlock));
+				Parameter catchType = new Parameter(range(type.getTokenRange().get().getBegin(), paramEnd), exceptModifier.modifiers, exceptModifier.annotations, type, false, emptyList(), exceptId.a);
+  			    catchs = add(catchs, new CatchClause(range(catchBegin, token()), catchType, catchBlock));
   			    exceptionTypes = emptyList(); }
   		)*
   		[ "finally" finallyBlock = Block() ]
   	|
   		"finally" finallyBlock = Block()
   )
-  { return new TryStmt(range(begin, tokenEnd()), resources, tryBlock, catchs, finallyBlock); }
+  { return new TryStmt(range(begin, token()), resources, tryBlock, catchs, finallyBlock); }
 }
 
 
@@ -2561,21 +2563,21 @@ AnnotationExpr Annotation():
 	AnnotationExpr ret;
 	Name name;
 	NodeList<MemberValuePair> pairs = emptyList();
-	Position begin;
+	JavaToken begin;
 	Expression memberVal;
 }
 {
-    "@" { begin=tokenBegin(); } name = Name()
+    "@" { begin=token(); } name = Name()
     (
         LOOKAHEAD( "(" ( Identifier() "=" | ")" ))
         "(" [ pairs = MemberValuePairs() ] ")"
-        { ret = new NormalAnnotationExpr(range(begin, tokenEnd()), name, pairs); }
+        { ret = new NormalAnnotationExpr(range(begin, token()), name, pairs); }
     |
         LOOKAHEAD( "(" )
         "(" memberVal = MemberValue() ")"
-        { ret = new SingleMemberAnnotationExpr(range(begin, tokenEnd()), name, memberVal); }
+        { ret = new SingleMemberAnnotationExpr(range(begin, token()), name, memberVal); }
     |
-        { ret = new MarkerAnnotationExpr(range(begin, tokenEnd()), name); }
+        { ret = new MarkerAnnotationExpr(range(begin, token()), name); }
     )
     { return ret; }
 }
@@ -2594,11 +2596,11 @@ MemberValuePair MemberValuePair():
 {
 	SimpleName name;
 	Expression value;
-	Position begin;
+	JavaToken begin;
 }
 {
-    name = SimpleName() { begin=tokenBegin();} "=" value = MemberValue()
-    { return new MemberValuePair(range(begin, tokenEnd()),name, value); }
+    name = SimpleName() { begin=token();} "=" value = MemberValue()
+    { return new MemberValuePair(range(begin, token()),name, value); }
 }
 
 Expression MemberValue():
@@ -2620,13 +2622,13 @@ Expression  MemberValueArrayInitializer():
 {
 	NodeList<Expression> ret = emptyList();
 	Expression member;
-	Position begin;
+	JavaToken begin;
 }
 {
-  "{" {begin=tokenBegin();}
+  "{" {begin=token();}
   (	member = MemberValue() { ret.add(member); } ( LOOKAHEAD(2) "," member = MemberValue() { ret.add(member); } )*  )? [ "," ]
   "}"
-  { return new ArrayInitializerExpr(range(begin, tokenEnd()),ret); }
+  { return new ArrayInitializerExpr(range(begin, token()),ret); }
 }
 
 
@@ -2636,13 +2638,13 @@ AnnotationDeclaration AnnotationTypeDeclaration(ModifierHolder modifier):
 {
 	SimpleName name;
     NodeList<BodyDeclaration<?>> members = emptyList();
-	Position begin = modifier.begin;
+	JavaToken begin = modifier.begin;
 }
 {
-  "@" { begin=begin.orIfInvalid(tokenBegin()); }
+  "@" { begin=begin.orIfInvalid(token()); }
   "interface" name = SimpleName() members = AnnotationTypeBody()
   { 
-      return new AnnotationDeclaration(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, name, members);
+      return new AnnotationDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, name, members);
   }
 }
 
@@ -2693,8 +2695,8 @@ AnnotationMemberDeclaration AnnotationTypeMemberDeclaration(ModifierHolder modif
   type = Type() name = SimpleName() "(" ")" [ defaultVal = DefaultValue() ] ";"
 
   {
-	Position begin = modifier.begin.orIfInvalid(type.getBegin().get());
-    return new AnnotationMemberDeclaration(range(begin, tokenEnd()), modifier.modifiers, modifier.annotations, type, name, defaultVal);
+	JavaToken begin = modifier.begin.orIfInvalid(type.getTokenRange().get().getBegin());
+    return new AnnotationMemberDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, type, name, defaultVal);
   }
 }
 
@@ -2719,20 +2721,20 @@ ModuleStmt ModuleStmt():
     Type type;
     Type tmpType;
     NodeList<Type> types=emptyList();
-    Position begin;
+    JavaToken begin;
     ModuleStmt stmt=new ModuleRequiresStmt();
 }
 {
     (
-        <REQUIRES> {begin=tokenBegin();} modifiers=Modifiers() name=Name() ";" {stmt=new ModuleRequiresStmt(range(begin, tokenEnd()), modifiers.modifiers, name);}
+        <REQUIRES> {begin=token();} modifiers=Modifiers() name=Name() ";" {stmt=new ModuleRequiresStmt(range(begin, token()), modifiers.modifiers, name);}
     |
-        <EXPORTS> {begin=tokenBegin();} name=Name() [<TO> tmpName=Name() {names.add(tmpName);} ("," tmpName=Name(){names.add(tmpName);} )* ] ";" {stmt=new ModuleExportsStmt(range(begin, tokenEnd()), name, names);}
+        <EXPORTS> {begin=token();} name=Name() [<TO> tmpName=Name() {names.add(tmpName);} ("," tmpName=Name(){names.add(tmpName);} )* ] ";" {stmt=new ModuleExportsStmt(range(begin, token()), name, names);}
     |
-        <OPENS> {begin=tokenBegin();} name=Name() [<TO> tmpName=Name() {names.add(tmpName);} ("," tmpName=Name(){names.add(tmpName);} )* ] ";" {stmt=new ModuleOpensStmt(range(begin, tokenEnd()), name, names);}
+        <OPENS> {begin=token();} name=Name() [<TO> tmpName=Name() {names.add(tmpName);} ("," tmpName=Name(){names.add(tmpName);} )* ] ";" {stmt=new ModuleOpensStmt(range(begin, token()), name, names);}
     |
-        <USES> { begin=tokenBegin();} type=Type() ";" {stmt=new ModuleUsesStmt(range(begin, tokenEnd()), type);}
+        <USES> { begin=token();} type=Type() ";" {stmt=new ModuleUsesStmt(range(begin, token()), type);}
     |
-        <PROVIDES> { begin=tokenBegin();} type=Type() <WITH> tmpType=Type() {types.add(tmpType);} ("," tmpType=Type() {types.add(tmpType);}  )* ";" {stmt=new ModuleProvidesStmt(range(begin, tokenEnd()), type, types);}
+        <PROVIDES> { begin=token();} type=Type() <WITH> tmpType=Type() {types.add(tmpType);} ("," tmpType=Type() {types.add(tmpType);}  )* ";" {stmt=new ModuleProvidesStmt(range(begin, token()), type, types);}
     )
     { return stmt; }
 }
@@ -2743,13 +2745,13 @@ ModuleDeclaration ModuleDeclaration(ModifierHolder modifier):
     boolean open=false;
     ModuleStmt st;
     Name name;
-    Position begin = modifier.begin;
+    JavaToken begin = modifier.begin;
 }
 {
-    [ <OPEN> {open=true; begin = begin.orIfInvalid(tokenBegin());} ]
-    <MODULE> { begin = begin.orIfInvalid(tokenBegin()); }
+    [ <OPEN> {open=true; begin = begin.orIfInvalid(token());} ]
+    <MODULE> { begin = begin.orIfInvalid(token()); }
     name = Name() "{"
     ( st = ModuleStmt() { statements = add(statements, st); } )*
     "}"
-    { return new ModuleDeclaration(range(begin, tokenEnd()), modifier.annotations, name, open, statements); }
+    { return new ModuleDeclaration(range(begin, token()), modifier.annotations, name, open, statements); }
 }

--- a/javaparser-core/src/main/javacc_support/com/github/javaparser/ModifierHolder.java
+++ b/javaparser-core/src/main/javacc_support/com/github/javaparser/ModifierHolder.java
@@ -14,9 +14,9 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 class ModifierHolder {
         final EnumSet<Modifier> modifiers;
         final NodeList<AnnotationExpr> annotations;
-        final Position begin;
+        final JavaToken begin;
 
-        public ModifierHolder(Position begin, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations) {
+        public ModifierHolder(JavaToken begin, EnumSet<Modifier> modifiers, NodeList<AnnotationExpr> annotations) {
             this.begin = begin;
             this.modifiers = assertNotNull(modifiers);
             this.annotations = annotations;

--- a/javaparser-core/src/main/javacc_support/com/github/javaparser/RangedList.java
+++ b/javaparser-core/src/main/javacc_support/com/github/javaparser/RangedList.java
@@ -3,26 +3,24 @@ package com.github.javaparser;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 
-import static com.github.javaparser.Range.range;
-
 /**
  * Helper class for {@link GeneratedJavaParser}
  */
 class RangedList<T extends Node> {
     /* A ranged list MUST be set to a begin and end,
        or these temporary values will leak out */
-    Range range = range(0, 0, 0, 0);
+    TokenRange range = new TokenRange(JavaToken.INVALID, JavaToken.INVALID);
     NodeList<T> list;
 
     RangedList(NodeList<T> list) {
         this.list = list;
     }
 
-    void beginAt(Position begin) {
+    void beginAt(JavaToken begin) {
         range = range.withBegin(begin);
     }
 
-    void endAt(Position end) {
+    void endAt(JavaToken end) {
         range = range.withEnd(end);
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -94,7 +94,7 @@ public class JavaParserTest {
         ParseResult<CompilationUnit> result = new JavaParser().parse(COMPILATION_UNIT, Providers.provider("class X { // blah"));
 
         Problem problem = result.getProblem(0);
-        assertEquals(range(1, 9, 1, 9), problem.getLocation().get());
+        assertEquals(range(1, 9, 1, 9), problem.getLocation().get().getRange());
         assertEquals("Parse error. Found <EOF>, expected one of  \";\" \"<\" \"@\" \"abstract\" \"boolean\" \"byte\" \"char\" \"class\" \"default\" \"double\" \"enum\" \"exports\" \"final\" \"float\" \"int\" \"interface\" \"long\" \"module\" \"native\" \"open\" \"opens\" \"private\" \"protected\" \"provides\" \"public\" \"requires\" \"short\" \"static\" \"strictfp\" \"synchronized\" \"to\" \"transient\" \"transitive\" \"uses\" \"void\" \"volatile\" \"with\" \"{\" \"}\" <IDENTIFIER>", problem.getMessage());
         assertInstanceOf(ParseException.class, problem.getCause().get());
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ProblemTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ProblemTest.java
@@ -9,18 +9,18 @@ import static org.junit.Assert.assertEquals;
 public class ProblemTest {
     @Test
     public void testSimpleGetters() {
-        Problem problem = new Problem("Parse error", range(10, 10, 20, 20), new Exception());
+        Problem problem = new Problem("Parse error", TokenRange.INVALID, new Exception());
 
-        assertEquals(range(10, 10, 20, 20), problem.getLocation().get());
+        assertEquals(TokenRange.INVALID, problem.getLocation().get());
         assertEquals("Parse error", problem.getMessage());
         assertInstanceOf(Exception.class, problem.getCause().get());
     }
 
     @Test
     public void testVerboseMessage() {
-        Problem problem = new Problem("Parse error", range(10, 10, 20, 20), null);
+        Problem problem = new Problem("Parse error", TokenRange.INVALID, null);
 
-        assertEquals("(line 10,col 10) Parse error", problem.getVerboseMessage());
+        assertEquals("(line -1,col -1) Parse error", problem.getVerboseMessage());
     }
 
     @Test


### PR DESCRIPTION
Finally finished this: in addition to `range` we now have `tokenRange`. `range` keeps location information by using line/column position. `tokenRange` keeps location information by pointing to the begin/end `JavaToken` (which has line/column information inside.)

We could now deprecate `range`.

There are some API breakages (like `Problem` indicating the location as a `TokenRange` instead of a `Range`) and I may spend some more time there.

@ftomassetti this should be a lot of help with the lexical preservation code.

See #812.