### PR TITLE
Hide setAsParentOf

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
@@ -24,7 +24,6 @@ package com.github.javaparser;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.observer.Observable;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -63,21 +62,4 @@ public interface HasParentNode<T> extends Observable {
         }
         return Optional.empty();
     }
-
-    // TODO should become protected once Java lets us
-    default void setAsParentNodeOf(List<? extends Node> childNodes) {
-        if (childNodes != null) {
-            for (HasParentNode current : childNodes) {
-                current.setParentNode(getParentNodeForChildren());
-            }
-        }
-    }
-
-    // TODO should become protected once Java lets us
-    default void setAsParentNodeOf(Node childNode) {
-        if (childNode != null) {
-            childNode.setParentNode(getParentNodeForChildren());
-        }
-    }
-
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -44,7 +44,6 @@ import javax.annotation.Generated;
 import java.util.*;
 import static com.github.javaparser.ast.Node.Parsedness.*;
 import static java.util.Collections.unmodifiableList;
-import com.github.javaparser.ast.Node;
 
 /**
  * Base class for all nodes of the abstract syntax tree.
@@ -380,6 +379,12 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
             parentNode.childNodes.add(this);
         }
         return this;
+    }
+
+    protected void setAsParentNodeOf(Node childNode) {
+        if (childNode != null) {
+            childNode.setParentNode(getParentNodeForChildren());
+        }
     }
 
     public static final int ABSOLUTE_BEGIN_LINE = -1;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
@@ -32,7 +32,6 @@ import com.github.javaparser.metamodel.InternalProperty;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -460,5 +459,19 @@ public class NodeList<N extends Node> implements List<N>, Iterable<N>, HasParent
             left.addAll(right);
             return left;
         });
+    }
+
+    private void setAsParentNodeOf(List<? extends Node> childNodes) {
+        if (childNodes != null) {
+            for (HasParentNode current : childNodes) {
+                current.setParentNode(getParentNodeForChildren());
+            }
+        }
+    }
+
+    private void setAsParentNodeOf(Node childNode) {
+        if (childNode != null) {
+            childNode.setParentNode(getParentNodeForChildren());
+        }
     }
 }


### PR DESCRIPTION
This was never supposed to be a public API, and a user got into trouble with JSON serialization thanks to these methods, so now I've hidden them. This causes a little duplication. Ah well...