### PR TITLE
Parse java files from a zip or jar

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceZip.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceZip.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.utils;
+
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
+import static com.github.javaparser.Providers.provider;
+
+/**
+ * A collection of Java source files and its sub-directories located in a ZIP or JAR file on the file system.
+ * Files can be parsed with a callback.
+ */
+public class SourceZip {
+
+    private final Path zipPath;
+    private JavaParser javaParser;
+
+    /**
+     * Create a new ZIP parser. A default instance of {@link JavaParser} will be used to parse the ZIP.
+     *
+     * @param zipPath The absolute path of ZIP file to parse.
+     */
+    public SourceZip(Path zipPath) {
+        assertNotNull(zipPath);
+        if (Files.isDirectory(zipPath)
+                || !(zipPath.toString().endsWith(".zip") || zipPath.toString().endsWith(".jar"))) {
+            throw new IllegalArgumentException("SourceZip only parses ZIP and JAR files.");
+        }
+        this.zipPath = zipPath.normalize();
+        this.javaParser = new JavaParser();
+        Log.info("New source zip at \"%s\"", this.zipPath);
+    }
+
+    /**
+     * Create a new ZIP parser.
+     *
+     * @param zipPath The absolute path of ZIP file to parse.
+     * @param javaParser The parser used to parse the ZIP files.
+     */
+    public SourceZip(Path zipPath, JavaParser javaParser) {
+        this(zipPath);
+        assertNotNull(javaParser);
+        this.javaParser = javaParser;
+    }
+
+    /**
+     * Tries to parse all '.java' files in the ZIP located at this <i>SourceZip</i>'s path and passes them one by one
+     * to the provided callback.
+     *
+     * @param callback A callback method for the post-processing of a parsed ZIP file.
+     * @return This {@link SourceZip} object.
+     */
+    public SourceZip parse(Callback callback) throws IOException {
+        assertNotNull(callback);
+        Log.info("Parsing zip at \"%s\"", zipPath);
+        ZipFile zipFile = new ZipFile(zipPath.toFile());
+        for (ZipEntry entry : Collections.list(zipFile.entries())) {
+            if (!entry.isDirectory() && entry.getName().endsWith(".java")) {
+                final ParseResult<CompilationUnit> result = javaParser.parse(COMPILATION_UNIT,
+                        provider(zipFile.getInputStream(entry)));
+                callback.process(Paths.get(entry.getName()), result);
+            }
+        }
+        zipFile.close();
+        return this;
+    }
+
+    /**
+     * Get the path of the ZIP file to be parsed.
+     *
+     * @return The absolute path of this ZIP file.
+     */
+    public Path getZipPath() {
+        return zipPath;
+    }
+
+    /**
+     * Get the parser used for parsing.
+     *
+     * @return The currently set parser.
+     */
+    public JavaParser getJavaParser() {
+        return javaParser;
+    }
+
+    /**
+     * Set the parser that is used for parsing.
+     *
+     * @param javaParser The parser to use.
+     */
+    public SourceZip setJavaParser(JavaParser javaParser) {
+        assertNotNull(javaParser);
+        this.javaParser = javaParser;
+        return this;
+    }
+
+    /**
+     * An interface to define a callback for each file that's parsed.
+     *
+     */
+    public interface Callback {
+
+        /**
+         * Process the given parse result.
+         *
+         * @param relativeZipEntryPath The relative path of the entry in the ZIP file that was parsed.
+         * @param result The parse result of file located at <i>absolutePath</i>.
+         */
+        void process(Path relativeZipEntryPath, ParseResult<CompilationUnit> result);
+    }
+}

--- a/javaparser-testing/src/test/java/com/github/javaparser/utils/SourceZipTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/utils/SourceZipTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.utils;
+
+import static com.github.javaparser.utils.CodeGenerationUtils.f;
+import static com.github.javaparser.utils.TestUtils.download;
+import static com.github.javaparser.utils.TestUtils.temporaryDirectory;
+import static java.util.Comparator.comparing;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Test;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.Problem;
+import com.github.javaparser.ast.validator.Java9Validator;
+
+public class SourceZipTest {
+
+    private final static String PROJECT_NAME = "JavaParser";
+    private final static String PROJECT_TEST_RESULT_FILE = PROJECT_NAME + "_Test_Results.txt";
+    private final static String ZIP_URL = "https://github.com/javaparser/javaparser/archive/master.zip";
+    private final static String ZIP_DOWNLOAD_DIR = PROJECT_NAME + "_Download";
+    private final static String ZIP_NAME = "master.zip";
+
+    @Test
+    public void parseProjectZip() throws IOException {
+        Path workdir = CodeGenerationUtils.mavenModuleRoot(SourceZipTest.class)
+                .resolve(Paths.get(temporaryDirectory(), ZIP_DOWNLOAD_DIR));
+        workdir.toFile().mkdirs();
+        Path zipPath = workdir.resolve(ZIP_NAME);
+        if (Files.notExists(zipPath)) {
+            Log.info("Downloading " + PROJECT_NAME);
+            download(new URL(ZIP_URL), zipPath);
+        }
+        bulkTest(new SourceZip(zipPath), PROJECT_TEST_RESULT_FILE);
+    }
+
+    private void bulkTest(SourceZip sourceZip, String testResultsFileName) throws IOException {
+        sourceZip.setJavaParser(new JavaParser(new ParserConfiguration().setValidator(new Java9Validator())));
+        Path testResults = CodeGenerationUtils.mavenModuleRoot(SourceZipTest.class).resolve(Paths.get("..",
+                "javaparser-testing", "src", "test", "resources", "com", "github", "javaparser", "bulk_test_results"))
+                .normalize();
+        testResults.toFile().mkdirs();
+        testResults = testResults.resolve(testResultsFileName);
+        TreeMap<Path, List<Problem>> results = new TreeMap<>(comparing(o -> o.toString().toLowerCase()));
+        sourceZip.parse((relativeFilePath, result) -> {
+            if (!relativeFilePath.toString().contains("target")) {
+                if (!result.isSuccessful()) {
+                    results.put(relativeFilePath, result.getProblems());
+                }
+            }
+        });
+        Log.info("Writing results...");
+
+        int problemTotal = 0;
+        try (BufferedWriter writer = Files.newBufferedWriter(testResults)) {
+            for (Map.Entry<Path, List<Problem>> file : results.entrySet()) {
+                writer.write(file.getKey().toString().replace("\\", "/"));
+                writer.newLine();
+                for (Problem problem : file.getValue()) {
+                    writer.write(problem.getVerboseMessage());
+                    writer.newLine();
+                    problemTotal++;
+                }
+                writer.newLine();
+            }
+            writer.write(f("%s problems in %s files", problemTotal, results.size()));
+        }
+
+        Log.info("Results are in %s", testResults);
+    }
+
+}


### PR DESCRIPTION
See #1079 

@matozoid: Let me know if you want API changes and/or additions. I edited your BulkParseTest to accommodate SourceZip and used the JavaParser ZIP (via GitHub download) to test against. Everything works as expected.