### PR TITLE
Solve fields of classes with unresolvable ancestors

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -90,8 +90,8 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
     @Override
     public String toString() {
         return "JavaParserClassDeclaration{" +
-                "wrappedNode=" + wrappedNode +
-                '}';
+               "wrappedNode=" + wrappedNode +
+               '}';
     }
 
     ///
@@ -101,40 +101,40 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
     @Override
     public List<ResolvedFieldDeclaration> getAllFields() {
         List<ResolvedFieldDeclaration> fields = javaParserTypeAdapter.getFieldsForDeclaredVariables();
-        
-        getAncestors().forEach(ancestor -> ancestor.getTypeDeclaration().getAllFields().forEach(f -> {
+
+        getAncestors(true).forEach(ancestor -> ancestor.getTypeDeclaration().getAllFields().forEach(f -> {
             fields.add(new ResolvedFieldDeclaration() {
-                
+
                 @Override
                 public AccessSpecifier accessSpecifier() {
                     return f.accessSpecifier();
                 }
-                
+
                 @Override
                 public String getName() {
                     return f.getName();
                 }
-                
+
                 @Override
                 public ResolvedType getType() {
                     return ancestor.useThisTypeParametersOnTheGivenType(f.getType());
                 }
-                
+
                 @Override
                 public boolean isStatic() {
                     return f.isStatic();
                 }
-                
+
                 @Override
                 public ResolvedTypeDeclaration declaringType() {
                     return f.declaringType();
                 }
             });
         }));
-        
+
         return fields;
     }
-    
+
     ///
     /// Public methods
     ///
@@ -287,8 +287,31 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         return getContext().getParent().solveType(name, typeSolver);
     }
 
+    /**
+     * Resolves the type of all ancestors (i.e., the extended class and the implemented interfaces) and returns the list
+     * of ancestors as a list of resolved reference types.
+     *
+     * @return The list of resolved ancestors.
+     * @throws UnsolvedSymbolException if some ancestor could not be resolved.
+     */
     @Override
     public List<ResolvedReferenceType> getAncestors() {
+        return getAncestors(false);
+    }
+
+    /**
+     * Resolves the type of all ancestors (i.e., the extended class and the implemented interfaces) and returns the list
+     * of ancestors as a list of resolved reference types.
+     *
+     * @param acceptIncompleteList When set to {@code false}, this method throws an {@link UnsolvedSymbolException} if
+     *                             one or more ancestor could not be resolved. When set to {@code true}, this method
+     *                             does not throw an {@link UnsolvedSymbolException}, but the list of returned ancestors
+     *                             may be incomplete in case one or more ancestor could not be resolved.
+     * @return The list of resolved ancestors.
+     * @throws UnsolvedSymbolException if some ancestor could not be resolved and {@code acceptIncompleteList} is set to
+     *                                 {@code false}.
+     */
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
 
         // We want to avoid infinite recursion in case of Object having Object as ancestor
@@ -297,9 +320,13 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
             try {
                 superclass = getSuperClass();
             } catch (UnsolvedSymbolException e) {
-                // in case we could not resolve the super class, we may still be able to resolve (some of) the
-                // implemented interfaces and so we continue gracefully with an (incomplete) list of ancestors
-                superclass = null;
+                if (acceptIncompleteList) {
+                    // in case we could not resolve the super class, we may still be able to resolve (some of) the
+                    // implemented interfaces and so we continue gracefully with an (incomplete) list of ancestors
+                    superclass = null;
+                } else {
+                    throw e;
+                }
             }
             if (superclass != null) {
                 ancestors.add(superclass);
@@ -310,10 +337,14 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
                     try {
                         ancestor = toReferenceType(implemented);
                     } catch (UnsolvedSymbolException e) {
-                        // in case we could not resolve some implemented interface, we may still be able to resolve the
-                        // extended class or (some of) the other implemented interfaces and so we continue gracefully
-                        // with an (incomplete) list of ancestors
-                        ancestor = null;
+                        if (acceptIncompleteList) {
+                            // in case we could not resolve some implemented interface, we may still be able to resolve the
+                            // extended class or (some of) the other implemented interfaces and so we continue gracefully
+                            // with an (incomplete) list of ancestors
+                            ancestor = null;
+                        } else {
+                            throw e;
+                        }
                     }
                     if (ancestor != null) {
                         ancestors.add(ancestor);
@@ -371,7 +402,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         Set<ResolvedReferenceTypeDeclaration> res = new HashSet<>();
         for (BodyDeclaration<?> member : this.wrappedNode.getMembers()) {
             if (member instanceof com.github.javaparser.ast.body.TypeDeclaration) {
-                res.add(JavaParserFacade.get(typeSolver).getTypeDeclaration((com.github.javaparser.ast.body.TypeDeclaration)member));
+                res.add(JavaParserFacade.get(typeSolver).getTypeDeclaration((com.github.javaparser.ast.body.TypeDeclaration) member));
             }
         }
         return res;
@@ -407,8 +438,8 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
             return new ReferenceTypeImpl(ref.getCorrespondingDeclaration().asReferenceType(), typeSolver);
         }
         List<ResolvedType> superClassTypeParameters = classOrInterfaceType.getTypeArguments().get()
-                .stream().map(ta -> new LazyType(v -> JavaParserFacade.get(typeSolver).convert(ta, ta)))
-                .collect(Collectors.toList());
+                                                              .stream().map(ta -> new LazyType(v -> JavaParserFacade.get(typeSolver).convert(ta, ta)))
+                                                              .collect(Collectors.toList());
         return new ReferenceTypeImpl(ref.getCorrespondingDeclaration().asReferenceType(), superClassTypeParameters, typeSolver);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
@@ -22,10 +22,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -153,6 +150,50 @@ public class FieldsResolutionTest extends AbstractResolutionTest {
         // get expected field declaration
         clazz = Navigator.demandClass(cu, "AccessThroughSuper.SuperClass");
         VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "field");
+
+        // check that the expected field declaration equals the resolved field declaration
+        assertEquals(variableDeclarator, ((JavaParserFieldDeclaration) resolvedValueDeclaration).getVariableDeclarator());
+    }
+
+    @Test
+    public void resolveClassFieldOfClassExtendingUnknownClass1() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get field access expression
+        CompilationUnit cu = parseSample("ClassExtendingUnknownClass");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ClassExtendingUnknownClass");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "getFoo");
+        ReturnStmt returnStmt = (ReturnStmt) method.getBody().get().getStatements().get(0);
+        NameExpr expression = returnStmt.getExpression().get().asNameExpr();
+
+        // resolve field access expression
+        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
+
+        // get expected field declaration
+        VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "foo");
+
+        // check that the expected field declaration equals the resolved field declaration
+        assertEquals(variableDeclarator, ((JavaParserFieldDeclaration) resolvedValueDeclaration).getVariableDeclarator());
+    }
+
+    @Test
+    public void resolveClassFieldOfClassExtendingUnknownClass2() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get field access expression
+        CompilationUnit cu = parseSample("ClassExtendingUnknownClass");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ClassExtendingUnknownClass");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "getFoo2");
+        ReturnStmt returnStmt = (ReturnStmt) method.getBody().get().getStatements().get(0);
+        FieldAccessExpr expression = returnStmt.getExpression().get().asFieldAccessExpr();
+
+        // resolve field access expression
+        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
+
+        // get expected field declaration
+        VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "foo");
 
         // check that the expected field declaration equals the resolved field declaration
         assertEquals(variableDeclarator, ((JavaParserFieldDeclaration) resolvedValueDeclaration).getVariableDeclarator());

