### PR TITLE
Update the test results for the unicode approach change

### DIFF
--- a/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_repo_test_results.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_repo_test_results.txt
@@ -2,10 +2,10 @@ langtools-5ecbed313125/test/com/sun/javadoc/testAnchorNames/pkg1/RegClass.java
 (line 68,col 16) '_' is a reserved keyword.
 
 langtools-5ecbed313125/test/com/sun/javadoc/testSourceTab/DoubleTab/C.java
-Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
+Lexical error at line 33, column 2.  Encountered: "t" (116), after : "\\"
 
 langtools-5ecbed313125/test/com/sun/javadoc/testSourceTab/SingleTab/C.java
-Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
+Lexical error at line 33, column 2.  Encountered: "t" (116), after : "\\"
 
 langtools-5ecbed313125/test/com/sun/javadoc/testTypeAnnotations/typeannos/Receivers.java
 (line 56,col 34) Parse error. Found "this", expected one of  "..." "@" "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
@@ -17,10 +17,10 @@ langtools-5ecbed313125/test/jdk/javadoc/doclet/testAnchorNames/pkg1/RegClass.jav
 (line 68,col 16) '_' is a reserved keyword.
 
 langtools-5ecbed313125/test/jdk/javadoc/doclet/testSourceTab/DoubleTab/C.java
-Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
+Lexical error at line 33, column 2.  Encountered: "t" (116), after : "\\"
 
 langtools-5ecbed313125/test/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
-Lexical error at line 33, column 1.  Encountered: "\\" (92), after : ""
+Lexical error at line 33, column 2.  Encountered: "t" (116), after : "\\"
 
 langtools-5ecbed313125/test/jdk/javadoc/doclet/testUnnamedPackage/BadSource.java
 Parse error. Found  "Just" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
@@ -35,7 +35,7 @@ langtools-5ecbed313125/test/jdk/javadoc/tool/enum/docComments/pkg1/Operation.jav
 (line 33,col 1) 'abstract' is not allowed here.
 
 langtools-5ecbed313125/test/jdk/javadoc/tool/T4994049/FileWithTabs.java
-Lexical error at line 25, column 1.  Encountered: "\\" (92), after : ""
+Lexical error at line 25, column 2.  Encountered: "t" (116), after : "\\"
 
 langtools-5ecbed313125/test/tools/javac/6302184/T6302184.java
 Lexical error at line 28, column 9.  Encountered: "\ufffd" (65533), after : ""
@@ -247,7 +247,7 @@ langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalLineEndInCharLit.j
 Lexical error at line 27, column 15.  Encountered: "\n" (10), after : "\'"
 
 langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalNonAsciiDigit.java
-Lexical error at line 27, column 14.  Encountered: "\u0660" (1632), after : ""
+(line 27,col 13) Parse error. Found  "\\u0660" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
 langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalStartOfExpr.java
 (line 27,col 11) Parse error. Found "=", expected one of  "!" "(" "+" "++" "-" "--" "@" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
@@ -264,7 +264,7 @@ langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalUnderscore.java
 (line 27,col 13) Parse error. Found  "_" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
 langtools-5ecbed313125/test/tools/javac/diags/examples/IllegalUnicodeEscape.java
-(line 27,col 11) Parse error. Found <EOF>, expected one of  "!" "(" "+" "++" "-" "--" "@" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+Lexical error at line 27, column 15.  Encountered: ";" (59), after : "\\u"
 
 langtools-5ecbed313125/test/tools/javac/diags/examples/InitializerNotAllowed.java
 (line 27,col 5) An interface cannot have initializers.
@@ -365,7 +365,7 @@ langtools-5ecbed313125/test/tools/javac/diags/examples/VarargsAndReceiver.java
 (line 27,col 30) Parse error. Found "this", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
 
 langtools-5ecbed313125/test/tools/javac/Digits.java
-Lexical error at line 11, column 43.  Encountered: "\u0663" (1635), after : ""
+(line 11,col 40) Parse error. Found  "\\u0663" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
 langtools-5ecbed313125/test/tools/javac/enum/EnumAsIdentifier.java
 (line 11,col 9) 'enum' cannot be used as an identifier as it is a keyword.
