### PR TITLE
Update bulk test results for Java 9

### DIFF
--- a/javaparser-testing/src/test/java/com/github/javaparser/manual/BulkParseTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/manual/BulkParseTest.java
@@ -44,17 +44,17 @@ public class BulkParseTest {
         Path openJdkZipPath = workdir.resolve("langtools.zip");
         if (Files.notExists(openJdkZipPath)) {
             Log.info("Downloading JDK langtools");
-            /* Found by choosing a tag here: http://hg.openjdk.java.net/jdk8/jdk8/langtools/tags
+            /* Found by choosing a tag here: http://hg.openjdk.java.net/jdk9/jdk9/langtools/tags
              then copying the "zip" link to the line below: */ 
-            download(new URL("http://hg.openjdk.java.net/jdk8/jdk8/langtools/archive/c8a87a58eb3e.zip"), openJdkZipPath);
+            download(new URL("http://hg.openjdk.java.net/jdk9/jdk9/langtools/archive/5ecbed313125.zip"), openJdkZipPath);
         }
-        bulkTest(new SourceZip(openJdkZipPath), "openjdk_src_repo_test_results.txt", new ParserConfiguration().setValidator(new Java8Validator()));
+        bulkTest(new SourceZip(openJdkZipPath), "openjdk_src_repo_test_results.txt", new ParserConfiguration().setValidator(new Java9Validator()));
     }
 
     private void parseJdkSrcZip() throws IOException {
         // This is where Ubuntu stores the contents of package openjdk-8-src
-        Path path = Paths.get("/usr/lib/jvm/openjdk-8/src.zip");
-        bulkTest(new SourceZip(path), "openjdk_src_zip_test_results.txt", new ParserConfiguration().setValidator(new Java8Validator()));
+        Path path = Paths.get("/usr/lib/jvm/openjdk-9/src.zip");
+        bulkTest(new SourceZip(path), "openjdk_src_zip_test_results.txt", new ParserConfiguration().setValidator(new Java9Validator()));
     }
 
     @Test

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_repo_test_results.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_repo_test_results.txt
@@ -1,19 +1,46 @@
-langtools-c8a87a58eb3e/test/com/sun/javadoc/testSourceTab/DoubleTab/C.java
+langtools-5ecbed313125/test/com/sun/javadoc/testAnchorNames/pkg1/RegClass.java
+(line 68,col 16) '_' is a reserved keyword.
+
+langtools-5ecbed313125/test/com/sun/javadoc/testSourceTab/DoubleTab/C.java
 Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
 
-langtools-c8a87a58eb3e/test/com/sun/javadoc/testSourceTab/SingleTab/C.java
+langtools-5ecbed313125/test/com/sun/javadoc/testSourceTab/SingleTab/C.java
 Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
 
-langtools-c8a87a58eb3e/test/com/sun/javadoc/testUnnamedPackage/BadSource.java
+langtools-5ecbed313125/test/com/sun/javadoc/testUnnamedPackage/BadSource.java
 Parse error. Found  "Just" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/6302184/T6302184.java
-Lexical error at line 29, column 9.  Encountered: "\ufffd" (65533), after : ""
+langtools-5ecbed313125/test/jdk/javadoc/doclet/testAnchorNames/pkg1/RegClass.java
+(line 68,col 16) '_' is a reserved keyword.
 
-langtools-c8a87a58eb3e/test/tools/javac/6440583/A.java
+langtools-5ecbed313125/test/jdk/javadoc/doclet/testSourceTab/DoubleTab/C.java
+Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
+
+langtools-5ecbed313125/test/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
+Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
+
+langtools-5ecbed313125/test/jdk/javadoc/doclet/testUnnamedPackage/BadSource.java
+Parse error. Found  "Just" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+
+langtools-5ecbed313125/test/jdk/javadoc/tool/6964914/Error.java
+(line 25,col 12) Parse error. Found "}", expected "("
+
+langtools-5ecbed313125/test/jdk/javadoc/tool/6964914/JavacWarning.java
+(line 25,col 12) '_' is a reserved keyword.
+
+langtools-5ecbed313125/test/jdk/javadoc/tool/enum/docComments/pkg1/Operation.java
+(line 33,col 1) 'abstract' is not allowed here.
+
+langtools-5ecbed313125/test/jdk/javadoc/tool/T4994049/FileWithTabs.java
+Lexical error at line 25, column 1.  Encountered: "\\" (92), after : ""
+
+langtools-5ecbed313125/test/tools/javac/6302184/T6302184.java
+Lexical error at line 28, column 9.  Encountered: "\ufffd" (65533), after : ""
+
+langtools-5ecbed313125/test/tools/javac/6440583/A.java
 (line 25,col 28) Parse error. Found  "1" <INTEGER_LITERAL>, expected "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/AnnotationTypeElementModifiers.java
+langtools-5ecbed313125/test/tools/javac/annotations/AnnotationTypeElementModifiers.java
 (line 17,col 5) 'private' is not allowed here.
 (line 18,col 5) 'private' is not allowed here.
 (line 20,col 5) 'protected' is not allowed here.
@@ -35,443 +62,626 @@ langtools-c8a87a58eb3e/test/tools/javac/annotations/AnnotationTypeElementModifie
 (line 44,col 5) 'default' is not allowed here.
 (line 45,col 5) 'default' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/AnnComma.java
-(line 35,col 35) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+langtools-5ecbed313125/test/tools/javac/annotations/neg/AnnComma.java
+(line 12,col 35) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/NoDefault.java
+langtools-5ecbed313125/test/tools/javac/annotations/neg/NoDefault.java
 (line 8,col 19) Parse error. Found "{", expected one of  ";" "default"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/NoDefaultAbstract.java
+langtools-5ecbed313125/test/tools/javac/annotations/neg/NoDefaultAbstract.java
 (line 8,col 5) 'default' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/NoStatic.java
+langtools-5ecbed313125/test/tools/javac/annotations/neg/NoStatic.java
 (line 9,col 18) Parse error. Found "{", expected one of  ";" "default"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/NoStaticAbstract.java
