### PR TITLE
Add getters to JavadocInlineTag

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/description/JavadocInlineTag.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/description/JavadocInlineTag.java
@@ -86,6 +86,18 @@ public class JavadocInlineTag implements JavadocDescriptionElement {
         this.content = content;
     }
 
+    public Type getType() {
+        return type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getName() {
+        return tagName;
+    }
+
     @Override
     public String toText() {
         return "{@" + tagName + this.content +"}";


### PR DESCRIPTION
This change adds getType(), getContent() and getName() methods to
JavadocInlineTag.