### PR TITLE
Upgrade JavaCC

### DIFF
--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -32,8 +32,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>javacc-maven-plugin</artifactId>
+                <groupId>com.helger.maven</groupId>
+                <artifactId>ph-javacc-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>javacc</id>

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -50,7 +50,7 @@
                     <dependency>
                         <groupId>net.java.dev.javacc</groupId>
                         <artifactId>javacc</artifactId>
-                        <version>6.1.2</version>
+                        <version>7.0.2</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
An update was overdue. Also: someone took over development of the JavaCC maven plugin, so I switched to that.

See #899 