### PR TITLE
Finalize Java 11 parsing support

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java11ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java11ValidatorTest.java
@@ -7,12 +7,12 @@ import com.github.javaparser.ast.stmt.Statement;
 import org.junit.Test;
 
 import static com.github.javaparser.ParseStart.STATEMENT;
-import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_11_PREVIEW;
+import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_11;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.TestUtils.assertNoProblems;
 
 public class Java11ValidatorTest {
-    public static final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_11_PREVIEW));
+    public static final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_11));
 
     @Test
     public void varAllowedInLocalVariableDeclaration() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -73,8 +73,8 @@ public class ParserConfiguration {
         JAVA_9(new Java9Validator(), null),
         /** Java 10 */
         JAVA_10(new Java10Validator(), new Java10PostProcessor()),
-        /** Java 11 (work in progress) */
-        JAVA_11_PREVIEW(new Java11Validator(), new Java11PostProcessor());
+        /** Java 11 */
+        JAVA_11(new Java11Validator(), new Java11PostProcessor());
 
         final Validator validator;
         final ParseResult.PostProcessor postProcessor;


### PR DESCRIPTION
Looks like `var` is the only syntax change, so here we go.