### PR TITLE
Use threads to visit directories and parse files in parallel in SourceRoot #1046

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -95,6 +95,15 @@ public final class JavaParser {
         JavaParser.staticConfiguration = staticConfiguration;
     }
 
+    /**
+     * Get the non-static configuration for this parser.
+     *
+     * @return The non-static configuration for this parser.
+     */
+    public ParserConfiguration getParserConfiguration() {
+        return this.configuration;
+    }
+
     private GeneratedJavaParser getParserForProvider(Provider provider) {
         if (astParser == null) {
             astParser = new GeneratedJavaParser(provider);

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -155,7 +155,7 @@ public class SourceRoot {
         assertNotNull(startPackage);
         Log.info("Parsing package \"%s\"", startPackage);
         final Path path = packageAbsolutePath(root, startPackage);
-        ParallelParse w = new ParallelParse(path, new ParallelParse.VisitFileCallback() {
+        ParallelParse parse = new ParallelParse(path, new ParallelParse.VisitFileCallback() {
             @Override
             public FileVisitResult process(Path file, BasicFileAttributes attrs) {
                 if (!attrs.isDirectory() && file.toString().endsWith(".java")) {
@@ -170,8 +170,8 @@ public class SourceRoot {
                 return FileVisitResult.CONTINUE;
             }
         });
-        ForkJoinPool p = new ForkJoinPool();
-        p.invoke(w);
+        ForkJoinPool pool = new ForkJoinPool();
+        pool.invoke(parse);
         return getCache();
     }
 
@@ -267,7 +267,7 @@ public class SourceRoot {
         assertNotNull(callback);
         Log.info("Parsing package \"%s\"", startPackage);
         final Path path = packageAbsolutePath(root, startPackage);
-        ParallelParse w = new ParallelParse(path, new ParallelParse.VisitFileCallback() {
+        ParallelParse parse = new ParallelParse(path, new ParallelParse.VisitFileCallback() {
             @Override
             public FileVisitResult process(Path file, BasicFileAttributes attrs) {
                 if (!attrs.isDirectory() && file.toString().endsWith(".java")) {
@@ -290,8 +290,8 @@ public class SourceRoot {
                 return FileVisitResult.CONTINUE;
             }
         });
-        ForkJoinPool p = new ForkJoinPool();
-        p.invoke(w);
+        ForkJoinPool pool = new ForkJoinPool();
+        pool.invoke(parse);
         return this;
     }
 


### PR DESCRIPTION
@matozoid:

1. I abstracted away some of the redundant code I had.

2. In this PR, other than switching the cache to a ConcurrentHashMap and the addition of my methods, the original SourceRoot code is functionally the same. I refactored a bit, but the copying of the parser no longer exists in **tryToParse()** and **parse()**.

3. In the javadocs for **parseParallelized(String, JavaParser, Callback)**, I've noted that the callback must be threadsafe. I've also noted in the javadocs for both parallelized methods that a new instance of the parser that's instantiated with the internal parser's configuration is used to parse each file.

4. Although variable at times, I'm seeing nearly a 50% speed up on my machine (and it's an ancient CPU) for ~20k files, with a marginal memory increase for both parse and cached parse.

5. Before taking steps to ensure thread safety, I was getting parse exceptions. Since implementing these steps, I've seen no such exceptions and all tests are passing.

I can't think of any other issues.