### PR TITLE
Fix error in resetting token manager

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
@@ -74,10 +74,16 @@ public class TokenRange implements Iterable<JavaToken> {
             @Override
             public JavaToken next() {
                 JavaToken retval = current;
+                if(current == null){
+                    throw new IllegalStateException("Attempting to move past end of range.");
+                }
                 if (current == end) {
                     hasNext = false;
                 }
                 current = current.getNextToken().orElse(null);
+                if(current == null && hasNext){
+                    throw new IllegalStateException("End token is not linked to begin token.");
+                }
                 return retval;
             }
         };

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -209,7 +209,7 @@ public class LexicalPreservingPrinter {
             }
         }.visitLeavesFirst(root);
 
-        // We go over tokens and find to which nodes belong. Note that we start from the most specific nodes
+        // We go over tokens and find to which nodes they belong. Note that we start from the most specific nodes
         // and we move up to more general nodes
         for (JavaToken token : root.getTokenRange().get()) {
             Range tokenRange = token.getRange().orElseThrow(() -> new RuntimeException("Token without range: " + token));

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -244,6 +244,7 @@ TOKEN_MGR_DECLS :
     void reset() {
         tokens = new ArrayList<JavaToken>();
         commentsCollection = new CommentsCollection();
+        homeToken = null;
     }
 
     List<JavaToken> getTokens() {


### PR DESCRIPTION
This meant that when reusing the JavaParser instance, the `CompilationUnit` always had the begin token from the first parse call. :-/