### PR TITLE
Create functional language levels. Fix a random superfluous interface.

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -44,10 +44,12 @@ public class ParserConfiguration {
     public enum LanguageLevel {
         /** Does no post processing or validation. Only for people wanting the fastest parsing. */
         RAW(null, null),
-        /** Always points to the most popular Java version. */
+        /** The most used Java version. */
         POPULAR(new Java8Validator(), null),
-        /** Always points to the newest Java version supported. */
-        LATEST(new Java11Validator(), new Java11PostProcessor()),
+        /** The latest Java version that is available. */
+        CURRENT(new Java8Validator(), null),
+        /** The newest Java features supported. */
+        BLEEDING_EDGE(new Java11Validator(), new Java11PostProcessor()),
         /** Java 1.0 */
         JAVA_1_0(new Java1_0Validator(), null),
         /** Java 1.1 */

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -42,19 +42,36 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  */
 public class ParserConfiguration {
     public enum LanguageLevel {
+        /** Does no post processing or validation. Only for people wanting the fastest parsing. */
         RAW(null, null),
+        /** Always points to the most popular Java version. */
+        POPULAR(new Java8Validator(), null),
+        /** Always points to the newest Java version supported. */
+        LATEST(new Java11Validator(), new Java11PostProcessor()),
+        /** Java 1.0 */
         JAVA_1_0(new Java1_0Validator(), null),
+        /** Java 1.1 */
         JAVA_1_1(new Java1_1Validator(), null),
+        /** Java 1.2 */
         JAVA_1_2(new Java1_2Validator(), null),
+        /** Java 1.3 */
         JAVA_1_3(new Java1_3Validator(), null),
+        /** Java 1.4 */
         JAVA_1_4(new Java1_4Validator(), null),
+        /** Java 5 */
         JAVA_5(new Java5Validator(), null),
+        /** Java 6 */
         JAVA_6(new Java6Validator(), null),
+        /** Java 7 */
         JAVA_7(new Java7Validator(), null),
+        /** Java 8 */
         JAVA_8(new Java8Validator(), null),
+        /** Java 9 */
         JAVA_9(new Java9Validator(), null),
-        JAVA_10_PREVIEW(null, new Java10PostProcessor()),
-        JAVA_11_PREVIEW(null, new Java11PostProcessor());
+        /** Java 10 (work in progress) */
+        JAVA_10_PREVIEW(new Java10Validator(), new Java10PostProcessor()),
+        /** Java 11 (work in progress) */
+        JAVA_11_PREVIEW(new Java11Validator(), new Java11PostProcessor());
 
         final Validator validator;
         final ParseResult.PostProcessor postProcessor;

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.github.javaparser.ParserConfiguration.LanguageLevel.*;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -91,7 +92,7 @@ public class ParserConfiguration {
     private boolean lexicalPreservationEnabled = false;
     private SymbolResolver symbolResolver = null;
     private int tabSize = 1;
-    private LanguageLevel languageLevel;
+    private LanguageLevel languageLevel = CURRENT;
 
     private final List<ParseResult.PostProcessor> postProcessors = new ArrayList<>();
 
@@ -126,7 +127,6 @@ public class ParserConfiguration {
                     }
                 })
         ));
-        setLanguageLevel(LanguageLevel.JAVA_8);
     }
 
     public boolean isAttributeComments() {
@@ -200,29 +200,29 @@ public class ParserConfiguration {
     public ParserConfiguration setValidator(Validator validator) {
         // This whole method is a backwards compatability hack.
         if (validator instanceof Java10Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_10_PREVIEW);
+            setLanguageLevel(JAVA_10_PREVIEW);
         } else if (validator instanceof Java9Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_9);
+            setLanguageLevel(JAVA_9);
         } else if (validator instanceof Java8Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_8);
+            setLanguageLevel(JAVA_8);
         } else if (validator instanceof Java7Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_7);
+            setLanguageLevel(JAVA_7);
         } else if (validator instanceof Java6Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_6);
+            setLanguageLevel(JAVA_6);
         } else if (validator instanceof Java5Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_5);
+            setLanguageLevel(JAVA_5);
         } else if (validator instanceof Java1_4Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_1_4);
+            setLanguageLevel(JAVA_1_4);
         } else if (validator instanceof Java1_3Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_1_3);
+            setLanguageLevel(JAVA_1_3);
         } else if (validator instanceof Java1_2Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_1_2);
+            setLanguageLevel(JAVA_1_2);
         } else if (validator instanceof Java1_1Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_1_1);
