### PR TITLE
Issue1709 name logic

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
@@ -11,7 +11,6 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.TypeParameter;
-import com.github.javaparser.symbolsolver.core.resolution.Context;
 
 /**
  * NameLogic contains a set of static methods to implement the abstraction of a "Name" as defined

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
@@ -5,9 +5,11 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.symbolsolver.core.resolution.Context;
 
 /**
  * NameLogic contains a set of static methods to implement the abstraction of a "Name" as defined
@@ -121,6 +123,33 @@ public class NameLogic {
             return NameRole.REFERENCE;
         }
         if (whenParentIs(ReturnStmt.class, name, (p, c) -> p.getExpression().isPresent() && p.getExpression().get() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ConstructorDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ModuleDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(ModuleRequiresStmt.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ModuleExportsStmt.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ModuleExportsStmt.class, name, (p, c) -> p.getModuleNames().contains(c))) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ModuleOpensStmt.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ModuleOpensStmt.class, name, (p, c) -> p.getModuleNames().contains(c))) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ModuleUsesStmt.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ModuleProvidesStmt.class, name, (p, c) -> p.getName() == c)) {
             return NameRole.REFERENCE;
         }
         if (name.getParentNode().isPresent() && NameLogic.isAName(name.getParentNode().get())) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
@@ -1,0 +1,176 @@
+package com.github.javaparser.symbolsolver.resolution.naming;
+
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.TypeParameter;
+
+/**
+ * NameLogic contains a set of static methods to implement the abstraction of a "Name" as defined
+ * in Chapter 6 of the JLS. This code could be moved to an interface or base class in a successive version of
+ * JavaParser.
+ */
+public class NameLogic {
+
+    /**
+     * Is the given node a non-qualified name?
+     *
+     * @throws IllegalArgumentException if the node is not a name
+     */
+    public static boolean isSimpleName(Node node) {
+        return !isQualifiedName(node);
+    }
+
+    /**
+     * Is the given node a qualified name?
+     *
+     * @throws IllegalArgumentException if the node is not a name
+     */
+    public static boolean isQualifiedName(Node node) {
+        if (!isAName(node)) {
+            throw new IllegalArgumentException();
+        }
+        return nameAsString(node).contains(".");
+    }
+
+    /**
+     * Does the Node represent a Name?
+     *
+     * Note that while most specific AST classes either always represent names or never represent names
+     * there are exceptions as the FieldAccessExpr
+     */
+    public static boolean isAName(Node node) {
+        if (node instanceof FieldAccessExpr) {
+            FieldAccessExpr fieldAccessExpr = (FieldAccessExpr)node;
+            return isAName(fieldAccessExpr.getScope());
+        } else {
+            return node instanceof SimpleName || node instanceof Name
+                    || node instanceof ClassOrInterfaceType || node instanceof NameExpr;
+        }
+    }
+
+    /**
+     * What is the Role of the given name? Does it represent a Declaration or a Reference?
+     *
+     * This classification is purely syntactical, i.e., it does not require symbol resolution. For this reason in the
+     * future this could be moved to the core module of JavaParser.
+     */
+    public static NameRole classifyRole(Node name) {
+        if (!isAName(name)) {
+            throw new IllegalArgumentException("The given node is not a name");
+        }
+        if (!name.getParentNode().isPresent()) {
+            throw new IllegalArgumentException("We cannot understand the role of a name if it has no parent");
+        }
+        if (whenParentIs(Name.class, name, (p, c) -> p.getQualifier().isPresent() && p.getQualifier().get() == c)) {
+            return classifyRole(name.getParentNode().get());
+        }
+        if (whenParentIs(PackageDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(ImportDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(MarkerAnnotationExpr.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ClassOrInterfaceDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(ClassOrInterfaceType.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(VariableDeclarator.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(NameExpr.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(FieldAccessExpr.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(MethodDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(Parameter.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(MethodCallExpr.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ConstructorDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(TypeParameter.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(EnumDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(EnumConstantDeclaration.class, name, (p, c) -> p.getName() == c)) {
+            return NameRole.DECLARATION;
+        }
+        if (whenParentIs(FieldAccessExpr.class, name, (p, c) -> p.getName() == c || p.getScope() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ObjectCreationExpr.class, name, (p, c) -> p.getType() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (whenParentIs(ReturnStmt.class, name, (p, c) -> p.getExpression().isPresent() && p.getExpression().get() == c)) {
+            return NameRole.REFERENCE;
+        }
+        if (name.getParentNode().isPresent() && NameLogic.isAName(name.getParentNode().get())) {
+            return classifyRole(name.getParentNode().get());
+        }
+        throw new UnsupportedOperationException("Unable to classify role of name contained in "
+                + name.getParentNode().get().getClass().getSimpleName());
+    }
+
+    /**
+     * Return the string representation of the name
+     */
+    public static String nameAsString(Node name) {
+        if (!isAName(name)) {
+            throw new IllegalArgumentException("A name was expected");
+        }
+        if (name instanceof Name) {
+            return ((Name)name).asString();
+        } else if (name instanceof SimpleName) {
+            return ((SimpleName) name).getIdentifier();
+        } else if (name instanceof ClassOrInterfaceType) {
+            return ((ClassOrInterfaceType) name).asString();
+        } else if (name instanceof FieldAccessExpr) {
+            FieldAccessExpr fieldAccessExpr = (FieldAccessExpr) name;
+            if (isAName(fieldAccessExpr.getScope())) {
+                return nameAsString(fieldAccessExpr.getScope()) + "." + nameAsString(fieldAccessExpr.getName());
+            } else {
+                throw new IllegalArgumentException();
+            }
+        } else if (name instanceof NameExpr) {
+            return ((NameExpr)name).getNameAsString();
+        } else {
+            throw new UnsupportedOperationException("Unknown type of name found: " + name + " ("
+                    + name.getClass().getCanonicalName() + ")");
+        }
+    }
+
+    private interface PredicateOnParentAndChild<P extends Node, C extends Node> {
+        boolean isSatisfied(P parent, C child);
+    }
+
+    private static <P extends Node, C extends Node> boolean whenParentIs(Class<P> parentClass,
+                                                                         C child,
+                                                                         PredicateOnParentAndChild<P, C> predicate) {
+        if (child.getParentNode().isPresent()) {
+            Node parent = child.getParentNode().get();
+            return parentClass.isInstance(parent) && predicate.isSatisfied(parentClass.cast(parent), child);
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameRole.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameRole.java
@@ -1,0 +1,9 @@
+package com.github.javaparser.symbolsolver.resolution.naming;
+
+/**
+ * Each Name can be part either of a Declaration or a Reference to a Declaration.
+ */
+public enum NameRole {
+    DECLARATION,
+    REFERENCE
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/AbstractNameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/AbstractNameLogicTest.java
@@ -26,19 +26,28 @@ public abstract class AbstractNameLogicTest extends AbstractResolutionTest {
         return getNameInCode(code, name, parseStart, false, Optional.empty());
     }
 
-    private Node getNameInCode(String code, String name, ParseStart parseStart, boolean tollerant,
-                               Optional<TypeSolver> typeSolver) {
+    protected <N extends Node> N parse(String code, ParseStart<N> parseStart) {
+        return parse(code, parseStart, Optional.empty());
+    }
+
+    protected <N extends Node> N parse(String code, ParseStart<N> parseStart, Optional<TypeSolver> typeSolver) {
         ParserConfiguration parserConfiguration = new ParserConfiguration();
         parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_10);
         if (typeSolver.isPresent()) {
             parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver.get()));
         }
-        ParseResult<? extends Node> parseResult = new JavaParser(parserConfiguration).parse(parseStart, new StringProvider(code));
+        ParseResult<N> parseResult = new JavaParser(parserConfiguration).parse(parseStart, new StringProvider(code));
         if (!parseResult.isSuccessful()) {
             parseResult.getProblems().forEach(p -> System.out.println("ERR: " + p));
         }
         assertTrue(parseResult.isSuccessful());
-        Node root = parseResult.getResult().get();
+        N root = parseResult.getResult().get();
+        return root;
+    }
+
+    private Node getNameInCode(String code, String name, ParseStart parseStart, boolean tollerant,
+                               Optional<TypeSolver> typeSolver) {
+        Node root = parse(code, parseStart, typeSolver);
         List<Node> allNames = root.findAll(Node.class).stream()
                 .filter(NameLogic::isAName)
                 .collect(Collectors.toList());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/AbstractNameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/AbstractNameLogicTest.java
@@ -1,0 +1,75 @@
+package com.github.javaparser.symbolsolver.resolution.naming;
+
+import com.github.javaparser.*;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractNameLogicTest extends AbstractResolutionTest {
+
+    protected Node getNameInCodeTollerant(String code, String name, ParseStart parseStart) {
+        return getNameInCode(code, name, parseStart, true, Optional.empty());
+    }
+
+    protected Node getNameInCodeTollerant(String code, String name, ParseStart parseStart, TypeSolver typeSolver) {
+        return getNameInCode(code, name, parseStart, true, Optional.of(typeSolver));
+    }
+
+    protected Node getNameInCode(String code, String name, ParseStart parseStart) {
+        return getNameInCode(code, name, parseStart, false, Optional.empty());
+    }
+
+    private Node getNameInCode(String code, String name, ParseStart parseStart, boolean tollerant,
+                               Optional<TypeSolver> typeSolver) {
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_10);
+        if (typeSolver.isPresent()) {
+            parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver.get()));
+        }
+        ParseResult<? extends Node> parseResult = new JavaParser(parserConfiguration).parse(parseStart, new StringProvider(code));
+        if (!parseResult.isSuccessful()) {
+            parseResult.getProblems().forEach(p -> System.out.println("ERR: " + p));
+        }
+        assertTrue(parseResult.isSuccessful());
+        Node root = parseResult.getResult().get();
+        List<Node> allNames = root.findAll(Node.class).stream()
+                .filter(NameLogic::isAName)
+                .collect(Collectors.toList());
+        List<Node> matchingNames = allNames.stream()
+                .filter(n -> NameLogic.nameAsString(n).equals(name))
+                .collect(Collectors.toList());
+        // In case of one name being contained in other as is, we remove it
+        for (int i=0;i<matchingNames.size();i++) {
+            Node container = matchingNames.get(i);
+            for (int j=i+1;j<matchingNames.size();j++) {
+                Node contained = matchingNames.get(j);
+                if (contained.getParentNode().isPresent() && contained.getParentNode().get() == container
+                        && NameLogic.nameAsString(contained).equals(NameLogic.nameAsString(container))) {
+                    matchingNames.remove(j);
+                    j--;
+                }
+            }
+        }
+
+        if (matchingNames.size() == 0) {
+            throw new IllegalArgumentException("Not found. Names found: " + String.join(", ",
+                    allNames.stream().map(NameLogic::nameAsString).collect(Collectors.toList())));
+        } else if (matchingNames.size() > 1) {
+            if (tollerant) {
+                return matchingNames.get(matchingNames.size() - 1);
+            } else {
+                throw new IllegalArgumentException("Ambiguous: there are several matching.");
+            }
+        } else {
+            return matchingNames.get(0);
+        }
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.modules.ModuleDeclaration;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import org.junit.Test;
 
@@ -112,6 +113,22 @@ public class NameLogicTest extends AbstractNameLogicTest {
                 .getScope().asFieldAccessExpr()
                 .getScope().asFieldAccessExpr()
                 .getScope())); // a
+    }
+
+    @Test
+    public void nameAsStringModuleName() {
+        ModuleDeclaration md = parse("module com.mydeveloperplanet.jpmshello {\n" +
+                "    requires java.base;\n" +
+                "    requires java.xml;\n" +
+                "    requires com.mydeveloperplanet.jpmshi;\n" +
+                "}\n", ParseStart.MODULE_DECLARATION);
+        assertEquals("com.mydeveloperplanet.jpmshello", NameLogic.nameAsString(md.getName()));
+    }
+
+    @Test
+    public void nameAsStringClassName() {
+        CompilationUnit cu = parse("class Foo extends bar.MyClass { }", ParseStart.COMPILATION_UNIT);
+        assertEquals("Foo", NameLogic.nameAsString(cu.getType(0).getName()));
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
@@ -503,5 +503,17 @@ public class NameLogicTest extends AbstractNameLogicTest {
                         "public static void travelThroughTime(Date destination) {  }",
                 "anExpression", REFERENCE, ParseStart.CLASS_BODY);
     }
+
+    @Test
+    public void classifyRoleDefaultValueDeclaration() {
+        assertNameInCodeHasRole("@RequestForEnhancement(\n" +
+                        "    id       = 2868724,\n" +
+                        "    synopsis = \"Provide time-travel functionality\",\n" +
+                        "    engineer = \"Mr. Peabody\",\n" +
+                        "    date     = anExpression" +
+                        ")\n" +
+                        "public static void travelThroughTime(Date destination) {  }",
+                "date", DECLARATION, ParseStart.CLASS_BODY);
+    }
     
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
@@ -14,12 +14,23 @@ import org.junit.Test;
 import static com.github.javaparser.symbolsolver.resolution.naming.NameRole.DECLARATION;
 import static com.github.javaparser.symbolsolver.resolution.naming.NameRole.REFERENCE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class NameLogicTest extends AbstractNameLogicTest {
 
     private void assertNameInCodeHasRole(String code, String name, NameRole nameRole, ParseStart parseStart) {
         Node nameNode = getNameInCode(code, name, parseStart);
         assertEquals(nameRole, NameLogic.classifyRole(nameNode));
+    }
+
+    private void assertIsSimpleName(String code, String name, ParseStart parseStart) {
+        Node nameNode = getNameInCode(code, name, parseStart);
+        assertTrue(NameLogic.isSimpleName(nameNode));
+    }
+
+    private void assertIsQualifiedName(String code, String name, ParseStart parseStart) {
+        Node nameNode = getNameInCode(code, name, parseStart);
+        assertTrue(NameLogic.isQualifiedName(nameNode));
     }
 
     @Test
@@ -101,6 +112,21 @@ public class NameLogicTest extends AbstractNameLogicTest {
                 .getScope().asFieldAccessExpr()
                 .getScope().asFieldAccessExpr()
                 .getScope())); // a
+    }
+
+    @Test
+    public void qualifiedModuleName() {
+        assertIsQualifiedName("module com.mydeveloperplanet.jpmshello {\n" +
+                "    requires java.base;\n" +
+                "    requires java.xml;\n" +
+                "    requires com.mydeveloperplanet.jpmshi;\n" +
+                "}\n", "com.mydeveloperplanet.jpmshello", ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void simpleNameUnqualifiedAnnotationMemberTypeTypeName() {
+        assertIsSimpleName("@interface MyAnno { MyClass myMember(); }", "MyClass",
+                ParseStart.COMPILATION_UNIT);
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
@@ -1,0 +1,462 @@
+package com.github.javaparser.symbolsolver.resolution.naming;
+
+import com.github.javaparser.*;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import org.junit.Test;
+
+import static com.github.javaparser.symbolsolver.resolution.naming.NameRole.DECLARATION;
+import static com.github.javaparser.symbolsolver.resolution.naming.NameRole.REFERENCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NameLogicTest extends AbstractNameLogicTest {
+
+    private void assertNameInCodeHasRole(String code, String name, NameRole nameRole, ParseStart parseStart) {
+        Node nameNode = getNameInCode(code, name, parseStart);
+        assertEquals(nameRole, NameLogic.classifyRole(nameNode));
+    }
+
+    @Test
+    public void identifyNamesInSimpleExamples() {
+        String code = "package a.b.c; class A { void foo(int param) { return a.b.c.D.e; } }";
+        CompilationUnit cu = JavaParser.parse(code);
+
+        assertEquals(false, NameLogic.isAName(cu));
+        assertEquals(false, NameLogic.isAName(cu.getPackageDeclaration().get()));
+
+        Name packageName = cu.getPackageDeclaration().get().getName();
+        assertEquals(true, NameLogic.isAName(packageName));
+        assertEquals(true, NameLogic.isAName(packageName.getQualifier().get()));
+        assertEquals(true, NameLogic.isAName(packageName.getQualifier().get().getQualifier().get()));
+
+        ClassOrInterfaceDeclaration classA = cu.getType(0).asClassOrInterfaceDeclaration();
+        assertEquals(false, NameLogic.isAName(classA));
+        assertEquals(true, NameLogic.isAName(classA.getName()));
+
+        MethodDeclaration methodFoo = classA.getMethods().get(0);
+        assertEquals(false, NameLogic.isAName(methodFoo));
+        assertEquals(true, NameLogic.isAName(methodFoo.getName()));
+        assertEquals(false, NameLogic.isAName(methodFoo.getParameter(0)));
+        assertEquals(true, NameLogic.isAName(methodFoo.getParameter(0).getName()));
+        assertEquals(false, NameLogic.isAName(methodFoo.getParameter(0).getType()));
+        assertEquals(false, NameLogic.isAName(methodFoo.getType()));
+
+        ReturnStmt returnStmt = methodFoo.getBody().get().getStatements().get(0).asReturnStmt();
+        assertEquals(false, NameLogic.isAName(returnStmt));
+        assertEquals(true, NameLogic.isAName(returnStmt.getExpression().get()));
+        FieldAccessExpr fieldAccessExpr = returnStmt.getExpression().get().asFieldAccessExpr();
+        assertEquals(true, NameLogic.isAName(fieldAccessExpr
+                .getScope())); // a.b.c.D
+        assertEquals(true, NameLogic.isAName(fieldAccessExpr
+                .getScope().asFieldAccessExpr()
+                .getScope())); // a.b.c
+        assertEquals(true, NameLogic.isAName(fieldAccessExpr
+                .getScope().asFieldAccessExpr()
+                .getScope().asFieldAccessExpr()
+                .getScope())); // a.b
+        assertEquals(true, NameLogic.isAName(fieldAccessExpr
+                .getScope().asFieldAccessExpr()
+                .getScope().asFieldAccessExpr()
+                .getScope().asFieldAccessExpr()
+                .getScope())); // a
+    }
+
+    @Test
+    public void identifyNameRolesInSimpleExamples() {
+        String code = "package a.b.c; class A { void foo(int param) { return a.b.c.D.e; } }";
+        CompilationUnit cu = JavaParser.parse(code);
+
+        Name packageName = cu.getPackageDeclaration().get().getName();
+        assertEquals(DECLARATION, NameLogic.classifyRole(packageName));
+        assertEquals(DECLARATION, NameLogic.classifyRole(packageName.getQualifier().get()));
+        assertEquals(DECLARATION, NameLogic.classifyRole(packageName.getQualifier().get().getQualifier().get()));
+
+        ClassOrInterfaceDeclaration classA = cu.getType(0).asClassOrInterfaceDeclaration();
+        assertEquals(DECLARATION, NameLogic.classifyRole(classA.getName()));
+
+        MethodDeclaration methodFoo = classA.getMethods().get(0);
+        assertEquals(DECLARATION, NameLogic.classifyRole(methodFoo.getName()));
+        assertEquals(DECLARATION, NameLogic.classifyRole(methodFoo.getParameter(0).getName()));
+
+        ReturnStmt returnStmt = methodFoo.getBody().get().getStatements().get(0).asReturnStmt();
+        assertEquals(REFERENCE, NameLogic.classifyRole(returnStmt.getExpression().get())); // a.b.c.D.e
+        FieldAccessExpr fieldAccessExpr = returnStmt.getExpression().get().asFieldAccessExpr();
+        assertEquals(REFERENCE, NameLogic.classifyRole(fieldAccessExpr
+                .getScope())); // a.b.c.D
+        assertEquals(REFERENCE, NameLogic.classifyRole(fieldAccessExpr
+                .getScope().asFieldAccessExpr()
+                .getScope())); // a.b.c
+        assertEquals(REFERENCE, NameLogic.classifyRole(fieldAccessExpr
+                .getScope().asFieldAccessExpr()
+                .getScope().asFieldAccessExpr()
+                .getScope())); // a.b
+        assertEquals(REFERENCE, NameLogic.classifyRole(fieldAccessExpr
+                .getScope().asFieldAccessExpr()
+                .getScope().asFieldAccessExpr()
+                .getScope().asFieldAccessExpr()
+                .getScope())); // a
+    }    
+
+    @Test
+    public void classifyRoleRequiresModuleName() {
+        assertNameInCodeHasRole("module com.mydeveloperplanet.jpmshello {\n" +
+                "    requires java.base;\n" +
+                "    requires java.xml;\n" +
+                "    requires com.mydeveloperplanet.jpmshi;\n" +
+                "}\n", "java.xml", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRoleExportsModuleName() {
+        assertNameInCodeHasRole("module my.module{\n" +
+                "  exports my.packag to other.module, another.module;\n" +
+                "}", "other.module", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRoleOpensModuleName() {
+        assertNameInCodeHasRole("module client.modul{\n" +
+                "    opens some.client.packag to framework.modul;\n" +
+                "    requires framework.modul2;\n" +
+                "}", "framework.modul", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRoleExportsPackageName() {
+        assertNameInCodeHasRole("module common.widget{\n" +
+                "  exports com.logicbig;\n" +
+                "}", "com.logicbig", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRoleOpensPackageName() {
+        assertNameInCodeHasRole("module foo {\n" +
+                "    opens com.example.bar;\n" +
+                "}", "com.example.bar", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRolePackageNameInPackageName() {
+        assertNameInCodeHasRole("module foo {\n" +
+                "    opens com.example.bar;\n" +
+                "}", "com.example", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRoleUsesTypeName() {
+        assertNameInCodeHasRole("module modi.mod {\n" +
+                "    uses modi.api;\n" +
+                "}", "modi.api", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRoleProvidesTypeName() {
+        assertNameInCodeHasRole("module foo {\n" +
+                "    provides com.modi.api.query.Query with ModuleQuery;\n" +
+                "}", "com.modi.api.query.Query", REFERENCE, ParseStart.MODULE_DECLARATION);
+    }
+
+    @Test
+    public void classifyRoleSingleTypeImportTypeName() {
+        assertNameInCodeHasRole("import a.b.c;", "a.b.c",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleSingleStaticTypeImportTypeName() {
+        assertNameInCodeHasRole("import static a.B.c;", "a.B",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleSingleStaticImportOnDemandTypeName() {
+        assertNameInCodeHasRole("import static a.B.*;", "a.B",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleConstructorDeclarationTypeName() {
+        assertNameInCodeHasRole("A() { }", "A",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleAnnotationTypeName() {
+        assertNameInCodeHasRole("@Anno class A {} ", "Anno",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleClassLiteralTypeName() {
+        assertNameInCodeHasRole("Class<?> c = String.class;", "String",
+                REFERENCE, ParseStart.STATEMENT);
+    }
+
+    @Test
+    public void classifyRoleThisExprTypeName() {
+        assertNameInCodeHasRole("Object o = String.this;", "String",
+                REFERENCE, ParseStart.STATEMENT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedSuperFieldAccessTypeName() {
+        assertNameInCodeHasRole("Object o = MyClass.super.myField;", "MyClass",
+                REFERENCE, ParseStart.STATEMENT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedSuperCallTypeName() {
+        assertNameInCodeHasRole("Object o = MyClass.super.myCall();", "MyClass",
+                REFERENCE, ParseStart.STATEMENT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedSuperMethodReferenceTypeName() {
+        assertNameInCodeHasRole("Object o = MyClass.super::myMethod;", "MyClass",
+                REFERENCE, ParseStart.STATEMENT);
+    }
+
+    @Test
+    public void classifyRoleExtendsClauseTypeName() {
+        assertNameInCodeHasRole("class Foo extends bar.MyClass { }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleImplementsClauseTypeName() {
+        assertNameInCodeHasRole("class Foo implements bar.MyClass { }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleReturnTypeTypeName() {
+        assertNameInCodeHasRole("class Foo { bar.MyClass myMethod() {} }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedAnnotationMemberTypeTypeName() {
+        assertNameInCodeHasRole("@interface MyAnno { bar.MyClass myMember(); }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleUnqualifiedAnnotationMemberTypeTypeName() {
+        assertNameInCodeHasRole("@interface MyAnno { MyClass myMember(); }", "MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleThrowClauseMethodTypeName() {
+        assertNameInCodeHasRole("class Foo { void myMethod() throws bar.MyClass {} }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedThrowClauseConstructorTypeName() {
+        assertNameInCodeHasRole("class Foo { Foo() throws bar.MyClass {} }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleUnualifiedThrowClauseConstructorTypeName() {
+        assertNameInCodeHasRole("class Foo { Foo() throws MyClass {} }", "MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedFieldTypeTypeName() {
+        assertNameInCodeHasRole("class Foo { bar.MyClass myField; }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleFieldTypeTypeNameSecondAttempt() {
+        assertNameInCodeHasRole("public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration implements InterfaceDeclaration {\n" +
+                        "private TypeSolver typeSolver; }", "TypeSolver",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleUnqualifiedFieldTypeTypeName() {
+        assertNameInCodeHasRole("class Foo { MyClass myField; }", "MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedFormalParameterOfMethodTypeName() {
+        assertNameInCodeHasRole("class Foo { void myMethod(bar.MyClass param) {} }", "bar.MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleUnqualifiedFormalParameterOfMethodTypeName() {
+        assertNameInCodeHasRole("class Foo { void myMethod(MyClass param) {} }", "MyClass",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleReceiverParameterOfMethodTypeName() {
+        assertNameInCodeHasRole("void myMethod(Foo this) {}", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleVariableDeclarationTypeTypeName() {
+        assertNameInCodeHasRole("void myMethod() { Foo myVar; }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleExceptionParameterTypeTypeName() {
+        assertNameInCodeHasRole("void myMethod() { try { } catch(Foo e) { } }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleExplicitParameterTypeInConstructorCallTypeName() {
+        assertNameInCodeHasRole("void myMethod() { new Call<Foo>(); }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleExplicitParameterTypeInMethodCallTypeName() {
+        assertNameInCodeHasRole("void myMethod() { new Call().<Foo>myMethod(); }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleInstantiationCallTypeName() {
+        assertNameInCodeHasRole("void myMethod() { new Foo(); }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleInstantiationCallOfAnonymousTypeTypeName() {
+        assertNameInCodeHasRole("void myMethod() { new Foo() { void method() { } } ; }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleArrayCreationExpressionTypeName() {
+        assertNameInCodeHasRole("void myMethod() { new Foo[0]; }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleCastTypeName() {
+        assertNameInCodeHasRole("void myMethod() { Object o = (Foo)someField; }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleInstanceOfTypeName() {
+        assertNameInCodeHasRole("void myMethod() { if (myValue instanceof Foo) { }; }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleMethodReferenceTypeName() {
+        assertNameInCodeHasRole("void myMethod() { Object o = Foo::myMethod; }", "Foo",
+                REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleQualifiedConstructorSuperClassInvocationExpressionName() {
+        assertNameInCodeHasRole("class Bar { Bar() { anExpression.super(); } } ", "anExpression",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleQualifiedClassInstanceCreationExpressionName() {
+        assertNameInCodeHasRole("class Bar { Bar() { anExpression.new MyClass(); } } ", "anExpression",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleArrayReferenceExpressionName() {
+        assertNameInCodeHasRole("class Bar { Bar() { anExpression[0]; } } ", "anExpression",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRolePostfixExpressionName() {
+        assertNameInCodeHasRole("class Bar { Bar() { anExpression++; } } ", "anExpression",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleLeftHandAssignmentExpressionName() {
+        assertNameInCodeHasRole("class Bar { Bar() { anExpression = 2; } } ", "anExpression",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleVariableAccessInTryWithResourceExpressionName() {
+        assertNameInCodeHasRole("class Bar { Bar() { try (anExpression) { }; } } ", "anExpression",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleVariableAccessInTryWithResourceWothTypeExpressionName() {
+        assertNameInCodeHasRole("class Bar {  Bar() { try (Object o = anExpression) { }; } } ", "anExpression",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleMethodInvocationMethodName() {
+        assertNameInCodeHasRole("class Bar {  Bar() { myMethod(); } } ", "myMethod",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleLeftOfQualifiedTypeNamePackageOrTypeName() {
+        assertNameInCodeHasRole("class Bar {  Bar() { new myQualified.path.to.TypeName(); } } ", "myQualified.path.to",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+        assertNameInCodeHasRole("class Bar {  Bar() { new myQualified.path.to.TypeName(); } } ", "myQualified.path",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+        assertNameInCodeHasRole("class Bar {  Bar() { new myQualified.path.to.TypeName(); } } ", "myQualified",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleTypeImportOnDemandPackageOrTypeName() {
+        assertNameInCodeHasRole("import a.B.*;", "a.B",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleLeftOfExpressionNameAmbiguousName() {
+        assertNameInCodeHasRole("class Bar { Bar() { a.b.c.anExpression[0]; } } ", "a.b.c",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+        assertNameInCodeHasRole("class Bar { Bar() { a.b.c.anExpression[0]; } } ", "a.b",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+        assertNameInCodeHasRole("class Bar { Bar() { a.b.c.anExpression[0]; } } ", "a",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleLeftOfMethodCallAmbiguousName() {
+        assertNameInCodeHasRole("class Bar { Bar() { a.b.c.aMethod(); } } ", "a.b.c",
+                REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleDefaultValueTypeName() {
+        assertNameInCodeHasRole("@RequestForEnhancement(\n" +
+                        "    id       = 2868724,\n" +
+                        "    synopsis = \"Provide time-travel functionality\",\n" +
+                        "    engineer = \"Mr. Peabody\",\n" +
+                        "    date     = anExpression" +
+                        ")\n" +
+                        "public static void travelThroughTime(Date destination) {  }",
+                "anExpression", REFERENCE, ParseStart.CLASS_BODY);
+    }
+    
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
@@ -1,6 +1,7 @@
 package com.github.javaparser.symbolsolver.resolution.naming;
 
-import com.github.javaparser.*;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseStart;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -13,7 +14,6 @@ import org.junit.Test;
 import static com.github.javaparser.symbolsolver.resolution.naming.NameRole.DECLARATION;
 import static com.github.javaparser.symbolsolver.resolution.naming.NameRole.REFERENCE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class NameLogicTest extends AbstractNameLogicTest {
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
@@ -101,7 +101,16 @@ public class NameLogicTest extends AbstractNameLogicTest {
                 .getScope().asFieldAccessExpr()
                 .getScope().asFieldAccessExpr()
                 .getScope())); // a
-    }    
+    }
+
+    @Test
+    public void classifyRoleModuleName() {
+        assertNameInCodeHasRole("module com.mydeveloperplanet.jpmshello {\n" +
+                "    requires java.base;\n" +
+                "    requires java.xml;\n" +
+                "    requires com.mydeveloperplanet.jpmshi;\n" +
+                "}\n", "com.mydeveloperplanet.jpmshello", DECLARATION, ParseStart.MODULE_DECLARATION);
+    }
 
     @Test
     public void classifyRoleRequiresModuleName() {
@@ -193,6 +202,12 @@ public class NameLogicTest extends AbstractNameLogicTest {
     }
 
     @Test
+    public void classifyRoleClassName() {
+        assertNameInCodeHasRole("@Anno class A {} ", "A",
+                DECLARATION, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
     public void classifyRoleClassLiteralTypeName() {
         assertNameInCodeHasRole("Class<?> c = String.class;", "String",
                 REFERENCE, ParseStart.STATEMENT);
@@ -247,6 +262,12 @@ public class NameLogicTest extends AbstractNameLogicTest {
     }
 
     @Test
+    public void classifyRoleAnnotationName() {
+        assertNameInCodeHasRole("@interface MyAnno { bar.MyClass myMember(); }", "MyAnno",
+                DECLARATION, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
     public void classifyRoleUnqualifiedAnnotationMemberTypeTypeName() {
         assertNameInCodeHasRole("@interface MyAnno { MyClass myMember(); }", "MyClass",
                 REFERENCE, ParseStart.COMPILATION_UNIT);
@@ -290,6 +311,12 @@ public class NameLogicTest extends AbstractNameLogicTest {
     }
 
     @Test
+    public void classifyRoleFieldName() {
+        assertNameInCodeHasRole("class Foo { MyClass myField; }", "myField",
+                DECLARATION, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
     public void classifyRoleQualifiedFormalParameterOfMethodTypeName() {
         assertNameInCodeHasRole("class Foo { void myMethod(bar.MyClass param) {} }", "bar.MyClass",
                 REFERENCE, ParseStart.COMPILATION_UNIT);
@@ -299,6 +326,12 @@ public class NameLogicTest extends AbstractNameLogicTest {
     public void classifyRoleUnqualifiedFormalParameterOfMethodTypeName() {
         assertNameInCodeHasRole("class Foo { void myMethod(MyClass param) {} }", "MyClass",
                 REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyRoleMethodName() {
+        assertNameInCodeHasRole("class Foo { void myMethod(MyClass param) {} }", "myMethod",
+                DECLARATION, ParseStart.COMPILATION_UNIT);
     }
 
     @Test
@@ -317,6 +350,12 @@ public class NameLogicTest extends AbstractNameLogicTest {
     public void classifyRoleExceptionParameterTypeTypeName() {
         assertNameInCodeHasRole("void myMethod() { try { } catch(Foo e) { } }", "Foo",
                 REFERENCE, ParseStart.CLASS_BODY);
+    }
+
+    @Test
+    public void classifyRoleExceptionParameterName() {
+        assertNameInCodeHasRole("void myMethod() { try { } catch(Foo e) { } }", "e",
+                DECLARATION, ParseStart.CLASS_BODY);
     }
 
     @Test
@@ -404,9 +443,15 @@ public class NameLogicTest extends AbstractNameLogicTest {
     }
 
     @Test
-    public void classifyRoleVariableAccessInTryWithResourceWothTypeExpressionName() {
+    public void classifyRoleVariableAccessInTryWithResourceWithTypeExpressionName() {
         assertNameInCodeHasRole("class Bar {  Bar() { try (Object o = anExpression) { }; } } ", "anExpression",
                 REFERENCE, ParseStart.COMPILATION_UNIT);
+    }
+
+    @Test
+    public void classifyTryWithResourceName() {
+        assertNameInCodeHasRole("class Bar {  Bar() { try (Object o = anExpression) { }; } } ", "o",
+                DECLARATION, ParseStart.COMPILATION_UNIT);
     }
 
     @Test


### PR DESCRIPTION
First part of #1709 

This is the first step at implementing Names as define in Ch 6 of JLS. We could introduce a new interface but to avoid confusion I prefered to create a utility class named NameLogic and put the code there. Why? Because there are already classes named "Name" and "SimpleName" and according to Ch 6 some FieldAccessExpr would be name and some would be not:

```
a.b.c // FieldAccessExpr which is a name
a.b().c .. // FieldAccessExpr which is not a name
```

We could revisit that in JP 4.0

NameLogic has a few methods, all taking a Node:

* isAName: is the node a name or not?
* isSimpleName: is the name simple or qualified?
* isQualifiedName: is the name simple or qualified?
* classifyRole: is the name part of a declaration or a reference?
* nameAsString: the string representing the name

69 Tests are included in this PR