+langtools-5ecbed313125/test/tools/javac/annotations/neg/NoStaticAbstract.java
 (line 9,col 5) 'static' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Syntax1.java
-(line 40,col 21) Parse error. Found ",", expected one of  "!=" "%" "&" "&&" "(" ")" "*" "+" "-" "/" "<" "<=" "==" ">" ">=" "?" "^" "instanceof" "|" "||"
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Syntax1.java
+(line 17,col 21) Parse error. Found ",", expected one of  "!=" "%" "&" "&&" "(" ")" "*" "+" "-" "/" "<" "<=" "==" ">" ">=" "?" "^" "instanceof" "|" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z12.java
-(line 35,col 15) Parse error. Found "void", expected one of  ";" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "volatile" "with" "}" <IDENTIFIER>
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z12.java
+(line 10,col 15) Parse error. Found "void", expected one of  ";" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "volatile" "with" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z13.java
-(line 34,col 11) Parse error. Found "throws", expected one of  ";" "default"
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z13.java
+(line 11,col 11) Parse error. Found "throws", expected one of  ";" "default"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z14.java
-(line 33,col 12) Parse error. Found "<", expected "{"
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z14.java
+(line 10,col 12) Parse error. Found "<", expected "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z2.java
-(line 36,col 17) Parse error. Found "default", expected one of  ";" "@" "[" "throws" "{"
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z2.java
+(line 13,col 17) Parse error. Found "default", expected one of  ";" "@" "[" "throws" "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z3.java
-(line 36,col 17) Parse error. Found "default", expected one of  ";" "@" "[" "throws" "{"
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z3.java
+(line 13,col 17) Parse error. Found "default", expected one of  ";" "@" "[" "throws" "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z5.java
-(line 35,col 12) Parse error. Found "extends", expected "{"
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z5.java
+(line 12,col 12) Parse error. Found "extends", expected "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z8.java
-(line 34,col 10) Parse error. Found "int", expected ")"
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z8.java
+(line 11,col 10) Parse error. Found "int", expected ")"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/neg/Z9.java
-(line 33,col 15) Parse error. Found "<", expected one of  ";" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "volatile" "with" "}" <IDENTIFIER>
+langtools-5ecbed313125/test/tools/javac/annotations/neg/Z9.java
+(line 10,col 15) Parse error. Found "<", expected one of  ";" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "volatile" "with" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/typeAnnotations/6967002/T6967002.java
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/6967002/T6967002.java
 (line 33,col 16) Parse error. Found "...", expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" ")" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/typeAnnotations/failures/BadCast.java
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/failures/AnnotatedClassExpr.java
+(line 12,col 15) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+(line 13,col 8) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+(line 17,col 8) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+(line 18,col 8) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest.java
+(line 12,col 14) Parse error. Found ".", expected one of  "%=" "&=" "(" "*=" "++" "+=" "--" "-=" "->" "/=" "::" ";" "<<=" "=" ">>=" ">>>=" "^=" "|="
+
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/failures/BadCast.java
 (line 12,col 16) Parse error. Found "@", expected one of  "!" "(" ")" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/typeAnnotations/failures/IncompleteArray.java
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/failures/IncompleteArray.java
 (line 11,col 11) Parse error. Found "@", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/typeAnnotations/failures/IndexArray.java
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/failures/IndexArray.java
 (line 12,col 11) Parse error. Found "@", expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/typeAnnotations/failures/OldArray.java
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/failures/OldArray.java
 (line 12,col 10) Parse error. Found "@", expected one of  "]"
 
-langtools-c8a87a58eb3e/test/tools/javac/annotations/typeAnnotations/failures/StaticFields.java
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/failures/StaticFields.java
 (line 13,col 10) Parse error. Found "@", expected one of  "(" "++" "--" ";" "assert" "boolean" "break" "byte" "char" "continue" "do" "double" "enum" "exports" "false" "float" "for" "if" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "return" "short" "strictfp" "super" "switch" "synchronized" "this" "throw" "to" "transitive" "true" "try" "uses" "void" "while" "with" "{" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 (line 17,col 9) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/api/T6265137a.java
+langtools-5ecbed313125/test/tools/javac/annotations/typeAnnotations/newlocations/AllLocations.java
+(line 59,col 112) Parse error. Found "return", expected "}"
+(line 68,col 78) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+(line 89,col 24) Parse error. Found "@", expected one of  "!" "(" ")" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+(line 90,col 24) Parse error. Found "@", expected one of  "!" "(" ")" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+
+langtools-5ecbed313125/test/tools/javac/api/T6265137a.java
 (line 24,col 1) Parse error. Found <EOF>, expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/BadAnnotation.java
-(line 34,col 21) Parse error. Found "int", expected ")"
+langtools-5ecbed313125/test/tools/javac/BadAnnotation.java
+(line 11,col 21) Parse error. Found "int", expected ")"
 
-langtools-c8a87a58eb3e/test/tools/javac/BadHexConstant.java
-(line 35,col 14) Parse error. Found  "xL" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+langtools-5ecbed313125/test/tools/javac/BadHexConstant.java
+(line 12,col 14) Parse error. Found  "xL" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/declaration/method/MethodVoidParameter.java
+langtools-5ecbed313125/test/tools/javac/declaration/method/MethodVoidParameter.java
 (line 7,col 16) Parse error. Found "void", expected one of  ")" "@" "abstract" "boolean" "byte" "char" "default" "double" "enum" "exports" "final" "float" "int" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "volatile" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/DefiniteAssignment/ConstantInfiniteWhile.java