+            setLanguageLevel(JAVA_1_1);
         } else if (validator instanceof Java1_0Validator) {
-            setLanguageLevel(LanguageLevel.JAVA_1_0);
+            setLanguageLevel(JAVA_1_0);
         } else if (validator instanceof NoProblemsValidator) {
-            setLanguageLevel(LanguageLevel.RAW);
+            setLanguageLevel(RAW);
         }
         return this;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -55,7 +55,7 @@ import java.util.Optional;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ConstructorDeclaration extends CallableDeclaration<ConstructorDeclaration> implements NodeWithBlockStmt<ConstructorDeclaration>, NodeWithAccessModifiers<ConstructorDeclaration>, NodeWithJavadoc<ConstructorDeclaration>, NodeWithDeclaration, NodeWithSimpleName<ConstructorDeclaration>, NodeWithParameters<ConstructorDeclaration>, NodeWithThrownExceptions<ConstructorDeclaration>, NodeWithTypeParameters<ConstructorDeclaration>, Resolvable<ResolvedConstructorDeclaration> {
+public final class ConstructorDeclaration extends CallableDeclaration<ConstructorDeclaration> implements NodeWithBlockStmt<ConstructorDeclaration>, NodeWithAccessModifiers<ConstructorDeclaration>, NodeWithJavadoc<ConstructorDeclaration>, NodeWithSimpleName<ConstructorDeclaration>, NodeWithParameters<ConstructorDeclaration>, NodeWithThrownExceptions<ConstructorDeclaration>, NodeWithTypeParameters<ConstructorDeclaration>, Resolvable<ResolvedConstructorDeclaration> {
 
     private BlockStmt body;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/version/Java10PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/version/Java10PostProcessor.java
@@ -1,23 +1,15 @@
 package com.github.javaparser.version;
 
-import com.github.javaparser.ParseResult;
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.VarType;
-import com.github.javaparser.ast.validator.Java10Validator;
-import com.github.javaparser.ast.validator.ProblemReporter;
 
-import static com.github.javaparser.ParseResult.*;
+import static com.github.javaparser.ParseResult.PostProcessor;
 
 /**
  * Processes the generic AST into a Java 10 AST and validates it.
  */
 public class Java10PostProcessor extends PostProcessors {
-    protected final PostProcessor java10Validator = new Java10Validator().postProcessor();
-    protected final PostProcessor varNodeCreator = new PostProcessor() {
-        @Override
-        public void process(ParseResult<? extends Node> result, ParserConfiguration configuration) {
+    protected final PostProcessor varNodeCreator = (result, configuration) ->
             result.getResult().ifPresent(node -> {
                 node.findAll(ClassOrInterfaceType.class).forEach(n -> {
                     if (n.getNameAsString().equals("var")) {
@@ -25,11 +17,8 @@ public class Java10PostProcessor extends PostProcessors {
                     }
                 });
             });
-        }
-    };
 
     public Java10PostProcessor() {
         add(varNodeCreator);
-        add(java10Validator);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/version/Java11PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/version/Java11PostProcessor.java
@@ -1,18 +1,7 @@
 package com.github.javaparser.version;
 
-import com.github.javaparser.ParseResult;
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.validator.Java11Validator;
-import com.github.javaparser.ast.validator.ProblemReporter;
-
 /**
  * Processes the generic AST into a Java 10 AST and validates it.
  */
 public class Java11PostProcessor extends Java10PostProcessor {
-    protected final ParseResult.PostProcessor java11Validator = new Java11Validator().postProcessor();
-
-    public Java11PostProcessor() {
-        replace(java10Validator, java11Validator);
-    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -330,7 +330,7 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
         assertEquals(true, constructorDeclaration.getAllSuperClasses().stream().anyMatch(s -> s.getQualifiedName().equals("com.github.javaparser.ast.Node")));
         assertEquals(true, constructorDeclaration.getAllSuperClasses().stream().anyMatch(s -> s.getQualifiedName().equals("java.lang.Object")));
 
-        ResolvedReferenceType ancestor = null;
+        ResolvedReferenceType ancestor;
 
         ancestor = constructorDeclaration.getAllSuperClasses().get(0);
         assertEquals("com.github.javaparser.ast.body.CallableDeclaration", ancestor.getQualifiedName());
@@ -368,9 +368,9 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
     public void testGetInterfacesWithParameters() {
         ReflectionClassDeclaration constructorDeclaration = (ReflectionClassDeclaration) typeResolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
         System.out.println(constructorDeclaration.getInterfaces().stream().map(t -> t.getQualifiedName()).collect(Collectors.toList()));
-        assertEquals(9, constructorDeclaration.getInterfaces().size());
+        assertEquals(8, constructorDeclaration.getInterfaces().size());
 
-        ResolvedReferenceType interfaze = null;
+        ResolvedReferenceType interfaze;
 
         interfaze = constructorDeclaration.getInterfaces().get(0);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt", interfaze.getQualifiedName());
@@ -385,25 +385,22 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc.N").get().asReferenceType().getQualifiedName());
 
         interfaze = constructorDeclaration.getInterfaces().get(3);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", interfaze.getQualifiedName());
-
-        interfaze = constructorDeclaration.getInterfaces().get(4);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithSimpleName", interfaze.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithSimpleName.N").get().asReferenceType().getQualifiedName());
 
-        interfaze = constructorDeclaration.getInterfaces().get(5);
+        interfaze = constructorDeclaration.getInterfaces().get(4);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithParameters", interfaze.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithParameters.N").get().asReferenceType().getQualifiedName());
 
-        interfaze = constructorDeclaration.getInterfaces().get(6);
+        interfaze = constructorDeclaration.getInterfaces().get(5);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithThrownExceptions", interfaze.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithThrownExceptions.N").get().asReferenceType().getQualifiedName());
 
-        interfaze = constructorDeclaration.getInterfaces().get(7);
+        interfaze = constructorDeclaration.getInterfaces().get(6);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters", interfaze.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters.N").get().asReferenceType().getQualifiedName());
 
