### PR TITLE
Fix annotation indenting in lexical preserving printer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ out
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# Project-specific stuff:
+.idea/*
+
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,6 @@ out
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# Project-specific stuff:
-.idea/*
-
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -77,10 +77,64 @@ public class MethodDeclarationTransformationsTest extends AbstractLexicalPreserv
     }
 
     @Test
+    public void removingModifiersWithExistingAnnotationsShort() {
+        MethodDeclaration it = consider("@Override public void A(){}");
+        it.setModifiers(EnumSet.noneOf(Modifier.class));
+        assertTransformedToString("@Override void A(){}", it);
+    }
+
+    @Test
+    public void removingModifiersWithExistingAnnotations() {
+        considerCode(
+                "class X {" + EOL +
+                        "  @Test" + EOL +
+                        "  public void testCase() {" + EOL +
+                        "  }" + EOL +
+                        "}" + EOL
+        );
+
+        cu.getType(0).getMethods().get(0).setModifiers(EnumSet.noneOf(Modifier.class));
+
+        String result = LexicalPreservingPrinter.print(cu.findCompilationUnit().get());
+        assertEqualsNoEol("class X {\n" +
+                "  @Test\n" +
+                "  void testCase() {\n" +
+                "  }\n" +
+                "}\n", result);
+    }
+
+    @Test
     public void replacingModifiers() {
         MethodDeclaration it = consider("public void A(){}");
         it.setModifiers(EnumSet.of(Modifier.PROTECTED));
         assertTransformedToString("protected void A(){}", it);
+    }
+
+    @Test
+    public void replacingModifiersWithExistingAnnotationsShort() {
+        MethodDeclaration it = consider("@Override public void A(){}");
+        it.setModifiers(EnumSet.of(Modifier.PROTECTED));
+        assertTransformedToString("@Override protected void A(){}", it);
+    }
+
+    @Test
+    public void replacingModifiersWithExistingAnnotations() {
+        considerCode(
+                "class X {" + EOL +
+                        "  @Test" + EOL +
+                        "  public void testCase() {" + EOL +
+                        "  }" + EOL +
+                        "}" + EOL
+        );
+
+        cu.getType(0).getMethods().get(0).setModifiers(EnumSet.of(Modifier.PROTECTED));
+
+        String result = LexicalPreservingPrinter.print(cu.findCompilationUnit().get());
+        assertEqualsNoEol("class X {\n" +
+                "  @Test\n" +
+                "  protected void testCase() {\n" +
+                "  }\n" +
+                "}\n", result);
     }
 
     // Parameters

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -826,9 +826,9 @@ public class Difference {
                         if (hasSamePreviousElement && hasSameNextElement) {
                             potentialMatches.putIfAbsent(MatchClassification.ALL, i);
                         } else if (hasSamePreviousElement) {
-                            potentialMatches.putIfAbsent(MatchClassification.PREVIOUS_ONLY, i);
+                            potentialMatches.putIfAbsent(MatchClassification.PREVIOUS_AND_SAME, i);
                         } else if (hasSameNextElement) {
-                            potentialMatches.putIfAbsent(MatchClassification.NEXT_ONLY, i);
+                            potentialMatches.putIfAbsent(MatchClassification.NEXT_AND_SAME, i);
                         } else {
                             potentialMatches.putIfAbsent(MatchClassification.SAME_ONLY, i);
                         }
@@ -843,6 +843,8 @@ public class Difference {
 
             if (bestMatchKey.isPresent()) {
                 correspondingIndices.add(potentialMatches.get(bestMatchKey.get()));
+            } else {
+                correspondingIndices.add(-1);
             }
         }
 
@@ -850,7 +852,7 @@ public class Difference {
     }
 
     private enum MatchClassification {
-        ALL(1), PREVIOUS_ONLY(2), NEXT_ONLY(3), SAME_ONLY(4);
+        ALL(1), PREVIOUS_AND_SAME(2), NEXT_AND_SAME(3), SAME_ONLY(4);
 
         private final int priority;
         MatchClassification(int priority) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -863,14 +863,12 @@ public class Difference {
     }
 
     private boolean isCorrespondingElement(TextElement textElement, CsmElement csmElement, Node node) {
-        boolean isMatch = false;
-
         if (csmElement instanceof CsmToken) {
             CsmToken csmToken = (CsmToken)csmElement;
             if (textElement instanceof TokenTextElement) {
                 TokenTextElement tokenTextElement = (TokenTextElement)textElement;
                 if (tokenTextElement.getTokenKind() == csmToken.getTokenType() && tokenTextElement.getText().equals(csmToken.getContent(node))) {
-                    isMatch = true;
+                    return  true;
                 }
             }
         } else if (csmElement instanceof CsmChild) {
@@ -878,14 +876,14 @@ public class Difference {
             if (textElement instanceof ChildTextElement) {
                 ChildTextElement childTextElement = (ChildTextElement)textElement;
                 if (childTextElement.getChild() == csmChild.getChild()) {
-                    isMatch = true;
+                    return true;
                 }
             }
         } else {
             throw new UnsupportedOperationException();
         }
 
-        return isMatch;
+        return false;
     }
 
     private int adjustIndentation(List<TokenTextElement> indentation, NodeText nodeText, int nodeTextIndex, boolean followedByUnindent) {


### PR DESCRIPTION
Ok I threw together a fix for #1461 which hopefully also makes the algorhitm a bit more robust for such cases. Please take a thorough look at it and tell me what you think and if you have any concerns or anything.

The main difference is that the corresponding elements that are searched in a `mix()` wrapper method when calculating the difference are prioritized by how good the match actually is. Priorization is done by checking if the previous and / or the next element are still the same (which would count as the best match) and so on up to the "worst" match, which is if just the elements themselves match (without their neighbours). That is also how it previously worked. 

@matozoid I have used your testcase for this, I hope you don't mind :-)