+langtools-5ecbed313125/test/tools/javac/defaultMethods/private/Private02.java
+(line 13,col 9) Cannot be 'abstract' and also 'private'.
+
+langtools-5ecbed313125/test/tools/javac/defaultMethods/private/Private07.java
+(line 9,col 5) 'private' is not allowed here.
+
+langtools-5ecbed313125/test/tools/javac/defaultMethods/private/Private08.java
+(line 13,col 9) Can have only one of 'public', 'private'.
+(line 14,col 9) Cannot be 'abstract' and also 'private'.
+
+langtools-5ecbed313125/test/tools/javac/defaultMethods/private/Private09.java
+(line 9,col 17) Duplicated modifier
+
+langtools-5ecbed313125/test/tools/javac/defaultMethods/private/Private10.java
+(line 11,col 9) Cannot be 'abstract' and also 'private'.
+(line 14,col 9) Cannot be 'abstract' and also 'private'.
+
+langtools-5ecbed313125/test/tools/javac/DefiniteAssignment/ConstantInfiniteWhile.java
 Lexical error at line 68, column 0.  Encountered: <EOF> after : ""
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/AnnotationMustBeNameValue.java
-(line 31,col 15) Parse error. Found ",", expected one of  "!=" "%" "&" "&&" ")" "*" "+" "-" "/" "<" "<=" "==" ">" ">=" "?" "^" "instanceof" "|" "||"
+langtools-5ecbed313125/test/tools/javac/diags/examples/AnnotationMustBeNameValue.java
+(line 32,col 15) Parse error. Found ",", expected one of  "!=" "%" "&" "&&" ")" "*" "+" "-" "/" "<" "<=" "==" ">" ">=" "?" "^" "instanceof" "|" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/ArrayAndReceiver.java
-(line 30,col 29) Parse error. Found "[", expected one of  ")" ","
+langtools-5ecbed313125/test/tools/javac/diags/examples/ArrayAndReceiver.java
+(line 27,col 29) Parse error. Found "[", expected one of  ")" ","
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/AssertAsIdentifier.java
-(line 28,col 5) Parse error. Found "assert", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/AssertAsIdentifier2.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/AssertAsIdentifier2.java
 (line 27,col 5) Parse error. Found "assert", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/CallMustBeFirst.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/CallMustBeFirst.java
 (line 28,col 18) Parse error. Found "super", expected "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/CantExtendIntfAnno.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/CantAssignToThis.java
