### PR TITLE
Solve method usage when type is instance of ResolvedUnionType

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedUnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedUnionType.java
@@ -21,10 +21,7 @@
 
 package com.github.javaparser.resolution.types;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -40,6 +37,18 @@ public class ResolvedUnionType implements ResolvedType {
             throw new IllegalArgumentException("An union type should have at least two elements. This has " + elements.size());
         }
         this.elements = new LinkedList<>(elements);
+    }
+
+    public Optional<ResolvedReferenceType> getCommonAncestor() {
+        Optional<List<ResolvedReferenceType>> reduce = elements.stream()
+                .map(ResolvedType::asReferenceType)
+                .map(ResolvedReferenceType::getAllAncestors)
+                .reduce((a, b) -> {
+                    ArrayList<ResolvedReferenceType> common = new ArrayList<>(a);
+                    common.retainAll(b);
+                    return common;
+                });
+        return reduce.orElse(new ArrayList<>()).stream().findFirst();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -24,6 +24,7 @@ import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.*;
 import com.github.javaparser.symbolsolver.core.resolution.Context;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
@@ -406,6 +407,13 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
         } else if (type instanceof ResolvedArrayType) {
             // An array inherits methods from Object not from it's component type
             return solveMethodAsUsage(new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver), name, argumentsTypes, typeSolver, invokationContext);
+        } else if (type instanceof ResolvedUnionType) {
+            Optional<ResolvedReferenceType> commonAncestor = type.asUnionType().getCommonAncestor();
+            if (commonAncestor.isPresent()) {
+                return solveMethodAsUsage(commonAncestor.get(), name, argumentsTypes, typeSolver, invokationContext);
+            } else {
+                throw new UnsupportedOperationException("no common ancestor available for " + type.describe());
+            }
         } else {
             throw new UnsupportedOperationException("type usage: " + type.getClass().getCanonicalName());
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MultiCatchMethodCallExprTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MultiCatchMethodCallExprTest.java
@@ -1,0 +1,31 @@
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+/**
+ * Test for issue 1482: https://github.com/javaparser/javaparser/issues/1482
+ * When trying to resolve a MethodCallExpr within a multi catch, an UnsupportedOperationException is thrown.
+ */
+public class MultiCatchMethodCallExprTest extends AbstractResolutionTest {
+
+    @Test
+    public void issue1482() {
+        CompilationUnit cu = parseSample("Issue1482");
+        cu.accept(new Visitor(), null);
+    }
+
+    private static class Visitor extends VoidVisitorAdapter<Void> {
+        @Override
+        public void visit(MethodCallExpr n, Void arg) {
+            if (n.getArguments().size() != 0) {
+                JavaParserFacade.get(new ReflectionTypeSolver(true)).getType(n.getArgument(0));
+            }
+        }
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/Issue1482.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Issue1482.java.txt
@@ -1,0 +1,13 @@
+public class MultiCatchMethodCallExpr {
+	public void test() {
+		try {
+			methodWithExceptions();
+		} catch (ArrayIndexOutOfBoundsException | ClassCastException e) {
+			System.out.println(e.getMessage());
+		}
+	}
+	
+	private void methodWithExceptions() throws ArrayIndexOutOfBoundsException, ClassCastException {
+		// do something
+	}
+}


### PR DESCRIPTION
The first common ancestor of all types in the union type is looked up, and that type is used to resolve the type of the MethodCallExpr. 

Fixes #1482 