### PR TITLE
Fix CsmAttribute(OPERATOR) problem 

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/BinaryOperatorTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/BinaryOperatorTransformationsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+
+/**
+ * Transforming BinaryExpr and verifying the LexicalPreservation works as expected.
+ */
+public class BinaryOperatorTransformationsTest extends AbstractLexicalPreservingTest {
+
+    @Test
+    public void instanceToStatic() throws IOException {
+        considerExpression("a && b");
+        expression.asBinaryExpr().setRight(new NameExpr("c"));
+        assertTransformedToString("a && c", expression);
+    }
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/OperatorTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/OperatorTransformationsTest.java
@@ -25,19 +25,34 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 
 /**
  * Transforming BinaryExpr and verifying the LexicalPreservation works as expected.
  */
-public class BinaryOperatorTransformationsTest extends AbstractLexicalPreservingTest {
+public class OperatorTransformationsTest extends AbstractLexicalPreservingTest {
 
     @Test
-    public void instanceToStatic() throws IOException {
+    public void binaryExpressionOperator() throws IOException {
         considerExpression("a && b");
         expression.asBinaryExpr().setRight(new NameExpr("c"));
         assertTransformedToString("a && c", expression);
+    }
+    
+    @Test
+    public void unaryExpressionOperator() throws IOException {
+        considerExpression("!a");
+        expression.asUnaryExpr().setExpression(new NameExpr("b"));
+        assertTransformedToString("!b", expression);
+    }
+    
+    @Test
+    public void assignExpressionOperator() throws IOException {
+        considerExpression("a <<= 1");
+        expression.asAssignExpr().setValue(new IntegerLiteralExpr(2));
+        assertTransformedToString("a <<= 2", expression);
     }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+
+/**
+ * Transforming Statement and verifying the LexicalPreservation works as expected.
+ */
+public class StatementTransformationsTest extends AbstractLexicalPreservingTest {
+
+    Statement consider(String code) {
+        Statement statement = JavaParser.parseStatement(code);
+        LexicalPreservingPrinter.setup(statement);
+        return statement;
+    }
+
+    @Test
+    public void ifStmtTransformation() throws IOException {
+        Statement ifStmt = consider("if (a) {} else {}");
+        ifStmt.asIfStmt().setCondition(new NameExpr("b"));
+        assertTransformedToString("if (b) {} else {}", ifStmt);
+    }
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
@@ -26,9 +26,12 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 
@@ -45,9 +48,17 @@ public class StatementTransformationsTest extends AbstractLexicalPreservingTest 
 
     @Test
     public void ifStmtTransformation() throws IOException {
-        Statement ifStmt = consider("if (a) {} else {}");
-        ifStmt.asIfStmt().setCondition(new NameExpr("b"));
-        assertTransformedToString("if (b) {} else {}", ifStmt);
+        Statement stmt = consider("if (a) {} else {}");
+        stmt.asIfStmt().setCondition(new NameExpr("b"));
+        assertTransformedToString("if (b) {} else {}", stmt);
+    }
+
+    @Test
+    public void switchEntryCsmHasTrailingUnindent() throws IOException {
+        Statement stmt = consider("switch (a) { case 1: a; a; }");
+        NodeList<Statement> statements = stmt.asSwitchStmt().getEntry(0).getStatements();
+        statements.set(1, statements.get(1).clone()); // clone() to force replacement
+        assertTransformedToString("switch (a) { case 1: a; a; }", stmt);
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
@@ -47,12 +47,13 @@ public class CsmAttribute implements CsmElement {
     /**
      * Obtain the token type corresponding to the specific value of the attribute.
      * For example, to the attribute "Operator" different token could correspond like PLUS or MINUS.
+     * @param tokenText Operator's token text
      */
-    public int getTokenType(Node node, String text) {
+    public int getTokenType(Node node, String text, String tokenText) {
         switch (property) {
             case IDENTIFIER:
                 return GeneratedJavaParserConstants.IDENTIFIER;
-            case TYPE:
+            case TYPE: {
                 String expectedImage = "\"" + text.toLowerCase() + "\"";
                 for (int i=0;i<GeneratedJavaParserConstants.tokenImage.length;i++) {
                     if (GeneratedJavaParserConstants.tokenImage[i].equals(expectedImage)) {
@@ -60,12 +61,16 @@ public class CsmAttribute implements CsmElement {
                     }
                 }
                 throw new RuntimeException("Attribute 'type' does not corresponding to any expected value. Text: " + text);
-            case OPERATOR:
-                try {
-                    return (Integer)(GeneratedJavaParserConstants.class.getDeclaredField(text).get(null));
-                } catch (IllegalAccessException|NoSuchFieldException e) {
-                    throw new RuntimeException("Attribute 'operator' does not corresponding to any expected value. Text: " + text, e);
+            }
+            case OPERATOR: {
+                String expectedImage = "\"" + tokenText.toLowerCase() + "\"";
+                for (int i = 0; i < GeneratedJavaParserConstants.tokenImage.length; i++) {
+                    if (GeneratedJavaParserConstants.tokenImage[i].equals(expectedImage)) {
+                        return i;
+                    }
                 }
+                throw new RuntimeException("Attribute 'operator' does not corresponding to any expected value. Text: " + tokenText);
+            }
             case VALUE:
                 if (node instanceof IntegerLiteralExpr) {
                     return GeneratedJavaParserConstants.INTEGER_LITERAL;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmConditional.java
@@ -45,6 +45,10 @@ public class CsmConditional implements CsmElement {
         }
         return properties.get(0);
     }
+    
+    public List<ObservableProperty> getProperties() {
+        return properties;
+    }
 
     public CsmElement getThenElement() {
         return thenElement;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -127,7 +127,7 @@ public class Difference {
                 if (diffElement instanceof Kept) {
                     Kept kept = (Kept) diffElement;
 
-                    if (kept.isWhiteSpaceOrComment()) {
+                    if (kept.isWhiteSpaceOrComment() || kept.isIndent() || kept.isUnindent()) {
                         diffIndex++;
                     } else {
                         throw new IllegalStateException("Cannot keep element because we reached the end of nodetext: "

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -235,7 +235,7 @@ class LexicalDifferenceCalculator {
             if (value instanceof Printable) {
                 text = ((Printable) value).asString();
             }
-            elements.add(new CsmToken(csmAttribute.getTokenType(node, value.toString()), text));
+            elements.add(new CsmToken(csmAttribute.getTokenType(node, value.toString(), text), text));
         } else if ((csm instanceof CsmString) && (node instanceof StringLiteralExpr)) {
             elements.add(new CsmToken(GeneratedJavaParserConstants.STRING_LITERAL,
                     "\"" + ((StringLiteralExpr) node).getValue() + "\""));

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
@@ -13,7 +13,7 @@ public interface Change {
     default boolean evaluate(CsmConditional csmConditional, Node node) {
         switch (csmConditional.getCondition()) {
             case FLAG:
-                return (Boolean) getValue(csmConditional.getProperty(), node);
+                return csmConditional.getProperties().stream().anyMatch(p -> (Boolean) getValue(p, node));
             case IS_NOT_EMPTY:
                 return !Utils.valueIsNullOrEmpty(getValue(csmConditional.getProperty(), node));
             case IS_EMPTY:


### PR DESCRIPTION
Binary/Unary/AssignExpr uses CsmAttribute(OPERATOR). It tries to get a token type according to the operator name. However (BinaryExp|UnaryExpr|AssignExpr).Operator uses same name for different operators, and uses different name with GeneratedToken's.

That's why code transformation related to operators fails.