+(line 28,col 9) Illegal left hand side of an assignment.
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/CantExtendIntfAnno.java
 (line 28,col 12) Parse error. Found "extends", expected "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/CatchWithoutTry.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/CatchWithoutTry.java
 (line 27,col 14) Parse error. Found "catch", expected "}"
 (line 30,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/DefaultAllowedInIntfAnnotationMember.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/DefaultAllowedInIntfAnnotationMember.java
 (line 27,col 18) Parse error. Found "default", expected one of  ";" "@" "[" "throws" "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/DotClassExpected.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/DotClassExpected.java
 (line 27,col 11) Parse error. Found "int", expected one of  "!" "(" "enum" "exports" "false" "module" "new" "null" "open" "opens" "provides" "requires" "strictfp" "super" "this" "to" "transitive" "true" "uses" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/ElseWithoutIf.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/ElseWithoutIf.java
 (line 27,col 14) Parse error. Found "else", expected "}"
 (line 30,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/EmptyCharLiteral.java
-Lexical error at line 29, column 15.  Encountered: "\'" (39), after : "\'"
+langtools-5ecbed313125/test/tools/javac/diags/examples/EmptyCharLiteral.java
+Lexical error at line 27, column 15.  Encountered: "\'" (39), after : "\'"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/EnumAsIdentifier.java
-(line 28,col 9) 'enum' cannot be used as an identifier as it is a keyword.
-
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/EnumAsIdentifier2.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/EnumAsIdentifier2.java
 (line 27,col 9) 'enum' cannot be used as an identifier as it is a keyword.
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/Expected2.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/Expected2.java
+(line 30,col 13) Parse error. Found ";", expected one of  "(" "@" "["
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/Expected3.java
 Parse error. Found "int", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/Expected3.java
-Parse error. Found "int", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+langtools-5ecbed313125/test/tools/javac/diags/examples/ExpectedModule.java
+(line 26,col 1) Parse error. Found "class", expected "module"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/FinallyWithoutTry.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/FinallyWithoutTry.java
 (line 27,col 14) Parse error. Found "finally", expected "}"
 (line 30,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/ForeachBadInitialization.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/ForeachBadInitialization.java
 (line 29,col 14) Parse error. Found ":", expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 (line 31,col 2) Parse error. Found <EOF>, expected "}"
 (line 31,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IdentifierExpected.java
-(line 32,col 15) Parse error. Found  "BL" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+langtools-5ecbed313125/test/tools/javac/diags/examples/IdentifierExpected.java
+(line 30,col 1) Parse error. Found "{", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalChar.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalChar.java
 Lexical error at line 27, column 13.  Encountered: "`" (96), after : ""
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalComboModifiers.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalComboModifiers.java
 (line 27,col 5) Can have only one of 'public', 'private'.
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalDot.java
-(line 29,col 12) Parse error. Found ".", expected one of  "..." "@" "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalDot.java
+(line 27,col 12) Parse error. Found ".", expected one of  "..." "@" "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalEscapeChar.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalEscapeChar.java
 Lexical error at line 27, column 18.  Encountered: "!" (33), after : "\"\\"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalLineEndInCharLit.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalLineEndInCharLit.java
 Lexical error at line 27, column 15.  Encountered: "\n" (10), after : "\'"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalNonAsciiDigit.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalNonAsciiDigit.java
 Lexical error at line 27, column 14.  Encountered: "\u0660" (1632), after : ""
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalStartOfExpr.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalStartOfExpr.java
 (line 27,col 11) Parse error. Found "=", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalStartOfStmt.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalStartOfStmt.java
 (line 29,col 17) Parse error. Found "}", expected one of  "(" "++" "--" ";" "assert" "boolean" "break" "byte" "char" "continue" "do" "double" "enum" "exports" "false" "float" "for" "if" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "return" "short" "strictfp" "super" "switch" "synchronized" "this" "throw" "to" "transitive" "true" "try" "uses" "void" "while" "with" "{" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 (line 31,col 2) Parse error. Found <EOF>, expected one of  "else" "}"
 (line 31,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalUnderscore.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalStartOfType.java
+(line 27,col 27) Parse error. Found ")", expected one of  "boolean" "byte" "char" "double" "float" "int" "long" "short"
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalUnderscore.java
 (line 27,col 13) Parse error. Found  "_" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IllegalUnicodeEscape.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalUnicodeEscape.java
 (line 27,col 11) Parse error. Found <EOF>, expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/InterfaceNotAllowed.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/InitializerNotAllowed.java
+(line 27,col 5) An interface cannot have initializers.
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/InterfaceNotAllowed.java
 (line 28,col 9) There is no such thing as a local interface.
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IntfAnnotationCantHaveTypeParams.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IntfAnnotationCantHaveTypeParams.java
 (line 26,col 12) Parse error. Found "<", expected "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IntfAnnotationsCantHaveParams.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IntfAnnotationsCantHaveParams.java
 (line 27,col 17) Parse error. Found "int", expected ")"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/IntfAnnotationsCantHaveTypeParams.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/IntfAnnotationsCantHaveTypeParams.java
 (line 26,col 14) Parse error. Found "<", expected one of  ";" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "volatile" "with" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/InvalidBinaryNumber.java
-(line 30,col 13) Parse error. Found  "b201000010" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+langtools-5ecbed313125/test/tools/javac/diags/examples/InvalidBinaryNumber.java
+(line 27,col 13) Parse error. Found  "b201000010" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/InvalidHexNumber.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/InvalidHexNumber.java
 (line 28,col 13) Parse error. Found  "xz1357abc" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/LocalEnum.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/InvalidModuleDirective/module-info.java
+(line 27,col 21) Parse error. Found  "resuires" <IDENTIFIER>, expected one of  "exports" "opens" "provides" "requires" "uses" "}"
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/LocalEnum.java
 (line 28,col 14) Parse error. Found "{", expected one of  "," ";" "=" "@" "["
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/MalformedFpLit.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/MalformedFpLit.java
 (line 28,col 15) Parse error. Found  "e" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/ModifierNotAllowed.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/ModifierNotAllowed.java
 (line 26,col 1) 'synchronized' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/NoAnnotationsOnDotClass.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/NoAnnotationsOnDotClass.java
 (line 30,col 14) Parse error. Found "@", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/NotAllowedClass.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/NotAllowedClass.java
 (line 28,col 17) Parse error. Found "class", expected one of  "(" "++" "--" ";" "assert" "boolean" "break" "byte" "char" "continue" "do" "double" "enum" "exports" "false" "float" "for" "if" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "return" "short" "strictfp" "super" "switch" "synchronized" "this" "throw" "to" "transitive" "true" "try" "uses" "void" "while" "with" "{" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 (line 31,col 2) Parse error. Found <EOF>, expected one of  "else" "}"
 (line 31,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/NotAllowedVariable.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/NotAllowedVariable.java
 (line 28,col 17) Parse error. Found "int", expected one of  "(" "enum" "exports" "false" "module" "new" "null" "open" "opens" "provides" "requires" "strictfp" "super" "this" "to" "transitive" "true" "uses" "with" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/NotAStatement.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/NotAStatement.java
 (line 27,col 14) Parse error. Found  "x" <IDENTIFIER>, expected "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/Orphaned.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/Orphaned.java
 (line 27,col 14) Parse error. Found "case", expected "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/PrematureEOF.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/PrematureEOF.java
 (line 26,col 20) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/ProcessorWrongType/ProcessorWrongType.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/ProcessorWrongType/ProcessorWrongType.java
 Parse error. Found  "clas" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/RepeatedModifier.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/RepeatedModifier.java
 (line 27,col 12) Duplicated modifier
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/ThisAsIdentifier.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/ThisAsIdentifier.java
 (line 27,col 5) Parse error. Found "this", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/ThrowsNotAllowedInAnno.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/ThrowsNotAllowedInAnno.java
 (line 27,col 18) Parse error. Found "throws", expected one of  ";" "default"
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/TryWithoutCatchOrFinally.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/TryWithoutCatchOrFinally.java
 (line 29,col 9) Try has no finally, no catch, and no resources.
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/TryWithoutCatchOrFinallyOrResource.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/TryWithoutCatchOrFinallyOrResource.java
 (line 28,col 9) Try has no finally, no catch, and no resources.
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/TypeReqClassArray.java
-(line 30,col 34) Parse error. Found ")", expected "["
+langtools-5ecbed313125/test/tools/javac/diags/examples/TryWithResourcesExprEffectivelyFinalVar.java
+(line 30,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 33,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/UnclosedCharLiteral.java
-Lexical error at line 27, column 16.  Encountered: ";" (59), after : "\'a"
-
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/UnclosedComment.java
-Lexical error at line 31, column 0.  Encountered: <EOF> after : ""
-
-langtools-c8a87a58eb3e/test/tools/javac/diags/examples/UnclosedStringLiteral.java
-Lexical error at line 27, column 21.  Encountered: "\n" (10), after : "\"abc;"
-
-langtools-c8a87a58eb3e/test/tools/javac/Digits.java
-Lexical error at line 11, column 43.  Encountered: "\u0663" (1635), after : ""
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/6384542/T6384542.java
-(line 24,col 1) Parse error. Found  "klass" <IDENTIFIER>, expected one of  ";" "@" "class" "enum" "interface" "module" "open"
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/6384542/T6384542a.java
-(line 13,col 15) 'enum' cannot be used as an identifier as it is a keyword.
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/EnumAsIdentifier.java
-(line 13,col 9) 'enum' cannot be used as an identifier as it is a keyword.
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/EnumMembersOrder.java
-(line 11,col 10) Parse error. Found  "d" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" ")" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/ExplicitlyAbstractEnum1.java
-(line 33,col 1) 'abstract' is not allowed here.
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/ExplicitlyAbstractEnum2.java
-(line 33,col 1) 'abstract' is not allowed here.
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/ExplicitlyFinalEnum1.java
-(line 33,col 1) 'final' is not allowed here.
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/ExplicitlyFinalEnum2.java
-(line 33,col 1) 'final' is not allowed here.
-
-langtools-c8a87a58eb3e/test/tools/javac/enum/LocalEnum.java
-(line 35,col 14) Parse error. Found "{", expected one of  "," ";" "=" "@" "["
+langtools-5ecbed313125/test/tools/javac/diags/examples/TryWithResourcesExprNeedsVar.java
+(line 28,col 13) Parse error. Found "new", expected one of  "boolean" "byte" "char" "double" "float" "int" "long" "short"
 (line 37,col 2) Parse error. Found <EOF>, expected "}"
 (line 37,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/EOI.java
-(line 33,col 16) Parse error. Found  "foobar\u001a" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+langtools-5ecbed313125/test/tools/javac/diags/examples/TypeReqClassArray.java
+(line 30,col 34) Parse error. Found ")", expected "["
 
-langtools-c8a87a58eb3e/test/tools/javac/ExtendArray.java
+langtools-5ecbed313125/test/tools/javac/diags/examples/UnclosedCharLiteral.java
+Lexical error at line 27, column 16.  Encountered: ";" (59), after : "\'a"
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/UnclosedComment.java
+Lexical error at line 31, column 0.  Encountered: <EOF> after : ""
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/UnclosedStringLiteral.java
+Lexical error at line 27, column 21.  Encountered: "\n" (10), after : "\"abc;"
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/UnderscoreAsIdentifierError.java
+(line 27,col 12) '_' is a reserved keyword.
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/UnderscoreAsIdentifierWarning.java
+(line 28,col 12) '_' is a reserved keyword.
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/UnderscoreInLambdaExpression.java
+(line 26,col 52) '_' is a reserved keyword.
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/UnexpectedTokenInModuleInfo/module-info.java
+Parse error. Found  "weak" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+
+langtools-5ecbed313125/test/tools/javac/diags/examples/VarInTryWithResourcesNotSupportedInSource.java
+(line 32,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 41,col 2) Parse error. Found <EOF>, expected "}"
+(line 41,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/Digits.java
+Lexical error at line 11, column 43.  Encountered: "\u0663" (1635), after : ""
+
+langtools-5ecbed313125/test/tools/javac/enum/EnumAsIdentifier.java
+(line 11,col 9) 'enum' cannot be used as an identifier as it is a keyword.
+
+langtools-5ecbed313125/test/tools/javac/enum/EnumMembersOrder.java
+(line 11,col 10) Parse error. Found  "d" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" ")" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+
+langtools-5ecbed313125/test/tools/javac/enum/ExplicitlyAbstractEnum1.java
+(line 9,col 1) 'abstract' is not allowed here.
+
+langtools-5ecbed313125/test/tools/javac/enum/ExplicitlyAbstractEnum2.java
+(line 9,col 1) 'abstract' is not allowed here.
+
+langtools-5ecbed313125/test/tools/javac/enum/ExplicitlyFinalEnum1.java
+(line 9,col 1) 'final' is not allowed here.
+
+langtools-5ecbed313125/test/tools/javac/enum/ExplicitlyFinalEnum2.java
+(line 9,col 1) 'final' is not allowed here.
+
+langtools-5ecbed313125/test/tools/javac/enum/LocalEnum.java
+(line 11,col 14) Parse error. Found "{", expected one of  "," ";" "=" "@" "["
+(line 13,col 2) Parse error. Found <EOF>, expected "}"
+(line 13,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/EOI.java
+(line 10,col 16) Parse error. Found  "foobar\u001a" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+
+langtools-5ecbed313125/test/tools/javac/ExtendArray.java
 (line 11,col 34) Parse error. Found "[", expected one of  "," "implements" "{"
 
-langtools-c8a87a58eb3e/test/tools/javac/ExtraneousEquals.java
-(line 33,col 22) Parse error. Found "=", expected one of  "!" "(" "+" "++" "-" "--" "]" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+langtools-5ecbed313125/test/tools/javac/ExtraneousEquals.java
+(line 10,col 22) Parse error. Found "=", expected one of  "!" "(" "+" "++" "-" "--" "]" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/failover/FailOver01.java
+langtools-5ecbed313125/test/tools/javac/failover/FailOver01.java
 (line 10,col 20) Parse error. Found "}", expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 (line 10,col 26) Parse error. Found <EOF>, expected "}"
 (line 10,col 26) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/failover/FailOver15.java
+langtools-5ecbed313125/test/tools/javac/failover/FailOver15.java
 (line 17,col 9) Parse error. Found "}", expected one of  "%=" "&=" "*=" "++" "+=" "--" "-=" "->" "/=" "::" ";" "<<=" "=" ">>=" ">>>=" "^=" "|="
 (line 19,col 2) Parse error. Found <EOF>, expected "}"
 (line 19,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/FloatingPointChanges/BadConstructorModifiers.java
+langtools-5ecbed313125/test/tools/javac/FloatingPointChanges/BadConstructorModifiers.java
 (line 12,col 5) 'strictfp' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javac/generics/typevars/5060485/Compatibility02.java
+langtools-5ecbed313125/test/tools/javac/generics/typevars/5060485/Compatibility02.java
 (line 36,col 9) 'static' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javac/generics/typevars/6680106/T6680106.java
+langtools-5ecbed313125/test/tools/javac/generics/typevars/6680106/T6680106.java
 (line 11,col 24) Parse error. Found "[", expected one of  "&" "," ">"
 
-langtools-c8a87a58eb3e/test/tools/javac/IllegalAnnotation.java
-(line 10,col 5) Parse error. Found "@", expected "}"
-(line 12,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+langtools-5ecbed313125/test/tools/javac/IllegalAnnotation.java
+(line 9,col 5) Parse error. Found "@", expected "}"
+(line 11,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/incompleteStatements/T8000484.java
+langtools-5ecbed313125/test/tools/javac/incompleteStatements/T8000484.java
 (line 9,col 14) Parse error. Found "catch", expected "}"
 (line 10,col 29) Parse error. Found "else", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/LabeledDeclaration.java
-(line 35,col 8) Parse error. Found "int", expected one of  "(" "enum" "exports" "false" "module" "new" "null" "open" "opens" "provides" "requires" "strictfp" "super" "this" "to" "transitive" "true" "uses" "with" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+langtools-5ecbed313125/test/tools/javac/LabeledDeclaration.java
+(line 12,col 8) Parse error. Found "int", expected one of  "(" "enum" "exports" "false" "module" "new" "null" "open" "opens" "provides" "requires" "strictfp" "super" "this" "to" "transitive" "true" "uses" "with" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/lambda/BadLambdaPos.java
+langtools-5ecbed313125/test/tools/javac/lambda/BadLambdaPos.java
 (line 18,col 26) Parse error. Found "+", expected one of  ")" ","
 (line 19,col 26) Parse error. Found "instanceof", expected one of  ")" ","
 (line 23,col 30) Parse error. Found "+", expected one of  "," ";"
 (line 24,col 33) Parse error. Found "instanceof", expected one of  "," ";"
 
-langtools-c8a87a58eb3e/test/tools/javac/lambda/BadStatementInLambda.java
+langtools-5ecbed313125/test/tools/javac/lambda/BadStatementInLambda.java
 (line 18,col 19) Parse error. Found  "1" <INTEGER_LITERAL>, expected "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/lambda/funcInterfaces/LambdaTest1_neg1.java
+langtools-5ecbed313125/test/tools/javac/lambda/funcInterfaces/LambdaTest1_neg1.java
 (line 13,col 64) Parse error. Found "}", expected one of  "," ";"
 (line 15,col 2) Parse error. Found <EOF>, expected "}"
 (line 15,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/lambda/lambdaExpression/InvalidExpression1.java
+langtools-5ecbed313125/test/tools/javac/lambda/IdentifierTest.java
+(line 41,col 11) '_' is a reserved keyword.
+(line 44,col 16) '_' is a reserved keyword.
+(line 45,col 20) '_' is a reserved keyword.
+(line 46,col 22) '_' is a reserved keyword.
+(line 51,col 13) '_' is a reserved keyword.
+(line 51,col 15) '_' is a reserved keyword.
+(line 51,col 23) '_' is a reserved keyword.
+(line 53,col 13) '_' is a reserved keyword.
+(line 55,col 13) '_' is a reserved keyword.
+(line 61,col 21) '_' is a reserved keyword.
+(line 62,col 42) '_' is a reserved keyword.
+(line 63,col 67) '_' is a reserved keyword.
+(line 70,col 13) '_' is a reserved keyword.
+(line 71,col 14) '_' is a reserved keyword.
+(line 72,col 18) '_' is a reserved keyword.
+(line 77,col 22) '_' is a reserved keyword.
+(line 79,col 13) '_' is a reserved keyword.
+(line 79,col 15) '_' is a reserved keyword.
+(line 81,col 13) '_' is a reserved keyword.
+(line 81,col 15) '_' is a reserved keyword.
+(line 88,col 10) '_' is a reserved keyword.
+(line 88,col 38) '_' is a reserved keyword.
+(line 94,col 14) '_' is a reserved keyword.
+(line 101,col 17) '_' is a reserved keyword.
+(line 101,col 26) '_' is a reserved keyword.
+(line 118,col 20) '_' is a reserved keyword.
+(line 123,col 10) '_' is a reserved keyword.
+(line 128,col 17) '_' is a reserved keyword.
+(line 131,col 17) '_' is a reserved keyword.
+(line 138,col 17) '_' is a reserved keyword.
+(line 138,col 24) '_' is a reserved keyword.
+(line 138,col 33) '_' is a reserved keyword.
+(line 139,col 39) '_' is a reserved keyword.
+(line 143,col 13) '_' is a reserved keyword.
+(line 144,col 15) '_' is a reserved keyword.
+(line 145,col 13) '_' is a reserved keyword.
+(line 150,col 15) '_' is a reserved keyword.
+(line 151,col 17) '_' is a reserved keyword.
+(line 157,col 16) '_' is a reserved keyword.
+(line 159,col 25) '_' is a reserved keyword.
+(line 168,col 5) '_' is a reserved keyword.
+(line 172,col 26) '_' is a reserved keyword.
+(line 174,col 19) '_' is a reserved keyword.
+(line 180,col 11) '_' is a reserved keyword.
+
+langtools-5ecbed313125/test/tools/javac/lambda/lambdaExpression/InvalidExpression1.java
 (line 15,col 66) Parse error. Found "}", expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 (line 16,col 5) Parse error. Found "}", expected one of  "," ";"
 (line 17,col 2) Parse error. Found <EOF>, expected "}"
 (line 17,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/literals/BadBinaryLiterals.java
+langtools-5ecbed313125/test/tools/javac/lambda/UnderscoreAsIdent.java
+(line 30,col 9) '_' is a reserved keyword.
+(line 30,col 9) '_' is a reserved keyword.
+(line 32,col 8) '_' is a reserved keyword.
+(line 32,col 8) '_' is a reserved keyword.
+(line 34,col 7) '_' is a reserved keyword.
+(line 35,col 12) '_' is a reserved keyword.
+(line 36,col 10) '_' is a reserved keyword.
+(line 36,col 19) '_' is a reserved keyword.
+(line 38,col 16) '_' is a reserved keyword.
+(line 41,col 18) '_' is a reserved keyword.
+(line 41,col 25) '_' is a reserved keyword.
+(line 41,col 33) '_' is a reserved keyword.
+(line 44,col 34) '_' is a reserved keyword.
+(line 47,col 9) '_' is a reserved keyword.
+(line 49,col 19) '_' is a reserved keyword.
+(line 51,col 9) '_' is a reserved keyword.
+(line 53,col 22) '_' is a reserved keyword.
+
+langtools-5ecbed313125/test/tools/javac/lambda/VoidLambdaParameter.java
+(line 7,col 18) Parse error. Found "void", expected one of  "!" "(" ")" "enum" "exports" "false" "module" "new" "null" "open" "opens" "provides" "requires" "strictfp" "super" "this" "to" "transitive" "true" "uses" "with" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+
+langtools-5ecbed313125/test/tools/javac/literals/BadBinaryLiterals.java
 (line 11,col 20) Parse error. Found  "2" <INTEGER_LITERAL>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/literals/BadUnderscoreLiterals.java
-(line 18,col 14) Parse error. Found  "_" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+langtools-5ecbed313125/test/tools/javac/literals/BadUnderscoreLiterals.java
+(line 15,col 14) Parse error. Found  "_" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/literals/T6891079.java
+langtools-5ecbed313125/test/tools/javac/literals/T6891079.java
 (line 8,col 14) Parse error. Found  "B" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
-langtools-c8a87a58eb3e/test/tools/javac/overrridecrash/A.java
+langtools-5ecbed313125/test/tools/javac/modules/InvalidModuleDirective/module-info.java
+(line 9,col 21) Parse error. Found  "resuires" <IDENTIFIER>, expected one of  "exports" "opens" "provides" "requires" "uses" "}"
+
+langtools-5ecbed313125/test/tools/javac/overrridecrash/A.java
 (line 25,col 5) Can have only one of 'protected', 'private'.
 
-langtools-c8a87a58eb3e/test/tools/javac/overrridecrash/B.java
-(line 35,col 5) Can have only one of 'protected', 'private'.
+langtools-5ecbed313125/test/tools/javac/overrridecrash/B.java
+(line 12,col 5) Can have only one of 'protected', 'private'.
 
-langtools-c8a87a58eb3e/test/tools/javac/Parens3.java
-(line 35,col 9) Parse error. Found ":", expected one of  "%=" "&=" "*=" "++" "+=" "--" "-=" "->" "/=" "::" ";" "<<=" "=" ">>=" ">>>=" "^=" "|="
+langtools-5ecbed313125/test/tools/javac/Parens3.java
+(line 12,col 9) Parse error. Found ":", expected one of  "%=" "&=" "*=" "++" "+=" "--" "-=" "->" "/=" "::" ";" "<<=" "=" ">>=" ">>>=" "^=" "|="
 
-langtools-c8a87a58eb3e/test/tools/javac/ParseConditional.java
-(line 41,col 13) Illegal left hand side of an assignment.
+langtools-5ecbed313125/test/tools/javac/ParseConditional.java
+(line 23,col 13) Illegal left hand side of an assignment.
 
-langtools-c8a87a58eb3e/test/tools/javac/parser/7157165/T7157165.java
+langtools-5ecbed313125/test/tools/javac/parser/7157165/T7157165.java
 (line 11,col 19) Parse error. Found "|", expected one of  "," ">"
 
-langtools-c8a87a58eb3e/test/tools/javac/parser/SingleCommaAnnotationValueFail.java
+langtools-5ecbed313125/test/tools/javac/parser/8081769/T8081769.java
+(line 9,col 20) Parse error. Found ".", expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 10,col 20) Parse error. Found ".", expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 11,col 20) Parse error. Found ".", expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 12,col 20) Parse error. Found ".", expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 14,col 31) Parse error. Found ".", expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+
+langtools-5ecbed313125/test/tools/javac/parser/ErroneousParameters.java
+(line 11,col 34) Parse error. Found "...", expected one of  ")" "," "@" "["
+
+langtools-5ecbed313125/test/tools/javac/parser/MissingClosingBrace.java
+(line 13,col 1) Parse error. Found <EOF>, expected one of  "else" "}"
+(line 13,col 2) Parse error. Found <EOF>, expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/parser/SingleCommaAnnotationValueFail.java
 (line 34,col 11) Parse error. Found  "0" <INTEGER_LITERAL>, expected "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/parser/T4881269.java
+langtools-5ecbed313125/test/tools/javac/parser/T4881269.java
 (line 32,col 10) Parse error. Found ".", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/policy/test3/A.java
-(line 3,col 36) Parse error. Found  "0" <INTEGER_LITERAL>, expected "}"
+langtools-5ecbed313125/test/tools/javac/policy/test3/A.java
+(line 5,col 36) Parse error. Found  "0" <INTEGER_LITERAL>, expected "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/processing/6994946/SyntaxErrorTest.java
-(line 12,col 9) Parse error. Found "}", expected "("
+langtools-5ecbed313125/test/tools/javac/processing/6994946/SyntaxErrorTest.java
+(line 14,col 9) Parse error. Found "}", expected "("
 
-langtools-c8a87a58eb3e/test/tools/javac/processing/errors/TestParseErrors/ParseErrors.java
+langtools-5ecbed313125/test/tools/javac/processing/errors/TestParseErrors/ParseErrors.java
 (line 37,col 36) Parse error. Found ",", expected one of  "..." "@" "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/quid/T6999438.java
+langtools-5ecbed313125/test/tools/javac/quid/T6999438.java
 Lexical error at line 8, column 9.  Encountered: "#" (35), after : ""
 
-langtools-c8a87a58eb3e/test/tools/javac/rawDiags/Error.java
+langtools-5ecbed313125/test/tools/javac/rawDiags/Error.java
 (line 9,col 17) Parse error. Found <EOF>, expected "("
 
-langtools-c8a87a58eb3e/test/tools/javac/StoreClass.java
-(line 35,col 9) Illegal left hand side of an assignment.
-(line 36,col 9) Illegal left hand side of an assignment.
+langtools-5ecbed313125/test/tools/javac/StoreClass.java
+(line 12,col 9) Illegal left hand side of an assignment.
+(line 13,col 9) Illegal left hand side of an assignment.
 
-langtools-c8a87a58eb3e/test/tools/javac/SynchronizedClass.java
+langtools-5ecbed313125/test/tools/javac/SynchronizedClass.java
 (line 9,col 1) 'synchronized' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javac/T4994049/T4994049.java
+langtools-5ecbed313125/test/tools/javac/T4994049/T4994049.java
 (line 11,col 5) Parse error. Found  "BAR" <IDENTIFIER>, expected one of  "," ";" "}"
 
-langtools-c8a87a58eb3e/test/tools/javac/T6882235.java
-(line 11,col 11) Parse error. Found ";", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+langtools-5ecbed313125/test/tools/javac/T6882235.java
+(line 10,col 11) Parse error. Found ";", expected one of  "!" "(" "+" "++" "-" "--" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 
-langtools-c8a87a58eb3e/test/tools/javac/T8026963/TypeAnnotationsCrashWithErroneousTreeTest.java
+langtools-5ecbed313125/test/tools/javac/T8026963/TypeAnnotationsCrashWithErroneousTreeTest.java
 (line 9,col 19) Parse error. Found "this", expected one of  ")" "@" "abstract" "boolean" "byte" "char" "default" "double" "enum" "exports" "final" "float" "int" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "volatile" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/TryWithResources/BadTwrSyntax.java
+langtools-5ecbed313125/test/tools/javac/T8171325/NPEClearingLocalClassNameIndexesTest.java
+(line 19,col 42) Type arguments may not be primitive.
+
+langtools-5ecbed313125/test/tools/javac/T8175198/AnnotationsAndFormalParamsTest.java
+(line 9,col 14) Parse error. Found "int", expected ")"
+
+langtools-5ecbed313125/test/tools/javac/TryWithResources/BadTwrSyntax.java
 (line 14,col 42) Parse error. Found ";", expected ")"
 (line 14,col 43) Parse error. Found ")", expected "}"
 (line 16,col 9) Parse error. Found "try", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/TryWithResources/PlainTry.java
+langtools-5ecbed313125/test/tools/javac/TryWithResources/PlainTry.java
 (line 11,col 9) Try has no finally, no catch, and no resources.
 
-langtools-c8a87a58eb3e/test/tools/javac/TryWithResources/ResDeclOutsideTry.java
+langtools-5ecbed313125/test/tools/javac/TryWithResources/ResDeclOutsideTry.java
 (line 14,col 14) Parse error. Found "=", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 (line 14,col 48) Parse error. Found ")", expected "}"
-(line 16,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+(line 15,col 9) Parse error. Found "return", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/unicode/NonasciiDigit.java
-Lexical error at line 35, column 21.  Encountered: "\uff11" (65297), after : ""
+langtools-5ecbed313125/test/tools/javac/TryWithResources/T7022711.java
+(line 22,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 26,col 9) Parse error. Found "catch", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/unicode/NonasciiDigit2.java
-Lexical error at line 35, column 18.  Encountered: "\uff11" (65297), after : ""
+langtools-5ecbed313125/test/tools/javac/TryWithResources/T7032633.java
+(line 43,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 46,col 5) Parse error. Found "}", expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
 
-langtools-c8a87a58eb3e/test/tools/javac/unicode/TripleQuote.java
-Lexical error at line 35, column 15.  Encountered: "\'" (39), after : "\'"
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrAndLambda.java
+(line 25,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javac/UseEnum.java
-(line 37,col 14) Parse error. Found "{", expected one of  "," ";" "=" "@" "["
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrAndTypeVariables.java
+(line 14,col 14) Parse error. Found ";", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 14,col 18) Parse error. Found ")", expected "}"
+(line 19,col 12) Parse error. Found "<", expected one of  ";" "@" "class" "enum" "interface" "module" "open"
 
-langtools-c8a87a58eb3e/test/tools/javac/VoidArray.java
-(line 35,col 5) Parse error. Found "[", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrForVariable1.java
+(line 13,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 15,col 9) Parse error. Found "try", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
-langtools-c8a87a58eb3e/test/tools/javadoc/6964914/Error.java
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrForVariable2.java
+(line 13,col 20) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 15,col 9) Parse error. Found "try", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrForVariable3.java
+(line 15,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 17,col 9) Parse error. Found "try", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrForVariable4.java
+(line 11,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 14,col 9) Parse error. Found "=", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrVarKinds.java
+(line 20,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 30,col 9) Parse error. Found "try", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrVarRedeclaration.java
+(line 13,col 14) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 15,col 9) Parse error. Found "try", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javac/unicode/NonasciiDigit.java
+Lexical error at line 12, column 18.  Encountered: "\uff11" (65297), after : ""
+
+langtools-5ecbed313125/test/tools/javac/unicode/TripleQuote.java
+Lexical error at line 12, column 15.  Encountered: "\'" (39), after : "\'"
+
+langtools-5ecbed313125/test/tools/javac/VoidArray.java
+(line 12,col 5) Parse error. Found "[", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+
+langtools-5ecbed313125/test/tools/javadoc/6964914/Error.java
 (line 25,col 12) Parse error. Found "}", expected "("
 
-langtools-c8a87a58eb3e/test/tools/javadoc/6964914/JavacWarning.java
-(line 25,col 9) 'enum' cannot be used as an identifier as it is a keyword.
+langtools-5ecbed313125/test/tools/javadoc/6964914/JavacWarning.java
+(line 25,col 12) '_' is a reserved keyword.
 
-langtools-c8a87a58eb3e/test/tools/javadoc/enum/docComments/pkg1/Operation.java
+langtools-5ecbed313125/test/tools/javadoc/enum/docComments/pkg1/Operation.java
 (line 33,col 1) 'abstract' is not allowed here.
 
-langtools-c8a87a58eb3e/test/tools/javadoc/sourceOption/p/A.java
-(line 27,col 5) Parse error. Found "assert", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
-
-langtools-c8a87a58eb3e/test/tools/javadoc/T4994049/FileWithTabs.java
+langtools-5ecbed313125/test/tools/javadoc/T4994049/FileWithTabs.java
 Lexical error at line 25, column 1.  Encountered: "\\" (92), after : ""
 
-192 problems in 142 files
+320 problems in 183 files

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_zip_test_results.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_zip_test_results.txt
@@ -1,1 +1,17 @@
-0 problems in 0 files
+java/awt/Cursor.java
+(line 339,col 18) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 342,col 13) Parse error. Found "catch", expected one of  "else" "}"
+(line 346,col 13) Parse error. Found "if", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+javax/sql/rowset/spi/SyncFactory.java
+(line 392,col 30) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 394,col 25) Parse error. Found "return", expected one of  ")" ","
+(line 396,col 21) Parse error. Found ")", expected one of  "catch" "finally" "}"
+(line 412,col 13) Parse error. Found "catch", expected one of  "else" "}"
+(line 414,col 13) Parse error. Found "catch", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+sun/reflect/misc/MethodUtil.java
+(line 335,col 22) Parse error. Found ")", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
+(line 340,col 9) Parse error. Found "catch", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
+
+10 problems in 3 files


### PR DESCRIPTION
The latest bulk parse test results, resulting in #1120, #1121, and #1122.