### PR TITLE
PrettyPrint option to wrap-and-column-align parameters of method calls

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.printer;
 
+import com.github.javaparser.Position;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
@@ -130,12 +131,18 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
 
     private void printArguments(final NodeList<Expression> args, final Void arg) {
         printer.print("(");
+        Position cursorRef = printer.getCursor();
         if (!isNullOrEmpty(args)) {
             for (final Iterator<Expression> i = args.iterator(); i.hasNext(); ) {
                 final Expression e = i.next();
                 e.accept(this, arg);
                 if (i.hasNext()) {
-                    printer.print(", ");
+                    printer.print(",");
+                    if (configuration.isColumnAlignParameters()) {
+                        printer.wrapToColumn(cursorRef.column);
+                    } else {
+                        printer.print(" ");
+                    }
                 }
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
@@ -29,6 +29,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 public class PrettyPrinterConfiguration {
     private boolean printComments = true;
     private boolean printJavaDoc = true;
+    private boolean columnAlignParameters = false;
     private String indent = "    ";
     private String endOfLineCharacter = EOL;
     private Function<PrettyPrinterConfiguration, PrettyPrintVisitor> visitorFactory = PrettyPrintVisitor::new;
@@ -53,6 +54,10 @@ public class PrettyPrinterConfiguration {
     public boolean isPrintJavaDoc() {
         return printJavaDoc;
     }
+    
+    public boolean isColumnAlignParameters() {
+        return columnAlignParameters;
+    }
 
     public PrettyPrinterConfiguration setPrintComments(boolean printComments) {
         this.printComments = printComments;
@@ -61,6 +66,11 @@ public class PrettyPrinterConfiguration {
 
     public PrettyPrinterConfiguration setPrintJavaDoc(boolean printJavaDoc) {
         this.printJavaDoc = printJavaDoc;
+        return this;
+    }
+    
+    public PrettyPrinterConfiguration setColumnAlignParameters(boolean columnAlignParameters) {
+        this.columnAlignParameters = columnAlignParameters;
         return this;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
@@ -21,12 +21,17 @@
 
 package com.github.javaparser.printer;
 
+import java.text.Normalizer;
+
+import com.github.javaparser.Position;
+
 public class SourcePrinter {
     private final String indentation;
     private final String endOfLineCharacter;
     private int level = 0;
     private boolean indented = false;
     private final StringBuilder buf = new StringBuilder();
+    private Position cursor = new Position(1, 0);
 
     SourcePrinter(final String indentation, final String endOfLineCharacter) {
         this.indentation = indentation;
@@ -45,7 +50,7 @@ public class SourcePrinter {
 
     private void makeIndent() {
         for (int i = 0; i < level; i++) {
-            buf.append(indentation);
+            bufAppend(indentation);
         }
     }
 
@@ -54,7 +59,7 @@ public class SourcePrinter {
             makeIndent();
             indented = true;
         }
-        buf.append(arg);
+        bufAppend(arg);
         return this;
     }
 
@@ -65,9 +70,44 @@ public class SourcePrinter {
     }
 
     public SourcePrinter println() {
-        buf.append(endOfLineCharacter);
+        bufAppend(endOfLineCharacter);
         indented = false;
         return this;
+    }
+    
+    private StringBuilder bufAppend(final String arg) {
+        updateCursor(arg);
+        return buf.append(arg);
+    }
+
+    private void updateCursor(String arg) {
+        String[] lines = arg.split("\r\n|\r|\n");
+        if ( lines.length == 0 ) {
+            cursor = Position.pos(cursor.line + 1, 0);
+        } else if ( lines.length == 1 ) {
+            cursor = Position.pos(cursor.line, cursor.column + Normalizer.normalize(lines[0],Normalizer.Form.NFC).length() );
+        } else {
+            cursor = Position.pos(cursor.line + (lines.length -1), 0 + Normalizer.normalize(lines[lines.length-1],Normalizer.Form.NFC).length());
+        }
+    }
+    
+    public Position getCursor() {
+        return cursor;
+    }
+    
+    /**
+     * Performs a new line and indent, then prints enough space characters until aligned to the specified column.
+     * @param column the column to align to
+     */
+    public void wrapToColumn(int column) {
+        println();
+        if (!indented) {
+            makeIndent();
+            indented = true;
+        }
+        while ( cursor.column < column ) {
+            print(" ");
+        }
     }
 
     public String getSource() {

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -94,5 +94,25 @@ public class PrettyPrinterTest {
         code = "class A { void foo(){ int a, b[]; }}";
         assertEquals("test", prettyPrintConfigurable(code));
     }
+    
+    @Test
+    public void prettyColumnAlignParameters() {
+        String code = "class Example { void foo(Object arg0,Object arg1){ myMethod(1, 2, 3, 5, Object.class); } }";
+        String expected = "class Example {\n" + 
+                "\n" + 
+                "\tvoid foo(Object arg0, Object arg1) {\n" + 
+                "\t\tmyMethod(1,\n" + 
+                "\t\t         2,\n" + 
+                "\t\t         3,\n" + 
+                "\t\t         5,\n" + 
+                "\t\t         Object.class);\n" + 
+                "\t}\n" + 
+                "}\n" + 
+                "";
+        PrettyPrinterConfiguration config = new PrettyPrinterConfiguration();
+        config.setIndent("\t");
+        config.setColumnAlignParameters(true);
+        assertEquals(expected, new PrettyPrinter(config).print(JavaParser.parse(code)));
+    }
 
 }


### PR DESCRIPTION
This option wrap-and-column align parameters passed inside method calls.

Example.
source
```
myMethod(1, 2, 3, 5, Object.class);
```
pretty-printed with this option
```
myMethod(1,
         2,
         3,
         5,
         Object.class);
```

It use the configured indentation, followed by space-padding in order to align to the required column. In other words, leverage configured indentation as much as possible, but in order to align to column in the final parts space is used. The test included highlight this behaviour.

I have also "in the works" an additional configuration option to wrap-align chained method calls like fluent DSL or Java 8 stream API call like. Kindly let me know if sensible to include in this PR or better to manage as a separate PR later.

Thanks!