### PR TITLE
Allow strictfp and enum in lower Java versions

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java1_2Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java1_2Validator.java
@@ -7,9 +7,11 @@ import com.github.javaparser.ast.validator.chunks.ModifierValidator;
  */
 public class Java1_2Validator extends Java1_1Validator {
     protected final Validator modifiersWithoutDefaultAndStaticInterfaceMethodsAndPrivateInterfaceMethods = new ModifierValidator(true, false, false);
-
+    protected final Validator strictfpNotAllowed = new ReservedKeywordValidator("strictfp");
+    
     public Java1_2Validator() {
         super();
         replace(modifiersWithoutStrictfpAndDefaultAndStaticInterfaceMethodsAndPrivateInterfaceMethods, modifiersWithoutDefaultAndStaticInterfaceMethodsAndPrivateInterfaceMethods);
+        add(strictfpNotAllowed);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java5Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java5Validator.java
@@ -32,10 +32,13 @@ public class Java5Validator extends Java1_4Validator {
         }
     });
 
+    protected final Validator enumNotAllowed = new ReservedKeywordValidator("enum");
+
     public Java5Validator() {
         super();
         replace(noGenerics, genericsWithoutDiamondOperator);
         add(noPrimitiveGenericArguments);
+        add(enumNotAllowed);
         
         // TODO validate annotations on classes, fields and methods but nowhere else
         // The following is probably too simple.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/ReservedKeywordValidator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/ReservedKeywordValidator.java
@@ -1,0 +1,36 @@
+package com.github.javaparser.ast.validator;
+
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.SimpleName;
+
+import static com.github.javaparser.utils.CodeGenerationUtils.f;
+
+/**
+ * Validates that identifiers are not keywords - this for the few keywords that the parser
+ * accepts because they were added after Java 1.0.
+ */
+public class ReservedKeywordValidator extends VisitorValidator {
+    private final String keyword;
+    private final String error;
+
+    public ReservedKeywordValidator(String keyword) {
+        this.keyword = keyword;
+        error = f("'%s' cannot be used as an identifier as it is a keyword.", keyword);
+    }
+
+    @Override
+    public void visit(Name n, ProblemReporter arg) {
+        if (n.getIdentifier().equals(keyword)) {
+            arg.report(n, error);
+        }
+        super.visit(n, arg);
+    }
+
+    @Override
+    public void visit(SimpleName n, ProblemReporter arg) {
+        if (n.getIdentifier().equals(keyword)) {
+            arg.report(n, error);
+        }
+        super.visit(n, arg);
+    }
+}

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1493,9 +1493,12 @@ String Identifier():
 }
 {
     // Make sure the module info keywords don't interfere with normal Java parsing by matching them as normal identifiers.
-  (<MODULE> | <REQUIRES> | <TO> | <WITH> | <OPEN> | <OPENS> | <USES> | <EXPORTS> | <PROVIDES> | <TRANSITIVE> |
-   <IDENTIFIER>) { ret = token.image; setTokenKind(IDENTIFIER);}
-  { return ret; }
+    (<MODULE> | <REQUIRES> | <TO> | <WITH> | <OPEN> | <OPENS> | <USES> | <EXPORTS> | <PROVIDES> | <TRANSITIVE> |
+    // Make sure older Java versions parse
+    <ENUM> | <STRICTFP> |
+    // An actual plain old identifier
+    <IDENTIFIER>) { ret = token.image; setTokenKind(IDENTIFIER);}
+    { return ret; }
 }
 
 /*

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/ParseResultTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/ParseResultTest.java
@@ -58,7 +58,7 @@ public class ParseResultTest {
         assertThat(result.getProblems().size()).isEqualTo(1);
 
         Problem problem = result.getProblem(0);
-        assertThat(problem.getMessage()).isEqualTo("Parse error. Found \"{\", expected one of  \"exports\" \"module\" \"open\" \"opens\" \"provides\" \"requires\" \"to\" \"transitive\" \"uses\" \"with\" <IDENTIFIER>");
+        assertThat(problem.getMessage()).isEqualTo("Parse error. Found \"{\", expected one of  \"enum\" \"exports\" \"module\" \"open\" \"opens\" \"provides\" \"requires\" \"strictfp\" \"to\" \"transitive\" \"uses\" \"with\" <IDENTIFIER>");
         assertThat(result.getTokens().isPresent()).isTrue();
 
         assertThat(result.toString()).startsWith("Parsing failed:" + EOL + "(line 1,col 1) Parse error.");

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java1_1ValidatorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java1_1ValidatorTest.java
@@ -5,10 +5,12 @@ import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.stmt.Statement;
 import org.junit.Test;
 
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.ParseStart.EXPRESSION;
+import static com.github.javaparser.ParseStart.STATEMENT;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.TestUtils.assertNoProblems;
 import static com.github.javaparser.utils.TestUtils.assertProblems;
@@ -278,6 +280,12 @@ public class Java1_1ValidatorTest {
     @Test
     public void reflection() {
         ParseResult<Expression> result = javaParser.parse(EXPRESSION, provider("Abc.class"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    public void strictfpAllowedAsIdentifier() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int strictfp;"));
         assertNoProblems(result);
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java1_2ValidatorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java1_2ValidatorTest.java
@@ -4,9 +4,12 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.stmt.Statement;
 import org.junit.Test;
 
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
+import static com.github.javaparser.ParseStart.STATEMENT;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.TestUtils.assertProblems;
 
@@ -261,5 +264,11 @@ public class Java1_2ValidatorTest {
                 "(line 1,col 144) 'public' is not allowed here.",
                 "(line 1,col 144) 'protected' is not allowed here."
         );
+    }
+    
+    @Test
+    public void strictfpNotAllowedAsIdentifier() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int strictfp;"));
+        assertProblems(result, "(line 1,col 5) 'strictfp' cannot be used as an identifier as it is a keyword.");
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java1_4ValidatorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java1_4ValidatorTest.java
@@ -60,4 +60,10 @@ public class Java1_4ValidatorTest {
                 "(line 1,col 17) Static imports are not supported.",
                 "(line 1,col 1) Static imports are not supported.");
     }
+
+    @Test
+    public void enumAllowedAsIdentifier() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int enum;"));
+        assertNoProblems(result);
+    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java5ValidatorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/validator/Java5ValidatorTest.java
@@ -145,4 +145,10 @@ public class Java5ValidatorTest {
         ParseResult<CompilationUnit> result = javaParser.parse(COMPILATION_UNIT, provider("class X extends Y<int> {}"));
         assertProblems(result, "(line 1,col 17) Type arguments may not be primitive.");
     }
+
+    @Test
+    public void enumAllowedAsIdentifier() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int enum;"));
+        assertProblems(result, "(line 1,col 5) 'enum' cannot be used as an identifier as it is a keyword.");
+    }
 }


### PR DESCRIPTION
See #1012 and #1020 

`assert` was not included because it is quite an obscure keyword and would require more than just an easy fix.