### PR TITLE
Fix containsKey, get, putAll and Equals of VisitorMap

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
@@ -99,7 +99,7 @@ public class VisitorMap<N extends Node, V> implements Map<N, V> {
 
     @Override
     public void putAll(Map<? extends N, ? extends V> m) {
-        innerMap.putAll(m);
+        m.forEach((key, value) -> this.put(key,value));
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
@@ -17,15 +17,15 @@ import java.util.stream.Collectors;
  */
 public class VisitorMap<N extends Node, V> implements Map<N, V> {
     // Cheat generics by removing them
-    private final Map innerMap;
+    private final Map<EqualsHashcodeOverridingFacade, V> innerMap;
     private final GenericVisitor<Integer, Void> hashcodeVisitor;
     private final GenericVisitor<Boolean, Visitable> equalsVisitor;
 
     /**
      * Wrap a map and use different visitors for equals and hashcode.
      */
-    public VisitorMap(Map<N, V> innerMap, GenericVisitor<Integer, Void> hashcodeVisitor, GenericVisitor<Boolean, Visitable> equalsVisitor) {
-        this.innerMap = innerMap;
+    public VisitorMap(GenericVisitor<Integer, Void> hashcodeVisitor, GenericVisitor<Boolean, Visitable> equalsVisitor) {
+        this.innerMap = new HashMap<>();
         this.hashcodeVisitor = hashcodeVisitor;
         this.equalsVisitor = equalsVisitor;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorMap.java
@@ -43,7 +43,7 @@ public class VisitorMap<N extends Node, V> implements Map<N, V> {
 
     @Override
     public boolean containsKey(Object key) {
-        return innerMap.containsKey(key);
+        return innerMap.containsKey(new EqualsHashcodeOverridingFacade((N) key));
     }
 
     @Override
@@ -53,7 +53,7 @@ public class VisitorMap<N extends Node, V> implements Map<N, V> {
 
     @Override
     public V get(Object key) {
-        return (V) innerMap.get(key);
+        return (V) innerMap.get(new EqualsHashcodeOverridingFacade((N) key));
     }
 
     @Override
@@ -85,10 +85,10 @@ public class VisitorMap<N extends Node, V> implements Map<N, V> {
 
         @Override
         public boolean equals(final Object obj) {
-            if (obj == null || !(obj instanceof Node)) {
+            if (obj == null || !(obj instanceof VisitorMap.EqualsHashcodeOverridingFacade)) {
                 return false;
             }
-            return overridden.accept(equalsVisitor, (Node) obj);
+            return overridden.accept(equalsVisitor, ((EqualsHashcodeOverridingFacade) obj).overridden);
         }
     }
 

--- a/javaparser-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class VisitorMapTest {
     @Test
@@ -33,4 +34,36 @@ public class VisitorMapTest {
         normalMap.put(x2, 2);
         assertEquals(2, normalMap.size());
     }
+    
+    @Test
+    public void visitorMapGet(){
+    	CompilationUnit x1 = JavaParser.parse("class X{}");
+
+        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        normalMap.put(x1, 1);
+        assertEquals(1, (int)normalMap.get(x1));
+    }
+    
+    @Test
+    public void visitorMapContainsKey(){
+    	CompilationUnit x1 = JavaParser.parse("class X{}");
+
+        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        normalMap.put(x1, 1);
+        assertTrue(normalMap.containsKey(x1));
+    }
+    
+    @Test
+    public void visitorMapPutAll(){
+    	CompilationUnit x1 = JavaParser.parse("class X{}");
+    	CompilationUnit x2 = JavaParser.parse("class Y{}");
+    	Map<CompilationUnit, Integer> normalMap = new HashMap<>();
+    	normalMap.put(x1, 1);
+    	normalMap.put(x2, 2);
+    	Map<CompilationUnit, Integer> visitorMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        visitorMap.putAll(normalMap);
+        assertEquals(2, visitorMap.size());
+    }
+    
+
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
@@ -29,7 +29,7 @@ public class VisitorMapTest {
         CompilationUnit x1 = JavaParser.parse("class X{}");
         CompilationUnit x2 = JavaParser.parse("class X{}");
 
-        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         normalMap.put(x1, 1);
         normalMap.put(x2, 2);
         assertEquals(2, normalMap.size());
@@ -39,7 +39,7 @@ public class VisitorMapTest {
     public void visitorMapGet(){
     	CompilationUnit x1 = JavaParser.parse("class X{}");
 
-        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         normalMap.put(x1, 1);
         assertEquals(1, (int)normalMap.get(x1));
     }
@@ -48,7 +48,7 @@ public class VisitorMapTest {
     public void visitorMapContainsKey(){
     	CompilationUnit x1 = JavaParser.parse("class X{}");
 
-        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        Map<CompilationUnit, Integer> normalMap = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         normalMap.put(x1, 1);
         assertTrue(normalMap.containsKey(x1));
     }
@@ -60,7 +60,7 @@ public class VisitorMapTest {
     	Map<CompilationUnit, Integer> normalMap = new HashMap<>();
     	normalMap.put(x1, 1);
     	normalMap.put(x2, 2);
-    	Map<CompilationUnit, Integer> visitorMap = new VisitorMap<>(new HashMap<>(), new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+    	Map<CompilationUnit, Integer> visitorMap = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         visitorMap.putAll(normalMap);
         assertEquals(2, visitorMap.size());
     }


### PR DESCRIPTION
See #1065
There is still `putAll` to fix, but I don't know how to do that.