### PR TITLE
Bugfix: Solve member types of other types

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparser/Navigator.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparser/Navigator.java
@@ -102,6 +102,14 @@ public final class Navigator {
         return cd;
     }
 
+    public static ClassOrInterfaceDeclaration demandInterface(CompilationUnit cu, String qualifiedName) {
+        ClassOrInterfaceDeclaration cd = demandClassOrInterface(cu, qualifiedName);
+        if (!cd.isInterface()) {
+            throw new IllegalStateException("Type is not an interface");
+        }
+        return cd;
+    }
+
     public static EnumDeclaration demandEnum(CompilationUnit cu, String qualifiedName) {
         Optional<TypeDeclaration<?>> res = findType(cu, qualifiedName);
         if (!res.isPresent()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -116,7 +116,10 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
 
     @Override
     public SymbolReference<ResolvedTypeDeclaration> solveType(String name, TypeSolver typeSolver) {
+
         if (wrappedNode.getTypes() != null) {
+            // Look for types in this compilation unit. For instance, if the given name is "A", there may be a class or
+            // interface in this compilation unit called "A".
             for (TypeDeclaration<?> type : wrappedNode.getTypes()) {
                 if (type.getName().getId().equals(name)) {
                     if (type instanceof ClassOrInterfaceDeclaration) {
@@ -130,7 +133,11 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                     }
                 }
             }
-            // look for member classes/interfaces of types in this compilation unit
+            // Look for member classes/interfaces of types in this compilation unit. For instance, if the given name is
+            // "A.B", there may be a class or interface in this compilation unit called "A" which has another member
+            // class or interface called "B". Since the type that we're looking for can be nested arbitrarily deeply
+            // ("A.B.C.D"), we look for the outermost type ("A" in the previous example) first, then recursively invoke
+            // this method for the remaining part of the given name.
             if (name.indexOf('.') > -1) {
                 SymbolReference<ResolvedTypeDeclaration> ref = null;
                 SymbolReference<ResolvedTypeDeclaration> outerMostRef =

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -32,6 +32,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserAnnotationDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserEnumDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserInterfaceDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.resolution.MethodResolutionLogic;
@@ -134,9 +135,13 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                 SymbolReference<ResolvedTypeDeclaration> ref = null;
                 SymbolReference<ResolvedTypeDeclaration> outerMostRef =
                         solveType(name.substring(0, name.indexOf(".")), typeSolver);
-                if (outerMostRef.isSolved() &&
+                if (outerMostRef != null && outerMostRef.isSolved() &&
                     outerMostRef.getCorrespondingDeclaration() instanceof JavaParserClassDeclaration) {
                     ref = ((JavaParserClassDeclaration) outerMostRef.getCorrespondingDeclaration())
+                                  .solveType(name.substring(name.indexOf(".") + 1), typeSolver);
+                } else if (outerMostRef != null && outerMostRef.isSolved() &&
+                           outerMostRef.getCorrespondingDeclaration() instanceof JavaParserInterfaceDeclaration) {
+                    ref = ((JavaParserInterfaceDeclaration) outerMostRef.getCorrespondingDeclaration())
                                   .solveType(name.substring(name.indexOf(".") + 1), typeSolver);
                 }
                 if (ref != null && ref.isSolved()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -304,7 +304,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
 
     private ResolvedReferenceType toReferenceType(ClassOrInterfaceType classOrInterfaceType) {
         SymbolReference<? extends ResolvedTypeDeclaration> ref = null;
-        String typeName = classOrInterfaceType.getNameAsString();
+        String typeName = classOrInterfaceType.asString();
         if (typeName.indexOf('.') > -1) {
             ref = typeSolver.tryToSolveType(typeName);
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
@@ -90,14 +90,18 @@ public class JavaParserTypeAdapter<T extends Node & NodeWithSimpleName<T> & Node
             }
         }
 
-        // Internal classes
+        // Member classes & interfaces
         for (BodyDeclaration<?> member : this.wrappedNode.getMembers()) {
             if (member instanceof com.github.javaparser.ast.body.TypeDeclaration) {
                 com.github.javaparser.ast.body.TypeDeclaration<?> internalType = (com.github.javaparser.ast.body.TypeDeclaration<?>) member;
                 String prefix = internalType.getName() + ".";
                 if (internalType.getName().getId().equals(name)) {
                     if (internalType instanceof ClassOrInterfaceDeclaration) {
-                        return SymbolReference.solved(new JavaParserClassDeclaration((com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) internalType, typeSolver));
+                        if (((ClassOrInterfaceDeclaration) internalType).isInterface()) {
+                            return SymbolReference.solved(new JavaParserInterfaceDeclaration((com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) internalType, typeSolver));
+                        } else {
+                            return SymbolReference.solved(new JavaParserClassDeclaration((com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) internalType, typeSolver));
+                        }
                     } else if (internalType instanceof EnumDeclaration) {
                         return SymbolReference.solved(new JavaParserEnumDeclaration((com.github.javaparser.ast.body.EnumDeclaration) internalType, typeSolver));
                     } else {
@@ -105,7 +109,11 @@ public class JavaParserTypeAdapter<T extends Node & NodeWithSimpleName<T> & Node
                     }
                 } else if (name.startsWith(prefix) && name.length() > prefix.length()) {
                     if (internalType instanceof ClassOrInterfaceDeclaration) {
-                        return new JavaParserClassDeclaration((com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) internalType, typeSolver).solveType(name.substring(prefix.length()), typeSolver);
+                        if (((ClassOrInterfaceDeclaration) internalType).isInterface()) {
+                            return new JavaParserInterfaceDeclaration((com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) internalType, typeSolver).solveType(name.substring(prefix.length()), typeSolver);
+                        } else {
+                            return new JavaParserClassDeclaration((com.github.javaparser.ast.body.ClassOrInterfaceDeclaration) internalType, typeSolver).solveType(name.substring(prefix.length()), typeSolver);
+                        }
                     } else if (internalType instanceof EnumDeclaration) {
                         return new SymbolSolver(typeSolver).solveTypeInType(new JavaParserEnumDeclaration((com.github.javaparser.ast.body.EnumDeclaration) internalType, typeSolver), name.substring(prefix.length()));
                     } else {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
@@ -400,7 +400,6 @@ public class MethodsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void resolveMethodCallOfMethodInMemberClassOfAnotherClass() {
-
         CompilationUnit cu = parseSample("NestedClasses");
         ClassOrInterfaceDeclaration classA = Navigator.demandClass(cu, "A");
 
@@ -418,7 +417,6 @@ public class MethodsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void resolveMethodCallOfMethodInMemberInterfaceOfAnotherInterface() {
-
         CompilationUnit cu = parseSample("NestedInterfaces");
         ClassOrInterfaceDeclaration classA = Navigator.demandInterface(cu, "A");
 
@@ -436,7 +434,6 @@ public class MethodsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void resolveMethodCallOfMethodInMemberInterfaceWithIdenticalNameOfAnotherInterface() {
-
         CompilationUnit cu = parseSample("NestedInterfacesWithIdenticalNames");
         ClassOrInterfaceDeclaration classA = Navigator.demandInterface(cu, "A");
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
@@ -415,4 +415,40 @@ public class MethodsResolutionTest extends AbstractResolutionTest {
         assertTrue(reference.isSolved());
         assertEquals("X.Y.bar()", reference.getCorrespondingDeclaration().getQualifiedSignature());
     }
+
+    @Test
+    public void resolveMethodCallOfMethodInMemberInterfaceOfAnotherInterface() {
+
+        CompilationUnit cu = parseSample("NestedInterfaces");
+        ClassOrInterfaceDeclaration classA = Navigator.demandInterface(cu, "A");
+
+        MethodDeclaration method = Navigator.demandMethod(classA, "foo");
+
+        MethodCallExpr callExpr = method.getBody().get().getStatement(1)
+                                          .asExpressionStmt().getExpression().asMethodCallExpr();
+
+        SymbolReference<ResolvedMethodDeclaration> reference = JavaParserFacade.get(new ReflectionTypeSolver())
+                                                                       .solve(callExpr);
+
+        assertTrue(reference.isSolved());
+        assertEquals("X.Y.bar()", reference.getCorrespondingDeclaration().getQualifiedSignature());
+    }
+
+    @Test
+    public void resolveMethodCallOfMethodInMemberInterfaceWithIdenticalNameOfAnotherInterface() {
+
+        CompilationUnit cu = parseSample("NestedInterfacesWithIdenticalNames");
+        ClassOrInterfaceDeclaration classA = Navigator.demandInterface(cu, "A");
+
+        MethodDeclaration method = Navigator.demandMethod(classA, "foo");
+
+        MethodCallExpr callExpr = method.getBody().get().getStatement(1)
+                                          .asExpressionStmt().getExpression().asMethodCallExpr();
+
+        SymbolReference<ResolvedMethodDeclaration> reference = JavaParserFacade.get(new ReflectionTypeSolver())
+                                                                       .solve(callExpr);
+
+        assertTrue(reference.isSolved());
+        assertEquals("X.A.bar()", reference.getCorrespondingDeclaration().getQualifiedSignature());
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
@@ -397,4 +397,22 @@ public class MethodsResolutionTest extends AbstractResolutionTest {
 
         assertEquals(mainClass, resolvedTypeDeclaration.getParentNode().get());
     }
+
+    @Test
+    public void resolveMethodCallOfMethodInMemberClassOfAnotherClass() {
+
+        CompilationUnit cu = parseSample("NestedClasses");
+        ClassOrInterfaceDeclaration classA = Navigator.demandClass(cu, "A");
+
+        MethodDeclaration method = Navigator.demandMethod(classA, "foo");
+
+        MethodCallExpr callExpr = method.getBody().get().getStatement(1)
+                                          .asExpressionStmt().getExpression().asMethodCallExpr();
+
+        SymbolReference<ResolvedMethodDeclaration> reference = JavaParserFacade.get(new ReflectionTypeSolver())
+                                                                       .solve(callExpr);
+
+        assertTrue(reference.isSolved());
+        assertEquals("X.Y.bar()", reference.getCorrespondingDeclaration().getQualifiedSignature());
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/NestedClasses.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/NestedClasses.java.txt
@@ -1,0 +1,13 @@
+class A extends X.Y {
+
+	void foo() {
+		X.Y xy = null;
+		xy.bar();
+	}
+}
+
+class X {
+	static class Y {
+		void bar() {}
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/NestedInterfaces.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/NestedInterfaces.java.txt
@@ -1,0 +1,13 @@
+interface A extends X.Y {
+
+	default void foo() {
+		X.Y xy = null;
+		xy.bar();
+	}
+}
+
+interface X {
+	interface Y {
+		void bar();
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/NestedInterfacesWithIdenticalNames.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/NestedInterfacesWithIdenticalNames.java.txt
@@ -1,0 +1,13 @@
+interface A extends X.A {
+
+	default void foo() {
+		X.A xa = null;
+		xa.bar();
+	}
+}
+
+interface X {
+	interface A {
+		void bar();
+	}
+}


### PR DESCRIPTION
This PR fixes a few related bugs. Since they are related, this is a single PR composed of two commits:

- Commit a2e4d9e fixes problem 1.
- Commit cadc6c5 fixes problems 2 and 3.

None of these bugs has been reported so far as an issue, as far as I am aware.

**Problem 1**

Consider:

```
class A extends X.Y {
	void foo() {
		X.Y xy = null;
		xy.bar();
	}
}

class X {
	static class Y {
		void bar() {}
	}
}
```

Try to solve the method call expression `xy.bar()` (Note: Obviously, ignore the fact that this code would throw a null pointer exception at runtime if it was actually run. This is irrelevant for the symbol solver. I just wanted to make the example as simple and concise as possible.)

_Expected behavior / behavior after commit a2e4d9e:_ Solving the call expression should succeed and return the resolved method declaration `X.Y#bar()`.

_Actual behavior / behavior before commit a2e4d9e:_ An `UnsolvedSymbolException` is thrown.

**Problem 2:**

This is similar to the previous example, but uses interfaces instead of classes. Consider:

```
interface A extends X.Y {
	default void foo() {
		X.Y xy = null;
		xy.bar();
	}
}

interface X {
	interface Y {
		void bar();
	}
}
```

As above, try to solve the method call expression `xy.bar()`.

_Expected behavior / behavior after commit cadc6c5:_ Solving the call expression should succeed and return the resolved method declaration `X.Y#bar()`.

_Actual behavior / behavior before commit cadc6c5:_ An `UnsolvedSymbolException` is thrown.

**Problem 3:**

This is similar to the previous example, but the member interface which contains the called method has the same simple name as the interface from which the call originates (i.e., it is called `A` instead of `Y`).

```
interface A extends X.A {
	default void foo() {
		X.A xa = null;
		xa.bar();
	}
}

interface X {
	interface A {
		void bar();
	}
}
```

As above, try to solve the method call expression `xa.bar()`.

_Expected behavior / behavior after commit cadc6c5:_ Solving the call expression should succeed and return the resolved method declaration `X.A#bar()`.

_Actual behavior / behavior before commit cadc6c5:_ JSS gets completely confused because of the same names and ends up in an infinite recursion within the method `JavaParserTypeDeclarationAdapter#checkAncestorsForType(String, ResolvedReferenceTypeDeclaration)`, until the JVM crashes with a `StackOverflowError`.
