### PR TITLE
Resolving constructor declarations from object creation expressions

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -3,10 +3,7 @@ package com.github.javaparser.symbolsolver;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.*;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.resolution.SymbolResolver;
@@ -114,6 +111,16 @@ public class JavaSymbolSolver implements SymbolResolver {
                 }
             } else {
                 throw new UnsolvedSymbolException("We are unable to find the method declaration corresponding to " + node);
+            }
+        }
+        if (node instanceof ObjectCreationExpr) {
+            SymbolReference<ResolvedConstructorDeclaration> result = JavaParserFacade.get(typeSolver).solve((ObjectCreationExpr) node);
+            if (result.isSolved()) {
+                if (resultClass.isInstance(result.getCorrespondingDeclaration())) {
+                    return resultClass.cast(result.getCorrespondingDeclaration());
+                }
+            } else {
+                throw new UnsolvedSymbolException("We are unable to find the constructor declaration corresponding to " + node);
             }
         }
         if (node instanceof NameExpr) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/DefaultConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/DefaultConstructorDeclaration.java
@@ -32,7 +32,7 @@ import java.util.List;
  *
  * @author Federico Tomassetti
  */
-class DefaultConstructorDeclaration implements ResolvedConstructorDeclaration {
+public class DefaultConstructorDeclaration implements ResolvedConstructorDeclaration {
 
     private ResolvedClassDeclaration classDeclaration;
 


### PR DESCRIPTION
Currently, the method `ObjectCreationExpr#invokeResolvedConstructor()` invariably throws an `UnsupportedOperationException`.

This is because the latter method calls `JavaSymbolSolver#resolveDeclaration(Node, Class)`, passing the `ObjectCreationExpr` as the first argument. This method in turn checks if the given node is an instance of one of several supported types, and throws an `UnsupportedOperationException` otherwise. `ObjectCreationExpr` is not among those supported types, thus the exception is thrown.

This PR adds the missing piece of logic to the method `JavaSymbolSolver#resolveDeclaration(Node, Class)`, such that `ObjectCreationExpr#invokeResolvedConstructor()` now works.

Additionally, I made the class `DefaultConstructorDeclaration` public. Otherwise, it is not possible for users to check if a `ResolvedConstructorDeclaration` returned by `ObjectCreationExpr#invokeResolvedConstructor()` is an instance of `DefaultConstructorDeclaration`.
