### PR TITLE
add FieldAccessExpr isInternal/isTopLevel

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -287,4 +287,18 @@ public final class FieldAccessExpr extends Expression implements NodeWithSimpleN
     public Optional<FieldAccessExpr> toFieldAccessExpr() {
         return Optional.of(this);
     }
+
+    /**
+     * Indicate if this FieldAccessExpr is an element directly contained in a larger FieldAccessExpr.
+     */
+    public boolean isInternal() {
+        return this.getParentNode().isPresent() && this.getParentNode().get() instanceof FieldAccessExpr;
+    }
+
+    /**
+     * Indicate if this FieldAccessExpr is top level, i.e., it is not directly contained in a larger FieldAccessExpr.
+     */
+    public boolean isTopLevel() {
+        return !isInternal();
+    }
 }


### PR DESCRIPTION
Add these methods to distinguish between different types of field accesses. Typically we are interested only in top level field accesses, because others could refer to the path through packages or through internal types. For example, we should resolve only top level FieldAccessExpr unless we know what we are doing.