### PR TITLE
Fix binary operator transformations.

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/FieldDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/FieldDeclarationTransformationsTest.java
@@ -21,16 +21,17 @@
 
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
 
+import java.util.EnumSet;
+
+import org.junit.Test;
+
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.EnumSet;
 
 /**
- * Transforming FieldDeclaration and verifying the LexicalPreservation works as expected.
+ * Transforming FieldDeclaration and verifying the LexicalPreservation works as
+ * expected.
  */
 public class FieldDeclarationTransformationsTest extends AbstractLexicalPreservingTest {
 
@@ -73,4 +74,14 @@ public class FieldDeclarationTransformationsTest extends AbstractLexicalPreservi
         it.getVariable(1).setType("Xyz");
         assertTransformedToString("Xyz a, b;", it);
     }
+
+    // @Test
+    // public void changingTypeArgument() {
+    // FieldDeclaration it = consider("List<A> a;");
+    // VariableDeclarator variable = it.getVariable(0);
+    // ClassOrInterfaceType type = (ClassOrInterfaceType) variable.getType();
+    // NodeList<Type> nodeList = type.getTypeArguments().get();
+    // nodeList.set(0, JavaParser.parseType("String"));
+    // assertTransformedToString("List<String> a;", it);
+    // }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
@@ -203,7 +203,7 @@ public class TokenTypes {
             case SLASH:
             case BIT_AND:
             case BIT_OR:
-            case XOR:
+            case BIT_XOR:
             case REM:
             case LSHIFT:
             case PLUSASSIGN:

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AssignExpr.java
@@ -83,11 +83,11 @@ public final class AssignExpr extends Expression {
                 case DIVIDE:
                     return Optional.of(BinaryExpr.Operator.DIVIDE);
                 case BINARY_AND:
-                    return Optional.of(BinaryExpr.Operator.BINARY_AND);
+                    return Optional.of(BinaryExpr.Operator.BIT_AND);
                 case BINARY_OR:
-                    return Optional.of(BinaryExpr.Operator.BINARY_OR);
+                    return Optional.of(BinaryExpr.Operator.BIT_OR);
                 case XOR:
-                    return Optional.of(BinaryExpr.Operator.XOR);
+                    return Optional.of(BinaryExpr.Operator.BIT_XOR);
                 case REMAINDER:
                     return Optional.of(BinaryExpr.Operator.REMAINDER);
                 case LEFT_SHIFT:

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -47,11 +47,11 @@ public final class BinaryExpr extends Expression {
 
     public enum Operator implements Printable {
 
-        OR("||"),
-        AND("&&"),
-        BINARY_OR("|"),
-        BINARY_AND("&"),
-        XOR("^"),
+        SC_OR("||"),
+        SC_AND("&&"),
+        BIT_OR("|"),
+        BIT_AND("&"),
+        BIT_XOR("^"),
         EQUALS("=="),
         NOT_EQUALS("!="),
         LESS("<"),
@@ -79,11 +79,11 @@ public final class BinaryExpr extends Expression {
 
         public Optional<AssignExpr.Operator> toAssignOperator() {
             switch(this) {
-                case BINARY_OR:
+                case BIT_OR:
                     return Optional.of(AssignExpr.Operator.BINARY_OR);
-                case BINARY_AND:
+                case BIT_AND:
                     return Optional.of(AssignExpr.Operator.BINARY_AND);
-                case XOR:
+                case BIT_XOR:
                     return Optional.of(AssignExpr.Operator.XOR);
                 case LEFT_SHIFT:
                     return Optional.of(AssignExpr.Operator.LEFT_SHIFT);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
@@ -45,6 +45,10 @@ public class CsmConditional implements CsmElement {
         }
         return properties.get(0);
     }
+    
+    public List<ObservableProperty> getProperties() {
+        return properties;
+    }
 
     public CsmElement getThenElement() {
         return thenElement;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
@@ -13,7 +13,7 @@ public interface Change {
     default boolean evaluate(CsmConditional csmConditional, Node node) {
         switch (csmConditional.getCondition()) {
             case FLAG:
-                return (Boolean) getValue(csmConditional.getProperty(), node);
+                return csmConditional.getProperties().stream().anyMatch(p -> (Boolean) getValue(p, node));
             case IS_NOT_EMPTY:
                 return !Utils.valueIsNullOrEmpty(getValue(csmConditional.getProperty(), node));
             case IS_EMPTY:

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -558,7 +558,7 @@ TOKEN :
 | < SLASH: "/" >
 | < BIT_AND: "&" >
 | < BIT_OR: "|" >
-| < XOR: "^" >
+| < BIT_XOR: "^" >
 | < REM: "%" >
 | < LSHIFT: "<<" >
 | < PLUSASSIGN: "+=" >
@@ -1501,7 +1501,7 @@ Expression ConditionalOrExpression():
 	Expression right;
 }
 {
-  ret = ConditionalAndExpression() ( "||" right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.OR); } )*
+  ret = ConditionalAndExpression() ( "||" right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.SC_OR); } )*
   { return ret; }
 }
 
@@ -1511,7 +1511,7 @@ Expression ConditionalAndExpression():
 	Expression right;
 }
 {
-  ret = InclusiveOrExpression() ( "&&" right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.AND); } )*
+  ret = InclusiveOrExpression() ( "&&" right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.SC_AND); } )*
   { return ret; }
 }
 
@@ -1521,7 +1521,7 @@ Expression InclusiveOrExpression():
 	Expression right;
 }
 {
-  ret = ExclusiveOrExpression() ( "|" right = ExclusiveOrExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.BINARY_OR); } )*
+  ret = ExclusiveOrExpression() ( "|" right = ExclusiveOrExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.BIT_OR); } )*
   { return ret; }
 }
 
@@ -1531,7 +1531,7 @@ Expression ExclusiveOrExpression():
 	Expression right;
 }
 {
-  ret = AndExpression() ( "^" right = AndExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.XOR); } )*
+  ret = AndExpression() ( "^" right = AndExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.BIT_XOR); } )*
   { return ret; }
 }
 
@@ -1541,7 +1541,7 @@ Expression AndExpression():
 	Expression right;
 }
 {
-  ret = EqualityExpression() ( "&" right = EqualityExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.BINARY_AND); } )*
+  ret = EqualityExpression() ( "&" right = EqualityExpression() { ret = new BinaryExpr(range(ret, token()), ret, right, BinaryExpr.Operator.BIT_AND); } )*
   { return ret; }
 }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -123,16 +123,16 @@ public class TypeExtractor extends DefaultVisitorAdapter {
             case GREATER_EQUALS:
             case EQUALS:
             case NOT_EQUALS:
-            case OR:
-            case AND:
+            case SC_OR:
+            case SC_AND:
                 return ResolvedPrimitiveType.BOOLEAN;
-            case BINARY_AND:
-            case BINARY_OR:
+            case BIT_AND:
+            case BIT_OR:
             case SIGNED_RIGHT_SHIFT:
             case UNSIGNED_RIGHT_SHIFT:
             case LEFT_SHIFT:
             case REMAINDER:
-            case XOR:
+            case BIT_XOR:
                 return node.getLeft().accept(this, solveLambdas);
             default:
                 throw new UnsupportedOperationException("Operator " + node.getOperator().name());


### PR DESCRIPTION
java.jj 's operator names used to find BinaryExpr.Operator using reflection.
Therefore their names should be same with each others.