--- a/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
@@ -1,0 +1,14 @@
+import com.third.party.library.UnknownClass;
+
+public class ClassExtendingUnknownClass extends UnknownClass {
+
+    private int foo;
+
+    public int getFoo() {
+        return foo;
+    }
+
+    public int getFoo2() {
+        return this.foo;
+    }
+}


### PR DESCRIPTION
Consider the following code:

```java
import com.third.party.library.UnknownClass;

public class ClassExtendingUnknownClass extends UnknownClass {

    private int foo;

    public int getFoo() {
        return foo;
    }

    public int getFoo2() {
        return this.foo;
    }
}
```

The point here is that while we do have the source code of `ClassExtendingUnknownClass`, we do not have the source code of its parent class `UnknownClass`, which comes from some external third-party library that is unknown.

Nevertheless, we should be able to resolve the field declaration corresponding to the `NameExpr` `foo` in method `getFoo()`, as well as the field declaration corresponding to the `FieldAccessExpr` `this.foo` in method `getFoo2()`. We don't need to know the source code of the parent class for that. However, when we try to instruct the symbol solver to resolve the field declaration of either the `NameExpr` or the `FieldAccessExpr`, an `UnsolvedSymbolException` is thrown.

This is because, essentially, the symbol solver attempts to resolve the parent class and the implemented interfaces *before* it even looks at the fields of the current class. In the above example, an `UnsolvedSymbolException` is thrown while trying to resolve the parent class (since the parent class is unknown), which propagates backwards to the original call to `resolve()` of the `NameExpr` or the `FieldAccessExpr`.

This PR fixes that bug, thus making it possible to resolve a field declaration in scenarios such as the above.
