### PR TITLE
Addressing test failure due to package name/class name conflict

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/ReflectionTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/ReflectionTypeSolver.java
@@ -77,6 +77,14 @@ public class ReflectionTypeSolver implements TypeSolver {
 
                 Class<?> clazz = classLoader.loadClass(name);
                 return SymbolReference.solved(ReflectionFactory.typeDeclarationFor(clazz, getRoot()));
+            } catch (NoClassDefFoundError e) {
+                // We can safely ignore this one because it is triggered when there are package names which are almost the
+                // same as class name, with the exclusion of the case.
+                // For example:
+                // java.lang.NoClassDefFoundError: com/github/javaparser/printer/ConcreteSyntaxModel
+                // (wrong name: com/github/javaparser/printer/concretesyntaxmodel)
+                // note that this exception seems to be thrown only on certain platform (mac yes, linux no)
+                return SymbolReference.unsolved(ResolvedReferenceTypeDeclaration.class);
             } catch (ClassNotFoundException e) {
                 // it could be an inner class
                 int lastDot = name.lastIndexOf('.');


### PR DESCRIPTION
I have this failure on my mac due to the fact that we are trying to load classes to figure out which parts of a qualified name corresponds to classes. At some point we find a package name (`com/github/javaparser/printer/concretesyntaxmodel`) which corresponds to a class name but for the case ('com/github/javaparser/printer/ConcreteSyntaxModel`). This on mac causes a NoClassDefFound error to be thrown (`java.lang.NoClassDefFoundError: com/github/javaparser/printer/ConcreteSyntaxModel (wrong name: com/github/javaparser/printer/concretesyntaxmodel)`). I think this should be ignored.