### PR TITLE
using string.replace with char instead of string

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/utils/CodeGenerationUtils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/CodeGenerationUtils.java
@@ -83,7 +83,7 @@ public final class CodeGenerationUtils {
      * Converts a package name like "com.laamella.parser" to a path like "com/laamella/parser"
      */
     public static String packageToPath(String pkg) {
-        return pkg.replace(".", File.separator);
+        return pkg.replace('.', File.separatorChar);
     }
 
     /**


### PR DESCRIPTION
`CodeGenerationUtils.packageToPath(String package)` only replace one single char in the package, using the appropriate method circumvents a call to `Pattern.compile(regex)`, which is considered expensive.