### PR TITLE
Stop preprocessing unicode escapes

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -28,10 +28,7 @@ import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.comments.CommentsCollection;
-import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.Name;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.Statement;
@@ -501,6 +498,17 @@ public final class JavaParser {
      */
     public static Name parseName(String qualifiedName) {
         return simplifiedParse(NAME, provider(qualifiedName));
+    }
+
+    /**
+     * Parses a simple name (one that can NOT have "."s in it) and returns it as a SimpleName.
+     *
+     * @param name a name like "parameter_source"
+     * @return the AST for the name
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static SimpleName parseSimpleName(String name) {
+        return simplifiedParse(SIMPLE_NAME, provider(name));
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseStart.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseStart.java
@@ -26,10 +26,7 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.Name;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.Statement;
@@ -60,6 +57,7 @@ public interface ParseStart<R> {
     ParseStart<VariableDeclarationExpr> VARIABLE_DECLARATION_EXPR = GeneratedJavaParser::VariableDeclarationExpressionParseStart;
     ParseStart<ExplicitConstructorInvocationStmt> EXPLICIT_CONSTRUCTOR_INVOCATION_STMT = GeneratedJavaParser::ExplicitConstructorInvocationParseStart;
     ParseStart<Name> NAME = GeneratedJavaParser::NameParseStart;
+    ParseStart<SimpleName> SIMPLE_NAME = GeneratedJavaParser::SimpleNameParseStart;
     ParseStart<Parameter> PARAMETER = GeneratedJavaParser::ParameterParseStart;
     ParseStart<PackageDeclaration> PACKAGE_DECLARATION = GeneratedJavaParser::PackageDeclarationParseStart;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
@@ -171,6 +171,7 @@ public class TokenTypes {
                 return JavaToken.Category.LITERAL;
             case IDENTIFIER:
             case LETTER:
+            case UNICODE_ESCAPE:
             case PART_LETTER:
                 return JavaToken.Category.IDENTIFIER;
             case LPAREN:

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
@@ -86,6 +86,7 @@ public class TokenTypes {
                 return JavaToken.Category.EOL;
             case EOF:
             case SPACE:
+            case CTRL_Z:
                 return JavaToken.Category.WHITESPACE_NO_EOL;
             case SINGLE_LINE_COMMENT:
             case JAVADOC_COMMENT:
@@ -170,9 +171,6 @@ public class TokenTypes {
             case STRING_LITERAL:
                 return JavaToken.Category.LITERAL;
             case IDENTIFIER:
-            case LETTER:
-            case UNICODE_ESCAPE:
-            case PART_LETTER:
                 return JavaToken.Category.IDENTIFIER;
             case LPAREN:
             case RPAREN:
@@ -226,6 +224,14 @@ public class TokenTypes {
             case RSIGNEDSHIFT:
             case GT:
                 return JavaToken.Category.OPERATOR;
+            // The following are tokens that are only used internally by the lexer
+            case ENTER_JAVADOC_COMMENT:
+            case ENTER_MULTILINE_COMMENT:
+            case COMMENT_CONTENT:
+            case HEX_DIGITS:
+            case LETTER:
+            case UNICODE_ESCAPE:
+            case PART_LETTER:
             default:
                 throw new AssertionError("Invalid token kind " + kind);
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
  * A literal string.
  * <br/><code>"Hello World!"</code>
  * <br/><code>"\"\n"</code>
+ * <br/><code>"\u2122"</code>
  * <br/><code>"™"</code>
  * <br/><code>"💩"</code>
  *

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -2760,28 +2760,26 @@ Type ResultTypeParseStart():
 { NodeList<AnnotationExpr> annotations; Type ret; }
 { annotations = Annotations() ret = ResultType(annotations) <EOF> { return ret; } }
 
-
 VariableDeclarationExpr VariableDeclarationExpressionParseStart():
 { VariableDeclarationExpr ret; }
 { ret = VariableDeclarationExpression() <EOF> { return ret; } }
-
 
 ExplicitConstructorInvocationStmt ExplicitConstructorInvocationParseStart():
 { ExplicitConstructorInvocationStmt ret; }
 { ret = ExplicitConstructorInvocation() <EOF> { return ret; } }
 
-
 Name NameParseStart():
 { Name ret; }
 { ret = Name() <EOF> { return ret; } }
 
+SimpleName SimpleNameParseStart():
+{ SimpleName ret; }
+{ ret = SimpleName() <EOF> { return ret; } }
 
 Parameter ParameterParseStart():
 { Parameter ret; }
 { ret = Parameter() <EOF> { return ret; } }
 
-
 PackageDeclaration PackageDeclarationParseStart():
 { PackageDeclaration ret; }
 { ret = PackageDeclaration() <EOF> { return ret; } }
-

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -176,7 +176,7 @@ MORE :
 {
   <ENTER_JAVADOC_COMMENT: "/**" ~["/"]> { input_stream.backup(1); } : IN_JAVADOC_COMMENT
 |
-  <"/*"> : IN_MULTI_LINE_COMMENT
+  <ENTER_MULTILINE_COMMENT: "/*"> : IN_MULTI_LINE_COMMENT
 }
 
 <IN_JAVADOC_COMMENT>
@@ -595,6 +595,7 @@ TOKEN :
 | < GT: ">" >
 }
 
+TOKEN: { <CTRL_Z: "\u001A" /** ctrl+z char **/> }
 
 /*****************************************
  * THE JAVA LANGUAGE GRAMMAR STARTS HERE *
@@ -636,7 +637,7 @@ CompilationUnit CompilationUnit():
                 )
             )
         )*
-        (<EOF> | "\u001A" /** ctrl+z char **/)
+        (<EOF> | <CTRL_Z>)
         { return new CompilationUnit(range(token_source.getHomeToken(), token()), pakage, imports, types, module); }
     } catch (ParseException e) {
         recover(EOF, e);

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -315,6 +315,13 @@ TOKEN :
 |
   < #HEX_DIGITS: ["0"-"9","a"-"f","A"-"F"]((["0"-"9","a"-"f","A"-"F","_"])*["0"-"9","a"-"f","A"-"F"])? >
 |
+  < #UNICODE_ESCAPE:
+    "\\u"
+    ["0"-"9","A"-"F","a"-"f"]
+    ["0"-"9","A"-"F","a"-"f"]
+    ["0"-"9","A"-"F","a"-"f"]
+    ["0"-"9","A"-"F","a"-"f"] >
+|
   < CHARACTER_LITERAL:
       "'"
       (   (~["'","\\","\n","\r"])
@@ -324,12 +331,7 @@ TOKEN :
             | ["0"-"3"] ["0"-"7"] ["0"-"7"]
             )
           )
