### PR TITLE
Throw an UnsolvedSymbolException instead of a RuntimeException

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/UnsolvedSymbolException.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/UnsolvedSymbolException.java
@@ -28,26 +28,48 @@ package com.github.javaparser.resolution;
  */
 public class UnsolvedSymbolException extends RuntimeException {
 
-    private String context;
+    /**
+     * The name of the symbol that could not be resolved.
+     */
     private String name;
 
-    public UnsolvedSymbolException(String name, String context) {
-        super("Unsolved symbol in " + context + " : " + name);
-        this.context = context;
-        this.name = name;
-    }
+    /**
+     * Additional information that provides more details on the context that a symbol could not be resolved in, or
+     * {@code null} if there is no contextual information, or if the contextual information is unknown.
+     */
+    private String context;
+
+    /**
+     * The throwable that caused this {@code UnsolvedSymbolException} to get thrown, or {@code null} if this
+     * {@code UnsolvedSymbolException} was not caused by another throwable, or if the causative throwable is unknown.
+     */
+    private Throwable cause;
 
     public UnsolvedSymbolException(String name) {
-        super("Unsolved symbol : " + name);
-        this.context = "unknown";
+        this(name, null, null);
+    }
+
+    public UnsolvedSymbolException(String name, String context) {
+        this(name, context, null);
+    }
+
+    public UnsolvedSymbolException(String name, Throwable cause) {
+        this(name, null, cause);
+    }
+
+    public UnsolvedSymbolException(String name, String context, Throwable cause) {
+        super("Unsolved symbol" + (context != null ? " in " + context : "") + " : " + name);
         this.name = name;
+        this.context = context;
+        this.cause = cause;
     }
 
     @Override
     public String toString() {
         return "UnsolvedSymbolException{" +
-                "context='" + context + '\'' +
-                ", name='" + name + '\''+
-                '}';
+               "context='" + context + "'" +
+               ", name='" + name + "'" +
+               ", cause='" + cause + "'" +
+               "}";
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -166,7 +166,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             try {
                 typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
             } catch (Exception e) {
-                throw new UnsolvedSymbolException("Issue calculating the type of the scope of " + this);
+                throw new UnsolvedSymbolException(scope.toString(), wrappedNode.toString(), e);
             }
             if (typeOfScope.isWildcard()) {
                 if (typeOfScope.asWildcard().isExtends() || typeOfScope.asWildcard().isSuper()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -166,7 +166,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             try {
                 typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
             } catch (Exception e) {
-                throw new RuntimeException("Issue calculating the type of the scope of " + this, e);
+                throw new UnsolvedSymbolException("Issue calculating the type of the scope of " + this);
             }
             if (typeOfScope.isWildcard()) {
                 if (typeOfScope.asWildcard().isExtends() || typeOfScope.asWildcard().isSuper()) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/UnknownMethodsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/UnknownMethodsResolutionTest.java
@@ -1,0 +1,40 @@
+package com.github.javaparser.symbolsolver.resolution;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+public class UnknownMethodsResolutionTest extends AbstractResolutionTest {
+
+	@Test(expected = UnsolvedSymbolException.class)
+	public void testUnknownMethod1() {
+		CompilationUnit cu = parseSample("UnknownMethods");
+		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
+		MethodDeclaration method = Navigator.demandMethod(clazz, "test1");
+		MethodCallExpr methodCallExpr = method.getBody().get().getStatement(0).asExpressionStmt().getExpression()
+                                                .asMethodCallExpr();
+
+		SymbolReference<ResolvedMethodDeclaration> ref =
+				JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
+	}
+
+	@Test(expected = UnsolvedSymbolException.class)
+	public void testUnknownMethod2() {
+		CompilationUnit cu = parseSample("UnknownMethods");
+		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
+		MethodDeclaration method = Navigator.demandMethod(clazz, "test2");
+		MethodCallExpr methodCallExpr = method.getBody().get().getStatement(1).asExpressionStmt().getExpression()
+                                                .asMethodCallExpr();
+
+		SymbolReference<ResolvedMethodDeclaration> ref =
+				JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/UnknownMethods.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/UnknownMethods.java.txt
@@ -1,0 +1,16 @@
+package testcase;
+
+import java.io.IOException;
+import javax.servlet.http.*;
+
+public abstract class UnknownMethods extends HttpServlet {
+
+	public void test1(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		response.getWriter().println("hello world!");
+	}
+
+	public void test2(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String data = "world!";
+		response.getWriter().println("hello " + data);
+	}
+}


### PR DESCRIPTION
Consider the following code:

```
package testcase;

import java.io.IOException;
import javax.servlet.http.*;

public abstract class UnknownMethods extends HttpServlet {
	public void test2(HttpServletRequest request, HttpServletResponse response) throws IOException {
		String data = "world!";
		response.getWriter().println("hello " + data);
	}
}
```

Trying to resolve the method call expression `response.getWriter().println("hello " + data)` correctly throws an `UnsolvedSymbolException`, since the symbol solver obviously cannot resolve the method call expression whose corresponding method declaration is buried in the javax package (the reflection type solver only supports resolution for classes that are in the classloader, if I understand correctly).

Now consider instead the following code:

```
package testcase;

import java.io.IOException;
import javax.servlet.http.*;

public abstract class UnknownMethods extends HttpServlet {
	public void test1(HttpServletRequest request, HttpServletResponse response) throws IOException {
		response.getWriter().println("hello world!");
	}
}
```

Now again try to resolve the method call expression `response.getWriter().println("hello world!")`.

**Expected behavior:** The symbol solver should throw an `UnsolvedSymbolException`, as above.
**Actual behavior:** The symbol solver throws an unspecific `RuntimeException`.

This PR fixes this bug and adds corresponding tests.

