### PR TITLE
Improve build speed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: '{build}'
 os: Windows Server 2012
+environment:
+  appveyor_build_worker_cloud: gce
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem


### PR DESCRIPTION
this build process does not work OK with dynamic memory on Hyper-V VMs, e.g. does not increase it as needed. Moving to GCE where VMs are with static memory.