-        | ("\\u"
-        	["0"-"9","A"-"F","a"-"f"]
-        	["0"-"9","A"-"F","a"-"f"]
-        	["0"-"9","A"-"F","a"-"f"]
-        	["0"-"9","A"-"F","a"-"f"]
-          )
+        | <UNICODE_ESCAPE>
       )
       "'"
   >
@@ -428,6 +430,7 @@ TOKEN :
          "\ufe76"-"\ufefc",  "\uff04",  "\uff21"-"\uff3a",  "\uff3f",  "\uff41"-"\uff5a",  "\uff66"-"\uffbe",  
          "\uffc2"-"\uffc7",  "\uffca"-"\uffcf",  "\uffd2"-"\uffd7",  "\uffda"-"\uffdc",  "\uffe0"-"\uffe1",  
          "\uffe5"-"\uffe6"  ]
+        | <UNICODE_ESCAPE>
   >
 |
   < #PART_LETTER: [
@@ -511,6 +514,7 @@ TOKEN :
          "\ufe4d"-"\ufe4f",  "\ufe69",  "\ufe70"-"\ufe74",  "\ufe76"-"\ufefc",  "\ufeff",  "\uff04",  "\uff10"-"\uff19",  
          "\uff21"-"\uff3a",  "\uff3f",  "\uff41"-"\uff5a",  "\uff66"-"\uffbe",  "\uffc2"-"\uffc7",  "\uffca"-"\uffcf",  
          "\uffd2"-"\uffd7",  "\uffda"-"\uffdc",  "\uffe0"-"\uffe1",  "\uffe5"-"\uffe6",  "\ufff9"-"\ufffb" ]
