### PR TITLE
Added documentation to the CompilationUnit.Storage#save and changed l…

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -597,9 +597,15 @@ public class CompilationUnit extends Node {
          * Saves the compilation unit to its original location
          */
         public void save() {
-            save(cu -> new PrettyPrinter().print(getCompilationUnit()));
+            save(cu -> new PrettyPrinter().print(cu));
         }
 
+        /**
+         * Saves a compilation unit to its original location with formatting according to the function
+         * passed as a parameter.
+         *
+         * @param makeOutput a function that formats the compilation unit
+         */
         public void save(Function<CompilationUnit, String> makeOutput) {
             try {
                 Files.createDirectories(path.getParent());


### PR DESCRIPTION
…amda expression

Lambda expression has to work the same way because in the save(Function<CompilationUnit, String> makeOutput) method the same argument is passed to the function makeOutput.