### PR TITLE
Redo Javadoc formatting

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -25,13 +25,13 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.github.javaparser.javadoc.description.JavadocDescription;
-import com.github.javaparser.utils.Utils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.github.javaparser.utils.Utils.*;
 import static com.github.javaparser.utils.Utils.nextWord;
 
 /**
@@ -67,13 +67,13 @@ class JavadocParser {
                 .stream()
                 .collect(Collectors.joining("\n"));
 
-            //Split up the entire tag black again, considering now that some lines belong to the same block tag.
-            //The pattern used splits the block at each new line starting with the '@' symbol, thus the symbol
+            //Split up the entire tag back again, considering now that some lines belong to the same block tag.
+            //The pattern splits the block at each new line starting with the '@' symbol, thus the symbol
             //then needs to be added again so that the block parsers handles everything correctly.
             blockLines = BLOCK_PATTERN
                 .splitAsStream(tagBlock)
-                .filter(Utils.STRING_NOT_EMPTY)
-                .map(s -> BLOCK_TAG_PREFIX + s.replace("\n", " ").trim())
+                .filter(STRING_NOT_EMPTY)
+                .map(s -> BLOCK_TAG_PREFIX + s)
                 .collect(Collectors.toList());
         }
         Javadoc document = new Javadoc(JavadocDescription.parseText(descriptionText));

--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -47,7 +47,7 @@ class JavadocParser {
     }
 
     public static Javadoc parse(String commentContent) {
-        List<String> cleanLines = cleanLines(commentContent);
+        List<String> cleanLines = cleanLines(normalizeEolInTextBlock(commentContent, EOL));
         int indexOfFirstBlockTag = cleanLines.stream()
                 .filter(JavadocParser::isABlockLine)
                 .map(cleanLines::indexOf)
@@ -56,16 +56,16 @@ class JavadocParser {
         List<String> blockLines;
         String descriptionText;
         if (indexOfFirstBlockTag == -1) {
-            descriptionText = trimRight(String.join("\n", cleanLines));
+            descriptionText = trimRight(String.join(EOL, cleanLines));
             blockLines = Collections.emptyList();
         } else {
-            descriptionText = trimRight(String.join("\n", cleanLines.subList(0, indexOfFirstBlockTag)));
+            descriptionText = trimRight(String.join(EOL, cleanLines.subList(0, indexOfFirstBlockTag)));
 
             //Combine cleaned lines, but only starting with the first block tag till the end
             //In this combined string it is easier to handle multiple lines which actually belong together
             String tagBlock = cleanLines.subList(indexOfFirstBlockTag, cleanLines.size())
                 .stream()
-                .collect(Collectors.joining("\n"));
+                .collect(Collectors.joining(EOL));
 
             //Split up the entire tag back again, considering now that some lines belong to the same block tag.
             //The pattern splits the block at each new line starting with the '@' symbol, thus the symbol
@@ -100,7 +100,7 @@ class JavadocParser {
     }
 
     private static List<String> cleanLines(String content) {
-        String[] lines = content.split("\n");
+        String[] lines = content.split(EOL);
         List<String> cleanedLines = Arrays.stream(lines).map(l -> {
             int asteriskIndex = startsWithAsterisk(l);
             if (asteriskIndex == -1) {

--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
@@ -27,6 +27,8 @@ import com.github.javaparser.javadoc.description.JavadocDescription;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.github.javaparser.utils.Utils.*;
+
 /**
  * The structured content of a single Javadoc comment.
  * <p>
@@ -66,14 +68,14 @@ public class Javadoc {
         StringBuilder sb = new StringBuilder();
         if (!description.isEmpty()) {
             sb.append(description.toText());
-            sb.append("\n");
+            sb.append(EOL);
         }
         if (!blockTags.isEmpty()) {
-            sb.append("\n");
+            sb.append(EOL);
         }
         blockTags.forEach(bt -> {
             sb.append(bt.toText());
-            sb.append("\n");
+            sb.append(EOL);
         });
         return sb.toString();
     }
@@ -88,13 +90,14 @@ public class Javadoc {
             }
         }
         StringBuilder sb = new StringBuilder();
-        sb.append("\n");
-        if (!toText().isEmpty()) {
-            for (String line : toText().split("\n")) {
+        sb.append(EOL);
+        final String text = toText();
+        if (!text.isEmpty()) {
+            for (String line : text.split(EOL)) {
                 sb.append(indentation);
                 sb.append(" * ");
                 sb.append(line);
-                sb.append("\n");
+                sb.append(EOL);
             }
         }
         sb.append(indentation);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -44,6 +44,7 @@ import static com.github.javaparser.ast.Node.Parsedness.UNPARSABLE;
 import static com.github.javaparser.utils.PositionUtils.sortByBeginPosition;
 import static com.github.javaparser.utils.Utils.isNullOrEmpty;
 import static com.github.javaparser.utils.Utils.normalizeEolInTextBlock;
+import static com.github.javaparser.utils.Utils.trimTrailingSpaces;
 
 /**
  * Outputs the AST as formatted Java source code.
@@ -328,10 +329,11 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
             boolean skippingLeadingEmptyLines = true;
             boolean prependEmptyLine = false;
             for (String line : lines) {
-                line = line.trim();
-                if (line.startsWith("*")) {
-                    line = line.substring(1).trim();
+                final String trimmedLine = line.trim();
+                if (trimmedLine.startsWith("*")) {
+                    line = trimmedLine.substring(1);
                 }
+                line = trimTrailingSpaces(line);
                 if (line.isEmpty()) {
                     if (!skippingLeadingEmptyLines) {
                         prependEmptyLine = true;
@@ -342,7 +344,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
                         printer.println(" *");
                         prependEmptyLine = false;
                     }
-                    printer.println(" * " + line);
+                    printer.println(" *" + line);
                 }
             }
             printer.println(" */");