+        | <UNICODE_ESCAPE>
   >
 }
 

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -21,7 +21,6 @@
 
 options {
   STATIC=false;
-  JAVA_UNICODE_ESCAPE=true;
   COMMON_TOKEN_ACTION=true;
   JDK_VERSION = "1.8";
   TOKEN_EXTENDS ="TokenBase";

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -31,16 +31,20 @@ import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.stmt.SwitchEntryStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.IntersectionType;
 import com.github.javaparser.ast.type.Type;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
-import static com.github.javaparser.Providers.*;
+import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.Range.range;
+import static com.github.javaparser.utils.CodeGenerationUtils.mavenModuleRoot;
 import static com.github.javaparser.utils.TestUtils.assertInstanceOf;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
@@ -191,7 +195,7 @@ public class JavaParserTest {
         Statement lambdaBody = lambdaExpr.getBody();
         assertEquals(range(3, 68, 3, 101), lambdaBody.getRange().get());
     }
-    
+
     @Test
     public void testNotStoringTokens() {
         JavaParser javaParser = new JavaParser(new ParserConfiguration().setStoreTokens(false));
@@ -208,5 +212,16 @@ public class JavaParserTest {
     public void trailingWhitespaceIsIgnored() {
         BlockStmt blockStmt = JavaParser.parseBlock("{} // hello");
         assertEquals("{}", blockStmt.getTokenRange().get().toString());
+    }
+
+    @Test
+    public void everyTokenHasACategory() throws IOException {
+        final int tokenCount = GeneratedJavaParserConstants.tokenImage.length;
+        Path tokenTypesPath = mavenModuleRoot(JavaParserTest.class).resolve("../javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java");
+        CompilationUnit tokenTypesCu = JavaParser.parse(tokenTypesPath);
+        // -1 to take off the default: case.
+        int switchEntries = tokenTypesCu.findAll(SwitchEntryStmt.class).size()-1;
+        // The amount of "case XXX:" in TokenTypes.java should be equal to the amount of tokens JavaCC knows about:
+        assertEquals(tokenCount, switchEntries);
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -207,6 +207,6 @@ public class JavaParserTest {
     @Test
     public void trailingWhitespaceIsIgnored() {
         BlockStmt blockStmt = JavaParser.parseBlock("{} // hello");
-        assertEquals("\"}\"   <95>   (line 1,col 2)-(line 1,col 2)", blockStmt.getTokenRange().get().getEnd().toString());
+        assertEquals("{}", blockStmt.getTokenRange().get().toString());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -207,6 +207,6 @@ public class JavaParserTest {
     @Test
     public void trailingWhitespaceIsIgnored() {
         BlockStmt blockStmt = JavaParser.parseBlock("{} // hello");
-        assertEquals("\"}\"   <94>   (line 1,col 2)-(line 1,col 2)", blockStmt.getTokenRange().get().getEnd().toString());
+        assertEquals("\"}\"   <95>   (line 1,col 2)-(line 1,col 2)", blockStmt.getTokenRange().get().getEnd().toString());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
@@ -64,7 +64,7 @@ public class CommentTest {
     }
 
     @Test
-    public void mayContainUnicodeEscapes() {
+    public void unicodeEscapesArePreservedInComments() {
         CompilationUnit cu = parse("// xxx\\u2122xxx");
         Comment comment = cu.getAllContainedComments().get(0);
         assertEquals(" xxx\\u2122xxx", comment.getContent());

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
@@ -21,12 +21,16 @@
 
 package com.github.javaparser.ast.comments;
 
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.Name;
 import org.junit.Test;
 
 import java.util.EnumSet;
 
+import static com.github.javaparser.JavaParser.parse;
+import static com.github.javaparser.JavaParser.parseName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -57,5 +61,12 @@ public class CommentTest {
     public void cannotRemoveCommentNotUsedAnywhere() {
         Comment c = new LineComment("A comment");
         assertFalse(c.remove());
+    }
+
+    @Test
+    public void mayContainUnicodeEscapes() {
+        CompilationUnit cu = parse("// xxx\\u2122xxx");
+        Comment comment = cu.getAllContainedComments().get(0);
+        assertEquals(" xxx\\u2122xxx", comment.getContent());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
@@ -44,7 +44,7 @@ public class SimpleNameTest {
     }
 
     @Test
-    public void mayContainUnicodeEscapes() {
+    public void unicodeEscapesArePreservedInIdentifiers() {
         SimpleName name = parseSimpleName("xxx\\u2122xxx");
         assertEquals("xxx\\u2122xxx", name.asString());
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.expr;
 
 import org.junit.Test;
 
+import static com.github.javaparser.JavaParser.parseSimpleName;
 import static junit.framework.TestCase.assertEquals;
 
 public class SimpleNameTest {
@@ -42,4 +43,9 @@ public class SimpleNameTest {
         new SimpleName(null);
     }
 
+    @Test
+    public void mayContainUnicodeEscapes() {
+        SimpleName name = parseSimpleName("xxx\\u2122xxx");
+        assertEquals("xxx\\u2122xxx", name.asString());
+    }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
@@ -8,12 +8,7 @@ import static org.junit.Assert.*;
 public class StringLiteralExprTest {
     @Test
     public void unicodeEscapesDoNotGetPreprocessed() {
-        StringLiteralExpr omega = parseExpression("\"\\u03a9\"");
-        assertEquals('\\', omega.getValue().charAt(0));
-        assertEquals('u', omega.getValue().charAt(1));
-        assertEquals('0', omega.getValue().charAt(2));
-        assertEquals('3', omega.getValue().charAt(3));
-        assertEquals('a', omega.getValue().charAt(4));
-        assertEquals('9', omega.getValue().charAt(5));
+        StringLiteralExpr omega = parseExpression("\"xxx\\u03a9xxx\"");
+        assertEquals("xxx\\u03a9xxx", omega.getValue());
     }
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.*;
 
 public class StringLiteralExprTest {
     @Test
-    public void unicodeEscapesDoNotGetPreprocessed() {
+    public void unicodeEscapesArePreservedInStrings() {
         StringLiteralExpr omega = parseExpression("\"xxx\\u03a9xxx\"");
         assertEquals("xxx\\u03a9xxx", omega.getValue());
     }

--- a/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
@@ -1,0 +1,19 @@
+package com.github.javaparser.ast.expr;
+
+import org.junit.Test;
+
+import static com.github.javaparser.JavaParser.parseExpression;
+import static org.junit.Assert.*;
+
+public class StringLiteralExprTest {
+    @Test
+    public void unicodeEscapesDoNotGetPreprocessed() {
+        StringLiteralExpr omega = parseExpression("\"\\u03a9\"");
+        assertEquals('\\', omega.getValue().charAt(0));
+        assertEquals('u', omega.getValue().charAt(1));
+        assertEquals('0', omega.getValue().charAt(2));
+        assertEquals('3', omega.getValue().charAt(3));
+        assertEquals('a', omega.getValue().charAt(4));
+        assertEquals('9', omega.getValue().charAt(5));
+    }
+}


### PR DESCRIPTION
Fixes #1236 
Fixes #801 
Fixes #600
Fixes #209 

@ftomassetti @cal101 @Gottox @digulla @cdietrich - @ptitjes tells us in the original #209 that unicode escape sequences should be gone before the lexer even starts. This allows for unicode escapes in every element of the source code. This is what we currently do, and this is what causes the escape sequences from the source code to be irretrievably lost to the user.

I would like to reverse this decision and stop preprocessing the escapes. This will be the result:
- good: the original escape sequences will be kept and can be printed out again.
- bad: it becomes impossible to use escape sequences in many positions. However, non-ASCII characters are only allowed in comments, string and char literals, and identifiers, so if we make sure they are allowed there this should be a very marginal issue. Intellij doesn't even recognize this case.

I think doing this will support a lot more use cases, and will break few to none.
