### PR TITLE
NormalAnnotationExpr: addPair should allow any expression as a value

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -109,7 +109,7 @@ public final class NormalAnnotationExpr extends AnnotationExpr {
      *
      * @return this, the {@link NormalAnnotationExpr}
      */
-    public NormalAnnotationExpr addPair(String key, NameExpr value) {
+    public NormalAnnotationExpr addPair(String key, Expression value) {
         MemberValuePair memberValuePair = new MemberValuePair(key, value);
         getPairs().add(memberValuePair);
         return this;


### PR DESCRIPTION
NormalAnnotationExpr.addPair should allow any expression as a value, instead of just NameExpr.