### PR TITLE
Resolving annotation expressions

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -20,25 +20,30 @@
  */
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.observer.ObservableProperty;
-import static com.github.javaparser.utils.Utils.assertNotNull;
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.AnnotationExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.TokenRange;
-import com.github.javaparser.ast.Generated;
-import java.util.function.Consumer;
+import com.github.javaparser.resolution.Resolvable;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
+
 import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * A base class for the different types of annotations.
  *
  * @author Julio Vilmar Gesser
  */
-public abstract class AnnotationExpr extends Expression implements NodeWithName<AnnotationExpr> {
+public abstract class AnnotationExpr extends Expression implements NodeWithName<AnnotationExpr>, Resolvable<ResolvedAnnotationDeclaration> {
 
     protected Name name;
 
@@ -127,6 +132,20 @@ public abstract class AnnotationExpr extends Expression implements NodeWithName<
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifAnnotationExpr(Consumer<AnnotationExpr> action) {
         action.accept(this);
+    }
+
+    /**
+     * Attempts to resolve the declaration corresponding to the annotation expression. If successful, a
+     * {@link ResolvedAnnotationDeclaration} representing the declaration of the annotation referenced by this
+     * {@code AnnotationExpr} is returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
+     *
+     * @return a {@link ResolvedAnnotationDeclaration} representing the declaration of the annotation expression.
+     * @throws UnsolvedSymbolException if the declaration corresponding to the annotation expression could not be
+     *                                 resolved.
+     */
+    @Override
+    public ResolvedAnnotationDeclaration resolve() {
+        return getSymbolResolver().resolveDeclaration(this, ResolvedAnnotationDeclaration.class);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -223,6 +223,16 @@ public class JavaSymbolSolver implements SymbolResolver {
                 }
             }
         }
+        if (node instanceof AnnotationExpr) {
+            SymbolReference<ResolvedAnnotationDeclaration> result = JavaParserFacade.get(typeSolver).solve((AnnotationExpr) node);
+            if (result.isSolved()) {
+                if (resultClass.isInstance(result.getCorrespondingDeclaration())) {
+                    return resultClass.cast(result.getCorrespondingDeclaration());
+                }
+            } else {
+                throw new UnsolvedSymbolException("We are unable to find the annotation declaration corresponding to " + node);
+            }
+        }
         throw new UnsupportedOperationException("Unable to find the declaration of type " + resultClass.getSimpleName()
                 + " from " + node.getClass().getSimpleName());
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -252,8 +252,8 @@ public class JavaParserFacade {
     public SymbolReference<ResolvedAnnotationDeclaration> solve(AnnotationExpr annotationExpr) {
         Context context = JavaParserFactory.getContext(annotationExpr, typeSolver);
         SymbolReference<ResolvedTypeDeclaration> typeDeclarationSymbolReference = context.solveType(annotationExpr.getNameAsString(), typeSolver);
-        ResolvedAnnotationDeclaration annotationDeclaration = (ResolvedAnnotationDeclaration) typeDeclarationSymbolReference.getCorrespondingDeclaration();
         if (typeDeclarationSymbolReference.isSolved()) {
+            ResolvedAnnotationDeclaration annotationDeclaration = (ResolvedAnnotationDeclaration) typeDeclarationSymbolReference.getCorrespondingDeclaration();
             return SymbolReference.solved(annotationDeclaration);
         } else {
             return SymbolReference.unsolved(ResolvedAnnotationDeclaration.class);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -34,16 +34,19 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public List<ResolvedFieldDeclaration> getAllFields() {
+        // TODO #1837
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
+        // TODO #1838
         throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isAssignableBy(ResolvedType type) {
+        // TODO #1836
         throw new UnsupportedOperationException();
     }
 
@@ -54,6 +57,7 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public boolean hasDirectlyAnnotation(String qualifiedName) {
+        // TODO #1839
         throw new UnsupportedOperationException();
     }
 
@@ -84,11 +88,13 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+        // TODO #1840
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Optional<ResolvedReferenceTypeDeclaration> containerType() {
+        // TODO #1841
         throw new UnsupportedOperationException("containerType is not supported for " + this.getClass().getCanonicalName());
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -63,11 +63,12 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public String getClassName() {
-        String className = ctClass.getName().replace('$', '.');
-        if (getPackageName() != null) {
-            return className.substring(getPackageName().length() + 1, className.length());
+        String qualifiedName = getQualifiedName();
+        if(qualifiedName.contains(".")) {
+            return qualifiedName.substring(qualifiedName.lastIndexOf("."), qualifiedName.length());
+        } else {
+            return qualifiedName;
         }
-        return className;
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -78,11 +78,13 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public boolean isAssignableBy(ResolvedType type) {
+        // TODO #1836
         throw new UnsupportedOperationException();
     }
 
     @Override
     public List<ResolvedFieldDeclaration> getAllFields() {
+        // TODO #1837
         throw new UnsupportedOperationException();
     }
 
@@ -98,11 +100,13 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
+        // TODO #1838
         throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean hasDirectlyAnnotation(String canonicalName) {
+        // TODO #1839
         throw new UnsupportedOperationException();
     }
 
@@ -113,11 +117,13 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+        // TODO #1840
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Optional<ResolvedReferenceTypeDeclaration> containerType() {
+        // TODO #1841
         throw new UnsupportedOperationException("containerType() is not supported for " + this.getClass().getCanonicalName());
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -65,7 +65,7 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
     public String getClassName() {
         String qualifiedName = getQualifiedName();
         if(qualifiedName.contains(".")) {
-            return qualifiedName.substring(qualifiedName.lastIndexOf("."), qualifiedName.length());
+            return qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1, qualifiedName.length());
         } else {
             return qualifiedName;
         }
@@ -108,8 +108,7 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public String getName() {
-        String[] nameElements = ctClass.getSimpleName().replace('$', '.').split("\\.");
-        return nameElements[nameElements.length - 1];
+        return getClassName();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 Federico Tomassetti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.javaparser.symbolsolver.javassistmodel;
+
+import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import javassist.CtClass;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Malte Skoruppa
+ */
+public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration implements ResolvedAnnotationDeclaration {
+
+    private CtClass ctClass;
+    private TypeSolver typeSolver;
+    private JavassistTypeDeclarationAdapter javassistTypeDeclarationAdapter;
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" +
+               "ctClass=" + ctClass.getName() +
+               ", typeSolver=" + typeSolver +
+               '}';
+    }
+
+    public JavassistAnnotationDeclaration(CtClass ctClass, TypeSolver typeSolver) {
+        if (!ctClass.isAnnotation()) {
+            throw new IllegalArgumentException("Not an annotation: " + ctClass.getName());
+        }
+        this.ctClass = ctClass;
+        this.typeSolver = typeSolver;
+        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver);
+    }
+
+    @Override
+    public String getPackageName() {
+        return ctClass.getPackageName();
+    }
+
+    @Override
+    public String getClassName() {
+        String className = ctClass.getName().replace('$', '.');
+        if (getPackageName() != null) {
+            return className.substring(getPackageName().length() + 1, className.length());
+        }
+        return className;
+    }
+
+    @Override
+    public String getQualifiedName() {
+        return ctClass.getName().replace('$', '.');
+    }
+
+    @Override
+    public boolean isAssignableBy(ResolvedType type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ResolvedFieldDeclaration> getAllFields() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAssignableBy(ResolvedReferenceTypeDeclaration other) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ResolvedReferenceType> getAncestors() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasDirectlyAnnotation(String canonicalName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        String[] nameElements = ctClass.getSimpleName().replace('$', '.').split("\\.");
+        return nameElements[nameElements.length - 1];
+    }
+
+    @Override
+    public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ResolvedReferenceTypeDeclaration> containerType() {
+        throw new UnsupportedOperationException("containerType() is not supported for " + this.getClass().getCanonicalName());
+    }
+
+    @Override
+    public List<ResolvedConstructorDeclaration> getConstructors() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ResolvedAnnotationMemberDeclaration> getAnnotationMembers() {
+        return Stream.of(ctClass.getDeclaredMethods())
+                       .map(m -> new JavassistAnnotationMemberDeclaration(m, typeSolver))
+                       .collect(Collectors.toList());
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationMemberDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationMemberDeclaration.java
@@ -1,28 +1,31 @@
-package com.github.javaparser.symbolsolver.reflectionmodel;
+package com.github.javaparser.symbolsolver.javassistmodel;
 
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-
-import java.lang.reflect.Method;
+import javassist.CtMethod;
 
 /**
  * @author Malte Skoruppa
  */
-public class ReflectionAnnotationMemberDeclaration implements ResolvedAnnotationMemberDeclaration {
+public class JavassistAnnotationMemberDeclaration implements ResolvedAnnotationMemberDeclaration {
 
-    private Method annotationMember;
+    private CtMethod annotationMember;
     private TypeSolver typeSolver;
 
-    public ReflectionAnnotationMemberDeclaration(Method annotationMember, TypeSolver typeSolver) {
+    public JavassistAnnotationMemberDeclaration(CtMethod annotationMember, TypeSolver typeSolver) {
         this.annotationMember = annotationMember;
         this.typeSolver = typeSolver;
     }
 
     @Override
     public Expression getDefaultValue() {
-        throw new UnsupportedOperationException("Obtaining the default value of reflection annotation member is not supported yet.");
+        // TODO we should do something like this:
+        // AnnotationDefaultAttribute defaultAttribute = (AnnotationDefaultAttribute) annotationMember.getMethodInfo().getAttribute(AnnotationDefaultAttribute.tag);
+        // return defaultAttribute != null ? defaultAttribute.getDefaultValue() : null;
+        // TODO ...but the interface wants us to return a JavaParser Expression node.
+        throw new UnsupportedOperationException("Obtaining the default value of a library annotation member is not supported yet.");
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationMemberDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationMemberDeclaration.java
@@ -1,0 +1,37 @@
+package com.github.javaparser.symbolsolver.reflectionmodel;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Malte Skoruppa
+ */
+public class ReflectionAnnotationMemberDeclaration implements ResolvedAnnotationMemberDeclaration {
+
+    private Method annotationMember;
+    private TypeSolver typeSolver;
+
+    public ReflectionAnnotationMemberDeclaration(Method annotationMember, TypeSolver typeSolver) {
+        this.annotationMember = annotationMember;
+        this.typeSolver = typeSolver;
+    }
+
+    @Override
+    public Expression getDefaultValue() {
+        throw new UnsupportedOperationException("Obtaining the default value of reflection annotation member is not supported yet.");
+    }
+
+    @Override
+    public ResolvedType getType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        return annotationMember.getName();
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFactory.java
@@ -57,12 +57,12 @@ public class JavassistFactory {
   }
 
   public static ResolvedReferenceTypeDeclaration toTypeDeclaration(CtClass ctClazz, TypeSolver typeSolver) {
-    if (ctClazz.isInterface()) {
+    if (ctClazz.isAnnotation()) {
+      return new JavassistAnnotationDeclaration(ctClazz, typeSolver);
+    } else if (ctClazz.isInterface()) {
       return new JavassistInterfaceDeclaration(ctClazz, typeSolver);
     } else if (ctClazz.isEnum()) {
       return new JavassistEnumDeclaration(ctClazz, typeSolver);
-    } else if (ctClazz.isAnnotation()) {
-      throw new UnsupportedOperationException("CtClass of annotation not yet supported");
     } else if (ctClazz.isArray()) {
       throw new IllegalArgumentException("This method should not be called passing an array");
     } else {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016 Federico Tomassetti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.javaparser.symbolsolver.reflectionmodel;
+
+import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Malte Skoruppa
+ */
+public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration implements ResolvedAnnotationDeclaration {
+
+    ///
+    /// Fields
+    ///
+
+    private Class<?> clazz;
+    private TypeSolver typeSolver;
+    private ReflectionClassAdapter reflectionClassAdapter;
+
+    ///
+    /// Constructor
+    ///
+
+    public ReflectionAnnotationDeclaration(Class<?> clazz, TypeSolver typeSolver) {
+        if (!clazz.isAnnotation()) {
+            throw new IllegalArgumentException("The given type is not an annotation.");
+        }
+
+        this.clazz = clazz;
+        this.typeSolver = typeSolver;
+        this.reflectionClassAdapter = new ReflectionClassAdapter(clazz, typeSolver, this);
+    }
+
+    ///
+    /// Public methods
+    ///
+
+    @Override
+    public String getPackageName() {
+        if (clazz.getPackage() != null) {
+            return clazz.getPackage().getName();
+        }
+        return null;
+    }
+
+    @Override
+    public String getClassName() {
+        String canonicalName = clazz.getCanonicalName();
+        if (canonicalName != null && getPackageName() != null) {
+            return canonicalName.substring(getPackageName().length() + 1, canonicalName.length());
+        }
+        return null;
+    }
+
+    @Override
+    public String getQualifiedName() {
+        return clazz.getCanonicalName();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" +
+               "clazz=" + clazz.getCanonicalName() +
+               '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ReflectionAnnotationDeclaration)) return false;
+
+        ReflectionAnnotationDeclaration that = (ReflectionAnnotationDeclaration) o;
+
+        return clazz.getCanonicalName().equals(that.clazz.getCanonicalName());
+    }
+
+    @Override
+    public int hashCode() {
+        return clazz.hashCode();
+    }
+
+    @Override
+    public boolean isAssignableBy(ResolvedType type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAssignableBy(ResolvedReferenceTypeDeclaration other) {
+        return false;
+    }
+
+    @Override
+    public boolean hasDirectlyAnnotation(String qualifiedName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ResolvedFieldDeclaration> getAllFields() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ResolvedReferenceType> getAncestors() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        return clazz.getSimpleName();
+    }
+
+    @Override
+    public Optional<ResolvedReferenceTypeDeclaration> containerType() {
+        throw new UnsupportedOperationException("containerType() is not supported for " + this.getClass().getCanonicalName());
+    }
+
+    @Override
+    public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ResolvedConstructorDeclaration> getConstructors() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ResolvedAnnotationMemberDeclaration> getAnnotationMembers() {
+        return Stream.of(clazz.getDeclaredMethods())
+                       .map(m -> new ReflectionAnnotationMemberDeclaration(m, typeSolver))
+                       .collect(Collectors.toList());
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -107,6 +107,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public boolean isAssignableBy(ResolvedType type) {
+        // TODO #1836
         throw new UnsupportedOperationException();
     }
 
@@ -117,11 +118,13 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public boolean hasDirectlyAnnotation(String qualifiedName) {
+        // TODO #1839
         throw new UnsupportedOperationException();
     }
 
     @Override
     public List<ResolvedFieldDeclaration> getAllFields() {
+        // TODO #1837
         throw new UnsupportedOperationException();
     }
 
@@ -132,6 +135,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
+        // TODO #1838
         throw new UnsupportedOperationException();
     }
 
@@ -142,11 +146,13 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public Optional<ResolvedReferenceTypeDeclaration> containerType() {
+        // TODO #1841
         throw new UnsupportedOperationException("containerType() is not supported for " + this.getClass().getCanonicalName());
     }
 
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+        // TODO #1840
         throw new UnsupportedOperationException();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -65,16 +65,17 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
         if (clazz.getPackage() != null) {
             return clazz.getPackage().getName();
         }
-        return null;
+        return "";
     }
 
     @Override
     public String getClassName() {
-        String canonicalName = clazz.getCanonicalName();
-        if (canonicalName != null && getPackageName() != null) {
-            return canonicalName.substring(getPackageName().length() + 1, canonicalName.length());
+        String qualifiedName = getQualifiedName();
+        if(qualifiedName.contains(".")) {
+            return qualifiedName.substring(qualifiedName.lastIndexOf("."), qualifiedName.length());
+        } else {
+            return qualifiedName;
         }
-        return null;
     }
 
     @Override
@@ -101,7 +102,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public int hashCode() {
-        return clazz.hashCode();
+        return clazz.getCanonicalName().hashCode();
     }
 
     @Override
@@ -111,7 +112,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public boolean isAssignableBy(ResolvedReferenceTypeDeclaration other) {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationMemberDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationMemberDeclaration.java
@@ -1,0 +1,40 @@
+package com.github.javaparser.symbolsolver.reflectionmodel;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Malte Skoruppa
+ */
+public class ReflectionAnnotationMemberDeclaration implements ResolvedAnnotationMemberDeclaration {
+
+    private Method annotationMember;
+    private TypeSolver typeSolver;
+
+    public ReflectionAnnotationMemberDeclaration(Method annotationMember, TypeSolver typeSolver) {
+        this.annotationMember = annotationMember;
+        this.typeSolver = typeSolver;
+    }
+
+    @Override
+    public Expression getDefaultValue() {
+        // TODO we should do this:
+        // return annotationMember.getDefaultValue();
+        // TODO ...but the interface wants us to return a JavaParser Expression node.
+        throw new UnsupportedOperationException("Obtaining the default value of a reflection annotation member is not supported yet.");
+    }
+
+    @Override
+    public ResolvedType getType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        return annotationMember.getName();
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionFactory.java
@@ -43,6 +43,8 @@ public class ReflectionFactory {
             throw new IllegalArgumentException("No type declaration available for an Array");
         } else if (clazz.isPrimitive()) {
             throw new IllegalArgumentException();
+        } else if (clazz.isAnnotation()) {
+            return new ReflectionAnnotationDeclaration(clazz, typeSolver);
         } else if (clazz.isInterface()) {
             return new ReflectionInterfaceDeclaration(clazz, typeSolver);
         } else if (clazz.isEnum()) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/JavaParserAPIIntegrationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/JavaParserAPIIntegrationTest.java
@@ -59,7 +59,7 @@ public class JavaParserAPIIntegrationTest extends AbstractSymbolResolutionTest {
         ParserConfiguration parserConfiguration = new ParserConfiguration();
         parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver));
         CompilationUnit cu = new JavaParser(parserConfiguration).parse(ParseStart.COMPILATION_UNIT, provider(f)).getResult().get();
-        AnnotationDeclaration declaration = (AnnotationDeclaration)cu.getType(2);
+        AnnotationDeclaration declaration = (AnnotationDeclaration)cu.getType(3);
         assertEquals("MyAnnotationWithFields", declaration.getNameAsString());
         AnnotationMemberDeclaration memberDeclaration = (AnnotationMemberDeclaration)declaration.getMember(0);
         ResolvedAnnotationMemberDeclaration resolvedDeclaration = memberDeclaration.resolve();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/JavaParserAPIIntegrationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/JavaParserAPIIntegrationTest.java
@@ -60,7 +60,7 @@ public class JavaParserAPIIntegrationTest extends AbstractSymbolResolutionTest {
         parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver));
         CompilationUnit cu = new JavaParser(parserConfiguration).parse(ParseStart.COMPILATION_UNIT, provider(f)).getResult().get();
         AnnotationDeclaration declaration = (AnnotationDeclaration)cu.getType(3);
-        assertEquals("MyAnnotationWithFields", declaration.getNameAsString());
+        assertEquals("MyAnnotationWithElements", declaration.getNameAsString());
         AnnotationMemberDeclaration memberDeclaration = (AnnotationMemberDeclaration)declaration.getMember(0);
         ResolvedAnnotationMemberDeclaration resolvedDeclaration = memberDeclaration.resolve();
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -13,6 +13,8 @@ import com.github.javaparser.symbolsolver.javaparser.Navigator;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -26,11 +28,23 @@ import static org.junit.Assert.assertEquals;
  */
 public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
+    @BeforeClass
+    public static void configureSymbolSolver() throws IOException {
+        // configure symbol solver before parsing
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+        typeSolver.add(new ReflectionTypeSolver());
+        typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+    }
+
+    @AfterClass
+    public static void unConfigureSymbolSolver() {
+        // unconfigure symbol solver so as not to potentially disturb tests in other classes
+        JavaParser.getStaticConfiguration().setSymbolResolver(null);
+    }
+
     @Test
     public void solveJavaParserMarkerAnnotation() {
-        // configure symbol solver before parsing
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CA");
@@ -45,9 +59,6 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void solveJavaParserSingleMemberAnnotation() {
-        // configure symbol solver before parsing
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CC");
@@ -62,9 +73,6 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void solveJavaParserNormalAnnotation() {
-        // configure symbol solver before parsing
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CD");
@@ -79,9 +87,6 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void solveReflectionMarkerAnnotation() {
-        // configure symbol solver before parsing
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CA");
@@ -97,9 +102,6 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void solveReflectionSingleMemberAnnotation() {
-        // configure symbol solver before parsing
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CC");
@@ -118,12 +120,6 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void solveJavassistMarkerAnnotation() throws IOException {
-        // configure symbol solver before parsing
-        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
-        typeSolver.add(new ReflectionTypeSolver());
-        typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CA");
@@ -139,12 +135,6 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void solveJavassistSingleMemberAnnotation() throws IOException {
-        // configure symbol solver before parsing
-        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
-        typeSolver.add(new ReflectionTypeSolver());
-        typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CC");
@@ -160,12 +150,6 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
     @Test
     public void solveJavassistNormalAnnotation() throws IOException {
-        // configure symbol solver before parsing
-        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
-        typeSolver.add(new ReflectionTypeSolver());
-        typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
-        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
-
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CD");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -1,0 +1,79 @@
+package com.github.javaparser.symbolsolver.resolution;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedClassDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserConstructorDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests resolution of annotation expressions.
+ *
+ * @author Malte Skoruppa
+ */
+public class AnnotationsResolutionTest extends AbstractResolutionTest {
+
+    @Test
+    public void solveJavaParserMarkerAnnotation() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CA");
+        MarkerAnnotationExpr annotationExpr = (MarkerAnnotationExpr) clazz.getAnnotation(0);
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
+
+        // check that the expected annotation declaration equals the resolved annotation declaration
+        assertEquals("foo.bar.MyAnnotation", resolved.getQualifiedName());
+    }
+
+    @Test
+    public void solveJavaParserSingleMemberAnnotation() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CC");
+        SingleMemberAnnotationExpr annotationExpr = (SingleMemberAnnotationExpr) clazz.getAnnotation(0);
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
+
+        // check that the expected annotation declaration equals the resolved annotation declaration
+        assertEquals("foo.bar.MyAnnotationWithSingleValue", resolved.getQualifiedName());
+    }
+
+    @Test
+    public void solveJavaParserNormalAnnotation() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CD");
+        NormalAnnotationExpr annotationExpr = (NormalAnnotationExpr) clazz.getAnnotation(0);
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
+
+        // check that the expected annotation declaration equals the resolved annotation declaration
+        assertEquals("foo.bar.MyAnnotationWithFields", resolved.getQualifiedName());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -55,6 +55,8 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("foo.bar.MyAnnotation", resolved.getQualifiedName());
+        assertEquals("foo.bar", resolved.getPackageName());
+        assertEquals("MyAnnotation", resolved.getName());
     }
 
     @Test
@@ -69,6 +71,8 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("foo.bar.MyAnnotationWithSingleValue", resolved.getQualifiedName());
+        assertEquals("foo.bar", resolved.getPackageName());
+        assertEquals("MyAnnotationWithSingleValue", resolved.getName());
     }
 
     @Test
@@ -82,7 +86,9 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
         ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
 
         // check that the expected annotation declaration equals the resolved annotation declaration
-        assertEquals("foo.bar.MyAnnotationWithFields", resolved.getQualifiedName());
+        assertEquals("foo.bar.MyAnnotationWithElements", resolved.getQualifiedName());
+        assertEquals("foo.bar", resolved.getPackageName());
+        assertEquals("MyAnnotationWithElements", resolved.getName());
     }
 
     @Test
@@ -98,6 +104,8 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("java.lang.Override", resolved.getQualifiedName());
+        assertEquals("java.lang", resolved.getPackageName());
+        assertEquals("Override", resolved.getName());
     }
 
     @Test
@@ -108,14 +116,16 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
         MethodDeclaration method = Navigator.demandMethod(clazz, "foo");
         SingleMemberAnnotationExpr annotationExpr =
                 (SingleMemberAnnotationExpr) method.getBody().get().getStatement(0)
-                                                     .asExpressionStmt().getExpression()
-                                                     .asVariableDeclarationExpr().getAnnotation(0);
+                        .asExpressionStmt().getExpression()
+                        .asVariableDeclarationExpr().getAnnotation(0);
 
         // resolve annotation expression
         ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("java.lang.SuppressWarnings", resolved.getQualifiedName());
+        assertEquals("java.lang", resolved.getPackageName());
+        assertEquals("SuppressWarnings", resolved.getName());
     }
 
     @Test
@@ -131,6 +141,8 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("org.junit.Before", resolved.getQualifiedName());
+        assertEquals("org.junit", resolved.getPackageName());
+        assertEquals("Before", resolved.getName());
     }
 
     @Test
@@ -146,6 +158,8 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("org.junit.Ignore", resolved.getQualifiedName());
+        assertEquals("org.junit", resolved.getPackageName());
+        assertEquals("Ignore", resolved.getName());
     }
 
     @Test
@@ -161,5 +175,7 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("org.junit.Test", resolved.getQualifiedName());
+        assertEquals("org.junit", resolved.getPackageName());
+        assertEquals("Test", resolved.getName());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -10,8 +10,12 @@ import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -110,5 +114,68 @@ public class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // check that the expected annotation declaration equals the resolved annotation declaration
         assertEquals("java.lang.SuppressWarnings", resolved.getQualifiedName());
+    }
+
+    @Test
+    public void solveJavassistMarkerAnnotation() throws IOException {
+        // configure symbol solver before parsing
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+        typeSolver.add(new ReflectionTypeSolver());
+        typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CA");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "setUp");
+        MarkerAnnotationExpr annotationExpr = (MarkerAnnotationExpr) method.getAnnotation(0);
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
+
+        // check that the expected annotation declaration equals the resolved annotation declaration
+        assertEquals("org.junit.Before", resolved.getQualifiedName());
+    }
+
+    @Test
+    public void solveJavassistSingleMemberAnnotation() throws IOException {
+        // configure symbol solver before parsing
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+        typeSolver.add(new ReflectionTypeSolver());
+        typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CC");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "testSomething");
+        SingleMemberAnnotationExpr annotationExpr = (SingleMemberAnnotationExpr) method.getAnnotation(0);
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
+
+        // check that the expected annotation declaration equals the resolved annotation declaration
+        assertEquals("org.junit.Ignore", resolved.getQualifiedName());
+    }
+
+    @Test
+    public void solveJavassistNormalAnnotation() throws IOException {
+        // configure symbol solver before parsing
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+        typeSolver.add(new ReflectionTypeSolver());
+        typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CD");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "testSomethingElse");
+        NormalAnnotationExpr annotationExpr = (NormalAnnotationExpr) method.getAnnotation(0);
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
+
+        // check that the expected annotation declaration equals the resolved annotation declaration
+        assertEquals("org.junit.Test", resolved.getQualifiedName());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
@@ -6,8 +6,13 @@ public @interface MyAnnotation {
 public @interface MyAnnotation2 {
 }
 
+public @interface MyAnnotationWithSingleValue {
+    int value();
+}
+
 public @interface MyAnnotationWithFields {
-    int field();
+    int num();
+    String str();
 }
 
 @MyAnnotation
@@ -20,3 +25,12 @@ class CB extends CA {
 
 }
 
+@MyAnnotationWithSingleValue(42)
+class CC {
+
+}
+
+@MyAnnotationWithFields(num = 42, str = "test")
+class CD {
+
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
@@ -17,7 +17,8 @@ public @interface MyAnnotationWithFields {
 
 @MyAnnotation
 class CA {
-
+    @Override
+    public boolean equals(Object o) { return true; }
 }
 
 @MyAnnotation2
@@ -27,7 +28,7 @@ class CB extends CA {
 
 @MyAnnotationWithSingleValue(42)
 class CC {
-
+    public boolean foo(Object o) { @SuppressWarnings("unchecked") String s = (String) o; }
 }
 
 @MyAnnotationWithFields(num = 42, str = "test")

--- a/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
@@ -12,7 +12,7 @@ public @interface MyAnnotationWithSingleValue {
     int value();
 }
 
-public @interface MyAnnotationWithFields {
+public @interface MyAnnotationWithElements {
     int num();
     String str();
 }
@@ -38,7 +38,7 @@ class CC {
     @Ignore("lalala") @Test public void testSomething() {}
 }
 
-@MyAnnotationWithFields(num = 42, str = "test")
+@MyAnnotationWithElements(num = 42, str = "test")
 class CD {
     @Test(expected = Throwable.class, timeout = 42L) public void testSomethingElse() {}
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
@@ -1,5 +1,7 @@
 package foo.bar;
 
+import org.junit.*;
+
 public @interface MyAnnotation {
 }
 
@@ -19,6 +21,9 @@ public @interface MyAnnotationWithFields {
 class CA {
     @Override
     public boolean equals(Object o) { return true; }
+
+    @Before
+    public void setUp() {}
 }
 
 @MyAnnotation2
@@ -29,9 +34,11 @@ class CB extends CA {
 @MyAnnotationWithSingleValue(42)
 class CC {
     public boolean foo(Object o) { @SuppressWarnings("unchecked") String s = (String) o; }
+
+    @Ignore("lalala") @Test public void testSomething() {}
 }
 
 @MyAnnotationWithFields(num = 42, str = "test")
 class CD {
-
+    @Test(expected = Throwable.class, timeout = 42L) public void testSomethingElse() {}
 }


### PR DESCRIPTION
This PR heavily improves support for resolving annotation expressions in JSS. Resolving annotation expressions is very important for static analysis tools that wish to parse code and exhibit a certain behavior when annotated expressions are encountered.

* Commit 451b09e implements the method `AnnotationExpr#resolve()` to enable resolution of annotations directly from an annotation expression node. This is in the spirit of moving symbol resolution away from `JavaParserFacade` and into the AST nodes.
* Commit a4ce98e adds the new classes `ReflectionAnnotationDeclaration` and `ReflectionAnnotationMemberDeclaration` as well as the logic to enable resolution of annotation expressions whose declaration lives in the standard library (such as `@Override`, `@SuppressWarnings`, etc.). Previously, it was only possible to resolve declarations of annotation expressions when the annotation declaration had been parsed using JavaParser.
* Commit 11d97f0 adds the new classes `JavassistAnnotationDeclaration` and `JavassistAnnotationMemberDeclaration` as well as the logic to enable resolution of annotation expressions whose declaration lives in a provided jar file (e.g., when providing a JUnit 4 jar file, declarations such as `@Test`, `@Ignore`, `@Before`, etc.). Previously, it was only possible to resolve declarations of annotation expressions when the annotation declaration had been parsed using JavaParser or when the annotation declaration lived in the standard library.
* Commits dc99432 and 0471fe4 only make some minor improvements to the code.

Note that support for annotations in JSS is still not 100% complete. For example, it is not possible to get the default value of a `ReflectionAnnotationMemberDeclaration` or a `JavassistAnnotationMemberDeclaration` (instead, an `UnsupportedOperationException` is thrown). However, it is also not possible to get the default value of a `JavaParserAnnotationMemberDeclaration` either (here too, an `UnsupportedOperationException` is thrown), and that class has been around for much longer.

So support for annotations is still not complete, but definitely improved. If support for annotations in JSS was at 70% before, it is now maybe at 80%. :-) (random numbers of course, but you get the point)