@@ -484,7 +486,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         if (!n.getVariables().isEmpty()) {
             Optional<Type> maximumCommonType = n.getMaximumCommonType();
             maximumCommonType.ifPresent(t -> t.accept(this, arg));
-            if(!maximumCommonType.isPresent()){
+            if (!maximumCommonType.isPresent()) {
                 printer.print("???");
             }
         }
@@ -507,10 +509,9 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         n.getName().accept(this, arg);
 
         n.getAncestorOfType(NodeWithVariables.class).ifPresent(ancestor -> {
-            Optional<Type> maximumCommonType = ancestor.getMaximumCommonType();
-            maximumCommonType.ifPresent(commonType -> {
+            ((NodeWithVariables<?>) ancestor).getMaximumCommonType().ifPresent(commonType -> {
 
-                Type type = n.getType();
+                final Type type = n.getType();
 
                 ArrayType arrayType = null;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -49,7 +49,7 @@ public class Utils {
     public static <E> boolean isNullOrEmpty(Collection<E> collection) {
         return collection == null || collection.isEmpty();
     }
-    
+
     public static <T> T assertNotNull(T o) {
         if (o == null) {
             throw new AssertionError("A reference was unexpectedly null.");
@@ -239,4 +239,15 @@ public class Utils {
 
         return filename.substring(0, extensionIndex);
     }
+
+    /**
+     * Like {@link String#trim()}, but only the trailing spaces.
+     */
+    public static String trimTrailingSpaces(String line) {
+        while (line.length() > 0 && line.charAt(line.length() - 1) <= 0x20) {
+            line = line.substring(0, line.length() - 1);
+        }
+        return line;
+    }
+
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
@@ -27,6 +27,7 @@ import com.github.javaparser.javadoc.description.JavadocDescription;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
 
 public class JavadocParserTest {
@@ -46,46 +47,46 @@ public class JavadocParserTest {
     @Test
     public void parseSingleLineWithNewLines() {
         assertEquals(new Javadoc(JavadocDescription.parseText("The string image of the token.")),
-                JavadocParser.parse("\n" +
-                        "   * The string image of the token.\n" +
+                JavadocParser.parse(EOL +
+                        "   * The string image of the token." + EOL +
                         "   "));
     }
 
     @Test
     public void parseCommentWithNewLines() {
-        String text = "\n" +
-                "   * The version identifier for this Serializable class.\n" +
-                "   * Increment only if the <i>serialized</i> form of the\n" +
-                "   * class changes.\n" +
+        String text = EOL +
+                "   * The version identifier for this Serializable class." + EOL +
+                "   * Increment only if the <i>serialized</i> form of the" + EOL +
+                "   * class changes." + EOL +
                 "   ";
-        assertEquals(new Javadoc(JavadocDescription.parseText("The version identifier for this Serializable class.\n" +
-                        "Increment only if the <i>serialized</i> form of the\n" +
+        assertEquals(new Javadoc(JavadocDescription.parseText("The version identifier for this Serializable class." + EOL +
+                        "Increment only if the <i>serialized</i> form of the" + EOL +
                         "class changes.")),
                 JavadocParser.parse(text));
     }
 
     @Test
     public void parseCommentWithIndentation() {
-        String text = "Returns a new Token object, by default.\n" +
-                "   * However, if you want, you can create and return subclass objects based on the value of ofKind.\n" +
-                "   *\n" +
-                "   *    case MyParserConstants.ID : return new IDToken(ofKind, image);\n" +
-                "   *\n" +
+        String text = "Returns a new Token object, by default." + EOL +
+                "   * However, if you want, you can create and return subclass objects based on the value of ofKind." + EOL +
+                "   *" + EOL +
+                "   *    case MyParserConstants.ID : return new IDToken(ofKind, image);" + EOL +
+                "   *" + EOL +
                 "   * to the following switch statement. Then you can cast matchedToken";
-        assertEquals(new Javadoc(JavadocDescription.parseText("Returns a new Token object, by default.\n" +
-                        "However, if you want, you can create and return subclass objects based on the value of ofKind.\n" +
-                        "\n" +
-                        "   case MyParserConstants.ID : return new IDToken(ofKind, image);\n" +
-                        "\n" +
+        assertEquals(new Javadoc(JavadocDescription.parseText("Returns a new Token object, by default." + EOL +
+                        "However, if you want, you can create and return subclass objects based on the value of ofKind." + EOL +
+                        EOL +
+                        "   case MyParserConstants.ID : return new IDToken(ofKind, image);" + EOL +
+                        EOL +
                         "to the following switch statement. Then you can cast matchedToken")),
                 JavadocParser.parse(text));
     }
 
     @Test
     public void parseBlockTagsAndEmptyDescription() {
-        String text = "\n" +
-                "   * @deprecated\n" +
-                "   * @see #getEndColumn\n" +
+        String text = EOL +
+                "   * @deprecated" + EOL +
+                "   * @see #getEndColumn" + EOL +
                 "   ";
         assertEquals(new Javadoc(JavadocDescription.parseText(""))
                 .addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.DEPRECATED, ""))
@@ -94,8 +95,8 @@ public class JavadocParserTest {
 
     @Test
     public void parseBlockTagsAndProvideTagName() {
-        String expectedText = "\n" +
-                "   * @unofficial\n " +
+        String expectedText = EOL +
+                "   * @unofficial" + EOL + " " +
                 "   ";
 
         Javadoc underTest = new Javadoc(JavadocDescription.parseText(""))
@@ -108,13 +109,13 @@ public class JavadocParserTest {
 
     @Test
     public void parseParamBlockTags() {
-        String text = "\n" +
-                "     * Add a field to this and automatically add the import of the type if needed\n" +
-                "     *\n" +
-                "     * @param typeClass the type of the field\n" +
-                "     * @param name the name of the field\n" +
-                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}\n" +
-                "     * @return the {@link FieldDeclaration} created\n" +
+        String text = EOL +
+                "     * Add a field to this and automatically add the import of the type if needed" + EOL +
+                "     *" + EOL +
+                "     * @param typeClass the type of the field" + EOL +
+                "     * @param name the name of the field" + EOL +
+                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}" + EOL +
+                "     * @return the {@link FieldDeclaration} created" + EOL +
                 "     ";
         Javadoc res = JavadocParser.parse(text);
         assertEquals(new Javadoc(JavadocDescription.parseText("Add a field to this and automatically add the import of the type if needed"))
@@ -126,18 +127,18 @@ public class JavadocParserTest {
 
     @Test
     public void parseMultilineParamBlockTags() {
-        String text = "\n" +
-                "     * Add a field to this and automatically add the import of the type if needed\n" +
-                "     *\n" +
-                "     * @param typeClass the type of the field\n" +
-                "     *     continued in a second line\n" +
-                "     * @param name the name of the field\n" +
-                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}\n" +
-                "     * @return the {@link FieldDeclaration} created\n" +
+        String text = EOL +
+                "     * Add a field to this and automatically add the import of the type if needed" + EOL +
+                "     *" + EOL +
+                "     * @param typeClass the type of the field" + EOL +
+                "     *     continued in a second line" + EOL +
+                "     * @param name the name of the field" + EOL +
+                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}" + EOL +
+                "     * @return the {@link FieldDeclaration} created" + EOL +
                 "     ";
         Javadoc res = JavadocParser.parse(text);
         assertEquals(new Javadoc(JavadocDescription.parseText("Add a field to this and automatically add the import of the type if needed"))
-                .addBlockTag(JavadocBlockTag.createParamBlockTag("typeClass", "the type of the field\n    continued in a second line"))
+                .addBlockTag(JavadocBlockTag.createParamBlockTag("typeClass", "the type of the field" + EOL + "    continued in a second line"))
                 .addBlockTag(JavadocBlockTag.createParamBlockTag("name", "the name of the field"))
                 .addBlockTag(JavadocBlockTag.createParamBlockTag("modifiers", "the modifiers like {@link Modifier#PUBLIC}"))
                 .addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.RETURN, "the {@link FieldDeclaration} created")), res);

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
@@ -130,19 +130,18 @@ public class JavadocParserTest {
                 "     * Add a field to this and automatically add the import of the type if needed\n" +
                 "     *\n" +
                 "     * @param typeClass the type of the field\n" +
-                "     * continued in a second line\n" +
+                "     *     continued in a second line\n" +
                 "     * @param name the name of the field\n" +
                 "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}\n" +
                 "     * @return the {@link FieldDeclaration} created\n" +
                 "     ";
         Javadoc res = JavadocParser.parse(text);
         assertEquals(new Javadoc(JavadocDescription.parseText("Add a field to this and automatically add the import of the type if needed"))
-                             .addBlockTag(JavadocBlockTag.createParamBlockTag("typeClass", "the type of the field continued in a second line"))
-                             .addBlockTag(JavadocBlockTag.createParamBlockTag("name", "the name of the field"))
-                             .addBlockTag(JavadocBlockTag.createParamBlockTag("modifiers", "the modifiers like {@link Modifier#PUBLIC}"))
-                             .addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.RETURN, "the {@link FieldDeclaration} created")), res);
+                .addBlockTag(JavadocBlockTag.createParamBlockTag("typeClass", "the type of the field\n    continued in a second line"))
+                .addBlockTag(JavadocBlockTag.createParamBlockTag("name", "the name of the field"))
+                .addBlockTag(JavadocBlockTag.createParamBlockTag("modifiers", "the modifiers like {@link Modifier#PUBLIC}"))
+                .addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.RETURN, "the {@link FieldDeclaration} created")), res);
     }
-
 
     @Test
     public void startsWithAsteriskEmpty() {

--- a/javaparser-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
@@ -26,82 +26,80 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import org.junit.Test;
 
-import java.io.FileNotFoundException;
-
+import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class JavadocTest {
 
     @Test
-    public void toTextForEmptyJavadoc() throws FileNotFoundException {
+    public void toTextForEmptyJavadoc() {
         Javadoc javadoc = new Javadoc(new JavadocDescription());
         assertEquals("", javadoc.toText());
     }
 
     @Test
-    public void toTextForJavadocWithTwoLinesOfJustDescription() throws FileNotFoundException {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line\nsecond line"));
-        assertEquals("first line\nsecond line\n", javadoc.toText());
+    public void toTextForJavadocWithTwoLinesOfJustDescription() {
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + EOL + "second line"));
+        assertEquals("first line" + EOL + "second line" + EOL, javadoc.toText());
     }
 
     @Test
-    public void toTextForJavadocWithTwoLinesOfJustDescriptionAndOneBlockTag() throws FileNotFoundException {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line\nsecond line"));
+    public void toTextForJavadocWithTwoLinesOfJustDescriptionAndOneBlockTag() {
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + EOL + "second line"));
         javadoc.addBlockTag("foo", "something useful");
-        assertEquals("first line\nsecond line\n\n@foo something useful\n", javadoc.toText());
+        assertEquals("first line" + EOL + "second line" + EOL + EOL + "@foo something useful" + EOL, javadoc.toText());
     }
 
     @Test
-    public void toCommentForEmptyJavadoc() throws FileNotFoundException {
+    public void toCommentForEmptyJavadoc() {
         Javadoc javadoc = new Javadoc(new JavadocDescription());
-        assertEquals(new JavadocComment("\n\t\t "), javadoc.toComment("\t\t"));
+        assertEquals(new JavadocComment("" + EOL + "\t\t "), javadoc.toComment("\t\t"));
     }
 
     @Test
-    public void toCommentorJavadocWithTwoLinesOfJustDescription() throws FileNotFoundException {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line\nsecond line"));
-        assertEquals(new JavadocComment("\n\t\t * first line\n\t\t * second line\n\t\t "), javadoc.toComment("\t\t"));
+    public void toCommentorJavadocWithTwoLinesOfJustDescription() {
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + EOL + "second line"));
+        assertEquals(new JavadocComment("" + EOL + "\t\t * first line" + EOL + "\t\t * second line" + EOL + "\t\t "), javadoc.toComment("\t\t"));
     }
 
     @Test
-    public void toCommentForJavadocWithTwoLinesOfJustDescriptionAndOneBlockTag() throws FileNotFoundException {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line\nsecond line"));
+    public void toCommentForJavadocWithTwoLinesOfJustDescriptionAndOneBlockTag() {
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + EOL + "second line"));
         javadoc.addBlockTag("foo", "something useful");
-        assertEquals(new JavadocComment("\n\t\t * first line\n\t\t * second line\n\t\t * \n\t\t * @foo something useful\n\t\t "), javadoc.toComment("\t\t"));
+        assertEquals(new JavadocComment("" + EOL + "\t\t * first line" + EOL + "\t\t * second line" + EOL + "\t\t * " + EOL + "\t\t * @foo something useful" + EOL + "\t\t "), javadoc.toComment("\t\t"));
     }
 
     @Test
     public void descriptionAndBlockTagsAreRetrievable() {
-        Javadoc javadoc = JavaParser.parseJavadoc("first line\nsecond line\n\n@param node a node\n@return result the result");
-        assertEquals(javadoc.getDescription().toText(), "first line\nsecond line");
-        assertEquals(javadoc.getBlockTags().size(), 2);
+        Javadoc javadoc = JavaParser.parseJavadoc("first line" + EOL + "second line" + EOL + EOL + "@param node a node" + EOL + "@return result the result");
+        assertEquals("first line" + EOL + "second line", javadoc.getDescription().toText());
+        assertEquals(2, javadoc.getBlockTags().size());
     }
 
     @Test
     public void inlineTagsAreParsable() {
         String docText =
-                "Returns the {@link TOFilename}s of all files that existed during the requested\n" +
-                        "{@link TOVersion}.\n" +
-                        "\n" +
-                        "@param versionID the id of the {@link TOVersion}.\n" +
-                        "@return the filenames\n" +
-                        "@throws InvalidIDException if the {@link IPersistence} doesn't recognize the given versionID.\n";
+                "Returns the {@link TOFilename}s of all files that existed during the requested" + EOL +
+                        "{@link TOVersion}." + EOL +
+                        "" + EOL +
+                        "@param versionID the id of the {@link TOVersion}." + EOL +
+                        "@return the filenames" + EOL +
+                        "@throws InvalidIDException if the {@link IPersistence} doesn't recognize the given versionID." + EOL;
         String javadoc = JavaParser.parseJavadoc(docText).toText();
         assertTrue(javadoc.contains("{@link TOVersion}"));
     }
 
     @Test
     public void emptyLinesBetweenBlockTagsGetsFiltered() {
-        String comment = " * The type of the Object to be mapped.\n" +
-                " * This interface maps the given Objects to existing ones in the database and\n" +
-                " * saves them.\n" +
-                " * \n" +
-                " * @author censored\n" +
-                " * \n" +
-                " * @param <T>\n";
+        String comment = " * The type of the Object to be mapped." + EOL +
+                " * This interface maps the given Objects to existing ones in the database and" + EOL +
+                " * saves them." + EOL +
+                " * " + EOL +
+                " * @author censored" + EOL +
+                " * " + EOL +
+                " * @param <T>" + EOL;
         Javadoc javadoc = JavaParser.parseJavadoc(comment);
-        assertEquals(javadoc.getBlockTags().size(), 2);
+        assertEquals(2, javadoc.getBlockTags().size());
     }
-
 }

--- a/javaparser-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -178,13 +178,13 @@ public class PrettyPrintVisitorTest {
     @Test
     public void multilineJavadocGetsFormatted() {
         CompilationUnit cu = new CompilationUnit();
-        cu.addClass("X").addMethod("abc").setJavadocComment("line1\n   line2 *\n * line3");
+        cu.addClass("X").addMethod("abc").setJavadocComment(" line1\n   line2 *\n * line3");
 
         assertEqualsNoEol("public class X {\n" +
                 "\n" +
                 "    /**\n" +
                 "     * line1\n" +
-                "     * line2 *\n" +
+                "     *   line2 *\n" +
                 "     * line3\n" +
                 "     */\n" +
                 "    void abc() {\n" +
@@ -209,7 +209,7 @@ public class PrettyPrintVisitorTest {
     @Test
     public void multilineJavadocWithLotsOfEmptyLinesGetsFormattedNeatly() {
         CompilationUnit cu = new CompilationUnit();
-        cu.addClass("X").addMethod("abc").setJavadocComment("\n\n\nab\n\n\ncd\n\n\n");
+        cu.addClass("X").addMethod("abc").setJavadocComment("\n\n\n ab\n\n\n cd\n\n\n");
 
         assertEqualsNoEol("public class X {\n" +
                 "\n" +
@@ -226,7 +226,7 @@ public class PrettyPrintVisitorTest {
     @Test
     public void singlelineJavadocGetsFormatted() {
         CompilationUnit cu = new CompilationUnit();
-        cu.addClass("X").addMethod("abc").setJavadocComment("line1");
+        cu.addClass("X").addMethod("abc").setJavadocComment(" line1");
 
         assertEqualsNoEol("public class X {\n" +
                 "\n" +

--- a/javaparser-testing/src/test/java/com/github/javaparser/utils/UtilsTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/utils/UtilsTest.java
@@ -78,4 +78,15 @@ public class UtilsTest {
         String result = Utils.normalizeEolInTextBlock("\r\n \r \n", "Q");
         assertEquals("Q Q Q", result);
     }
+
+    @Test
+    public void testTrimTrailingSpaces() {
+        assertEquals("abc", trimTrailingSpaces("abc"));
+        assertEquals("  abc", trimTrailingSpaces("  abc"));
+        assertEquals("abc", trimTrailingSpaces("abc  "));
+        assertEquals("  abc", trimTrailingSpaces("  abc  "));
+        assertEquals("abc", trimTrailingSpaces("abc\t\0"));
+        assertEquals("", trimTrailingSpaces("    "));
+        assertEquals("", trimTrailingSpaces(""));
+    }
 }


### PR DESCRIPTION
Fixes #1371 

End of lines and indentation are now left alone. This changes current behaviour a bit, but seeing how little reports we get on this I guess it's not a big issue :-)

Anyway, it's a combination of the Javadoc parser and the pretty printer, they were both doing their best to mess up any formatting.