### PR TITLE
Fix infinite recursion when solving java.lang.Object

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -290,16 +290,21 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
     @Override
     public List<ResolvedReferenceType> getAncestors() {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
-        ResolvedReferenceType superclass = getSuperClass();
-        if (superclass != null) {
-            ancestors.add(superclass);
-        }
-        if (wrappedNode.getImplementedTypes() != null) {
-            for (ClassOrInterfaceType implemented : wrappedNode.getImplementedTypes()) {
-                ResolvedReferenceType ancestor = toReferenceType(implemented);
-                ancestors.add(ancestor);
+
+        // We want to avoid infinite recursion in case of Object having Object as ancestor
+        if (!(Object.class.getCanonicalName().equals(getQualifiedName()))) {
+            ResolvedReferenceType superclass = getSuperClass();
+            if (superclass != null) {
+                ancestors.add(superclass);
+            }
+            if (wrappedNode.getImplementedTypes() != null) {
+                for (ClassOrInterfaceType implemented : wrappedNode.getImplementedTypes()) {
+                    ResolvedReferenceType ancestor = toReferenceType(implemented);
+                    ancestors.add(ancestor);
+                }
             }
         }
+
         return ancestors;
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1364.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1364.java
@@ -1,0 +1,91 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParseStart;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.Providers;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.UnsolvedSymbolException;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Dominik Hardtke
+ * @since 02.02.2018
+ */
+public class Issue1364 extends AbstractResolutionTest {
+    private JavaParser javaParser;
+
+    @Before
+    public void setup() {
+        ClassOrInterfaceDeclaration fakeObject = new ClassOrInterfaceDeclaration();
+        fakeObject.setName(new SimpleName("java.lang.Object"));
+
+        TypeSolver typeSolver = new TypeSolver() {
+            @Override
+            public TypeSolver getParent() {
+                return null;
+            }
+
+            @Override
+            public void setParent(TypeSolver parent) {
+            }
+
+            @Override
+            public SymbolReference<ResolvedReferenceTypeDeclaration> tryToSolveType(String name) {
+                if ("java.lang.Object".equals(name)) {
+                    // custom handling
+                    return SymbolReference.solved(new JavaParserClassDeclaration(fakeObject, this));
+                }
+
+                return SymbolReference.unsolved(ResolvedReferenceTypeDeclaration.class);
+            }
+        };
+
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        javaParser = new JavaParser(config);
+    }
+
+    @Test(timeout = 1000)
+    public void resolveSubClassOfObject() {
+        String code = String.join(System.lineSeparator(),
+                "package graph;",
+                "public class Vertex {",
+                "    public static void main(String[] args) {",
+                "        System.out.println();",
+                "    }",
+                "}"
+        );
+
+        ParseResult<CompilationUnit> parseResult = javaParser.parse(ParseStart.COMPILATION_UNIT, Providers.provider(code));
+        assertTrue(parseResult.isSuccessful());
+        assertTrue(parseResult.getResult().isPresent());
+
+        List<MethodCallExpr> methodCallExprs = parseResult.getResult().get().findAll(MethodCallExpr.class);
+        assertEquals(1, methodCallExprs.size());
+
+        try {
+            methodCallExprs.get(0).calculateResolvedType();
+            fail("An UnsolvedSymbolException should be thrown");
+        } catch (UnsolvedSymbolException ignored) {
+            // all is fine if an UnsolvedSymbolException is thrown
+        }
+    }
+}
+


### PR DESCRIPTION
This fixes #1364 by not recursing in the `getAllAncestors()` method when being the `java.lang.Object` class already.