### PR TITLE
Solve fields of classes with unresolvable ancestors

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -166,7 +166,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             try {
                 typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
             } catch (Exception e) {
-                throw new RuntimeException("Issue calculating the type of the scope of " + this, e);
+                throw new UnsolvedSymbolException("Issue calculating the type of the scope of " + this);
             }
             if (typeOfScope.isWildcard()) {
                 if (typeOfScope.asWildcard().isExtends() || typeOfScope.asWildcard().isSuper()) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
@@ -22,10 +22,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -153,6 +150,50 @@ public class FieldsResolutionTest extends AbstractResolutionTest {
         // get expected field declaration
         clazz = Navigator.demandClass(cu, "AccessThroughSuper.SuperClass");
         VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "field");
+
+        // check that the expected field declaration equals the resolved field declaration
+        assertEquals(variableDeclarator, ((JavaParserFieldDeclaration) resolvedValueDeclaration).getVariableDeclarator());
+    }
+
+    @Test
+    public void resolveClassFieldOfClassExtendingUnknownClass1() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get field access expression
+        CompilationUnit cu = parseSample("ClassExtendingUnknownClass");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ClassExtendingUnknownClass");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "getFoo");
+        ReturnStmt returnStmt = (ReturnStmt) method.getBody().get().getStatements().get(0);
+        NameExpr expression = returnStmt.getExpression().get().asNameExpr();
+
+        // resolve field access expression
+        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
+
+        // get expected field declaration
+        VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "foo");
+
+        // check that the expected field declaration equals the resolved field declaration
+        assertEquals(variableDeclarator, ((JavaParserFieldDeclaration) resolvedValueDeclaration).getVariableDeclarator());
+    }
+
+    @Test
+    public void resolveClassFieldOfClassExtendingUnknownClass2() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get field access expression
+        CompilationUnit cu = parseSample("ClassExtendingUnknownClass");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ClassExtendingUnknownClass");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "getFoo2");
+        ReturnStmt returnStmt = (ReturnStmt) method.getBody().get().getStatements().get(0);
+        FieldAccessExpr expression = returnStmt.getExpression().get().asFieldAccessExpr();
+
+        // resolve field access expression
+        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
+
+        // get expected field declaration
+        VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "foo");
 
         // check that the expected field declaration equals the resolved field declaration
         assertEquals(variableDeclarator, ((JavaParserFieldDeclaration) resolvedValueDeclaration).getVariableDeclarator());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/UnknownMethodsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/UnknownMethodsResolutionTest.java
@@ -1,0 +1,40 @@
+package com.github.javaparser.symbolsolver.resolution;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+public class UnknownMethodsResolutionTest extends AbstractResolutionTest {
+
+	@Test(expected = UnsolvedSymbolException.class)
+	public void testUnknownMethod1() {
+		CompilationUnit cu = parseSample("UnknownMethods");
+		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
+		MethodDeclaration method = Navigator.demandMethod(clazz, "test1");
+		MethodCallExpr methodCallExpr = method.getBody().get().getStatement(0).asExpressionStmt().getExpression()
+                                                .asMethodCallExpr();
+
+		SymbolReference<ResolvedMethodDeclaration> ref =
+				JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
+	}
+
+	@Test(expected = UnsolvedSymbolException.class)
+	public void testUnknownMethod2() {
+		CompilationUnit cu = parseSample("UnknownMethods");
+		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
+		MethodDeclaration method = Navigator.demandMethod(clazz, "test2");
+		MethodCallExpr methodCallExpr = method.getBody().get().getStatement(1).asExpressionStmt().getExpression()
+                                                .asMethodCallExpr();
+
+		SymbolReference<ResolvedMethodDeclaration> ref =
+				JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
@@ -2,7 +2,7 @@ import com.third.party.library.UnknownClass;
 
 public class ClassExtendingUnknownClass extends UnknownClass {
 
-    private final int foo;
+    private int foo;
 
     public int getFoo() {
         return foo;

--- a/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
@@ -1,0 +1,14 @@
+import com.third.party.library.UnknownClass;
+
+public class ClassExtendingUnknownClass extends UnknownClass {
+
+    private final int foo;
+
+    public int getFoo() {
+        return foo;
+    }
+
+    public int getFoo2() {
+        return this.foo;
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/UnknownMethods.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/UnknownMethods.java.txt
@@ -1,0 +1,16 @@
+package testcase;
+
+import java.io.IOException;
+import javax.servlet.http.*;
+
+public abstract class UnknownMethods extends HttpServlet {
+
+	public void test1(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		response.getWriter().println("hello world!");
+	}
+
+	public void test2(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String data = "world!";
+		response.getWriter().println("hello " + data);
+	}
+}


### PR DESCRIPTION
Consider the following code:

```
import com.third.party.library.UnknownClass;

public class ClassExtendingUnknownClass extends UnknownClass {

    private int foo;

    public int getFoo() {
        return foo;
    }

    public int getFoo2() {
        return this.foo;
    }
}
```

The point here is that while we do have the source code of `ClassExtendingUnknownClass`, we do not have the source code of its parent class `UnknownClass`, which comes from some external third-party library that is unknown.

Nevertheless, we should be able to resolve the field declaration corresponding to the `NameExpr` `foo` in method `getFoo()`, as well as the field declaration corresponding to the `FieldAccessExpr` `this.foo` in method `getFoo2()`. We don't need to know the source code of the parent class for that. However, when we try to instruct the symbol solver to resolve the field declaration of either the `NameExpr` or the `FieldAccessExpr`, an `UnsolvedSymbolException` is thrown.

This is because, essentially, the symbol solver attempts to resolve the parent class and the implemented interfaces *before* it even looks at the fields of the current class. In the above example, an `UnsolvedSymbolException` is thrown while trying to resolve the parent class (since the parent class is unknown), which propagates backwards to the original call to `resolve()` of the `NameExpr` or the `FieldAccessExpr`.

This PR fixes that bug, thus making it possible to resolve a field declaration in scenarios such as the above.
