### PR TITLE
Fix broken replace implementation

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/ReplaceMethodGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/ReplaceMethodGenerator.java
@@ -37,11 +37,7 @@ public class ReplaceMethodGenerator extends NodeGenerator {
             if (property.isNodeList()) {
                 check = nodeListCheck(property);
             } else {
-                if (property.isRequired()) {
-                    continue;
-                }
-                String replaceAttributeMethodName = generateReplaceMethodForAttribute(nodeCoid, nodeMetaModel, property);
-                check = attributeCheck(property, replaceAttributeMethodName);
+                check = attributeCheck(property, property.getSetterMethodName());
             }
             if (property.isOptional()) {
                 check = f("if (%s != null) { %s }", property.getName(), check);
@@ -58,11 +54,11 @@ public class ReplaceMethodGenerator extends NodeGenerator {
         annotateGenerated(replaceNodeMethod);
     }
 
-    private String attributeCheck(PropertyMetaModel property, String replaceAttributeMethodName) {
+    private String attributeCheck(PropertyMetaModel property, String attributeSetterName) {
         return f("if (node == %s) {" +
                 "    %s((%s) replacementNode);" +
                 "    return true;\n" +
-                "}", property.getName(), replaceAttributeMethodName, property.getTypeName());
+                "}", property.getName(), attributeSetterName, property.getTypeName());
     }
 
     private String nodeListCheck(PropertyMetaModel property) {
@@ -72,17 +68,5 @@ public class ReplaceMethodGenerator extends NodeGenerator {
                 "    return true;" +
                 "  }" +
                 "}", property.getName(), property.getName(), property.getName(), property.getTypeName());
-    }
-
-    private String generateReplaceMethodForAttribute(ClassOrInterfaceDeclaration nodeCoid, BaseNodeMetaModel nodeMetaModel, PropertyMetaModel property) {
-        final String methodName = "replace" + capitalize(property.getName());
-        final MethodDeclaration replaceMethod = (MethodDeclaration) parseBodyDeclaration(f("public %s %s(%s replacement) {}", nodeMetaModel.getTypeName(), methodName, property.getTypeName()));
-
-        final BlockStmt block = replaceMethod.getBody().get();
-        block.addStatement(f("return %s((%s) replacement);", property.getSetterMethodName(), property.getTypeNameForSetter()));
-
-        addOrReplaceWhenSameSignature(nodeCoid, replaceMethod);
-        annotateGenerated(replaceMethod);
-        return methodName;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ArrayCreationLevel.java
@@ -171,11 +171,6 @@ public class ArrayCreationLevel extends Node implements NodeWithAnnotations<Arra
         return JavaParserMetaModel.arrayCreationLevelMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ArrayCreationLevel replaceDimension(Expression replacement) {
-        return setDimension((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -189,7 +184,7 @@ public class ArrayCreationLevel extends Node implements NodeWithAnnotations<Arra
         }
         if (dimension != null) {
             if (node == dimension) {
-                replaceDimension((Expression) replacementNode);
+                setDimension((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -637,16 +637,6 @@ public class CompilationUnit extends Node {
         return JavaParserMetaModel.compilationUnitMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public CompilationUnit replaceModule(ModuleDeclaration replacement) {
-        return setModule((ModuleDeclaration) replacement);
-    }
-
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public CompilationUnit replacePackageDeclaration(PackageDeclaration replacement) {
-        return setPackageDeclaration((PackageDeclaration) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -660,13 +650,13 @@ public class CompilationUnit extends Node {
         }
         if (module != null) {
             if (node == module) {
-                replaceModule((ModuleDeclaration) replacementNode);
+                setModule((ModuleDeclaration) replacementNode);
                 return true;
             }
         }
         if (packageDeclaration != null) {
             if (node == packageDeclaration) {
-                replacePackageDeclaration((PackageDeclaration) replacementNode);
+                setPackageDeclaration((PackageDeclaration) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
@@ -161,6 +161,10 @@ public final class ImportDeclaration extends Node implements NodeWithName<Import
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((Name) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -607,17 +607,12 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     }
 
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public Node replaceComment(Comment replacement) {
-        return setComment((Comment) replacement);
-    }
-
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
         if (comment != null) {
             if (node == comment) {
-                replaceComment((Comment) replacementNode);
+                setComment((Comment) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/PackageDeclaration.java
@@ -182,6 +182,10 @@ public final class PackageDeclaration extends Node implements NodeWithAnnotation
                 return true;
             }
         }
+        if (node == name) {
+            setName((Name) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/AnnotationMemberDeclaration.java
@@ -218,11 +218,6 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
         return JavaParserMetaModel.annotationMemberDeclarationMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public AnnotationMemberDeclaration replaceDefaultValue(Expression replacement) {
-        return setDefaultValue((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -230,9 +225,17 @@ public final class AnnotationMemberDeclaration extends BodyDeclaration<Annotatio
             return false;
         if (defaultValue != null) {
             if (node == defaultValue) {
-                replaceDefaultValue((Expression) replacementNode);
+                setDefaultValue((Expression) replacementNode);
                 return true;
             }
+        }
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
         }
         return super.replace(node, replacementNode);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
@@ -339,6 +339,10 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
         for (int i = 0; i < parameters.size(); i++) {
             if (parameters.get(i) == node) {
                 parameters.set(i, (Parameter) replacementNode);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -200,6 +200,10 @@ public final class ConstructorDeclaration extends CallableDeclaration<Constructo
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((BlockStmt) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/EnumConstantDeclaration.java
@@ -199,6 +199,10 @@ public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantD
                 return true;
             }
         }
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/InitializerDeclaration.java
@@ -142,6 +142,10 @@ public final class InitializerDeclaration extends BodyDeclaration<InitializerDec
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((BlockStmt) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -291,11 +291,6 @@ public final class MethodDeclaration extends CallableDeclaration<MethodDeclarati
         return JavaParserMetaModel.methodDeclarationMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public MethodDeclaration replaceBody(BlockStmt replacement) {
-        return setBody((BlockStmt) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -303,9 +298,13 @@ public final class MethodDeclaration extends CallableDeclaration<MethodDeclarati
             return false;
         if (body != null) {
             if (node == body) {
-                replaceBody((BlockStmt) replacementNode);
+                setBody((BlockStmt) replacementNode);
                 return true;
             }
+        }
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
         }
         return super.replace(node, replacementNode);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/Parameter.java
@@ -286,6 +286,14 @@ public final class Parameter extends Node implements NodeWithType<Parameter, Typ
                 return true;
             }
         }
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
+        }
         for (int i = 0; i < varArgsAnnotations.size(); i++) {
             if (varArgsAnnotations.get(i) == node) {
                 varArgsAnnotations.set(i, (AnnotationExpr) replacementNode);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -218,6 +218,10 @@ public abstract class TypeDeclaration<T extends TypeDeclaration<?>> extends Body
                 return true;
             }
         }
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -242,11 +242,6 @@ public final class VariableDeclarator extends Node implements NodeWithType<Varia
         return JavaParserMetaModel.variableDeclaratorMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public VariableDeclarator replaceInitializer(Expression replacement) {
-        return setInitializer((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -254,9 +249,17 @@ public final class VariableDeclarator extends Node implements NodeWithType<Varia
             return false;
         if (initializer != null) {
             if (node == initializer) {
-                replaceInitializer((Expression) replacementNode);
+                setInitializer((Expression) replacementNode);
                 return true;
             }
+        }
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
         }
         return super.replace(node, replacementNode);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -101,6 +101,10 @@ public abstract class AnnotationExpr extends Expression implements NodeWithName<
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((Name) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayAccessExpr.java
@@ -135,6 +135,14 @@ public final class ArrayAccessExpr extends Expression {
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == index) {
+            setIndex((Expression) replacementNode);
+            return true;
+        }
+        if (node == name) {
+            setName((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -231,19 +231,18 @@ public final class ArrayCreationExpr extends Expression {
         return JavaParserMetaModel.arrayCreationExprMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ArrayCreationExpr replaceInitializer(ArrayInitializerExpr replacement) {
-        return setInitializer((ArrayInitializerExpr) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == elementType) {
+            setElementType((Type) replacementNode);
+            return true;
+        }
         if (initializer != null) {
             if (node == initializer) {
-                replaceInitializer((ArrayInitializerExpr) replacementNode);
+                setInitializer((ArrayInitializerExpr) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
@@ -171,6 +171,14 @@ public final class AssignExpr extends Expression {
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == target) {
+            setTarget((Expression) replacementNode);
+            return true;
+        }
+        if (node == value) {
+            setValue((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -172,6 +172,14 @@ public final class BinaryExpr extends Expression {
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == left) {
+            setLeft((Expression) replacementNode);
+            return true;
+        }
+        if (node == right) {
+            setRight((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/CastExpr.java
@@ -138,6 +138,14 @@ public final class CastExpr extends Expression implements NodeWithType<CastExpr,
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == expression) {
+            setExpression((Expression) replacementNode);
+            return true;
+        }
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ClassExpr.java
@@ -116,6 +116,10 @@ public final class ClassExpr extends Expression implements NodeWithType<ClassExp
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ConditionalExpr.java
@@ -158,6 +158,18 @@ public final class ConditionalExpr extends Expression implements NodeWithConditi
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == condition) {
+            setCondition((Expression) replacementNode);
+            return true;
+        }
+        if (node == elseExpr) {
+            setElseExpr((Expression) replacementNode);
+            return true;
+        }
+        if (node == thenExpr) {
+            setThenExpr((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
@@ -120,16 +120,15 @@ public final class EnclosedExpr extends Expression {
         return JavaParserMetaModel.enclosedExprMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public EnclosedExpr replaceInner(Expression replacement) {
-        return setInner((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == inner) {
+            setInner((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -218,6 +218,14 @@ public final class FieldAccessExpr extends Expression implements NodeWithSimpleN
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
+        if (node == scope) {
+            setScope((Expression) replacementNode);
+            return true;
+        }
         if (typeArguments != null) {
             for (int i = 0; i < typeArguments.size(); i++) {
                 if (typeArguments.get(i) == node) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -139,6 +139,14 @@ public final class InstanceOfExpr extends Expression implements NodeWithType<Ins
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == expression) {
+            setExpression((Expression) replacementNode);
+            return true;
+        }
+        if (node == type) {
+            setType((ReferenceType) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -189,6 +189,10 @@ public class LambdaExpr extends Expression implements NodeWithParameters<LambdaE
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((Statement) replacementNode);
+            return true;
+        }
         for (int i = 0; i < parameters.size(); i++) {
             if (parameters.get(i) == node) {
                 parameters.set(i, (Parameter) replacementNode);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MemberValuePair.java
@@ -140,6 +140,14 @@ public final class MemberValuePair extends Node implements NodeWithSimpleName<Me
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
+        if (node == value) {
+            setValue((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -234,11 +234,6 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
         return JavaParserMetaModel.methodCallExprMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public MethodCallExpr replaceScope(Expression replacement) {
-        return setScope((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -250,9 +245,13 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
                 return true;
             }
         }
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
         if (scope != null) {
             if (node == scope) {
-                replaceScope((Expression) replacementNode);
+                setScope((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
@@ -188,6 +188,10 @@ public class MethodReferenceExpr extends Expression implements NodeWithTypeArgum
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == scope) {
+            setScope((Expression) replacementNode);
+            return true;
+        }
         if (typeArguments != null) {
             for (int i = 0; i < typeArguments.size(); i++) {
                 if (typeArguments.get(i) == node) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -219,11 +219,6 @@ public class Name extends Node implements NodeWithIdentifier<Name>, NodeWithAnno
         return JavaParserMetaModel.nameMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public Name replaceQualifier(Name replacement) {
-        return setQualifier((Name) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -237,7 +232,7 @@ public class Name extends Node implements NodeWithIdentifier<Name>, NodeWithAnno
         }
         if (qualifier != null) {
             if (node == qualifier) {
-                replaceQualifier((Name) replacementNode);
+                setQualifier((Name) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
@@ -119,6 +119,10 @@ public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -284,11 +284,6 @@ public final class ObjectCreationExpr extends Expression implements NodeWithType
         return JavaParserMetaModel.objectCreationExprMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ObjectCreationExpr replaceScope(Expression replacement) {
-        return setScope((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -310,9 +305,13 @@ public final class ObjectCreationExpr extends Expression implements NodeWithType
         }
         if (scope != null) {
             if (node == scope) {
-                replaceScope((Expression) replacementNode);
+                setScope((Expression) replacementNode);
                 return true;
             }
+        }
+        if (node == type) {
+            setType((ClassOrInterfaceType) replacementNode);
+            return true;
         }
         if (typeArguments != null) {
             for (int i = 0; i < typeArguments.size(); i++) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
@@ -112,6 +112,10 @@ public final class SingleMemberAnnotationExpr extends AnnotationExpr {
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == memberValue) {
+            setMemberValue((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SuperExpr.java
@@ -127,11 +127,6 @@ public final class SuperExpr extends Expression {
         return JavaParserMetaModel.superExprMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public SuperExpr replaceClassExpr(Expression replacement) {
-        return setClassExpr((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -139,7 +134,7 @@ public final class SuperExpr extends Expression {
             return false;
         if (classExpr != null) {
             if (node == classExpr) {
-                replaceClassExpr((Expression) replacementNode);
+                setClassExpr((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ThisExpr.java
@@ -121,11 +121,6 @@ public final class ThisExpr extends Expression {
         return JavaParserMetaModel.thisExprMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ThisExpr replaceClassExpr(Expression replacement) {
-        return setClassExpr((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -133,7 +128,7 @@ public final class ThisExpr extends Expression {
             return false;
         if (classExpr != null) {
             if (node == classExpr) {
-                replaceClassExpr((Expression) replacementNode);
+                setClassExpr((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
@@ -117,6 +117,10 @@ public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type>
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/UnaryExpr.java
@@ -175,6 +175,10 @@ public final class UnaryExpr extends Expression implements NodeWithExpression<Un
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == expression) {
+            setExpression((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleDeclaration.java
@@ -193,6 +193,10 @@ public class ModuleDeclaration extends Node implements NodeWithName<ModuleDeclar
                 return true;
             }
         }
+        if (node == name) {
+            setName((Name) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleExportsStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleExportsStmt.java
@@ -132,6 +132,10 @@ public class ModuleExportsStmt extends ModuleStmt implements NodeWithName<Module
                 return true;
             }
         }
+        if (node == name) {
+            setName((Name) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleOpensStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleOpensStmt.java
@@ -132,6 +132,10 @@ public class ModuleOpensStmt extends ModuleStmt implements NodeWithName<ModuleOp
                 return true;
             }
         }
+        if (node == name) {
+            setName((Name) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleProvidesStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleProvidesStmt.java
@@ -127,6 +127,10 @@ public class ModuleProvidesStmt extends ModuleStmt implements NodeWithType<Modul
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
+        }
         for (int i = 0; i < withTypes.size(); i++) {
             if (withTypes.get(i) == node) {
                 withTypes.set(i, (Type) replacementNode);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleRequiresStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleRequiresStmt.java
@@ -123,6 +123,10 @@ public class ModuleRequiresStmt extends ModuleStmt implements NodeWithStaticModi
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((Name) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleUsesStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleUsesStmt.java
@@ -89,6 +89,10 @@ public class ModuleUsesStmt extends ModuleStmt implements NodeWithType<ModuleUse
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == type) {
+            setType((Type) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/AssertStmt.java
@@ -152,19 +152,18 @@ public final class AssertStmt extends Statement {
         return JavaParserMetaModel.assertStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public AssertStmt replaceMessage(Expression replacement) {
-        return setMessage((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == check) {
+            setCheck((Expression) replacementNode);
+            return true;
+        }
         if (message != null) {
             if (node == message) {
-                replaceMessage((Expression) replacementNode);
+                setMessage((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
@@ -129,11 +129,6 @@ public final class BreakStmt extends Statement {
         return JavaParserMetaModel.breakStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public BreakStmt replaceLabel(SimpleName replacement) {
-        return setLabel((SimpleName) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -141,7 +136,7 @@ public final class BreakStmt extends Statement {
             return false;
         if (label != null) {
             if (node == label) {
-                replaceLabel((SimpleName) replacementNode);
+                setLabel((SimpleName) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/CatchClause.java
@@ -152,6 +152,14 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((BlockStmt) replacementNode);
+            return true;
+        }
+        if (node == parameter) {
+            setParameter((Parameter) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ContinueStmt.java
@@ -131,11 +131,6 @@ public final class ContinueStmt extends Statement implements NodeWithOptionalLab
         return JavaParserMetaModel.continueStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ContinueStmt replaceLabel(SimpleName replacement) {
-        return setLabel((SimpleName) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -143,7 +138,7 @@ public final class ContinueStmt extends Statement implements NodeWithOptionalLab
             return false;
         if (label != null) {
             if (node == label) {
-                replaceLabel((SimpleName) replacementNode);
+                setLabel((SimpleName) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/DoStmt.java
@@ -139,6 +139,14 @@ public final class DoStmt extends Statement implements NodeWithBody<DoStmt>, Nod
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((Statement) replacementNode);
+            return true;
+        }
+        if (node == condition) {
+            setCondition((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -239,11 +239,6 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
         return JavaParserMetaModel.explicitConstructorInvocationStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ExplicitConstructorInvocationStmt replaceExpression(Expression replacement) {
-        return setExpression((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -257,7 +252,7 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
         }
         if (expression != null) {
             if (node == expression) {
-                replaceExpression((Expression) replacementNode);
+                setExpression((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExpressionStmt.java
@@ -115,6 +115,10 @@ public final class ExpressionStmt extends Statement implements NodeWithExpressio
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == expression) {
+            setExpression((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForStmt.java
@@ -216,19 +216,18 @@ public final class ForStmt extends Statement implements NodeWithBody<ForStmt> {
         return JavaParserMetaModel.forStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ForStmt replaceCompare(Expression replacement) {
-        return setCompare((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((Statement) replacementNode);
+            return true;
+        }
         if (compare != null) {
             if (node == compare) {
-                replaceCompare((Expression) replacementNode);
+                setCompare((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForeachStmt.java
@@ -165,6 +165,18 @@ public final class ForeachStmt extends Statement implements NodeWithBody<Foreach
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((Statement) replacementNode);
+            return true;
+        }
+        if (node == iterable) {
+            setIterable((Expression) replacementNode);
+            return true;
+        }
+        if (node == variable) {
+            setVariable((VariableDeclarationExpr) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/IfStmt.java
@@ -184,21 +184,24 @@ public final class IfStmt extends Statement implements NodeWithCondition<IfStmt>
         return JavaParserMetaModel.ifStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public IfStmt replaceElseStmt(Statement replacement) {
-        return setElseStmt((Statement) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == condition) {
+            setCondition((Expression) replacementNode);
+            return true;
+        }
         if (elseStmt != null) {
             if (node == elseStmt) {
-                replaceElseStmt((Statement) replacementNode);
+                setElseStmt((Statement) replacementNode);
                 return true;
             }
+        }
+        if (node == thenStmt) {
+            setThenStmt((Statement) replacementNode);
+            return true;
         }
         return super.replace(node, replacementNode);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LabeledStmt.java
@@ -139,6 +139,14 @@ public final class LabeledStmt extends Statement {
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == label) {
+            setLabel((SimpleName) replacementNode);
+            return true;
+        }
+        if (node == statement) {
+            setStatement((Statement) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/LocalClassDeclarationStmt.java
@@ -116,6 +116,10 @@ public final class LocalClassDeclarationStmt extends Statement {
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == classDeclaration) {
+            setClassDeclaration((ClassOrInterfaceDeclaration) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ReturnStmt.java
@@ -132,11 +132,6 @@ public final class ReturnStmt extends Statement {
         return JavaParserMetaModel.returnStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ReturnStmt replaceExpression(Expression replacement) {
-        return setExpression((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -144,7 +139,7 @@ public final class ReturnStmt extends Statement {
             return false;
         if (expression != null) {
             if (node == expression) {
-                replaceExpression((Expression) replacementNode);
+                setExpression((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -178,11 +178,6 @@ public final class SwitchEntryStmt extends Statement implements NodeWithStatemen
         return JavaParserMetaModel.switchEntryStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public SwitchEntryStmt replaceLabel(Expression replacement) {
-        return setLabel((Expression) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -190,7 +185,7 @@ public final class SwitchEntryStmt extends Statement implements NodeWithStatemen
             return false;
         if (label != null) {
             if (node == label) {
-                replaceLabel((Expression) replacementNode);
+                setLabel((Expression) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchStmt.java
@@ -174,6 +174,10 @@ public final class SwitchStmt extends Statement {
                 return true;
             }
         }
+        if (node == selector) {
+            setSelector((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SynchronizedStmt.java
@@ -139,6 +139,14 @@ public final class SynchronizedStmt extends Statement implements NodeWithBlockSt
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((BlockStmt) replacementNode);
+            return true;
+        }
+        if (node == expression) {
+            setExpression((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ThrowStmt.java
@@ -116,6 +116,10 @@ public final class ThrowStmt extends Statement implements NodeWithExpression<Thr
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == expression) {
+            setExpression((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/TryStmt.java
@@ -228,16 +228,6 @@ public final class TryStmt extends Statement {
         return JavaParserMetaModel.tryStmtMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public TryStmt replaceFinallyBlock(BlockStmt replacement) {
-        return setFinallyBlock((BlockStmt) replacement);
-    }
-
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public TryStmt replaceTryBlock(BlockStmt replacement) {
-        return setTryBlock((BlockStmt) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -251,7 +241,7 @@ public final class TryStmt extends Statement {
         }
         if (finallyBlock != null) {
             if (node == finallyBlock) {
-                replaceFinallyBlock((BlockStmt) replacementNode);
+                setFinallyBlock((BlockStmt) replacementNode);
                 return true;
             }
         }
@@ -260,6 +250,10 @@ public final class TryStmt extends Statement {
                 resources.set(i, (VariableDeclarationExpr) replacementNode);
                 return true;
             }
+        }
+        if (node == tryBlock) {
+            setTryBlock((BlockStmt) replacementNode);
+            return true;
         }
         return super.replace(node, replacementNode);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/WhileStmt.java
@@ -139,6 +139,14 @@ public final class WhileStmt extends Statement implements NodeWithBody<WhileStmt
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == body) {
+            setBody((Statement) replacementNode);
+            return true;
+        }
+        if (node == condition) {
+            setCondition((Expression) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -210,6 +210,10 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == componentType) {
+            setComponentType((Type) replacementNode);
+            return true;
+        }
         return super.replace(node, replacementNode);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -243,19 +243,18 @@ public final class ClassOrInterfaceType extends ReferenceType implements NodeWit
         return JavaParserMetaModel.classOrInterfaceTypeMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public ClassOrInterfaceType replaceScope(ClassOrInterfaceType replacement) {
-        return setScope((ClassOrInterfaceType) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
         if (scope != null) {
             if (node == scope) {
-                replaceScope((ClassOrInterfaceType) replacementNode);
+                setScope((ClassOrInterfaceType) replacementNode);
                 return true;
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
@@ -203,6 +203,10 @@ public final class TypeParameter extends ReferenceType implements NodeWithSimple
     public boolean replace(Node node, Node replacementNode) {
         if (node == null)
             return false;
+        if (node == name) {
+            setName((SimpleName) replacementNode);
+            return true;
+        }
         for (int i = 0; i < typeBound.size(); i++) {
             if (typeBound.get(i) == node) {
                 typeBound.set(i, (ClassOrInterfaceType) replacementNode);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -236,16 +236,6 @@ public final class WildcardType extends Type implements NodeWithAnnotations<Wild
         return JavaParserMetaModel.wildcardTypeMetaModel;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public WildcardType replaceExtendedType(ReferenceType replacement) {
-        return setExtendedType((ReferenceType) replacement);
-    }
-
-    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
-    public WildcardType replaceSuperType(ReferenceType replacement) {
-        return setSuperType((ReferenceType) replacement);
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
     public boolean replace(Node node, Node replacementNode) {
@@ -253,13 +243,13 @@ public final class WildcardType extends Type implements NodeWithAnnotations<Wild
             return false;
         if (extendedType != null) {
             if (node == extendedType) {
-                replaceExtendedType((ReferenceType) replacementNode);
+                setExtendedType((ReferenceType) replacementNode);
                 return true;
             }
         }
         if (superType != null) {
             if (node == superType) {
-                replaceSuperType((ReferenceType) replacementNode);
+                setSuperType((ReferenceType) replacementNode);
                 return true;
             }
         }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
@@ -8,16 +8,6 @@ import static org.junit.Assert.assertEquals;
 
 public class ReplaceNodeTest {
     @Test
-    public void testSimplePropertyWithDedicatedReplace() {
-        CompilationUnit cu = parse("package x; class Y {}");
-        cu.replacePackageDeclaration(parsePackageDeclaration("package z;"));
-        assertEquals("package z;\n" +
-                "\n" +
-                "class Y {\n" +
-                "}\n", cu.toString());
-    }
-
-    @Test
     public void testSimplePropertyWithGenericReplace() {
         CompilationUnit cu = parse("package x; class Y {}");
         cu.replace(cu.getPackageDeclaration().get(), parsePackageDeclaration("package z;"));


### PR DESCRIPTION
It was generating useless replaceXxx() methods that just called setXxx(), and it refused to replace required attributes. See #1016 