### PR TITLE
Issue1630: Fixing failing slow tests due to object creation expressions

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
@@ -99,7 +99,7 @@ public class PrettyPrinterConfiguration {
             indentSize = indent.length();
             indentType = TABS;
         } else {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("This type of indentation is not yet supported: '" + indent + "'");
         }
         return this;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinterConfiguration.java
@@ -21,8 +21,6 @@
 
 package com.github.javaparser.printer;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.util.function.Function;
 
 import static com.github.javaparser.printer.PrettyPrinterConfiguration.IndentType.SPACES;
@@ -101,7 +99,7 @@ public class PrettyPrinterConfiguration {
             indentSize = indent.length();
             indentType = TABS;
         } else {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
         return this;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -22,6 +22,7 @@
 package com.github.javaparser.resolution.types;
 
 import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParameterValueProvider;
@@ -217,6 +218,8 @@ public abstract class ResolvedReferenceType implements ResolvedType,
      */
     public abstract List<ResolvedReferenceType> getAllAncestors();
 
+    public abstract List<ResolvedReferenceType> getDirectAncestors();
+
     public final List<ResolvedReferenceType> getAllInterfacesAncestors() {
         return getAllAncestors().stream()
                 .filter(it -> it.getTypeDeclaration().isInterface())
@@ -358,6 +361,17 @@ public abstract class ResolvedReferenceType implements ResolvedType,
     }
 
     public abstract ResolvedType toRawType();
+
+    public List<ResolvedMethodDeclaration> getAllMethods() {
+        List<ResolvedMethodDeclaration> allMethods = new LinkedList<>();
+        allMethods.addAll(this.getDeclaredMethods().stream().map(m -> m.getDeclaration()).collect(Collectors.toList()));
+
+        System.out.println("Ancestors of " + this + ": " + getDirectAncestors());
+
+        getDirectAncestors().forEach(a ->
+                allMethods.addAll(a.getAllMethods()));
+        return allMethods;
+    }
 
     //
     // Protected methods

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -218,6 +218,11 @@ public abstract class ResolvedReferenceType implements ResolvedType,
      */
     public abstract List<ResolvedReferenceType> getAllAncestors();
 
+    /**
+     * Return direct ancestors, that means the superclasses and interfaces implemented directly.
+     * This list should include Object if the class has no other superclass or the interface is not extending another interface.
+     * There is an exception for Object itself.
+     */
     public abstract List<ResolvedReferenceType> getDirectAncestors();
 
     public final List<ResolvedReferenceType> getAllInterfacesAncestors() {
@@ -362,6 +367,11 @@ public abstract class ResolvedReferenceType implements ResolvedType,
 
     public abstract ResolvedType toRawType();
 
+    /**
+     * Get a list of all the methods available on this type. This list includes methods declared in this type and
+     * methods inherited. This list includes methods of all sort of visibility. However it does not include methods
+     * that have been overwritten.
+     */
     public List<ResolvedMethodDeclaration> getAllMethods() {
         List<ResolvedMethodDeclaration> allMethods = new LinkedList<>();
         allMethods.addAll(this.getDeclaredMethods().stream().map(m -> m.getDeclaration()).collect(Collectors.toList()));

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -97,7 +97,9 @@ public class JavaParserFactory {
                 }
             }
             final Node parentNode = requireParentNode(node);
-            if (parentNode instanceof ObjectCreationExpr && node == ((ObjectCreationExpr) parentNode).getType()) {
+            if (parentNode instanceof ObjectCreationExpr
+                    && (node == ((ObjectCreationExpr) parentNode).getType()
+                        || ((ObjectCreationExpr) parentNode).getArguments().contains(node))) {
                 return getContext(requireParentNode(parentNode), typeSolver);
             }
             if (parentNode == null) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -19,6 +19,7 @@ package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
@@ -112,7 +113,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             return solveMethodAsUsage(typeOfScope, name, argumentsTypes, typeSolver, this);
         } else {
             Context parentContext = getParent();
-            while (parentContext instanceof MethodCallExprContext) {
+            while (parentContext instanceof MethodCallExprContext || parentContext instanceof ObjectCreationContext) {
                 parentContext = parentContext.getParent();
             }
             return parentContext.solveMethodAsUsage(name, argumentsTypes, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
@@ -31,6 +31,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.resolution.Value;
+import com.github.javaparser.symbolsolver.resolution.MethodResolutionLogic;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 
 import java.util.Collection;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
@@ -214,7 +214,10 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
 
         // Avoid repetitions of Object
         ancestors.removeIf(a -> a.getQualifiedName().equals(Object.class.getCanonicalName()));
-        if (!this.getQualifiedName().equals(Object.class.getCanonicalName())) {
+        boolean isClassWithSuperClassOrObject = this.getTypeDeclaration().isClass()
+                && (this.getTypeDeclaration().asClass().getSuperClass() == null ||
+                !this.getTypeDeclaration().asClass().getSuperClass().getQualifiedName().equals(Object.class.getCanonicalName()));
+        if (!isClassWithSuperClassOrObject) {
             ResolvedReferenceTypeDeclaration objectType = typeSolver.solveType(Object.class.getCanonicalName());
             ResolvedReferenceType objectRef = create(objectType);
             ancestors.add(objectRef);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
@@ -204,6 +204,25 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
         return ancestors;
     }
 
+    public List<ResolvedReferenceType> getDirectAncestors() {
+        // We need to go through the inheritance line and propagate the type parametes
+
+        List<ResolvedReferenceType> ancestors = typeDeclaration.getAncestors();
+
+        ancestors = ancestors.stream()
+                .map(a -> typeParametersMap().replaceAll(a).asReferenceType())
+                .collect(Collectors.toList());
+
+        // Avoid repetitions of Object
+        ancestors.removeIf(a -> a.getQualifiedName().equals(Object.class.getCanonicalName()));
+        if (!this.getQualifiedName().equals(Object.class.getCanonicalName())) {
+            ResolvedReferenceTypeDeclaration objectType = typeSolver.solveType(Object.class.getCanonicalName());
+            ResolvedReferenceType objectRef = create(objectType);
+            ancestors.add(objectRef);
+        }
+        return ancestors;
+    }
+
     public ResolvedReferenceType deriveTypeParameters(ResolvedTypeParametersMap typeParametersMap) {
         return create(typeDeclaration, typeParametersMap);
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
@@ -30,7 +30,6 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -390,7 +390,8 @@ public class MethodResolutionLogic {
 
     public static SymbolReference<ResolvedMethodDeclaration> findMostApplicable(List<ResolvedMethodDeclaration> methods,
                                                                                 String name, List<ResolvedType> argumentsTypes, TypeSolver typeSolver, boolean wildcardTolerance) {
-        List<ResolvedMethodDeclaration> applicableMethods = getMethodsWithoutDuplicates(methods).stream().filter((m) -> isApplicable(m, name, argumentsTypes, typeSolver, wildcardTolerance)).collect(Collectors.toList());
+        List<ResolvedMethodDeclaration> methodsWithMatchingName = methods.stream().filter(m -> m.getName().equals(name)).collect(Collectors.toList());
+        List<ResolvedMethodDeclaration> applicableMethods = getMethodsWithoutDuplicates(methodsWithMatchingName).stream().filter((m) -> isApplicable(m, name, argumentsTypes, typeSolver, wildcardTolerance)).collect(Collectors.toList());
         if (applicableMethods.isEmpty()) {
             return SymbolReference.unsolved(ResolvedMethodDeclaration.class);
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -16,7 +16,6 @@
 
 package com.github.javaparser.symbolsolver.model.typesystem;
 
-import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.resolution.declarations.ResolvedClassDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedInterfaceDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
@@ -30,7 +29,6 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.Serializable;
 import java.nio.Buffer;
 import java.nio.CharBuffer;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseJavaSymbolSolver060Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseJavaSymbolSolver060Test.java
@@ -187,17 +187,25 @@ public class AnalyseJavaSymbolSolver060Test extends AbstractResolutionTest {
     }
 
     @Test
+    public void parseCoreJavaparsermodelJavaParserAnonymousClassDeclaration() throws IOException {
+        parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration");
+    }
+
+    @Test
+    public void parseCoreJavaparsermodelJavaParserInterfaceDeclaration() throws IOException {
+        parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration");
+    }
+
+    @Test
     public void parseCoreJavaparsermodelDeclarations() throws IOException {
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/DefaultConstructorDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/Helper");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration");
-        parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserConstructorDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumConstantDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration");
-        parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserParameterDeclaration");
         parse("java-symbol-solver-core", "com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclaration");
@@ -323,12 +331,16 @@ public class AnalyseJavaSymbolSolver060Test extends AbstractResolutionTest {
     }
 
     @Test
+    public void parseModelTypesystemReferenceType() throws IOException {
+        parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/ReferenceType");
+    }
+
+    @Test
     public void parseModelTypesystem() throws IOException {
         parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/ArrayType");
         parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/LambdaConstraintType");
         parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/NullType");
         parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/PrimitiveType");
-        parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/ReferenceType");
         parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/Type");
         parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/TypeTransformer");
         parse("java-symbol-solver-model", "com/github/javaparser/symbolsolver/model/typesystem/TypeVariable");


### PR DESCRIPTION
Fix #1630 

This test is failing locally as it was before my changes:

```
SymbolSolverCollectionStrategyTest.resolveExpressions:28->lambda$resolveExpressions$0:31 » NoClassDefFound
```

Any advice?