### PR TITLE
Added .iml file for javaparser-symbol-solver-model

### DIFF
--- a/javaparser-symbol-solver-model/.gitignore
+++ b/javaparser-symbol-solver-model/.gitignore
@@ -11,7 +11,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 .idea
-*.iml
 target
 build
 /.classpath

--- a/javaparser-symbol-solver-model/javaparser-symbol-solver-model.iml
+++ b/javaparser-symbol-solver-model/javaparser-symbol-solver-model.iml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="javaparser-core" />
+    <orderEntry type="library" name="Maven: org.javassist:javassist:3.22.0-GA" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:23.4-jre" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
+    <orderEntry type="library" name="Maven: com.google.errorprone:error_prone_annotations:2.0.18" level="project" />
+    <orderEntry type="library" name="Maven: com.google.j2objc:j2objc-annotations:1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
I cloned the repository since I intend to write a few PRs in the future. The command `mvn clean install` worked fine.

However, when I then imported the project into IntelliJ IDEA, the IDE complained because it refused to see the module `javaparser-symbol-solver-model`. Thus, any file throughout the project that depended on some class in the module `javaparser-symbol-solver-model` was marked as erroneous because the IDE could not find that dependency (even though it was there and I could see its files in the project window). Therefore, I could not sensibly work on the source code or run tests.

It turned out that the problem was that the module `javaparser-symbol-solver-model` is missing an `.iml` file in its root directory. *All* other modules (`javaparser-core`, `javaparser-symbol-solver-core`, etc.) come with an `.iml` file. Is there any reason why the module `javaparser-symbol-solver-model` is treated specially and is the *only* module that does not come with its own `.iml` file? Or has it simply been forgotten for this module?

Anyhow, I generated an `.iml` file for `javaparser-symbol-solver-model` from the POM and that solved all my problems. :-)

I'm creating a PR so that other users who want to import the project into IntelliJ IDEA in the future don't stumble upon the same problem.
