### PR TITLE
Extended LexicalPreservingPrinter to deal with final and abstract modifiers on a class.

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -258,6 +258,10 @@ class LexicalDifferenceCalculator {
                 return GeneratedJavaParserConstants.PROTECTED;
             case STATIC:
                 return GeneratedJavaParserConstants.STATIC;
+            case FINAL:
+                return GeneratedJavaParserConstants.FINAL;
+            case ABSTRACT:
+                return GeneratedJavaParserConstants.ABSTRACT;
             default:
                 throw new UnsupportedOperationException(modifier.name());
         }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -977,4 +977,38 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         cu.accept(new ModifierVisitor<>(), null);
     }
 
+    @Test
+    public void handleDeprecatedAnnotationFinalClass() {
+        String code = "public final class A {}";
+
+        Pair<ParseResult<CompilationUnit>, LexicalPreservingPrinter> result = LexicalPreservingPrinter
+                .setup(ParseStart.COMPILATION_UNIT, Providers.provider(code));
+
+        CompilationUnit cu = result.a.getResult().get();
+        cu.getTypes().forEach(type -> {
+            type.addAndGetAnnotation(Deprecated.class);
+        });
+
+        assertEquals("@Deprecated()" + EOL +
+                "public final class A {}" , result.b.print(cu));
+
+    }
+
+    @Test
+    public void handleDeprecatedAnnotationAbstractClass() {
+        String code = "public abstract class A {}";
+
+        Pair<ParseResult<CompilationUnit>, LexicalPreservingPrinter> result = LexicalPreservingPrinter
+                .setup(ParseStart.COMPILATION_UNIT, Providers.provider(code));
+
+        CompilationUnit cu = result.a.getResult().get();
+        cu.getTypes().forEach(type -> {
+            type.addAndGetAnnotation(Deprecated.class);
+        });
+
+        assertEquals("@Deprecated()" + EOL +
+                "public abstract class A {}" , result.b.print(cu));
+
+    }
+
 }


### PR DESCRIPTION
When using javaparser's LexicalPreservingPrinter I noticed that adding an annotation to a class that has either a final or abstract modifier would result in an UnsupportedOperationException.

I have extended the toToken method to handle these modifiers as well and added two basic tests to verify if it works. All other tests work as well, but I don't have the overview to see possible negative consequences of this patch.