### PR TITLE
Bugfix: Resolving declarations within switch entry statements

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/resources/TryInSwitch.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/TryInSwitch.java.txt
@@ -1,0 +1,20 @@
+import java.io.File;
+
+class TryInSwitch {
+
+	public void foo() {
+		int i = 42;
+
+		switch (i) {
+			default:
+				File file;
+				try {
+					file = new File("...");
+					file.delete();
+				} catch (Exception e) {
+					// ...
+				}
+				break;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes a bug in the symbol resolution logic that occurs in switch entry statements.

**Explanation**

Consider this code:

```
switch (i) {
	default:
		File file;
		try {
			file = new File("...");
			file.delete();
		} catch (Exception e) {
			// ...
		}
		break;
}
```

Now, try to resolve the method declaration that corresponds to the method call expression `file.delete()` using `MethodCallExpr#resolve()`.

_Expected result:_ A `ReflectionMethodDeclaration` which represents `java.io.File.delete()` should be returned.

_Actual result:_ An `UnsolvedSymbolException` is thrown.

_Technical details:_
Before this PR, the symbol solver proceeded as follows:
1. First, it looks through the statements within the try-block using a `TryWithResourcesContext`. There, it cannot find the declaration of the variable `file`, which is correct.
2. Then, it fetches the parent context, which is a `SwitchEntryContext`. Here it should be able to find the declaration, but it doesn't, because what this context does is to look through _all switch entry statements, except for the current one_. I do not understand why it doesn't look in the current switch entry statement, and indeed, this is exactly the cause of the bug. The correct behavior in my opinion would be to look through _all switch entry statements, up to and including the current one_, since any of these may contain the relevant declaration. Switch entry statements that occur lexicographically _after_ the current one cannot contain the relevant declaration.
3. Next, it fetches the parent context, which is a `StatementContext` for the `SwitchStmt` (which basically cannot find anything since the `SwitchStmt` is not a `NodeWithStatements`): At this point, it is already too late to find the declaration.

This PR makes it so that all switch entry statements _up to and including_ the current one are searched for the relevant declaration, thus solving the problem and making the test included with this PR pass.
