### PR TITLE
Normalize EOL inside comments

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -36,6 +36,7 @@ import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+import com.github.javaparser.utils.Utils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -304,7 +305,11 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
     @Override
     public void visit(final JavadocComment n, final Void arg) {
         printer.print("/**");
-        printer.print(n.getContent());
+        String commentContent = n.getContent();
+        if (configuration.isNormalizeEolInComments()) {
+            commentContent = Utils.normalizeEolInTextBlock(commentContent, configuration.getEndOfLineCharacter());
+        }
+        printer.print(commentContent);
         printer.println("*/");
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -306,7 +306,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
     public void visit(final JavadocComment n, final Void arg) {
         printer.print("/**");
         String commentContent = n.getContent();
-        if (configuration.isNormalizeEolInComments()) {
+        if (configuration.isNormalizeEolInComment()) {
             commentContent = Utils.normalizeEolInTextBlock(commentContent, configuration.getEndOfLineCharacter());
         }
         printer.print(commentContent);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
@@ -27,7 +27,7 @@ import static com.github.javaparser.utils.Utils.EOL;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 public class PrettyPrinterConfiguration {
-    private boolean normalizeEolInComments = false;
+    private boolean normalizeEolInComment = false;
     private boolean printComments = true;
     private boolean printJavaDoc = true;
     private boolean columnAlignParameters = false;
@@ -45,12 +45,12 @@ public class PrettyPrinterConfiguration {
         return this;
     }
 
-    public boolean isNormalizeEolInComments() {
-        return normalizeEolInComments;
+    public boolean isNormalizeEolInComment() {
+        return normalizeEolInComment;
     }
 
-    public PrettyPrinterConfiguration setNormalizeEolInComments(boolean normalizeEolInComments) {
-        this.normalizeEolInComments = normalizeEolInComments;
+    public PrettyPrinterConfiguration setNormalizeEolInComment(boolean normalizeEolInComment) {
+        this.normalizeEolInComment = normalizeEolInComment;
         return this;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
@@ -27,6 +27,7 @@ import static com.github.javaparser.utils.Utils.EOL;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 public class PrettyPrinterConfiguration {
+    private boolean normalizeEolInComments = false;
     private boolean printComments = true;
     private boolean printJavaDoc = true;
     private boolean columnAlignParameters = false;
@@ -44,6 +45,15 @@ public class PrettyPrinterConfiguration {
         return this;
     }
 
+    public boolean isNormalizeEolInComments() {
+        return normalizeEolInComments;
+    }
+
+    public PrettyPrinterConfiguration setNormalizeEolInComments(boolean normalizeEolInComments) {
+        this.normalizeEolInComments = normalizeEolInComments;
+        return this;
+    }
+
     public boolean isPrintComments() {
         return printComments;
     }
@@ -55,7 +65,7 @@ public class PrettyPrinterConfiguration {
     public boolean isPrintJavaDoc() {
         return printJavaDoc;
     }
-    
+
     public boolean isColumnAlignParameters() {
         return columnAlignParameters;
     }
@@ -73,12 +83,12 @@ public class PrettyPrinterConfiguration {
         this.printJavaDoc = printJavaDoc;
         return this;
     }
-    
+
     public PrettyPrinterConfiguration setColumnAlignParameters(boolean columnAlignParameters) {
         this.columnAlignParameters = columnAlignParameters;
         return this;
     }
-    
+
     public PrettyPrinterConfiguration setColumnAlignFirstMethodChain(boolean columnAlignFirstMethodChain) {
         this.columnAlignFirstMethodChain = columnAlignFirstMethodChain;
         return this;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.regex.Pattern;
 
 import com.github.javaparser.Position;
+import com.github.javaparser.utils.Utils;
 
 public class SourcePrinter {
 
@@ -142,5 +143,9 @@ public class SourcePrinter {
     @Override
     public String toString() {
         return getSource();
+    }
+
+    public String normalizeEolInTextBlock(String content) {
+        return Utils.normalizeEolInTextBlock(content, endOfLineCharacter);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmComment.java
@@ -28,22 +28,21 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.printer.SourcePrinter;
 
-import static com.github.javaparser.utils.Utils.EOL;
-
 public class CsmComment implements CsmElement {
 
     static void process(Comment comment, SourcePrinter printer) {
+        String content = printer.normalizeEolInTextBlock(comment.getContent());
         if (comment instanceof BlockComment) {
             printer.print("/*");
-            printer.print(comment.getContent());
-            printer.print("*/" + EOL);
+            printer.print(content);
+            printer.println("*/");
         } else if (comment instanceof JavadocComment) {
             printer.print("/**");
-            printer.print(comment.getContent());
-            printer.print("*/" + EOL);
+            printer.print(content);
+            printer.println("*/");
         } else if (comment instanceof LineComment) {
             printer.print("//");
-            printer.print(comment.getContent());
+            printer.print(content);
             printer.println();
         } else {
             throw new UnsupportedOperationException(comment.getClass().getSimpleName());

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -220,4 +220,10 @@ public class Utils {
     public static <T> Set<T> set(T... items) {
         return new HashSet<>(asList(items));
     }
+
+    public static String normalizeEolInTextBlock(String content, String endOfLineCharacter) {
+        content.replaceAll("\\r\\n", "\n");
+        content = content.replaceAll("\\r", "\n");
+        return content.replaceAll("\\n", endOfLineCharacter);
+    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -42,6 +42,7 @@ import java.util.EnumSet;
 import java.util.List;
 
 import static com.github.javaparser.JavaParser.parse;
+import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.*;
 
 public class NodeTest {
@@ -309,18 +310,18 @@ public class NodeTest {
         MethodDeclaration methodDeclaration = cu.getType(0).getMethods().get(0);
         methodDeclaration.getName().removeForced();
         // Name is required, so to remove it the whole method is removed.
-        assertEquals("class X {\n}\n", cu.toString());
+        assertEquals(String.format("class X {%1$s}%1$s", EOL), cu.toString());
     }
 
     @Test
     public void removingTheSecondOfAListOfIdenticalStatementsDoesNotMessUpTheParents() {
-        CompilationUnit unit = JavaParser.parse("public class Example {\n" +
-                "  public static void example() {\n" +
-                "    boolean swapped;\n" +
-                "    swapped=false;\n" +
-                "    swapped=false;\n" +
-                "  }\n" +
-                "}\n");
+        CompilationUnit unit = JavaParser.parse(String.format("public class Example {%1$s" +
+                "  public static void example() {%1$s" +
+                "    boolean swapped;%1$s" +
+                "    swapped=false;%1$s" +
+                "    swapped=false;%1$s" +
+                "  }%1$s" +
+                "}%1$s", EOL));
         // remove the second swapped=false
         Node target = unit.getChildNodes().get(0).getChildNodes().get(1).getChildNodes().get(2).getChildNodes().get(2);
         target.remove();

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static com.github.javaparser.JavaParser.parse;
 import static com.github.javaparser.JavaParser.parsePackageDeclaration;
+import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
 
 public class ReplaceNodeTest {
@@ -11,21 +12,21 @@ public class ReplaceNodeTest {
     public void testSimplePropertyWithGenericReplace() {
         CompilationUnit cu = parse("package x; class Y {}");
         cu.replace(cu.getPackageDeclaration().get(), parsePackageDeclaration("package z;"));
-        assertEquals("package z;\n" +
-                "\n" +
-                "class Y {\n" +
-                "}\n", cu.toString());
+        assertEquals(String.format("package z;%1$s" +
+                "%1$s" +
+                "class Y {%1$s" +
+                "}%1$s", EOL), cu.toString());
     }
 
     @Test
     public void testListProperty() {
         CompilationUnit cu = parse("package x; class Y {}");
         cu.replace(cu.getClassByName("Y").get(), parse("class B{int y;}").getClassByName("B").get());
-        assertEquals("package x;\n" +
-                "\n" +
-                "class B {\n" +
-                "\n" +
-                "    int y;\n" +
-                "}\n", cu.toString());
+        assertEquals(String.format("package x;%1$s" +
+                "%1$s" +
+                "class B {%1$s" +
+                "%1$s" +
+                "    int y;%1$s" +
+                "}%1$s", EOL), cu.toString());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
@@ -2,6 +2,7 @@ package com.github.javaparser.ast.body;
 
 import org.junit.Test;
 
+import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
 
 public class ConstructorDeclarationTest {
@@ -10,8 +11,8 @@ public class ConstructorDeclarationTest {
         ConstructorDeclaration cons = new ConstructorDeclaration("Cons");
         cons.createBody().addStatement("super();");
 
-        assertEquals("public Cons() {\n" +
-                "    super();\n" +
-                "}", cons.toString());
+        assertEquals(String.format("public Cons() {%1$s" +
+                "    super();%1$s" +
+                "}", EOL), cons.toString());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/PrettyPrintingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/PrettyPrintingSteps.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ParseException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.printer.PrettyPrinterConfiguration;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
@@ -37,6 +38,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import static com.github.javaparser.JavaParser.*;
+import static com.github.javaparser.utils.Utils.EOL;
 import static com.github.javaparser.utils.Utils.readerToString;
 import static org.junit.Assert.assertEquals;
 
@@ -112,4 +114,9 @@ public class PrettyPrintingSteps {
         assertEquals(src.trim(), resultNode.toString().trim());
     }
 
+    @Then("it is printed with normalized EOL in comments as:$src")
+    public void isPrintedWithEolAs(String src) {
+        PrettyPrinterConfiguration conf = new PrettyPrinterConfiguration().setNormalizeEolInComments(true);
+        assertEquals(src.trim(), resultNode.toString(conf).trim());
+    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/PrettyPrintingSteps.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/bdd/steps/PrettyPrintingSteps.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.bdd.steps;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -38,7 +37,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import static com.github.javaparser.JavaParser.*;
-import static com.github.javaparser.utils.Utils.EOL;
 import static com.github.javaparser.utils.Utils.readerToString;
 import static org.junit.Assert.assertEquals;
 
@@ -116,7 +114,7 @@ public class PrettyPrintingSteps {
 
     @Then("it is printed with normalized EOL in comments as:$src")
     public void isPrintedWithEolAs(String src) {
-        PrettyPrinterConfiguration conf = new PrettyPrinterConfiguration().setNormalizeEolInComments(true);
+        PrettyPrinterConfiguration conf = new PrettyPrinterConfiguration().setNormalizeEolInComment(true);
         assertEquals(src.trim(), resultNode.toString(conf).trim());
     }
 }

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bdd/pretty_printing_scenarios.story
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bdd/pretty_printing_scenarios.story
@@ -472,7 +472,7 @@ public class Abc<@C A, @C X extends @C String & @C Serializable> {
 Scenario: we can parse a package-info file.
 Given the class in the file "package-info.java"
 When the class is parsed by the Java parser
-Then it is printed as:
+Then it is printed with normalized EOL in comments as:
 /**
  * This package contains class for doing some stuff.
  */


### PR DESCRIPTION
Normalize EOL characters inside comment text.

Also, there are some test fixes for EOL differences under Windows.

See #1200 