### PR TITLE
Use threads to visit directories and parse files in parallel #1073

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -95,6 +95,15 @@ public final class JavaParser {
         JavaParser.staticConfiguration = staticConfiguration;
     }
 
+    /**
+     * Get the non-static configuration for this parser.
+     *
+     * @return The non-static configuration for this parser.
+     */
+    public ParserConfiguration getParserConfiguration() {
+        return this.configuration;
+    }
+
     private GeneratedJavaParser getParserForProvider(Provider provider) {
         if (astParser == null) {
             astParser = new GeneratedJavaParser(provider);


### PR DESCRIPTION
@matozoid: 

(1) I abstracted away some of the redundant code I had.

(2) I utilized your **xxxParallelized()** concept, so everything is intact from the original code, except that **tryToParse(String, String)** copies the internal parser. My code is still calling that method. That's the ONLY change, besides the methods and inner classes I've added, in terms of functionality. To put the method back to it's original code, I could simply copy it to my method, where I copy the internal parser, and now none of my stuff would depend on yours. Sound good? I know you don't like redundancy.

(3) In the javadocs for **parseParallelized(String, JavaParser, Callback)**, I've noted that the callback must be threadsafe.