### PR TITLE
Add workaround for JPMS edge case

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
@@ -35,7 +35,7 @@ public class JavaToken {
     public static final JavaToken INVALID = new JavaToken();
 
     private final Range range;
-    private final int kind;
+    private int kind;
     private final String text;
     private final Optional<JavaToken> previousToken;
     private Optional<JavaToken> nextToken = Optional.empty();
@@ -108,6 +108,10 @@ public class JavaToken {
 
     public int getKind() {
         return kind;
+    }
+
+    public void setKind(int kind) {
+        this.kind = kind;
     }
 
     public String getText() {

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
@@ -102,6 +102,14 @@ public class JavaToken {
         }
     }
 
+    public JavaToken(Range range, int kind, String text, Optional<JavaToken> previousToken, Optional<JavaToken> nextToken) {
+        this.range = range;
+        this.kind = kind;
+        this.text = text;
+        this.previousToken = previousToken;
+        this.nextToken = nextToken;
+    }
+
     public Range getRange() {
         return range;
     }
@@ -110,7 +118,7 @@ public class JavaToken {
         return kind;
     }
 
-    public void setKind(int kind) {
+    void setKind(int kind) {
         this.kind = kind;
     }
 

--- a/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserSupport.java
+++ b/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserSupport.java
@@ -22,10 +22,12 @@ import static com.github.javaparser.ast.type.ArrayType.wrapInArrayTypes;
  * Support class for {@link GeneratedJavaParser}
  */
 class GeneratedJavaParserSupport {
+    /** Quickly create a new NodeList */
     static <X extends Node> NodeList<X> emptyList() {
-        return new NodeList<X>();
+        return new NodeList<>();
     }
 
+    /** Add obj to list and return it. Create a new list if list is null */
     static <T extends Node> NodeList<T> add(NodeList<T> list, T obj) {
         if (list == null) {
             list = new NodeList<T>();
@@ -34,6 +36,7 @@ class GeneratedJavaParserSupport {
         return list;
     }
 
+    /** Add obj to list only when list is not null */
     static <T extends Node> NodeList<T> addWhenNotNull(NodeList<T> list, T obj) {
         if (obj == null) {
             return list;
@@ -41,6 +44,7 @@ class GeneratedJavaParserSupport {
         return add(list, obj);
     }
 
+    /** Add obj to list at position pos */
     static <T extends Node> NodeList<T> add(int pos, NodeList<T> list, T obj) {
         if (list == null) {
             list = new NodeList<T>();
@@ -49,6 +53,7 @@ class GeneratedJavaParserSupport {
         return list;
     }
 
+    /** Add obj to list */
     static <T> List<T> add(List<T> list, T obj) {
         if (list == null) {
             list = new LinkedList<T>();
@@ -57,6 +62,7 @@ class GeneratedJavaParserSupport {
         return list;
     }
 
+    /** Add modifier mod to modifiers */
     static void addModifier(GeneratedJavaParser generatedJavaParser, EnumSet<Modifier> modifiers, Modifier mod) {
         if (modifiers.contains(mod)) {
             generatedJavaParser.addProblem("Duplicated modifier");
@@ -64,14 +70,17 @@ class GeneratedJavaParserSupport {
         modifiers.add(mod);
     }
 
+    /** Return a TokenRange spanning from begin to end */
     static TokenRange range(JavaToken begin, JavaToken end) {
         return new TokenRange(begin, end);
     }
 
+    /** Return a TokenRange spanning from begin to end */
     static TokenRange range(Node begin, Node end) {
         return new TokenRange(begin.getTokenRange().get().getBegin(), end.getTokenRange().get().getEnd());
     }
 
+    /** Workaround for rather complex ambiguity that lambda's create */
     static Expression generateLambda(GeneratedJavaParser generatedJavaParser, Expression ret, Statement lambdaBody) {
         if (ret instanceof EnclosedExpr) {
             Optional<Expression> inner = ((EnclosedExpr) ret).getInner();
@@ -99,6 +108,7 @@ class GeneratedJavaParserSupport {
         return ret;
     }
 
+    /** Throws together an ArrayCreationExpr from a lot of pieces */
     static ArrayCreationExpr juggleArrayCreation(TokenRange range, List<TokenRange> levelRanges, Type type, NodeList<Expression> dimensions, List<NodeList<AnnotationExpr>> arrayAnnotations, ArrayInitializerExpr arrayInitializerExpr) {
         NodeList<ArrayCreationLevel> levels = new NodeList<ArrayCreationLevel>();
 
@@ -108,6 +118,7 @@ class GeneratedJavaParserSupport {
         return new ArrayCreationExpr(range, type, levels, arrayInitializerExpr);
     }
 
+    /** Throws together a Type, taking care of all the array brackets */
     static Type juggleArrayType(Type partialType, List<ArrayType.ArrayBracketPair> additionalBrackets) {
         Pair<Type, List<ArrayType.ArrayBracketPair>> partialParts = unwrapArrayTypes(partialType);
         Type elementType = partialParts.a;
@@ -115,11 +126,13 @@ class GeneratedJavaParserSupport {
         return wrapInArrayTypes(elementType, leftMostBrackets, additionalBrackets).clone();
     }
 
+    /** Create a TokenRange that spans exactly one token */
     static TokenRange tokenRange(Token token) {
         JavaToken javaToken = ((CustomToken) token).javaToken;
         return new TokenRange(javaToken, javaToken);
     }
 
+    /** Get the token that starts the NodeList l */
     static JavaToken nodeListBegin(NodeList<?> l) {
         if (l.isEmpty()) {
             return JavaToken.INVALID;
@@ -182,7 +195,5 @@ class GeneratedJavaParserSupport {
                     .append(expected.toString());
         }
         return sb.toString();
-
     }
-
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -68,14 +68,18 @@ import static com.github.javaparser.ast.type.ArrayType.*;
  * <p>This class was generated automatically by javacc, do not edit.</p>
  */
 final class GeneratedJavaParser {
+    /* The problems encountered while parsing */
     List<Problem> problems = new ArrayList<Problem>();
 
+    /* Resets the parser for reuse, gaining a little performance */
     void reset(Provider provider) {
         ReInit(provider);
         problems = new ArrayList<Problem>();
         token_source.reset();
     }
 
+    /* Called from within a catch block to skip forward to a known token,
+        and report the occurred exception as a problem. */
     TokenRange recover(int recoveryTokenType, ParseException p) {
         JavaToken begin = null;
         if (p.currentToken != null) {
@@ -101,8 +105,8 @@ final class GeneratedJavaParser {
     }
 
     /**
-     * Return the list of tokens that have been encountered while parsing code using
-     * this parser.
+     * Return the list of JavaParser specific tokens that have been encountered while 
+     * parsing code using this parser.
      *
      * @return a list of tokens
      */
@@ -110,15 +114,19 @@ final class GeneratedJavaParser {
         return token_source.getTokens();
     }
 
+    /* The collection of comments encountered */
     public CommentsCollection getCommentsCollection() {
         return token_source.getCommentsCollection();
     }
 
+    /* Reports a problem to the user */
     void addProblem(String message) {
         // TODO tokenRange only takes the final token. Need all the tokens.
         problems.add(new Problem(message, tokenRange(), null));
     }
 
+    /* Supports a case where >> should be two tokens instead of one,
+        and keeps track of the JavaParser specific token type for this token */
     static final class CustomToken extends Token {
         int realKind = GeneratedJavaParserConstants.GT;
         JavaToken javaToken;
@@ -132,15 +140,24 @@ final class GeneratedJavaParser {
             return new CustomToken(kind, image);
         }
     }
-    
+
+    /* Returns the JavaParser specific token type of the last matched token */
     private JavaToken token() {
         return ((CustomToken)token).javaToken;
     }
 
+    /* Returns a tokenRange that spans the last matched token */
     private TokenRange tokenRange() {
         return new TokenRange(token(), token());
     }
 
+    /* Sets the kind of the last matched token to newKind */
+    private void setTokenKind(int newKind) {
+        token().setKind(newKind);
+    }
+
+    /* Changes the amount by which the horizontal position is increased when a tab character is encountered.
+        One by default.*/
     public void setTabSize(int size) {
         jj_input_stream.setTabSize(size);
     }
@@ -1477,7 +1494,7 @@ String Identifier():
 {
     // Make sure the module info keywords don't interfere with normal Java parsing by matching them as normal identifiers.
   (<MODULE> | <REQUIRES> | <TO> | <WITH> | <OPEN> | <OPENS> | <USES> | <EXPORTS> | <PROVIDES> | <TRANSITIVE> |
-   <IDENTIFIER>) { ret = token.image; token().setKind(IDENTIFIER);}
+   <IDENTIFIER>) { ret = token.image; setTokenKind(IDENTIFIER);}
   { return ret; }
 }
 
@@ -2774,8 +2791,9 @@ ModuleStmt ModuleStmt():
 }
 {
     (
+        // This is a hack for the edge case "requires transitive;" which is supposed to mean "require the module named 'transitive'" 
         LOOKAHEAD(<REQUIRES> <TRANSITIVE> ";")
-        <REQUIRES> {begin=token();} <TRANSITIVE> {transitiveExceptionalToken=token(); transitiveExceptionalToken.setKind(IDENTIFIER);} ";" {stmt=new ModuleRequiresStmt(range(begin, token()), EnumSet.noneOf(Modifier.class), new Name(range(transitiveExceptionalToken, transitiveExceptionalToken), null, transitiveExceptionalToken.getText(), new NodeList<AnnotationExpr>()));}
+        <REQUIRES> {begin=token();} <TRANSITIVE> {transitiveExceptionalToken=token(); setTokenKind(IDENTIFIER);} ";" {stmt=new ModuleRequiresStmt(range(begin, token()), EnumSet.noneOf(Modifier.class), new Name(range(transitiveExceptionalToken, transitiveExceptionalToken), null, transitiveExceptionalToken.getText(), new NodeList<AnnotationExpr>()));}
     |
         <REQUIRES> {begin=token();} modifiers=Modifiers() name=Name() ";" {stmt=new ModuleRequiresStmt(range(begin, token()), modifiers.modifiers, name);}
     |

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1477,7 +1477,7 @@ String Identifier():
 {
     // Make sure the module info keywords don't interfere with normal Java parsing by matching them as normal identifiers.
   (<MODULE> | <REQUIRES> | <TO> | <WITH> | <OPEN> | <OPENS> | <USES> | <EXPORTS> | <PROVIDES> | <TRANSITIVE> |
-   <IDENTIFIER>) { ret = token.image; }
+   <IDENTIFIER>) { ret = token.image; token().setKind(IDENTIFIER);}
   { return ret; }
 }
 
@@ -2770,9 +2770,13 @@ ModuleStmt ModuleStmt():
     NodeList<Type> types=emptyList();
     JavaToken begin;
     ModuleStmt stmt=new ModuleRequiresStmt();
+    JavaToken transitiveExceptionalToken;
 }
 {
     (
+        LOOKAHEAD(<REQUIRES> <TRANSITIVE> ";")
+        <REQUIRES> {begin=token();} <TRANSITIVE> {transitiveExceptionalToken=token(); transitiveExceptionalToken.setKind(IDENTIFIER);} ";" {stmt=new ModuleRequiresStmt(range(begin, token()), EnumSet.noneOf(Modifier.class), new Name(range(transitiveExceptionalToken, transitiveExceptionalToken), null, transitiveExceptionalToken.getText(), new NodeList<AnnotationExpr>()));}
+    |
         <REQUIRES> {begin=token();} modifiers=Modifiers() name=Name() ";" {stmt=new ModuleRequiresStmt(range(begin, token()), modifiers.modifiers, name);}
     |
         <EXPORTS> {begin=token();} name=Name() [<TO> tmpName=Name() {names.add(tmpName);} ("," tmpName=Name(){names.add(tmpName);} )* ] ";" {stmt=new ModuleExportsStmt(range(begin, token()), name, names);}

--- a/javaparser-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
@@ -1,6 +1,7 @@
 package com.github.javaparser.modules;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.JavaToken;
 import com.github.javaparser.ParseStart;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
@@ -14,6 +15,7 @@ import com.github.javaparser.ast.validator.Java9Validator;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import org.junit.Test;
 
+import static com.github.javaparser.GeneratedJavaParserConstants.IDENTIFIER;
 import static com.github.javaparser.JavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.JavaParser.parseName;
 import static com.github.javaparser.Providers.provider;
@@ -30,7 +32,17 @@ public class ModuleDeclarationTest {
 
     @Test
     public void moduleInfoKeywordsAreSeenAsIdentifiers() {
-        parse("class module { }");
+        CompilationUnit cu = parse("class module { }");
+        JavaToken moduleToken = cu.getClassByName("module").get().getName().getTokenRange().get().getBegin();
+        assertEquals(IDENTIFIER, moduleToken.getKind());
+    }
+
+    @Test
+    public void issue988RequireTransitiveShouldRequireAModuleCalledTransitive() {
+        CompilationUnit cu = parse("module X { requires transitive; }");
+        ModuleRequiresStmt requiresTransitive = (ModuleRequiresStmt) cu.getModule().get().getModuleStmts().get(0);
+        assertEquals("transitive", requiresTransitive.getNameAsString());
+        assertEquals(IDENTIFIER, requiresTransitive.getName().getTokenRange().get().getBegin().getKind());
     }
 
     @Test


### PR DESCRIPTION
"requires transitive;" now requires a module called transitive. Which will never exist. But it needs exceptions all over the parser anyway. Thanks JPMS.

See #988