### PR TITLE
Move module name configuration to correct pom file

### DIFF
--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -168,6 +168,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Set JPMS module name to `com.github.javaparser.core` -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.github.javaparser.core</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -179,17 +179,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>com.github.javaparser.core</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>            
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Prior to this PR all artifacts were configured to the report `com.github.javaparser.core` as their module name. Now only the **core** jar contains the manifest attribute.