-        interfaze = constructorDeclaration.getInterfaces().get(8);
+        interfaze = constructorDeclaration.getInterfaces().get(7);
         assertEquals("com.github.javaparser.resolution.Resolvable", interfaze.getQualifiedName());
     }
 
@@ -446,9 +443,9 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
     public void testGetAllInterfacesWithParameters() {
         ReflectionClassDeclaration constructorDeclaration = (ReflectionClassDeclaration) typeResolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
         List<ResolvedReferenceType> interfaces = constructorDeclaration.getAllInterfaces();
-        assertEquals(35, interfaces.size());
+        assertEquals(34, interfaces.size());
 
-        ResolvedReferenceType interfaze = null;
+        ResolvedReferenceType interfaze;
         int i = 0;
 
         interfaze = constructorDeclaration.getAllInterfaces().get(i++);
@@ -478,9 +475,6 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
         interfaze = constructorDeclaration.getAllInterfaces().get(i++);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc", interfaze.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc.N").get().asReferenceType().getQualifiedName());
-
-        interfaze = constructorDeclaration.getAllInterfaces().get(i++);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", interfaze.getQualifiedName());
 
         interfaze = constructorDeclaration.getAllInterfaces().get(i++);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithSimpleName", interfaze.getQualifiedName());
@@ -589,9 +583,9 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
     @Test
     public void testGetAncestorsWithTypeParameters() {
         ReflectionClassDeclaration constructorDeclaration = (ReflectionClassDeclaration) typeResolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
-        assertEquals(10, constructorDeclaration.getAncestors().size());
+        assertEquals(9, constructorDeclaration.getAncestors().size());
 
-        ResolvedReferenceType ancestor = null;
+        ResolvedReferenceType ancestor;
         List<ResolvedReferenceType> ancestors = constructorDeclaration.getAncestors();
         ancestors.sort(Comparator.comparing(ResolvedReferenceType::getQualifiedName));
 
@@ -604,33 +598,30 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.N").get().asReferenceType().getQualifiedName());
 
         ancestor = ancestors.get(2);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", ancestor.getQualifiedName());
-
-        ancestor = ancestors.get(3);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithJavadoc.N").get().asReferenceType().getQualifiedName());
 
-        ancestor = ancestors.get(4);
+        ancestor = ancestors.get(3);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithParameters", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithParameters.N").get().asReferenceType().getQualifiedName());
 
-        ancestor = ancestors.get(5);
+        ancestor = ancestors.get(4);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithSimpleName", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithSimpleName.N").get().asReferenceType().getQualifiedName());
 
-        ancestor = ancestors.get(6);
+        ancestor = ancestors.get(5);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithThrownExceptions", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithThrownExceptions.N").get().asReferenceType().getQualifiedName());
 
-        ancestor = ancestors.get(7);
+        ancestor = ancestors.get(6);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters.N").get().asReferenceType().getQualifiedName());
 
-        ancestor = ancestors.get(8);
+        ancestor = ancestors.get(7);
         assertEquals("com.github.javaparser.ast.nodeTypes.modifiers.NodeWithAccessModifiers", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.modifiers.NodeWithAccessModifiers.N").get().asReferenceType().getQualifiedName());
 
-        ancestor = ancestors.get(9);
+        ancestor = ancestors.get(8);
         assertEquals("com.github.javaparser.resolution.Resolvable", ancestor.getQualifiedName());
     }
 
@@ -647,7 +638,7 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
     public void testGetAllAncestorsWithTypeParameters() {
         ReflectionClassDeclaration constructorDeclaration = (ReflectionClassDeclaration) typeResolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
 
-        ResolvedReferenceType ancestor = null;
+        ResolvedReferenceType ancestor;
         List<ResolvedReferenceType> ancestors = constructorDeclaration.getAllAncestors();
         ancestors.sort(Comparator.comparing(ResolvedReferenceType::getQualifiedName));
 
@@ -673,9 +664,6 @@ public class ReflectionClassDeclarationTest extends AbstractTest {
         ancestor = ancestors.remove(0);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.N").get().asReferenceType().getQualifiedName());
-
-        ancestor = ancestors.remove(0);
-        assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", ancestor.getQualifiedName());
 
         ancestor = ancestors.remove(0);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithDeclaration", ancestor.getQualifiedName());


### PR DESCRIPTION
Tears postprocessors and validators for language levels apart so advanced users can use them separately.

Creates new language levels for "the very latest features" and "the most common Java version."

@ftomassetti removes an "implements NodeWithDeclaration" that was already done in the parent class. It seems that the "getAllInterfaces" call now reports one less implemented interface. Is that correct? It implements the same interface twice, should it be reported twice?