### PR TITLE
Tests for resolving constructor declarations

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparser/Navigator.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparser/Navigator.java
@@ -121,6 +121,33 @@ public final class Navigator {
         return found;
     }
 
+    /**
+     * Returns the {@code (i+1)}'th constructor of the given type declaration, in textual order. The constructor that
+     * appears first has the index 0, the second one the index 1, and so on.
+     *
+     * @param td    The type declaration to search in. Note that only classes and enums have constructors.
+     * @param index The index of the desired constructor.
+     * @return The desired ConstructorDeclaration if it was found, and {@code null} otherwise.
+     */
+    public static ConstructorDeclaration demandConstructor(TypeDeclaration<?> td, int index) {
+        ConstructorDeclaration found = null;
+        int i = 0;
+        for (BodyDeclaration<?> bd : td.getMembers()) {
+            if (bd instanceof ConstructorDeclaration) {
+                ConstructorDeclaration cd = (ConstructorDeclaration) bd;
+                if (i == index) {
+                    found = cd;
+                    break;
+                }
+                i++;
+            }
+        }
+        if (found == null) {
+            throw new IllegalStateException("No constructor with index " + index);
+        }
+        return found;
+    }
+
     public static VariableDeclarator demandField(ClassOrInterfaceDeclaration cd, String name) {
         for (BodyDeclaration<?> bd : cd.getMembers()) {
             if (bd instanceof FieldDeclaration) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ConstructorsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ConstructorsResolutionTest.java
@@ -1,0 +1,60 @@
+package com.github.javaparser.symbolsolver.resolution;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserConstructorDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConstructorsResolutionTest extends AbstractResolutionTest {
+
+	@Test
+	public void solveNormalConstructor() {
+
+		CompilationUnit cu = parseSample("ConstructorCalls");
+		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ConstructorCalls");
+		MethodDeclaration method = Navigator.demandMethod(clazz, "testNormalConstructor");
+		ObjectCreationExpr objectCreationExpr = method.getBody().get().getStatements().get(0)
+				                                        .asExpressionStmt().getExpression().asObjectCreationExpr();
+
+		SymbolReference<ResolvedConstructorDeclaration> ref =
+				JavaParserFacade.get(new ReflectionTypeSolver()).solve(objectCreationExpr);
+		ConstructorDeclaration actualConstructor =
+				((JavaParserConstructorDeclaration) ref.getCorrespondingDeclaration()).getWrappedNode();
+
+		ClassOrInterfaceDeclaration otherClazz = Navigator.demandClass(cu, "OtherClass");
+		ConstructorDeclaration expectedConstructor = Navigator.demandConstructor(otherClazz, 0);
+
+		assertEquals(expectedConstructor, actualConstructor);
+	}
+
+	@Test
+	public void solveInnerClassConstructor() {
+
+		CompilationUnit cu = parseSample("ConstructorCalls");
+		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ConstructorCalls");
+		MethodDeclaration method = Navigator.demandMethod(clazz, "testInnerClassConstructor");
+		ObjectCreationExpr objectCreationExpr = method.getBody().get().getStatements().get(1)
+				                                        .asExpressionStmt().getExpression().asObjectCreationExpr();
+
+		SymbolReference<ResolvedConstructorDeclaration> ref =
+				JavaParserFacade.get(new ReflectionTypeSolver()).solve(objectCreationExpr);
+		ConstructorDeclaration actualConstructor =
+				((JavaParserConstructorDeclaration) ref.getCorrespondingDeclaration()).getWrappedNode();
+
+		ClassOrInterfaceDeclaration innerClazz = Navigator.demandClass(cu, "OtherClass.InnerClass");
+		ConstructorDeclaration expectedConstructor = Navigator.demandConstructor(innerClazz, 0);
+
+		assertEquals(expectedConstructor, actualConstructor);
+	}
+
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/ConstructorCalls.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/ConstructorCalls.java.txt
@@ -1,0 +1,21 @@
+class ConstructorCalls {
+
+    void testNormalConstructor() {
+        new OtherClass();
+    }
+
+    void testInnerClassConstructor() {
+        OtherClass oc = new OtherClass();
+        oc.new InnerClass();
+    }
+}
+
+class OtherClass {
+
+    OtherClass() {}
+
+    class InnerClass {
+
+        InnerClass() {}
+    }
+}


### PR DESCRIPTION
Here are two tests for resolving constructors using the symbol solver. :-)

The first one tests resolving a constructor declaration from a normal object creation expression without scope. This one works!

The second one tests resolving a constructor declaration from an object creation expression with scope. This one fails, unfortunately.

Please see #1522 for details.

Of course this PR is not (yet) meant to be merged, since the second test fails. But I am submitting this PR in the hope that it will help in solving this problem.

@ftomassetti Do you think it would be difficult to fix the symbol solver so that the second test passes? Unfortunately I don't know how... if you could add the corresponding code to this PR, it would help me understand how the symbol solver works (besides fixing a bug). I am willing to help out in the future as I can, but I do need some help to get started. :-)
