### PR TITLE
Visitor map

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
@@ -30,10 +30,12 @@ public class CoreGenerator {
         new GenericListVisitorAdapterGenerator(sourceRoot).generate();
         new GenericVisitorAdapterGenerator(sourceRoot).generate();
         new EqualsVisitorGenerator(sourceRoot).generate();
+        new ObjectIdentityEqualsVisitorGenerator(sourceRoot).generate();
         new VoidVisitorAdapterGenerator(sourceRoot).generate();
         new VoidVisitorGenerator(sourceRoot).generate();
         new GenericVisitorGenerator(sourceRoot).generate();
         new HashCodeVisitorGenerator(sourceRoot).generate();
+        new ObjectIdentityHashCodeVisitorGenerator(sourceRoot).generate();
         new CloneVisitorGenerator(sourceRoot).generate();
         new ModifierVisitorGenerator(sourceRoot).generate();
 

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/ObjectIdentityEqualsVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/ObjectIdentityEqualsVisitorGenerator.java
@@ -1,0 +1,30 @@
+package com.github.javaparser.generator.core.visitor;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
+import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.utils.SourceRoot;
+
+import static com.github.javaparser.utils.CodeGenerationUtils.f;
+
+/**
+ * Generates JavaParser's ObjectIdentityEqualsVisitor.
+ */
+public class ObjectIdentityEqualsVisitorGenerator extends VisitorGenerator {
+    public ObjectIdentityEqualsVisitorGenerator(SourceRoot sourceRoot) {
+        super(sourceRoot, "com.github.javaparser.ast.visitor", "ObjectIdentityEqualsVisitor", "Boolean", "Visitable", true);
+    }
+
+    @Override
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
+        visitMethod.getParameters().forEach(p -> p.setFinal(true));
+
+        BlockStmt body = visitMethod.getBody().get();
+        body.getStatements().clear();
+
+        body.addStatement("return n == arg;");
+    }
+}

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/ObjectIdentityHashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/ObjectIdentityHashCodeVisitorGenerator.java
@@ -1,0 +1,32 @@
+package com.github.javaparser.generator.core.visitor;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.generator.VisitorGenerator;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
+import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.utils.SeparatedItemStringBuilder;
+import com.github.javaparser.utils.SourceRoot;
+
+import java.util.List;
+
+import static com.github.javaparser.JavaParser.parseStatement;
+
+/**
+ * Generates JavaParser's ObjectIdentityHashCodeVisitor.
+ */
+public class ObjectIdentityHashCodeVisitorGenerator extends VisitorGenerator {
+    public ObjectIdentityHashCodeVisitorGenerator(SourceRoot sourceRoot) {
+        super(sourceRoot, "com.github.javaparser.ast.visitor", "ObjectIdentityHashCodeVisitor", "Integer", "Void", true);
+    }
+
+    @Override
+    protected void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit) {
+        visitMethod.getParameters().forEach(p -> p.setFinal(true));
+
+        final BlockStmt body = visitMethod.getBody().get();
+        body.getStatements().clear();
+        body.addStatement("return n.hashCode();");
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
@@ -1,0 +1,589 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.ast.visitor;
+
+import com.github.javaparser.ast.*;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.comments.BlockComment;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.modules.*;
+import com.github.javaparser.ast.stmt.*;
+import com.github.javaparser.ast.type.*;
+import javax.annotation.Generated;
+
+/**
+ * A visitor that calculates deep node equality by comparing all properties and child nodes of the node.
+ *
+ * @author Julio Vilmar Gesser
+ */
+public class ObjectIdentityEqualsVisitor implements GenericVisitor<Boolean, Visitable> {
+
+    private static final ObjectIdentityEqualsVisitor SINGLETON = new ObjectIdentityEqualsVisitor();
+
+    public static boolean equals(final Node n, final Node n2) {
+        return n.accept(SINGLETON, n2);
+    }
+
+    private ObjectIdentityEqualsVisitor() {
+    // hide constructor
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final CompilationUnit n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final PackageDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final TypeParameter n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final LineComment n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final BlockComment n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ClassOrInterfaceDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final EnumDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final EnumConstantDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final AnnotationDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final AnnotationMemberDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final FieldDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final VariableDeclarator n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ConstructorDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final MethodDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final Parameter n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final InitializerDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final JavadocComment n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ClassOrInterfaceType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final PrimitiveType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ArrayType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ArrayCreationLevel n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final IntersectionType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final UnionType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final VoidType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final WildcardType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final UnknownType n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ArrayAccessExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ArrayCreationExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ArrayInitializerExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final AssignExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final BinaryExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final CastExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ClassExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ConditionalExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final EnclosedExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final FieldAccessExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final InstanceOfExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final StringLiteralExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final IntegerLiteralExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final LongLiteralExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final CharLiteralExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final DoubleLiteralExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final BooleanLiteralExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final NullLiteralExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final MethodCallExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final NameExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ObjectCreationExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final Name n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final SimpleName n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ThisExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final SuperExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final UnaryExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final VariableDeclarationExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final MarkerAnnotationExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final SingleMemberAnnotationExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final NormalAnnotationExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final MemberValuePair n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ExplicitConstructorInvocationStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final LocalClassDeclarationStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final AssertStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final BlockStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final LabeledStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final EmptyStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ExpressionStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final SwitchStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final SwitchEntryStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final BreakStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ReturnStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final IfStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final WhileStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ContinueStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final DoStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ForeachStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ForStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ThrowStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final SynchronizedStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final TryStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final CatchClause n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final LambdaExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final MethodReferenceExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final TypeExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ImportDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    public Boolean visit(NodeList n, Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ModuleDeclaration n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ModuleRequiresStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override()
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ModuleExportsStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override()
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ModuleProvidesStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override()
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ModuleUsesStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final ModuleOpensStmt n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
+    public Boolean visit(final UnparsableStmt n, final Visitable arg) {
+        return n == arg;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
@@ -44,10 +44,6 @@ public class ObjectIdentityEqualsVisitor implements GenericVisitor<Boolean, Visi
         return n.accept(SINGLETON, n2);
     }
 
-    private ObjectIdentityEqualsVisitor() {
-    // hide constructor
-    }
-
     @Override
     @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityEqualsVisitorGenerator")
     public Boolean visit(final CompilationUnit n, final Visitable arg) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.ast.visitor;
+
+import com.github.javaparser.ast.*;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.comments.BlockComment;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.modules.*;
+import com.github.javaparser.ast.stmt.*;
+import com.github.javaparser.ast.type.*;
+import javax.annotation.Generated;
+
+/**
+ * A visitor that calculates a deep hash code for a node by using the hash codes of all its properties,
+ * and the hash codes of all its child nodes (by visiting those too.)
+ */
+public class ObjectIdentityHashCodeVisitor implements GenericVisitor<Integer, Void> {
+
+    private static final ObjectIdentityHashCodeVisitor SINGLETON = new ObjectIdentityHashCodeVisitor();
+
+    private ObjectIdentityHashCodeVisitor() {
+    // hide constructor
+    }
+
+    public static int hashCode(final Node node) {
+        return node.accept(SINGLETON, null);
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final AnnotationDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final AnnotationMemberDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ArrayAccessExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ArrayCreationExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ArrayCreationLevel n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ArrayInitializerExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ArrayType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final AssertStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final AssignExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final BinaryExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final BlockComment n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final BlockStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final BooleanLiteralExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final BreakStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final CastExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final CatchClause n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final CharLiteralExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ClassExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ClassOrInterfaceDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ClassOrInterfaceType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final CompilationUnit n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ConditionalExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ConstructorDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ContinueStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final DoStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final DoubleLiteralExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final EmptyStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final EnclosedExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final EnumConstantDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final EnumDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ExplicitConstructorInvocationStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ExpressionStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final FieldAccessExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final FieldDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ForStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ForeachStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final IfStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ImportDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final InitializerDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final InstanceOfExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final IntegerLiteralExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final IntersectionType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final JavadocComment n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final LabeledStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final LambdaExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final LineComment n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final LocalClassDeclarationStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final LongLiteralExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final MarkerAnnotationExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final MemberValuePair n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final MethodCallExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final MethodDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final MethodReferenceExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final NameExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final Name n, final Void arg) {
+        return n.hashCode();
+    }
+
+    public Integer visit(NodeList n, Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final NormalAnnotationExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final NullLiteralExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ObjectCreationExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final PackageDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final Parameter n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final PrimitiveType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ReturnStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final SimpleName n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final SingleMemberAnnotationExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final StringLiteralExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final SuperExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final SwitchEntryStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final SwitchStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final SynchronizedStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ThisExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ThrowStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final TryStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final TypeExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final TypeParameter n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final UnaryExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final UnionType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final UnknownType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final VariableDeclarationExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final VariableDeclarator n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final VoidType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final WhileStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final WildcardType n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ModuleDeclaration n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ModuleRequiresStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Override()
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ModuleExportsStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Override()
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ModuleProvidesStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Override()
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ModuleUsesStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final ModuleOpensStmt n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.ObjectIdentityHashCodeVisitorGenerator")
+    public Integer visit(final UnparsableStmt n, final Void arg) {
+        return n.hashCode();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
@@ -39,10 +39,6 @@ public class ObjectIdentityHashCodeVisitor implements GenericVisitor<Integer, Vo
 
     private static final ObjectIdentityHashCodeVisitor SINGLETON = new ObjectIdentityHashCodeVisitor();
 
-    private ObjectIdentityHashCodeVisitor() {
-    // hide constructor
-    }
-
     public static int hashCode(final Node node) {
         return node.accept(SINGLETON, null);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
@@ -1,0 +1,128 @@
+package com.github.javaparser.utils;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.visitor.GenericVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A facade for another java.util.Map that overrides the equals and hashcode calculation of the added nodes
+ * by using another visitor for those methods.
+ */
+public class VisitorMap<N extends Node, V> implements Map<N, V> {
+    // Cheat generics by removing them
+    private final Map innerMap;
+    private final GenericVisitor<Integer, Void> hashcodeVisitor;
+    private final GenericVisitor<Boolean, Visitable> equalsVisitor;
+
+    /**
+     * Wrap a map and use different visitors for equals and hashcode.
+     */
+    public VisitorMap(Map<N, V> innerMap, GenericVisitor<Integer, Void> hashcodeVisitor, GenericVisitor<Boolean, Visitable> equalsVisitor) {
+        this.innerMap = innerMap;
+        this.hashcodeVisitor = hashcodeVisitor;
+        this.equalsVisitor = equalsVisitor;
+    }
+
+
+    @Override
+    public int size() {
+        return innerMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return innerMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return innerMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return innerMap.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return (V) innerMap.get(key);
+    }
+
+    @Override
+    public V put(N key, V value) {
+        return (V) innerMap.put(new EqualsHashcodeOverridingFacade(key), value);
+    }
+
+    private class EqualsHashcodeOverridingFacade implements Visitable {
+        private final N overridden;
+
+        public EqualsHashcodeOverridingFacade(N overridden) {
+            this.overridden = overridden;
+        }
+
+        @Override
+        public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+            throw new AssertionError();
+        }
+
+        @Override
+        public <A> void accept(VoidVisitor<A> v, A arg) {
+            throw new AssertionError();
+        }
+
+        @Override
+        public final int hashCode() {
+            return overridden.accept(hashcodeVisitor, null);
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (obj == null || !(obj instanceof Node)) {
+                return false;
+            }
+            return overridden.accept(equalsVisitor, (Node) obj);
+        }
+    }
+
+    @Override
+    public V remove(Object key) {
+        return (V) innerMap.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends N, ? extends V> m) {
+        innerMap.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        innerMap.clear();
+    }
+
+    @Override
+    public Set<N> keySet() {
+        return ((Map<EqualsHashcodeOverridingFacade, V>) innerMap).keySet().stream()
+                .map(k -> k.overridden)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Collection<V> values() {
+        return innerMap.values();
+    }
+
+    @Override
+    public Set<Entry<N, V>> entrySet() {
+        return ((Map<EqualsHashcodeOverridingFacade, V>) innerMap).entrySet().stream()
+                .map(e -> new HashMap.SimpleEntry<N, V>(e.getKey().overridden, e.getValue()))
+                .collect(Collectors.toSet());
+    }
+}

--- a/javaparser-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
@@ -1,0 +1,36 @@
+package com.github.javaparser.utils;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.visitor.ObjectIdentityEqualsVisitor;
+import com.github.javaparser.ast.visitor.ObjectIdentityHashCodeVisitor;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class VisitorMapTest {
+    @Test
+    public void normalEqualsDoesDeepCompare() {
+        CompilationUnit x1 = JavaParser.parse("class X{}");
+        CompilationUnit x2 = JavaParser.parse("class X{}");
+
+        Map<CompilationUnit, Integer> normalMap = new HashMap<>();
+        normalMap.put(x1, 1);
+        normalMap.put(x2, 2);
+        assertEquals(1, normalMap.size());
+    }
+
+    @Test
+    public void objectIdentityEqualsDoesShallowCompare() {
+        CompilationUnit x1 = JavaParser.parse("class X{}");
+        CompilationUnit x2 = JavaParser.parse("class X{}");
+
+        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        normalMap.put(x1, 1);
+        normalMap.put(x2, 2);
+        assertEquals(2, normalMap.size());
+    }
+}


### PR DESCRIPTION
Allows overriding hashcode and equals for nodes used as keys in a `Map` by wrapping the map in a special map that wraps all keys in a wrapper node that catches `hashcode()` and `equals()` and sends to the requested visitor.

It sounds a lot more complicated than it is.