### PR TITLE
Fixed randomly failing tests.

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumLiteralsInAnnotatedClassTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumLiteralsInAnnotatedClassTest.java
@@ -1,7 +1,9 @@
 package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseStart;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StreamProvider;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
@@ -11,7 +13,8 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -20,9 +23,9 @@ import static org.junit.Assert.assertTrue;
 public class EnumLiteralsInAnnotatedClassTest {
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfClassUnqualifiedSamePackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfClassUnqualifiedSamePackage() throws IOException {
         File src = new File("src/test/resources/enumLiteralsInAnnotatedClass");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "AClass.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -30,9 +33,10 @@ public class EnumLiteralsInAnnotatedClassTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("BinaryExpr.Operator.OR") && n.getRange().get().begin.line == 4);
 
         assertTrue(fae.isPresent());
@@ -42,9 +46,9 @@ public class EnumLiteralsInAnnotatedClassTest {
     }
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfClassQualifiedSamePackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfClassQualifiedSamePackage() throws IOException {
         File src = new File("src/test/resources/enumLiteralsInAnnotatedClass");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "AClass.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -52,9 +56,10 @@ public class EnumLiteralsInAnnotatedClassTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("foo.bar.BinaryExpr.Operator.AND") && n.getRange().get().begin.line == 5);
 
         assertTrue(fae.isPresent());
@@ -64,9 +69,9 @@ public class EnumLiteralsInAnnotatedClassTest {
     }
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfClassUnqualifiedDifferentPackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfClassUnqualifiedDifferentPackage() throws IOException {
         File src = new File("src/test/resources/enumLiteralsInAnnotatedClass");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "differentpackage" + File.separator + "AClass2.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -74,9 +79,10 @@ public class EnumLiteralsInAnnotatedClassTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("BinaryExpr.Operator.OR") && n.getRange().get().begin.line == 6);
 
         assertTrue(fae.isPresent());
@@ -86,9 +92,9 @@ public class EnumLiteralsInAnnotatedClassTest {
     }
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfClassQualifiedDifferentPackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfClassQualifiedDifferentPackage() throws IOException {
         File src = new File("src/test/resources/enumLiteralsInAnnotatedClass");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "differentpackage" + File.separator + "AClass2.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -96,10 +102,10 @@ public class EnumLiteralsInAnnotatedClassTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
-
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("foo.bar.BinaryExpr.Operator.AND") && n.getRange().get().begin.line == 7);
 
         assertTrue(fae.isPresent());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InternalClassInInterfaceTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InternalClassInInterfaceTest.java
@@ -1,21 +1,20 @@
 package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseStart;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StreamProvider;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
-import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
-import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -24,9 +23,9 @@ import static org.junit.Assert.assertTrue;
 public class InternalClassInInterfaceTest {
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfInterfaceUnqualifiedSamePackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfInterfaceUnqualifiedSamePackage() throws IOException {
         File src = new File("src/test/resources/internalClassInInterface");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "AClass.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -34,9 +33,10 @@ public class InternalClassInInterfaceTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("AnInterface.ListChangeType.ADDITION") && n.getRange().get().begin.line == 4);
 
         assertTrue(fae.isPresent());
@@ -46,9 +46,9 @@ public class InternalClassInInterfaceTest {
     }
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfInterfaceQualifiedSamePackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfInterfaceQualifiedSamePackage() throws IOException {
         File src = new File("src/test/resources/internalClassInInterface");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "AClass.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -56,9 +56,10 @@ public class InternalClassInInterfaceTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("foo.bar.AnInterface.ListChangeType.ADDITION") && n.getRange().get().begin.line == 5);
 
         assertTrue(fae.isPresent());
@@ -68,9 +69,9 @@ public class InternalClassInInterfaceTest {
     }
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfInterfaceUnqualifiedDifferentPackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfInterfaceUnqualifiedDifferentPackage() throws IOException {
         File src = new File("src/test/resources/internalClassInInterface");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "differentpackage" + File.separator + "AClass2.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -78,9 +79,10 @@ public class InternalClassInInterfaceTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("AnInterface.ListChangeType.ADDITION") && n.getRange().get().begin.line == 6);
 
         assertTrue(fae.isPresent());
@@ -90,9 +92,9 @@ public class InternalClassInInterfaceTest {
     }
 
     @Test
-    public void resolveFieldOfEnumAsInternalClassOfInterfaceQualifiedDifferentPackage() throws FileNotFoundException {
+    public void resolveFieldOfEnumAsInternalClassOfInterfaceQualifiedDifferentPackage() throws IOException {
         File src = new File("src/test/resources/internalClassInInterface");
-        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator+ "bar"
+        File aClass = new File(src.getPath() + File.separator + "foo" + File.separator + "bar"
                 + File.separator + "differentpackage" + File.separator + "AClass2.java");
 
         CombinedTypeSolver localCts = new CombinedTypeSolver();
@@ -100,9 +102,10 @@ public class InternalClassInInterfaceTest {
         localCts.add(new JavaParserTypeSolver(src));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        JavaParser.setStaticConfiguration(parserConfiguration);
+        JavaParser parser = new JavaParser(parserConfiguration);
+        StreamProvider classProvider = new StreamProvider(new FileInputStream(aClass));
 
-        CompilationUnit cu = JavaParser.parse(aClass);
+        CompilationUnit cu = parser.parse(ParseStart.COMPILATION_UNIT, classProvider).getResult().get();
 
         Optional<FieldAccessExpr> fae = cu.findFirst(FieldAccessExpr.class, n -> n.toString().equals("foo.bar.AnInterface.ListChangeType.ADDITION") && n.getRange().get().begin.line == 7);
 


### PR DESCRIPTION
I had some test failing in around every third build, so I fixed them.

The tests failed, because the surefire plugin executes up to 4 test methods in parallel (configured in pom.xml), and in these test classes all test methods modify the static configuration. Depending on the interleaving of the execution, this makes the test fail, because the type solver needed to proceed in one method has already been changed by another method.

