### PR TITLE
Adding resolveAccessedValue() to FieldAccessExpr

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -38,6 +38,8 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+
 import java.util.function.Consumer;
 
 /**
@@ -252,6 +254,10 @@ public final class FieldAccessExpr extends Expression implements NodeWithSimpleN
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifFieldAccessExpr(Consumer<FieldAccessExpr> action) {
         action.accept(this);
+    }
+
+    public ResolvedValueDeclaration resolveAccessedValue() {
+        return getSymbolResolver().resolveDeclaration(this, ResolvedValueDeclaration.class);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -29,15 +29,21 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
 import java.util.Optional;
+
 import static com.github.javaparser.utils.Utils.assertNotNull;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.FieldAccessExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
+
 import javax.annotation.Generated;
+
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 
 import java.util.function.Consumer;
@@ -256,6 +262,17 @@ public final class FieldAccessExpr extends Expression implements NodeWithSimpleN
         action.accept(this);
     }
 
+    /**
+     * Attempts to resolve the declaration corresponding to the accessed field. If successful, a
+     * {@link ResolvedValueDeclaration} representing the declaration of the value accessed by this
+     * {@code FieldAccessExpr} is returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
+     *
+     * @return a {@link ResolvedValueDeclaration} representing the declaration of the accessed value.
+     * @throws UnsolvedSymbolException if the declaration corresponding to the field access expression could not be
+     *                                 resolved.
+     * @see MethodCallExpr#resolveInvokedMethod()
+     * @see ObjectCreationExpr#resolveInvokedConstructor()
+     */
     public ResolvedValueDeclaration resolveAccessedValue() {
         return getSymbolResolver().resolveDeclaration(this, ResolvedValueDeclaration.class);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
 import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -43,6 +44,7 @@ import javax.annotation.Generated;
 
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;
+import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 
@@ -54,7 +56,7 @@ import java.util.function.Consumer;
  *
  * @author Julio Vilmar Gesser
  */
-public final class FieldAccessExpr extends Expression implements NodeWithSimpleName<FieldAccessExpr>, NodeWithTypeArguments<FieldAccessExpr>, NodeWithScope<FieldAccessExpr> {
+public final class FieldAccessExpr extends Expression implements NodeWithSimpleName<FieldAccessExpr>, NodeWithTypeArguments<FieldAccessExpr>, NodeWithScope<FieldAccessExpr>, Resolvable<ResolvedValueDeclaration> {
 
     private Expression scope;
 
@@ -270,10 +272,13 @@ public final class FieldAccessExpr extends Expression implements NodeWithSimpleN
      * @return a {@link ResolvedValueDeclaration} representing the declaration of the accessed value.
      * @throws UnsolvedSymbolException if the declaration corresponding to the field access expression could not be
      *                                 resolved.
-     * @see MethodCallExpr#resolveInvokedMethod()
-     * @see ObjectCreationExpr#resolveInvokedConstructor()
+     * @see NameExpr#resolve()
+     * @see MethodCallExpr#resolve()
+     * @see ObjectCreationExpr#resolve()
+     * @see ExplicitConstructorInvocationStmt#resolve()
      */
-    public ResolvedValueDeclaration resolveAccessedValue() {
+    @Override
+    public ResolvedValueDeclaration resolve() {
         return getSymbolResolver().resolveDeclaration(this, ResolvedValueDeclaration.class);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -311,6 +311,14 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
         return getSymbolResolver().resolveDeclaration(this, ResolvedMethodDeclaration.class);
     }
 
+    /**
+     * @deprecated Call {@link #resolve()} instead.
+     */
+    @Deprecated
+    public ResolvedMethodDeclaration resolveInvokedMethod() {
+        return resolve();
+    }
+
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<MethodCallExpr> toMethodCallExpr() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
 import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -39,7 +40,10 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;
+import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.SymbolResolver;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import java.util.function.Consumer;
 
@@ -49,7 +53,7 @@ import java.util.function.Consumer;
  *
  * @author Julio Vilmar Gesser
  */
-public final class MethodCallExpr extends Expression implements NodeWithTypeArguments<MethodCallExpr>, NodeWithArguments<MethodCallExpr>, NodeWithSimpleName<MethodCallExpr>, NodeWithOptionalScope<MethodCallExpr> {
+public final class MethodCallExpr extends Expression implements NodeWithTypeArguments<MethodCallExpr>, NodeWithArguments<MethodCallExpr>, NodeWithSimpleName<MethodCallExpr>, NodeWithOptionalScope<MethodCallExpr>, Resolvable<ResolvedMethodDeclaration> {
 
     @OptionalProperty
     private Expression scope;
@@ -289,7 +293,21 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
         action.accept(this);
     }
 
-    public ResolvedMethodDeclaration resolveInvokedMethod() {
+    /**
+     * Attempts to resolve the declaration corresponding to the invoked method. If successful, a
+     * {@link ResolvedMethodDeclaration} representing the declaration of the constructor invoked by this
+     * {@code MethodCallExpr} is returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
+     *
+     * @return a {@link ResolvedMethodDeclaration} representing the declaration of the invoked method.
+     * @throws UnsolvedSymbolException if the declaration corresponding to the method call expression could not be
+     *                                 resolved.
+     * @see NameExpr#resolve()
+     * @see FieldAccessExpr#resolve()
+     * @see ObjectCreationExpr#resolve()
+     * @see ExplicitConstructorInvocationStmt#resolve()
+     */
+    @Override
+    public ResolvedMethodDeclaration resolve() {
         return getSymbolResolver().resolveDeclaration(this, ResolvedMethodDeclaration.class);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
@@ -23,18 +23,25 @@ package com.github.javaparser.ast.expr;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
 import static com.github.javaparser.utils.Utils.assertNotNull;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.NameExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
+
 import javax.annotation.Generated;
+
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.resolution.Resolvable;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedUnionType;
+
 import java.util.function.Consumer;
 import java.util.Optional;
 
@@ -152,6 +159,18 @@ public final class NameExpr extends Expression implements NodeWithSimpleName<Nam
         action.accept(this);
     }
 
+    /**
+     * Attempts to resolve the declaration corresponding to the accessed name. If successful, a
+     * {@link ResolvedValueDeclaration} representing the declaration of the value accessed by this {@code NameExpr} is
+     * returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
+     *
+     * @return a {@link ResolvedValueDeclaration} representing the declaration of the accessed value.
+     * @throws UnsolvedSymbolException if the declaration corresponding to the name expression could not be resolved.
+     * @see FieldAccessExpr#resolve()
+     * @see MethodCallExpr#resolve()
+     * @see ObjectCreationExpr#resolve()
+     * @see ExplicitConstructorInvocationStmt#resolve()
+     */
     @Override
     public ResolvedValueDeclaration resolve() {
         return getSymbolResolver().resolveDeclaration(this, ResolvedValueDeclaration.class);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -365,6 +365,14 @@ public final class ObjectCreationExpr extends Expression implements NodeWithType
         return getSymbolResolver().resolveDeclaration(this, ResolvedConstructorDeclaration.class);
     }
 
+    /**
+     * @deprecated Call {@link #resolve()} instead.
+     */
+    @Deprecated
+    public ResolvedConstructorDeclaration resolveInvokedConstructor() {
+        return resolve();
+    }
+
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<ObjectCreationExpr> toObjectCreationExpr() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
 import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
@@ -41,7 +42,10 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import javax.annotation.Generated;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;
+import com.github.javaparser.resolution.Resolvable;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+
 import java.util.function.Consumer;
 
 /**
@@ -54,7 +58,7 @@ import java.util.function.Consumer;
  *
  * @author Julio Vilmar Gesser
  */
-public final class ObjectCreationExpr extends Expression implements NodeWithTypeArguments<ObjectCreationExpr>, NodeWithType<ObjectCreationExpr, ClassOrInterfaceType>, NodeWithArguments<ObjectCreationExpr>, NodeWithOptionalScope<ObjectCreationExpr> {
+public final class ObjectCreationExpr extends Expression implements NodeWithTypeArguments<ObjectCreationExpr>, NodeWithType<ObjectCreationExpr, ClassOrInterfaceType>, NodeWithArguments<ObjectCreationExpr>, NodeWithOptionalScope<ObjectCreationExpr>, Resolvable<ResolvedConstructorDeclaration> {
 
     @OptionalProperty
     private Expression scope;
@@ -343,7 +347,21 @@ public final class ObjectCreationExpr extends Expression implements NodeWithType
         action.accept(this);
     }
 
-    public ResolvedConstructorDeclaration resolveInvokedConstructor() {
+    /**
+     * Attempts to resolve the declaration corresponding to the invoked constructor. If successful, a
+     * {@link ResolvedConstructorDeclaration} representing the declaration of the constructor invoked by this
+     * {@code ObjectCreationExpr} is returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
+     *
+     * @return a {@link ResolvedConstructorDeclaration} representing the declaration of the invoked constructor.
+     * @throws UnsolvedSymbolException if the declaration corresponding to the object creation expression could not be
+     *                                 resolved.
+     * @see NameExpr#resolve()
+     * @see FieldAccessExpr#resolve()
+     * @see MethodCallExpr#resolve()
+     * @see ExplicitConstructorInvocationStmt#resolve()
+     */
+    @Override
+    public ResolvedConstructorDeclaration resolve() {
         return getSymbolResolver().resolveDeclaration(this, ResolvedConstructorDeclaration.class);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -300,6 +300,14 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
         return getSymbolResolver().resolveDeclaration(this, ResolvedConstructorDeclaration.class);
     }
 
+    /**
+     * @deprecated Call {@link #resolve()} instead.
+     */
+    @Deprecated
+    public ResolvedConstructorDeclaration resolveInvokedConstructor() {
+        return resolve();
+    }
+
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<ExplicitConstructorInvocationStmt> toExplicitConstructorInvocationStmt() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -22,25 +22,34 @@ package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
 import static com.github.javaparser.utils.Utils.assertNotNull;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ExplicitConstructorInvocationStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
+
 import javax.annotation.Generated;
+
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;
+import com.github.javaparser.resolution.Resolvable;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+
 import java.util.function.Consumer;
 
 /**
@@ -52,7 +61,7 @@ import java.util.function.Consumer;
  * @see com.github.javaparser.ast.expr.SuperExpr
  * @see com.github.javaparser.ast.expr.ThisExpr
  */
-public final class ExplicitConstructorInvocationStmt extends Statement implements NodeWithTypeArguments<ExplicitConstructorInvocationStmt>, NodeWithArguments<ExplicitConstructorInvocationStmt> {
+public final class ExplicitConstructorInvocationStmt extends Statement implements NodeWithTypeArguments<ExplicitConstructorInvocationStmt>, NodeWithArguments<ExplicitConstructorInvocationStmt>, Resolvable<ResolvedConstructorDeclaration> {
 
     @OptionalProperty
     private NodeList<Type> typeArguments;
@@ -274,7 +283,20 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
         action.accept(this);
     }
 
-    public ResolvedConstructorDeclaration resolveInvokedConstructor() {
+    /**
+     * Attempts to resolve the declaration corresponding to the invoked constructor. If successful, a
+     * {@link ResolvedConstructorDeclaration} representing the declaration of the constructor invoked by this
+     * {@code ExplicitConstructorInvocationStmt} is returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
+     *
+     * @return a {@link ResolvedConstructorDeclaration} representing the declaration of the invoked constructor.
+     * @throws UnsolvedSymbolException if the declaration corresponding to the explicit constructor invocation statement
+     *                                 could not be resolved.
+     * @see NameExpr#resolve()
+     * @see FieldAccessExpr#resolve()
+     * @see MethodCallExpr#resolve()
+     * @see ObjectCreationExpr#resolve()
+     */
+    public ResolvedConstructorDeclaration resolve() {
         return getSymbolResolver().resolveDeclaration(this, ResolvedConstructorDeclaration.class);
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -133,6 +133,16 @@ public class JavaSymbolSolver implements SymbolResolver {
                 throw new UnsolvedSymbolException("We are unable to find the value declaration corresponding to " + node);
             }
         }
+        if (node instanceof FieldAccessExpr) {
+            SymbolReference<? extends ResolvedValueDeclaration> result = JavaParserFacade.get(typeSolver).solve((FieldAccessExpr) node);
+            if (result.isSolved()) {
+                if (resultClass.isInstance(result.getCorrespondingDeclaration())) {
+                    return resultClass.cast(result.getCorrespondingDeclaration());
+                }
+            } else {
+                throw new UnsolvedSymbolException("We are unable to find the value declaration corresponding to " + node);
+            }
+        }
         if (node instanceof ThisExpr) {
             SymbolReference<ResolvedTypeDeclaration> result = JavaParserFacade.get(typeSolver).solve((ThisExpr) node);
             if (result.isSolved()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
@@ -100,6 +100,10 @@ public class JavaParserFieldDeclaration implements ResolvedFieldDeclaration {
         return wrappedNode;
     }
 
+    public VariableDeclarator getVariableDeclarator() {
+        return variableDeclarator;
+    }
+
     @Override
     public String toString() {
         return "JPField{" + getName() + "}";

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
@@ -126,7 +126,7 @@ public class FieldsResolutionTest extends AbstractResolutionTest {
         FieldAccessExpr expression = returnStmt.getExpression().get().asFieldAccessExpr();
 
         // resolve field access expression
-        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolveAccessedValue();
+        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
 
         // get expected field declaration
         VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "label");
@@ -148,7 +148,7 @@ public class FieldsResolutionTest extends AbstractResolutionTest {
         FieldAccessExpr expression = returnStmt.getExpression().get().asFieldAccessExpr();
 
         // resolve field access expression
-        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolveAccessedValue();
+        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
 
         // get expected field declaration
         clazz = Navigator.demandClass(cu, "AccessThroughSuper.SuperClass");


### PR DESCRIPTION
This PR adds a method `resolveAccessedValue()` to `FieldAccessExpr` which allows the user to easily get from a field access expression to the corresponding field declaration. This functionality is similar in spirit to `MethodCallExpr#resolveInvokedMethod()` and `ObjectCreationExpr#resolveInvokedConstructor()`.

In passing, this PR also fixes a so-far unreported bug in `JavaSymbolSolver` where the case of a `FieldAccessExpr` was not handled in the method `resolveDeclaration(Node,Class)`, leading to an `UnsolvedSymbolException` when trying to call this method for a `FieldAccessExpr` node.

In addition, this PR adds two tests to test the new method.
