### PR TITLE
Fixing signatures of ReflectionConstructorDeclaration

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionConstructorDeclaration.java
@@ -69,7 +69,7 @@ public class ReflectionConstructorDeclaration implements ResolvedConstructorDecl
 
     @Override
     public String getName() {
-        return constructor.getName();
+        return constructor.getDeclaringClass().getSimpleName();
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodLikeSignaturesTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodLikeSignaturesTest.java
@@ -1,0 +1,51 @@
+package com.github.javaparser.symbolsolver.resolution;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MethodLikeSignaturesTest extends AbstractResolutionTest {
+
+    @Test
+    public void checkReflectionConstructorSignature() {
+        CompilationUnit cu = parseSample("MethodLikeSignaturesTest");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodLikeSignaturesTest");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "foo");
+        ObjectCreationExpr objectCreationExpr = method.getBody().get().getStatements().get(0)
+                                                        .asExpressionStmt().getExpression().asVariableDeclarationExpr()
+                                                        .getVariable(0).getInitializer().get().asObjectCreationExpr();
+
+        ResolvedConstructorDeclaration resolvedConstructorDeclaration =
+                JavaParserFacade.get(new ReflectionTypeSolver()).solve(objectCreationExpr).getCorrespondingDeclaration();
+
+        assertEquals("File", resolvedConstructorDeclaration.getName());
+        assertEquals("File(java.lang.String)", resolvedConstructorDeclaration.getSignature());
+        assertEquals("java.io.File.File(java.lang.String)", resolvedConstructorDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    public void checkReflectionMethodSignature() {
+        CompilationUnit cu = parseSample("MethodLikeSignaturesTest");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodLikeSignaturesTest");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "foo");
+        MethodCallExpr methodCallExpr = method.getBody().get().getStatements().get(1)
+                                                .asExpressionStmt().getExpression().asMethodCallExpr();
+
+        ResolvedMethodDeclaration resolvedMethodDeclaration =
+                JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr).getCorrespondingDeclaration();
+
+        assertEquals("delete", resolvedMethodDeclaration.getName());
+        assertEquals("delete()", resolvedMethodDeclaration.getSignature());
+        assertEquals("java.io.File.delete()", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/MethodLikeSignaturesTest.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/MethodLikeSignaturesTest.java.txt
@@ -1,0 +1,9 @@
+import java.io.File;
+
+class MethodLikeSignaturesTest {
+
+	public void foo() {
+		File file = new File("somepath");
+		file.delete();
+	}
+}


### PR DESCRIPTION
This PR fixes the following unreported bug.

Consider this code:

```
import java.io.File;

class MethodLikeSignaturesTest {

	public void foo() {
		File file = new File("somepath");
	}
}
```

Now when you try to resolve the constructor declaration that corresponds to the object creation expression `new File("somepath")` using a `ReflectionTypeSolver`, you get a `ReflectionConstructorDeclaration`. So far so good. If you now call `getQualifiedSignature` on this `ReflectionConstructorDeclaration`, you get the following String:

`java.io.File.java.io.File(java.lang.String)
`

I think we all agree that this is incorrect. Essentially, the problem is that the method `ResolvedDeclaration#getName()` is defined such that it should return the *simple* name of a constructor or method, but in the case of a `ReflectionConstructorDeclaration`, it returns the *qualified* name instead. This then leads to further bugs such as the above.

I fixed `ReflectionConstructorDeclaration#getName()` to return the simple name, as it should be. Therefore, in the above example, `getQualifiedSignature()` now returns:

`java.io.File.File(java.lang.String)
`

...as one would expect. :) (essentially the same as you would use in a Javadoc comment: `java.io.File#File(java.lang.String)`, except that JSS uses a dot (`.`) where Javadoc comments use a sharp (`#`)).

This was a quickie, hoping that this will still make it into this week-end's release so I can use it on Monday... :wink:

