### PR TITLE
Issue 1116 underscores hex float literals

### DIFF
--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -32,9 +32,9 @@ options {
 PARSER_BEGIN(GeneratedJavaParser)
 /*
  *
- * This file is part of JavaParser 9.
+ * This file is part of JavaParser.
  *
- * JavaParser 9 is free software: you can redistribute it and/or modify
+ * JavaParser is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -402,13 +402,13 @@ TOKEN :
       | <BINARY_LITERAL>
   >
 |
-  < #DECIMAL_LITERAL: (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) >
+  < #DECIMAL_LITERAL: ["0"-"9"]((["0"-"9","_"])*["0"-"9"])? >
 |
-  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"]((["0"-"9","a"-"f","A"-"F","_"])*["0"-"9","a"-"f","A"-"F"])?) >
+  < #HEX_LITERAL: "0" ["x","X"] <HEX_DIGITS> >
 |
-  < #OCTAL_LITERAL: "0" (["0"-"7"]((["0"-"7","_"])*["0"-"7"])?) >
+  < #OCTAL_LITERAL: "0" ["0"-"7"]((["0"-"7","_"])*["0"-"7"])? >
 |
-  < #BINARY_LITERAL: "0" ["b","B"] (["0","1"]((["0","1","_"])*["0","1"])?) >
+  < #BINARY_LITERAL: "0" ["b","B"] ["0","1"]((["0","1","_"])*["0","1"])? >
 |
   < FLOATING_POINT_LITERAL:
         <DECIMAL_FLOATING_POINT_LITERAL>
@@ -425,11 +425,13 @@ TOKEN :
   < #DECIMAL_EXPONENT: ["e","E"] (["+","-"])? (<DECIMAL_LITERAL>)+ >
 |
   < #HEXADECIMAL_FLOATING_POINT_LITERAL:
-        "0" ["x", "X"] (["0"-"9","a"-"f","A"-"F"])+ (".")? <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
-      | "0" ["x", "X"] (["0"-"9","a"-"f","A"-"F"])* "." (["0"-"9","a"-"f","A"-"F"])+ <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
+        <HEX_LITERAL> (".")? <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
+      | "0" ["x","X"] (<HEX_DIGITS>)? "." <HEX_DIGITS> <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
   >
 |
-  < #HEXADECIMAL_EXPONENT: ["p","P"] (["+","-"])? (["0"-"9"])+ >
+  < #HEXADECIMAL_EXPONENT: ["p","P"] (["+","-"])? <DECIMAL_LITERAL> >
+|
+  < #HEX_DIGITS: ["0"-"9","a"-"f","A"-"F"]((["0"-"9","a"-"f","A"-"F","_"])*["0"-"9","a"-"f","A"-"F"])? >
 |
   < CHARACTER_LITERAL:
       "'"

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -207,6 +207,6 @@ public class JavaParserTest {
     @Test
     public void trailingWhitespaceIsIgnored() {
         BlockStmt blockStmt = JavaParser.parseBlock("{} // hello");
-        assertEquals("\"}\" <120> (line 1,col 2)-(line 1,col 2)", blockStmt.getTokenRange().get().getEnd().toString());
+        assertEquals("\"}\" <121> (line 1,col 2)-(line 1,col 2)", blockStmt.getTokenRange().get().getEnd().toString());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/DoubleLiteralExprTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/DoubleLiteralExprTest.java
@@ -1,0 +1,37 @@
+package com.github.javaparser.ast.expr;
+
+import org.junit.Test;
+
+import static com.github.javaparser.JavaParser.parseExpression;
+
+public class DoubleLiteralExprTest {
+    @Test
+    public void test1() {
+        float x = 0x0.00_00_02p-126f;
+        parseExpression("0x0.00_00_02p-126f");
+    }
+
+    @Test
+    public void test2() {
+        double x = 0x0.000_000_000_000_1p-1_022;
+        parseExpression("0x0.000_000_000_000_1p-1_022");
+    }
+
+    @Test
+    public void test3() {
+        double a = 0x1.p+1;
+        parseExpression("0x1.p+1");
+    }
+
+    @Test
+    public void test4() {
+        double a = 0x.0p0;
+        parseExpression("0x.0p0");
+    }
+
+    @Test
+    public void test5() {
+        double x = 0x0_0.0_0p-1_0;
+        parseExpression("0x0_0.0_0p-1_0");
+    }
+}

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_repo_test_results.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_repo_test_results.txt
@@ -379,10 +379,6 @@ langtools-c8a87a58eb3e/test/tools/javac/literals/BadUnderscoreLiterals.java
 langtools-c8a87a58eb3e/test/tools/javac/literals/T6891079.java
 (line 8,col 14) Parse error. Found  "B" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/literals/UnderscoreLiterals.java
-(line 176,col 14) Parse error. Found  ".00_00_02" <FLOATING_POINT_LITERAL>, expected one of  "!=" "%" "%=" "&" "&&" "&=" ")" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
-(line 178,col 14) Parse error. Found  ".000_000_000_000_1" <FLOATING_POINT_LITERAL>, expected one of  "!=" "%" "%=" "&" "&&" "&=" ")" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
-
 langtools-c8a87a58eb3e/test/tools/javac/overrridecrash/A.java
 (line 25,col 5) Can have only one of 'protected', 'private'.
 
@@ -478,4 +474,4 @@ langtools-c8a87a58eb3e/test/tools/javadoc/sourceOption/p/A.java
 langtools-c8a87a58eb3e/test/tools/javadoc/T4994049/FileWithTabs.java
 Lexical error at line 25, column 1.  Encountered: "\\" (92), after : ""
 
-194 problems in 143 files
+192 problems in 142 files

--- a/run_core_generators.sh
+++ b/run_core_generators.sh
@@ -7,7 +7,7 @@
 pushd javaparser-core-generators
 
 # Generate code
-mvn clean package -P run-core-generators
+mvn clean package -P run-core-generators -DskipTests
 
 # Go back to previous directory
 popd

--- a/run_metamodel_generator.sh
+++ b/run_metamodel_generator.sh
@@ -12,7 +12,7 @@ fi
 pushd javaparser-metamodel-generator
 
 # Generate code
-mvn clean package -P run-metamodel-generator
+mvn clean package -P run-metamodel-generator -DskipTests
 
 # Go back to previous directory
 popd


### PR DESCRIPTION
With some embarrassment I present: support for underscores in hexadecimal floating point literals. See #1116 