### PR TITLE
fix #1814: Avoid infinite recursion when resolving java.lang.Object

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -408,8 +408,11 @@ public abstract class ResolvedReferenceType implements ResolvedType,
                 .filter(m -> m.accessSpecifier() != PRIVATE)
                 .collect(Collectors.toList()));
 
-        getDirectAncestors().forEach(a ->
-                res.addAll(a.getAllMethodsVisibleToInheritors()));
+        // We want to avoid infinite recursion in case of Object having Object as ancestor
+        if (!(Object.class.getCanonicalName().equals(getQualifiedName()))) {
+            getDirectAncestors().forEach(a ->
+                    res.addAll(a.getAllMethodsVisibleToInheritors()));
+        }
 
         return res;
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1364.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1364.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.fail;
 
 /**
  * @author Dominik Hardtke
- * @since 02.02.2018
+ * @since 02/02/2018
  */
 public class Issue1364 extends AbstractResolutionTest {
     private JavaParser javaParser;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1814.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1814.java
@@ -31,12 +31,12 @@ public class Issue1814 extends AbstractResolutionTest {
 
     @Before
     public void setup() {
+        final CompilationUnit compilationUnit = new CompilationUnit();
+        compilationUnit.setPackageDeclaration("java.lang");
         // construct a fake java.lang.Object class with only one method (java.lang.Object#equals(java.lang.Object)
-        ClassOrInterfaceDeclaration fakeObject = new ClassOrInterfaceDeclaration();
-        fakeObject.setName(new SimpleName("java.lang.Object"));
-
-        final MethodDeclaration equals = fakeObject.addMethod("equals", Modifier.PUBLIC);
-        equals.addParameter("java.lang.Object", "obj");
+        final ClassOrInterfaceDeclaration clazz = compilationUnit.addClass("Object", Modifier.PUBLIC);
+        final MethodDeclaration equals = clazz.addMethod("equals", Modifier.PUBLIC);
+        equals.addParameter("Object", "obj");
         final BlockStmt body = new BlockStmt();
         body.addStatement("return this == obj;");
         equals.setBody(body);
@@ -55,7 +55,7 @@ public class Issue1814 extends AbstractResolutionTest {
             public SymbolReference<ResolvedReferenceTypeDeclaration> tryToSolveType(String name) {
                 if ("java.lang.Object".equals(name)) {
                     // custom handling
-                    return SymbolReference.solved(new JavaParserClassDeclaration(fakeObject, this));
+                    return SymbolReference.solved(new JavaParserClassDeclaration(clazz, this));
                 }
 
                 return SymbolReference.unsolved(ResolvedReferenceTypeDeclaration.class);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1814.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1814.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dominik Hardtke
- * @since 01.09.2018
+ * @since 01/09/2018
  */
 public class Issue1814 extends AbstractResolutionTest {
     private JavaParser javaParser;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1814.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1814.java
@@ -1,0 +1,88 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.*;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Dominik Hardtke
+ * @since 01.09.2018
+ */
+public class Issue1814 extends AbstractResolutionTest {
+    private JavaParser javaParser;
+
+    @Before
+    public void setup() {
+        // construct a fake java.lang.Object class with only one method (java.lang.Object#equals(java.lang.Object)
+        ClassOrInterfaceDeclaration fakeObject = new ClassOrInterfaceDeclaration();
+        fakeObject.setName(new SimpleName("java.lang.Object"));
+
+        final MethodDeclaration equals = fakeObject.addMethod("equals", Modifier.PUBLIC);
+        equals.addParameter("java.lang.Object", "obj");
+        final BlockStmt body = new BlockStmt();
+        body.addStatement("return this == obj;");
+        equals.setBody(body);
+
+        TypeSolver typeSolver = new TypeSolver() {
+            @Override
+            public TypeSolver getParent() {
+                return null;
+            }
+
+            @Override
+            public void setParent(TypeSolver parent) {
+            }
+
+            @Override
+            public SymbolReference<ResolvedReferenceTypeDeclaration> tryToSolveType(String name) {
+                if ("java.lang.Object".equals(name)) {
+                    // custom handling
+                    return SymbolReference.solved(new JavaParserClassDeclaration(fakeObject, this));
+                }
+
+                return SymbolReference.unsolved(ResolvedReferenceTypeDeclaration.class);
+            }
+        };
+
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        javaParser = new JavaParser(config);
+    }
+
+    @Test(timeout = 1000)
+    public void getAllMethodsVisibleToInheritors() {
+        String code = String.join(System.lineSeparator(),
+                "public class AbstractExercise extends java.lang.Object {",
+                "}"
+        );
+
+        ParseResult<CompilationUnit> parseResult = javaParser.parse(ParseStart.COMPILATION_UNIT, Providers.provider(code));
+
+        assertTrue(parseResult.isSuccessful());
+        assertTrue(parseResult.getResult().isPresent());
+
+        List<ClassOrInterfaceType> referenceTypes = parseResult.getResult().get().findAll(ClassOrInterfaceType.class);
+        assertTrue(referenceTypes.size() > 0);
+
+        final List<ResolvedMethodDeclaration> methods = referenceTypes.get(0).resolve().getAllMethodsVisibleToInheritors();
+        assertEquals(1, methods.size());
+    }
+}


### PR DESCRIPTION
This was a surprisingly easy fix.