### PR TITLE
wrap strings in quotes when printing yaml

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 
 public class YamlPrinterTest {
@@ -89,6 +90,31 @@ public class YamlPrinterTest {
         YamlPrinter yamlPrinter = new YamlPrinter(true);
         Expression expression = JavaParser.parseExpression("\"a\\\\:\\\\nb\"");
         String output = yamlPrinter.output(expression);
+        assertEquals(expectedOutput, output);
+    }
+
+    @Test
+    public void testParsingJavadocWithQuoteAndNewline() {
+    	String code = "/**" + System.lineSeparator() + 
+				" * \" this comment contains a quote and newlines" + System.lineSeparator() + 
+				" */" + System.lineSeparator() +
+				"public class Dog {" + System.lineSeparator() +
+				"" + System.lineSeparator() +
+				"}";
+	    String expectedOutput = "---" + System.lineSeparator();
+	    expectedOutput += "root(Type=CompilationUnit): " + System.lineSeparator();
+	    expectedOutput += "    types: " + System.lineSeparator();
+	    expectedOutput += "        - type(Type=ClassOrInterfaceDeclaration): " + System.lineSeparator();
+	    expectedOutput += "            isInterface: \"false\"" + System.lineSeparator();
+	    expectedOutput += "            name(Type=SimpleName): " + System.lineSeparator();
+	    expectedOutput += "                identifier: \"Dog\"" + System.lineSeparator();
+	    expectedOutput += "            comment(Type=JavadocComment): " + System.lineSeparator();
+	    expectedOutput += "                content: \"\\n * \\\" this comment contains a quote\\n \"" + System.lineSeparator();
+	    expectedOutput += "...";
+	
+	    YamlPrinter yamlPrinter = new YamlPrinter(true);
+	    CompilationUnit computationUnit = JavaParser.parse(code);
+	    String output = yamlPrinter.output(computationUnit);
         assertEquals(expectedOutput, output);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/YamlPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/YamlPrinter.java
@@ -69,11 +69,7 @@ public class YamlPrinter {
 
         level++;
         for (PropertyMetaModel a : attributes) {
-        	String text = "\"" + a.getValue(node).toString().replace("\\", "\\\\").
-        			replaceAll("\"", "\\\\\"").replace("\n", "\\n").replace("\t", "\\t")
-        			+ "\"";
-            builder.append(System.lineSeparator() + indent(level) + a.getName() + ": \""
-                    + text + "\"");
+        	builder.append(System.lineSeparator() + indent(level) + a.getName() + ": " + escapeValue(a.getValue(node).toString()));
         }
 
         for (PropertyMetaModel sn : subNodes) {
@@ -100,5 +96,10 @@ public class YamlPrinter {
             for (int j = 0; j < NUM_SPACES_FOR_INDENT; j++)
                 sb.append(" ");
         return sb.toString();
+    }
+    
+    private String escapeValue(String value) {
+    	return "\"" + value.replace("\\", "\\\\").replaceAll("\"", "\\\\\"").replace("\n", "\\n").
+    			replace("\t", "\\t") + "\"";
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/YamlPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/YamlPrinter.java
@@ -69,8 +69,11 @@ public class YamlPrinter {
 
         level++;
         for (PropertyMetaModel a : attributes) {
+        	String text = "\"" + a.getValue(node).toString().replace("\\", "\\\\").
+        			replaceAll("\"", "\\\\\"").replace("\n", "\\n").replace("\t", "\\t")
+        			+ "\"";
             builder.append(System.lineSeparator() + indent(level) + a.getName() + ": \""
-                    + a.getValue(node).toString() + "\"");
+                    + text + "\"");
         }
 
         for (PropertyMetaModel sn : subNodes) {


### PR DESCRIPTION
Ran this against our massive Java code base and all yaml files are now valid.
First ever open-source PR ... looking forward to learn from mistakes :pray: 