### PR TITLE
[minor] Make Type implement Resolvable<ResolvedType> instead of Resolvable<Object>

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -45,7 +45,7 @@ import java.util.Optional;
  *
  * @author Julio Vilmar Gesser
  */
-public abstract class Type extends Node implements Resolvable<Object> {
+public abstract class Type extends Node implements Resolvable<ResolvedType> {
 
     private NodeList<AnnotationExpr> annotations;
 


### PR DESCRIPTION
I was just trying to call `resolve()` on objects that are instances of `Type` and was confused that my IDE told me that the return value of this call is a generic `Object`.

The reason is that `Type` implements `Resolvable<Object>`, which is very unspecific and somewhat confusing. After some investigation in the source code, I understood that `Type` can be much more specific: it implements `Resolvable<ResolvedType>` (well it doesn't itself, since it's abstract, but its subclasses do).

I think this is a useful change. This way, whenever we call `resolve()` on some subclass of `Type`, we know we get a `ResolvedType` and not only an `Object`.