### PR TITLE
Force vertical alignment when enum constants have comments.

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -484,7 +484,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         if (!n.getVariables().isEmpty()) {
             Optional<Type> maximumCommonType = n.getMaximumCommonType();
             maximumCommonType.ifPresent(t -> t.accept(this, arg));
-            if(!maximumCommonType.isPresent()){
+            if (!maximumCommonType.isPresent()) {
                 printer.print("???");
             }
         }
@@ -1066,7 +1066,11 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         printer.println(" {");
         printer.indent();
         if (n.getEntries().isNonEmpty()) {
-            boolean alignVertically = n.getEntries().size() > configuration.getMaxEnumConstantsToAlignHorizontally();
+            final boolean alignVertically =
+                    // Either we hit the constant amount limit in the configurations, or...
+                    n.getEntries().size() > configuration.getMaxEnumConstantsToAlignHorizontally() ||
+                            // any of the constants has a comment.
+                            n.getEntries().stream().anyMatch(e -> e.getComment().isPresent());
             printer.println();
             for (final Iterator<EnumConstantDeclaration> i = n.getEntries().iterator(); i.hasNext(); ) {
                 final EnumConstantDeclaration e = i.next();

--- a/javaparser-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
@@ -27,6 +27,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static com.github.javaparser.JavaParser.*;
+import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
+import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.Assert.assertEquals;
 
 public class CommentsInserterTest {
@@ -53,8 +56,29 @@ public class CommentsInserterTest {
 
     @Test
     public void issue624() throws IOException {
-        JavaParser.parseResource(makeFilename("Issue624"));
+        parseResource(makeFilename("Issue624"));
         // Should not fail
+    }
+
+    @Test
+    public void issue200EnumConstantsWithCommentsForceVerticalAlignment() {
+        CompilationUnit cu = parse("public enum X {" + EOL +
+                "    /** const1 javadoc */" + EOL +
+                "    BORDER_CONSTANT," + EOL +
+                "    /** const2 javadoc */" + EOL +
+                "    ANOTHER_CONSTANT" + EOL +
+                "}");
+        assertEqualsNoEol("public enum X {\n" +
+                "\n" +
+                "    /**\n" +
+                "     * const1 javadoc\n" +
+                "     */\n" +
+                "    BORDER_CONSTANT,\n" +
+                "    /**\n" +
+                "     * const2 javadoc\n" +
+                "     */\n" +
+                "    ANOTHER_CONSTANT\n" +
+                "}\n", cu.toString());
     }
 
 }


### PR DESCRIPTION
Fixes #200 

Sorry for the delay! Are you still around, @JLLeitschuh ?