@@ -621,11 +621,26 @@ langtools-5ecbed313125/test/tools/javac/TryWithResources/TwrForVariable2.java
 (line 13,col 13) Parse error. Found "final", expected one of  "(" "@" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
 (line 15,col 9) Parse error. Found "try", expected one of  ";" "<" "@" "abstract" "boolean" "byte" "char" "class" "default" "double" "enum" "exports" "final" "float" "int" "interface" "long" "module" "native" "open" "opens" "private" "protected" "provides" "public" "requires" "short" "static" "strictfp" "synchronized" "to" "transient" "transitive" "uses" "void" "volatile" "with" "{" "}" <IDENTIFIER>
 
+langtools-5ecbed313125/test/tools/javac/unicode/FirstChar2.java
+Parse error. Found  "\\u0070ublic" <IDENTIFIER>, expected one of  ";" "@" "\u001a" "abstract" "class" "default" "enum" "final" "import" "interface" "module" "native" "open" "private" "protected" "public" "static" "strictfp" "synchronized" "transient" "transitive" "volatile" <EOF>
+
 langtools-5ecbed313125/test/tools/javac/unicode/NonasciiDigit.java
-Lexical error at line 12, column 18.  Encountered: "\uff11" (65297), after : ""
+(line 13,col 18) Parse error. Found  "\\uff11" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 16,col 21) Parse error. Found  ".0" <FLOATING_POINT_LITERAL>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 17,col 21) Parse error. Found  "\\uff11" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 18,col 21) Parse error. Found  "P\\uff11" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 19,col 21) Parse error. Found  "E\\uff11" <IDENTIFIER>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
+(line 20,col 19) Parse error. Found ".", expected one of  "!" "(" "+" "++" "-" "--" "@" "boolean" "byte" "char" "double" "enum" "exports" "false" "float" "int" "long" "module" "new" "null" "open" "opens" "provides" "requires" "short" "strictfp" "super" "this" "to" "transitive" "true" "uses" "void" "with" "{" "~" <CHARACTER_LITERAL> <FLOATING_POINT_LITERAL> <IDENTIFIER> <INTEGER_LITERAL> <LONG_LITERAL> <STRING_LITERAL>
+(line 21,col 21) Parse error. Found  ".0" <FLOATING_POINT_LITERAL>, expected one of  "!=" "%" "%=" "&" "&&" "&=" "(" "*" "*=" "+" "+=" "," "-" "-=" "->" "/" "/=" "::" ";" "<" "<<=" "<=" "=" "==" ">" ">=" ">>=" ">>>=" "?" "^" "^=" "instanceof" "|" "|=" "||"
 
 langtools-5ecbed313125/test/tools/javac/unicode/TripleQuote.java
-Lexical error at line 12, column 15.  Encountered: "\'" (39), after : "\'"
+Lexical error at line 13, column 15.  Encountered: "\'" (39), after : "\'"
+
+langtools-5ecbed313125/test/tools/javac/unicode/UnicodeAtEOL.java
+(line 33,col 13) Parse error. Found  "\\u000D" <IDENTIFIER>, expected "}"
+
+langtools-5ecbed313125/test/tools/javac/unicode/UnicodeCommentDelimiter.java
+(line 44,col 22) Parse error. Found  "plugh" <IDENTIFIER>, expected one of  "," ";" "=" "@" "["
 
 langtools-5ecbed313125/test/tools/javac/VoidArray.java
 (line 12,col 5) Parse error. Found "[", expected one of  "enum" "exports" "module" "open" "opens" "provides" "requires" "strictfp" "to" "transitive" "uses" "with" <IDENTIFIER>
@@ -640,6 +655,6 @@ langtools-5ecbed313125/test/tools/javadoc/enum/docComments/pkg1/Operation.java
 (line 33,col 1) 'abstract' is not allowed here.
 
 langtools-5ecbed313125/test/tools/javadoc/T4994049/FileWithTabs.java
-Lexical error at line 25, column 1.  Encountered: "\\" (92), after : ""
+Lexical error at line 25, column 2.  Encountered: "t" (116), after : "\\"
 
-296 problems in 174 files
+305 problems in 177 files

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_zip_test_results.txt
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/openjdk_src_zip_test_results.txt
@@ -1,1 +1,4 @@
-0 problems in 0 files
+com/sun/xml/internal/rngom/parse/compact/CompactSyntax.java
+Lexical error at line 244, column 38.  Encountered: "n" (110), after : "\'\\u005c"
+
+1 problems in 1 files


### PR DESCRIPTION
As you can see, there are now a bunch of parse errors that shouldn't be there, exactly where they are expected. Cases are like "escape the backslash of an escape," "escape the EOL character after a line comment," "escape a digit in a number," and "escape a character from a keyword."