### PR TITLE
Make default JavaParserTypeSolver ParserConfiguration store tokens

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
@@ -85,8 +85,7 @@ public class JavaParserTypeSolver implements TypeSolver {
     public JavaParserTypeSolver(Path srcDir) {
         this(srcDir,
                 new ParserConfiguration()
-                        .setLanguageLevel(BLEEDING_EDGE)
-                        .setAttributeComments(false));
+                        .setLanguageLevel(BLEEDING_EDGE));
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
@@ -86,8 +86,7 @@ public class JavaParserTypeSolver implements TypeSolver {
         this(srcDir,
                 new ParserConfiguration()
                         .setLanguageLevel(BLEEDING_EDGE)
-                        .setAttributeComments(false)
-                        .setStoreTokens(false));
+                        .setAttributeComments(false));
     }
 
     @Override


### PR DESCRIPTION
Fixes #1580.
I would have liked to add a test but unfortunately there is no way I can get the tests to run, I get some obscure errors if I try to run them. Log here https://gist.github.com/joined/b97720fff0d531f005c347457940797c.
This is on a fresh VPS with Ubuntu 18.04.

edit: something is wrong with the log that I uploaded, will post soon the correct one
edit2: nevermind, it was just Github truncating the end of the log