### PR TITLE
Simplify the float/double grammar

### DIFF
--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -390,10 +390,10 @@ TOKEN :
   >
 |
   < #DECIMAL_FLOATING_POINT_LITERAL:
-        (<DECIMAL_LITERAL>)+ "." (<DECIMAL_LITERAL>)* (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
-      | "." (<DECIMAL_LITERAL>)+ (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
-      | (<DECIMAL_LITERAL>)+ <DECIMAL_EXPONENT> (["f","F","d","D"])?
-      | (<DECIMAL_LITERAL>)+ (<DECIMAL_EXPONENT>)? ["f","F","d","D"]
+        <DECIMAL_LITERAL> "." (<DECIMAL_LITERAL>)? (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
+      | "." <DECIMAL_LITERAL> (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
+      | <DECIMAL_LITERAL> <DECIMAL_EXPONENT> (["f","F","d","D"])?
+      | <DECIMAL_LITERAL> (<DECIMAL_EXPONENT>)? ["f","F","d","D"]
   >
 |
   < #DECIMAL_EXPONENT: ["e","E"] (["+","-"])? (<DECIMAL_LITERAL>)+ >


### PR DESCRIPTION
See #1024 

Simply did what @ftomassetti indicated, which seems logical, and no tests fail.