### PR TITLE
Disconnect LexicalPreservingPrinter and preparation

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -41,11 +41,12 @@ import com.github.javaparser.metamodel.NodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
+
 import javax.annotation.Generated;
 import java.util.*;
+
 import static com.github.javaparser.ast.Node.Parsedness.PARSED;
 import static java.util.Collections.unmodifiableList;
-import com.github.javaparser.ast.Node;
 
 /**
  * Base class for all nodes of the abstract syntax tree.
@@ -430,7 +431,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     }
 
     /**
-     * Gets data for this component using the given key.
+     * Gets data for this node using the given key.
      *
      * @param <M> The type of the data.
      * @param key The key for the data
@@ -446,7 +447,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     }
 
     /**
-     * Sets data for this component using the given key.
+     * Sets data for this node using the given key.
      * For information on creating DataKey, see {@link DataKey}.
      *
      * @param <M> The type of data
@@ -459,6 +460,16 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
             data = new IdentityHashMap<>();
         }
         data.put(key, object);
+    }
+
+    /**
+     * @return does this node have data for this key?
+     */
+    public boolean containsData(DataKey<?> key) {
+        if (data == null) {
+            return false;
+        }
+        return data.get(key) != null;
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
@@ -28,16 +28,14 @@ import com.github.javaparser.ast.comments.Comment;
  * Represent the position of a child node in the NodeText of its parent.
  */
 class ChildTextElement extends TextElement {
-    private final LexicalPreservingPrinter lexicalPreservingPrinter;
     private final Node child;
 
-    ChildTextElement(LexicalPreservingPrinter lexicalPreservingPrinter, Node child) {
-        this.lexicalPreservingPrinter = lexicalPreservingPrinter;
+    ChildTextElement(Node child) {
         this.child = child;
     }
 
     String expand() {
-        return lexicalPreservingPrinter.print(child);
+        return LexicalPreservingPrinter.print(child);
     }
 
     Node getChild() {
@@ -55,7 +53,7 @@ class ChildTextElement extends TextElement {
     }
 
     NodeText getNodeTextForWrappedNode() {
-        return lexicalPreservingPrinter.getOrCreateNodeText(child);
+        return LexicalPreservingPrinter.getOrCreateNodeText(child);
     }
 
     @Override
@@ -65,16 +63,13 @@ class ChildTextElement extends TextElement {
 
         ChildTextElement that = (ChildTextElement) o;
 
-        if (!lexicalPreservingPrinter.equals(that.lexicalPreservingPrinter)) return false;
         return child.equals(that.child);
 
     }
 
     @Override
     public int hashCode() {
-        int result = lexicalPreservingPrinter.hashCode();
-        result = 31 * result + child.hashCode();
-        return result;
+        return child.hashCode();
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -394,9 +394,9 @@ public class Difference {
         return new Difference(elements);
     }
 
-    private TextElement toTextElement(LexicalPreservingPrinter lpp, CsmElement csmElement) {
+    private TextElement toTextElement(CsmElement csmElement) {
         if (csmElement instanceof CsmChild) {
-            return new ChildTextElement(lpp, ((CsmChild) csmElement).getChild());
+            return new ChildTextElement(((CsmChild) csmElement).getChild());
         } else if (csmElement instanceof CsmToken) {
             return new TokenTextElement(((CsmToken) csmElement).getTokenType(), ((CsmToken) csmElement).getContent(null));
         } else {
@@ -484,7 +484,7 @@ public class Difference {
             throw new NullPointerException();
         }
         boolean addedIndentation = false;
-        List<TokenTextElement> indentation = nodeText.getLexicalPreservingPrinter().findIndentation(node);
+        List<TokenTextElement> indentation = LexicalPreservingPrinter.findIndentation(node);
         int diffIndex = 0;
         int nodeTextIndex = 0;
         do {
@@ -505,7 +505,7 @@ public class Difference {
                                 + nodeText + ". Difference: " + this);
                     }
                 } else if (diffEl instanceof Added) {
-                    nodeText.addElement(nodeTextIndex, toTextElement(nodeText.getLexicalPreservingPrinter(), ((Added) diffEl).element));
+                    nodeText.addElement(nodeTextIndex, toTextElement(((Added) diffEl).element));
                     nodeTextIndex++;
                     diffIndex++;
                 } else {
@@ -540,7 +540,7 @@ public class Difference {
                         diffIndex++;
                         continue;
                     }
-                    TextElement textElement = toTextElement(nodeText.getLexicalPreservingPrinter(), addedElement);
+                    TextElement textElement = toTextElement(addedElement);
                     boolean used = false;
                     if (nodeTextIndex > 0 && nodeText.getElements().get(nodeTextIndex - 1).isNewline()) {
                         for (TextElement e : processIndentation(indentation, nodeText.getElements().subList(0, nodeTextIndex - 1))) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -73,7 +73,7 @@ public class LexicalPreservingPrinter {
 
     /**
      * Parse the code and setup the LexicalPreservingPrinter.
-     * @deprecated just use the other constructor.
+     * @deprecated use setup(Node) and the static methods on this class.
      */
     public static <N extends Node> Pair<ParseResult<N>, LexicalPreservingPrinter> setup(ParseStart<N> parseStart,
                                                                                         Provider provider) {
@@ -86,25 +86,34 @@ public class LexicalPreservingPrinter {
         return new Pair<>(parseResult, lexicalPreservingPrinter);
     }
 
-    //
-    // Constructor and setup
-    //
-
-    public LexicalPreservingPrinter(Node node) {
+    public static void setup(Node node) {
         assertNotNull(node);
-        
+
         node.getTokenRange().ifPresent(r -> {
             // Store initial text
             storeInitialText(node);
 
             // Setup observer
-            AstObserver observer = createObserver(this);
+            AstObserver observer = createObserver();
 
             node.registerForSubtree(observer);
         });
     }
+    
+    //
+    // Constructor and setup
+    //
 
-    private static AstObserver createObserver(LexicalPreservingPrinter lpp) {
+    /**
+     * @deprecated use setup(Node) to prepare a node for lexical preservation,
+     * then use the static methods on this class to print it.
+     */
+    @Deprecated
+    public LexicalPreservingPrinter(Node node) {
+        setup(node);
+    }
+
+    private static AstObserver createObserver() {
         return new PropagatingAstObserver() {
             @Override
             public void concretePropertyChange(Node observedNode, ObservableProperty property, Object oldValue, Object newValue) {
@@ -119,7 +128,7 @@ public class LexicalPreservingPrinter {
                     if (!observedNode.getParentNode().isPresent()) {
                         throw new IllegalStateException();
                     }
-                    NodeText nodeText = lpp.getOrCreateNodeText(observedNode.getParentNode().get());
+                    NodeText nodeText = getOrCreateNodeText(observedNode.getParentNode().get());
                     if (oldValue == null) {
                         // Find the position of the comment node and put in front of it the comment and a newline
                         int index = nodeText.findChild(observedNode);
@@ -156,7 +165,7 @@ public class LexicalPreservingPrinter {
                         }
                     }
                 }
-                NodeText nodeText = lpp.getOrCreateNodeText(observedNode);
+                NodeText nodeText = getOrCreateNodeText(observedNode);
 
                 if (nodeText == null) {
                     throw new NullPointerException(observedNode.getClass().getSimpleName());
@@ -167,7 +176,7 @@ public class LexicalPreservingPrinter {
 
             @Override
             public void concreteListChange(NodeList changedList, ListChangeType type, int index, Node nodeAddedOrRemoved) {
-                NodeText nodeText = lpp.getOrCreateNodeText(changedList.getParentNodeForChildren());
+                NodeText nodeText = getOrCreateNodeText(changedList.getParentNodeForChildren());
                 if (type == ListChangeType.REMOVAL) {
                     new LexicalDifferenceCalculator().calculateListRemovalDifference(findNodeListName(changedList), changedList, index).apply(nodeText, changedList.getParentNodeForChildren());
                 } else if (type == ListChangeType.ADDITION) {
@@ -179,13 +188,13 @@ public class LexicalPreservingPrinter {
 
             @Override
             public void concreteListReplacement(NodeList changedList, int index, Node oldValue, Node newValue) {
-                NodeText nodeText = lpp.getOrCreateNodeText(changedList.getParentNodeForChildren());
+                NodeText nodeText = getOrCreateNodeText(changedList.getParentNodeForChildren());
                 new LexicalDifferenceCalculator().calculateListReplacementDifference(findNodeListName(changedList), changedList, index, newValue).apply(nodeText, changedList.getParentNodeForChildren());
             }
         };
     }
 
-    private void storeInitialText(Node root) {
+    private static void storeInitialText(Node root) {
         Map<Node, List<JavaToken>> tokensByNode = new IdentityHashMap<>();
 
         // Take all nodes and sort them to get the leaves first
@@ -219,13 +228,13 @@ public class LexicalPreservingPrinter {
             @Override
             public void process(Node node) {
                 if (!PhantomNodeLogic.isPhantomNode(node)) {
-                    LexicalPreservingPrinter.this.storeInitialTextForOneNode(node, tokensByNode.get(node));
+                    LexicalPreservingPrinter.storeInitialTextForOneNode(node, tokensByNode.get(node));
                 }
             }
         }.visitBreadthFirst(root);
     }
 
-    private void storeInitialTextForOneNode(Node node, List<JavaToken> nodeTokens) {
+    private static void storeInitialTextForOneNode(Node node, List<JavaToken> nodeTokens) {
         if (nodeTokens == null) {
             nodeTokens = Collections.emptyList();
         }
@@ -235,21 +244,21 @@ public class LexicalPreservingPrinter {
                 if (!child.getRange().isPresent()) {
                     throw new RuntimeException("Range not present on node " + child);
                 }
-                elements.add(new Pair<>(child.getRange().get(), new ChildTextElement(this, child)));
+                elements.add(new Pair<>(child.getRange().get(), new ChildTextElement(child)));
             }
         }
         for (JavaToken token : nodeTokens) {
             elements.add(new Pair<>(token.getRange().get(), new TokenTextElement(token)));
         }
         elements.sort(Comparator.comparing(e -> e.a.begin));
-        node.setData(NODE_TEXT_DATA, new NodeText(this, elements.stream().map(p -> p.b).collect(Collectors.toList())));
+        node.setData(NODE_TEXT_DATA, new NodeText(elements.stream().map(p -> p.b).collect(Collectors.toList())));
     }
     
     //
     // Iterators
     //
 
-    private Iterator<TokenTextElement> tokensPreceeding(final Node node) {
+    private static Iterator<TokenTextElement> tokensPreceeding(final Node node) {
         if (!node.getParentNode().isPresent()) {
             return new TextElementIteratorsFactory.EmptyIterator<>();
         }
@@ -280,7 +289,7 @@ public class LexicalPreservingPrinter {
     /**
      * Print a Node into a String, preserving the lexical information.
      */
-    public String print(Node node) {
+    public static String print(Node node) {
         StringWriter writer = new StringWriter();
         try {
             print(node, writer);
@@ -293,7 +302,7 @@ public class LexicalPreservingPrinter {
     /**
      * Print a Node into a Writer, preserving the lexical information.
      */
-    public void print(Node node, Writer writer) throws IOException {
+    public static void print(Node node, Writer writer) throws IOException {
         if (!node.containsData(NODE_TEXT_DATA)) {
             getOrCreateNodeText(node);
         }
@@ -305,7 +314,7 @@ public class LexicalPreservingPrinter {
     // Methods to handle transformations
     //
 
-    private NodeText prettyPrintingTextNode(Node node, NodeText nodeText) {
+    private static NodeText prettyPrintingTextNode(Node node, NodeText nodeText) {
         if (node instanceof PrimitiveType) {
             PrimitiveType primitiveType = (PrimitiveType)node;
             switch (primitiveType.getType()) {
@@ -346,7 +355,7 @@ public class LexicalPreservingPrinter {
         return interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
     }
 
-    private NodeText interpret(Node node, CsmElement csm, NodeText nodeText) {
+    private static NodeText interpret(Node node, CsmElement csm, NodeText nodeText) {
         LexicalDifferenceCalculator.CalculatedSyntaxModel calculatedSyntaxModel = new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(csm, node);
 
         List<TokenTextElement> indentation = findIndentation(node);
@@ -390,9 +399,9 @@ public class LexicalPreservingPrinter {
     }
 
     // Visible for testing
-    NodeText getOrCreateNodeText(Node node) {
+    static NodeText getOrCreateNodeText(Node node) {
         if (!node.containsData(NODE_TEXT_DATA)) {
-            NodeText nodeText = new NodeText(this);
+            NodeText nodeText = new NodeText();
             node.setData(NODE_TEXT_DATA, nodeText);
             prettyPrintingTextNode(node, nodeText);
         }
@@ -400,7 +409,7 @@ public class LexicalPreservingPrinter {
     }
 
     // Visible for testing
-    List<TokenTextElement> findIndentation(Node node) {
+    static List<TokenTextElement> findIndentation(Node node) {
         List<TokenTextElement> followingNewlines = new LinkedList<>();
         Iterator<TokenTextElement> it = tokensPreceeding(node);
         while (it.hasNext()) {
@@ -473,15 +482,5 @@ public class LexicalPreservingPrinter {
             }
         }
         throw new IllegalArgumentException("Cannot find list name of NodeList of size " + nodeList.size());
-    }
-
-    // Visible for testing
-    NodeText getTextForNode(Node node) {
-        return node.getData(NODE_TEXT_DATA);
-    }
-
-    @Override
-    public String toString() {
-        return this.getClass().getSimpleName();
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
@@ -31,14 +31,9 @@ import java.util.List;
  * It is basically a list of tokens and children.
  */
 class NodeText {
-    private final LexicalPreservingPrinter lexicalPreservingPrinter;
     private final List<TextElement> elements;
 
     public static final int NOT_FOUND = -1;
-
-    LexicalPreservingPrinter getLexicalPreservingPrinter() {
-        return lexicalPreservingPrinter;
-    }
 
     enum Option {
         REMOVE_SPACE_IMMEDIATELY_AFTER,
@@ -50,16 +45,15 @@ class NodeText {
     // Constructors
     //
 
-    NodeText(LexicalPreservingPrinter lexicalPreservingPrinter, List<TextElement> elements) {
-        this.lexicalPreservingPrinter = lexicalPreservingPrinter;
+    NodeText(List<TextElement> elements) {
         this.elements = elements;
     }
 
     /**
      * Initialize with an empty list of elements.
      */
-    NodeText(LexicalPreservingPrinter lexicalPreservingPrinter) {
-        this(lexicalPreservingPrinter, new LinkedList<>());
+    NodeText() {
+        this(new LinkedList<>());
     }
 
     //
@@ -81,11 +75,11 @@ class NodeText {
     }
 
     void addChild(Node child) {
-        addElement(new ChildTextElement(lexicalPreservingPrinter, child));
+        addElement(new ChildTextElement(child));
     }
 
     void addChild(int index, Node child) {
-        addElement(index, new ChildTextElement(lexicalPreservingPrinter, child));
+        addElement(index, new ChildTextElement(child));
     }
 
     void addToken(int tokenKind, String text) {

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -17,11 +17,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
+    // Visible for testing
+    NodeText getTextForNode(Node node) {
+        return node.getData(NODE_TEXT_DATA);
+    }
+
 
     //
     // Tests on TextNode definition
@@ -32,22 +38,22 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         considerCode("class A {}");
 
         // CU
-        assertEquals(1, lpp.getTextForNode(cu).numberOfElements());
-        assertEquals(true, lpp.getTextForNode(cu).getTextElement(0) instanceof ChildTextElement);
-        assertEquals(cu.getClassByName("A").get(), ((ChildTextElement)lpp.getTextForNode(cu).getTextElement(0)).getChild());
+        assertEquals(1, getTextForNode(cu).numberOfElements());
+        assertEquals(true, getTextForNode(cu).getTextElement(0) instanceof ChildTextElement);
+        assertEquals(cu.getClassByName("A").get(), ((ChildTextElement)getTextForNode(cu).getTextElement(0)).getChild());
 
         // Class
         ClassOrInterfaceDeclaration classA = cu.getClassByName("A").get();
-        assertEquals(7, lpp.getTextForNode(classA).numberOfElements());
-        assertEquals("class", lpp.getTextForNode(classA).getTextElement(0).expand());
-        assertEquals(" ", lpp.getTextForNode(classA).getTextElement(1).expand());
-        assertEquals("A", lpp.getTextForNode(classA).getTextElement(2).expand());
-        assertEquals(" ", lpp.getTextForNode(classA).getTextElement(3).expand());
-        assertEquals("{", lpp.getTextForNode(classA).getTextElement(4).expand());
-        assertEquals("}", lpp.getTextForNode(classA).getTextElement(5).expand());
-        assertEquals("", lpp.getTextForNode(classA).getTextElement(6).expand());
-        assertEquals(true, lpp.getTextForNode(classA).getTextElement(6) instanceof TokenTextElement);
-        assertEquals(GeneratedJavaParserConstants.EOF, ((TokenTextElement)lpp.getTextForNode(classA).getTextElement(6)).getTokenKind());
+        assertEquals(7, getTextForNode(classA).numberOfElements());
+        assertEquals("class", getTextForNode(classA).getTextElement(0).expand());
+        assertEquals(" ", getTextForNode(classA).getTextElement(1).expand());
+        assertEquals("A", getTextForNode(classA).getTextElement(2).expand());
+        assertEquals(" ", getTextForNode(classA).getTextElement(3).expand());
+        assertEquals("{", getTextForNode(classA).getTextElement(4).expand());
+        assertEquals("}", getTextForNode(classA).getTextElement(5).expand());
+        assertEquals("", getTextForNode(classA).getTextElement(6).expand());
+        assertEquals(true, getTextForNode(classA).getTextElement(6) instanceof TokenTextElement);
+        assertEquals(GeneratedJavaParserConstants.EOF, ((TokenTextElement)getTextForNode(classA).getTextElement(6)).getTokenKind());
     }
 
     @Test
@@ -656,7 +662,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
                 .getMethodsByName("setAField").get(0);
         NodeText nodeText;
 
-        nodeText = lpp.getTextForNode(setter);
+        nodeText = getTextForNode(setter);
         int index = 0;
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.PUBLIC));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
@@ -670,7 +676,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         assertTrue(nodeText.getElements().get(index++).isChildOfClass(BlockStmt.class));
         assertEquals(index, nodeText.getElements().size());
 
-        nodeText = lpp.getTextForNode(setter.getBody().get());
+        nodeText = getTextForNode(setter.getBody().get());
         index = 0;
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LBRACE));
         assertTrue(nodeText.getElements().get(index++).isNewline());
@@ -691,7 +697,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.RBRACE));
         assertEquals(index, nodeText.getElements().size());
 
-        nodeText = lpp.getTextForNode(setter.getBody().get().getStatement(0));
+        nodeText = getTextForNode(setter.getBody().get().getStatement(0));
         index = 0;
         assertTrue(nodeText.getElements().get(index++).isChildOfClass(AssignExpr.class));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SEMICOLON));
@@ -712,7 +718,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
                 )));
         NodeText nodeText;
 
-        nodeText = lpp.getTextForNode(setter);
+        nodeText = getTextForNode(setter);
         int index = 0;
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.PUBLIC));
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.SPACE));
@@ -726,7 +732,7 @@ public class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest 
         assertTrue(nodeText.getElements().get(index++).isChildOfClass(BlockStmt.class));
         assertEquals(index, nodeText.getElements().size());
 
-        nodeText = lpp.getTextForNode(setter.getBody().get());
+        nodeText = getTextForNode(setter.getBody().get());
         index = 0;
         assertTrue(nodeText.getElements().get(index++).isToken(GeneratedJavaParserConstants.LBRACE));
         assertTrue(nodeText.getElements().get(index++).isNewline());


### PR DESCRIPTION
Hey @ftomassetti - if I store the NodeText directly on the nodes instead of keeping a map inside the printer, I can disconnect the setup from the printing. Somehow all methods turned static now :-)