### PR TITLE
Make symbol resolution more robust when some ancestors cannot be resolved

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
  * @author Federico Tomassetti
  */
 public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaration,
-        ResolvedTypeParametrizable {
+                                                                  ResolvedTypeParametrizable {
 
     @Override
     default ResolvedReferenceTypeDeclaration asReferenceType() {
@@ -50,14 +50,41 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
     ///
 
     /**
-     * The list of all the direct ancestors of the current declaration.
-     * Note that the ancestor can be parametrized types with values specified. For example:
+     * Resolves the types of all direct ancestors (i.e., the directly extended class and the directly implemented
+     * interfaces) and returns the list of ancestors as a list of resolved reference types.
+     * <p>
+     * In case any ancestor cannot be resolved, an {@code UnsolvedSymbolException} is thrown. In order to obtain a list
+     * of only the resolvable direct ancestors, use {@link #getAncestors(boolean)} and pass the value {@code true}.
+     * <p>
+     * Note that an ancestor can be parametrized types with values specified. For example:
      * <p>
      * class A implements Comparable&lt;String&gt; {}
      * <p>
      * In this case the ancestor is Comparable&lt;String&gt;
+     *
+     * @return The list of resolved ancestors.
+     * @throws UnsolvedSymbolException if some ancestor could not be resolved.
      */
-    List<ResolvedReferenceType> getAncestors();
+    default List<ResolvedReferenceType> getAncestors() {
+        return getAncestors(false);
+    }
+
+    /**
+     * Resolves the types of all direct ancestors (i.e., the directly extended class and the directly implemented
+     * interfaces) and returns the list of ancestors as a list of resolved reference types.
+     * <p>
+     * If {@code acceptIncompleteList} is {@code false}, then an {@code UnsolvedSymbolException} is thrown if any
+     * ancestor cannot be resolved. Otherwise, a list of only the resolvable direct ancestors is returned.
+     *
+     * @param acceptIncompleteList When set to {@code false}, this method throws an {@link UnsolvedSymbolException} if
+     *                             one or more ancestor could not be resolved. When set to {@code true}, this method
+     *                             does not throw an {@link UnsolvedSymbolException}, but the list of returned ancestors
+     *                             may be incomplete in case one or more ancestor could not be resolved.
+     * @return The list of resolved ancestors.
+     * @throws UnsolvedSymbolException if some ancestor could not be resolved and {@code acceptIncompleteList} is set to
+     *                                 {@code false}.
+     */
+    List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList);
 
     /**
      * The list of all the ancestors of the current declaration, direct and indirect.
@@ -66,9 +93,9 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
     default List<ResolvedReferenceType> getAllAncestors() {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
         // We want to avoid infinite recursion in case of Object having Object as ancestor
-        if (!(Object.class.getCanonicalName().equals(getQualifiedName()))) {       
+        if (!(Object.class.getCanonicalName().equals(getQualifiedName()))) {
             for (ResolvedReferenceType ancestor : getAncestors()) {
-                ancestors.add(ancestor);    
+                ancestors.add(ancestor);
                 for (ResolvedReferenceType inheritedAncestor : ancestor.getAllAncestors()) {
                     if (!ancestors.contains(inheritedAncestor)) {
                         ancestors.add(inheritedAncestor);
@@ -139,8 +166,8 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      */
     default List<ResolvedFieldDeclaration> getVisibleFields() {
         return getAllFields().stream()
-                .filter(f -> f.declaringType().equals(this) || f.accessSpecifier() != AccessSpecifier.PRIVATE)
-                .collect(Collectors.toList());
+                       .filter(f -> f.declaringType().equals(this) || f.accessSpecifier() != AccessSpecifier.PRIVATE)
+                       .collect(Collectors.toList());
     }
 
     /**
@@ -162,7 +189,7 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      */
     default List<ResolvedFieldDeclaration> getDeclaredFields() {
         return getAllFields().stream().filter(it -> it.declaringType().getQualifiedName()
-                .equals(getQualifiedName())).collect(Collectors.toList());
+                                                            .equals(getQualifiedName())).collect(Collectors.toList());
     }
 
     ///

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -79,7 +79,7 @@ public class JavaParserTypeDeclarationAdapter {
      * @return A ResolvedTypeDeclaration matching the {@param name}, null otherwise
      */
     private ResolvedTypeDeclaration checkAncestorsForType(String name, ResolvedReferenceTypeDeclaration declaration) {
-        for (ResolvedReferenceType ancestor : declaration.getAncestors()) {
+        for (ResolvedReferenceType ancestor : declaration.getAncestors(true)) {
             try {
                 for (ResolvedTypeDeclaration internalTypeDeclaration : ancestor.getTypeDeclaration().internalTypes()) {
                     boolean visible = true;
@@ -112,7 +112,7 @@ public class JavaParserTypeDeclarationAdapter {
                 .collect(Collectors.toList());
         // We want to avoid infinite recursion in case of Object having Object as ancestor
         if (!Object.class.getCanonicalName().equals(typeDeclaration.getQualifiedName())) {
-            for (ResolvedReferenceType ancestor : typeDeclaration.getAncestors()) {
+            for (ResolvedReferenceType ancestor : typeDeclaration.getAncestors(true)) {
 		// Avoid recursion on self
                 if (typeDeclaration != ancestor.getTypeDeclaration()) {
                     candidateMethods.addAll(ancestor.getAllMethodsVisibleToInheritors()

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -28,7 +28,7 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         throw new UnsupportedOperationException();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -95,12 +95,12 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
   }
 
   @Override
-  public List<ResolvedReferenceType> getAncestors() {
+  public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
     return
         ImmutableList.
             <ResolvedReferenceType>builder()
             .add(getSuperClass())
-            .addAll(superTypeDeclaration.asReferenceType().getAncestors())
+            .addAll(superTypeDeclaration.asReferenceType().getAncestors(acceptIncompleteList))
             .build();
   }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -269,30 +269,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         return getContext().getParent().solveType(name, typeSolver);
     }
 
-    /**
-     * Resolves the type of all ancestors (i.e., the extended class and the implemented interfaces) and returns the list
-     * of ancestors as a list of resolved reference types.
-     *
-     * @return The list of resolved ancestors.
-     * @throws UnsolvedSymbolException if some ancestor could not be resolved.
-     */
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
-        return getAncestors(false);
-    }
-
-    /**
-     * Resolves the type of all ancestors (i.e., the extended class and the implemented interfaces) and returns the list
-     * of ancestors as a list of resolved reference types.
-     *
-     * @param acceptIncompleteList When set to {@code false}, this method throws an {@link UnsolvedSymbolException} if
-     *                             one or more ancestor could not be resolved. When set to {@code true}, this method
-     *                             does not throw an {@link UnsolvedSymbolException}, but the list of returned ancestors
-     *                             may be incomplete in case one or more ancestor could not be resolved.
-     * @return The list of resolved ancestors.
-     * @throws UnsolvedSymbolException if some ancestor could not be resolved and {@code acceptIncompleteList} is set to
-     *                                 {@code false}.
-     */
     public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -209,7 +209,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
         ResolvedReferenceType enumClass = ReflectionFactory.typeUsageFor(Enum.class, typeSolver).asReferenceType();
         ResolvedTypeParameterDeclaration eTypeParameter = enumClass.getTypeDeclaration().getTypeParameters().get(0);
@@ -218,7 +218,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
         if (wrappedNode.getImplementedTypes() != null) {
             for (ClassOrInterfaceType implementedType : wrappedNode.getImplementedTypes()) {
                 SymbolReference<ResolvedTypeDeclaration> implementedDeclRef = new SymbolSolver(typeSolver).solveTypeInType(this, implementedType.getName().getId());
-                if (!implementedDeclRef.isSolved()) {
+                if (!implementedDeclRef.isSolved() && !acceptIncompleteList) {
                     throw new UnsolvedSymbolException(implementedType.getName().getId());
                 }
                 ancestors.add(new ReferenceTypeImpl((ResolvedReferenceTypeDeclaration) implementedDeclRef.getCorrespondingDeclaration(), typeSolver));

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -242,16 +242,30 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
         if (wrappedNode.getExtendedTypes() != null) {
             for (ClassOrInterfaceType extended : wrappedNode.getExtendedTypes()) {
-                ancestors.add(toReferenceType(extended));
+                try {
+                    ancestors.add(toReferenceType(extended));
+                } catch (UnsolvedSymbolException e) {
+                    if (!acceptIncompleteList) {
+                        // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
+                        throw e;
+                    }
+                }
             }
         }
         if (wrappedNode.getImplementedTypes() != null) {
             for (ClassOrInterfaceType implemented : wrappedNode.getImplementedTypes()) {
-                ancestors.add(toReferenceType(implemented));
+                try {
+                    ancestors.add(toReferenceType(implemented));
+                } catch (UnsolvedSymbolException e) {
+                    if (!acceptIncompleteList) {
+                        // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
+                        throw e;
+                    }
+                }
             }
         }
         return ancestors;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
@@ -179,7 +179,7 @@ public class JavaParserTypeParameter extends AbstractTypeDeclaration implements 
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         throw new UnsupportedOperationException();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
@@ -115,7 +115,7 @@ public class JavaParserTypeVariableDeclaration extends AbstractTypeDeclaration {
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         throw new UnsupportedOperationException();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -94,7 +94,7 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         throw new UnsupportedOperationException();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -168,12 +168,27 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
-        if (getSuperClass() != null) {
-            ancestors.add(getSuperClass());
+        try {
+            ResolvedReferenceType superClass = getSuperClass();
+            if (superClass != null) {
+                ancestors.add(superClass);
+            }
+        } catch (UnsolvedSymbolException e) {
+            if (!acceptIncompleteList) {
+                // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
+                throw e;
+            }
         }
-        ancestors.addAll(getInterfaces());
+        try {
+            ancestors.addAll(getInterfaces());
+        } catch (UnsolvedSymbolException e) {
+            if (!acceptIncompleteList) {
+                // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
+                throw e;
+            }
+        }
         return ancestors;
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -88,18 +88,32 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration implements
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         // Direct ancestors of an enum are java.lang.Enum and interfaces
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
 
         String superClassName = ctClass.getClassFile().getSuperclass();
 
         if (superClassName != null) {
-            ancestors.add(new ReferenceTypeImpl(typeSolver.solveType(superClassName), typeSolver));
+            try {
+                ancestors.add(new ReferenceTypeImpl(typeSolver.solveType(superClassName), typeSolver));
+            } catch (UnsolvedSymbolException e) {
+                if (!acceptIncompleteList) {
+                    // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
+                    throw e;
+                }
+            }
         }
 
         for (String interfazeName : ctClass.getClassFile().getInterfaces()) {
-            ancestors.add(new ReferenceTypeImpl(typeSolver.solveType(interfazeName), typeSolver));
+            try {
+                ancestors.add(new ReferenceTypeImpl(typeSolver.solveType(interfazeName), typeSolver));
+            } catch (UnsolvedSymbolException e) {
+                if (!acceptIncompleteList) {
+                    // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
+                    throw e;
+                }
+            }
         }
 
         return ancestors;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -153,12 +153,19 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration imple
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         List<ResolvedReferenceType> ancestors = new ArrayList<>();
         try {
             for (CtClass interfaze : ctClass.getInterfaces()) {
-                ResolvedReferenceType superInterfaze = JavassistFactory.typeUsageFor(interfaze, typeSolver).asReferenceType();
-                ancestors.add(superInterfaze);
+                try {
+                    ResolvedReferenceType superInterfaze = JavassistFactory.typeUsageFor(interfaze, typeSolver).asReferenceType();
+                    ancestors.add(superInterfaze);
+                } catch (UnsolvedSymbolException e) {
+                    if (!acceptIncompleteList) {
+                        // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
+                        throw e;
+                    }
+                }
             }
         } catch (NotFoundException e) {
             throw new RuntimeException(e);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -129,7 +129,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         throw new UnsupportedOperationException();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -87,7 +87,9 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
+        // we do not attempt to perform any symbol solving when analyzing ancestors in the reflection model, so we can
+        // simply ignore the boolean parameter here; an UnsolvedSymbolException cannot occur
         return reflectionClassAdapter.getAncestors();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -106,7 +106,9 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration implement
   }
 
   @Override
-  public List<ResolvedReferenceType> getAncestors() {
+  public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
+    // we do not attempt to perform any symbol solving when analyzing ancestors in the reflection model, so we can
+    // simply ignore the boolean parameter here; an UnsolvedSymbolException cannot occur
     return reflectionClassAdapter.getAncestors();
   }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -240,7 +240,9 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
-    public List<ResolvedReferenceType> getAncestors() {
+    public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
+        // we do not attempt to perform any symbol solving when analyzing ancestors in the reflection model, so we can
+        // simply ignore the boolean parameter here; an UnsolvedSymbolException cannot occur
         return reflectionClassAdapter.getAncestors();
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
@@ -54,7 +54,7 @@ public class DefaultPackageTest {
         }
 
         @Override
-        public List<ResolvedReferenceType> getAncestors() {
+        public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
             throw new UnsupportedOperationException();
         }
 

--- a/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/ClassExtendingUnknownClass.java.txt
@@ -11,4 +11,10 @@ public class ClassExtendingUnknownClass extends UnknownClass {
     public int getFoo2() {
         return this.foo;
     }
+
+    public void foo(String s) {
+        bar(s);
+    }
+
+    public void bar(String s) {}
 }


### PR DESCRIPTION
This PR completes an older PR, namely, PR #1646.

Remember PR #1646: The problem was that it was not possible to resolve a field access of a field local to a class simply because the given class extended another, unknown class. During symbol resolution, JSS failed to resolve that ancestor and gave up completely, even though the field access could have been resolved without resolving the ancestor.

We solved that problem by making JSS more robust: More precisely, we made it so that JSS doesn't give up completely just because it cannot resolve an ancestor, but continues gracefully.

However, the implementation of that solution was specific to field accesses of JavaParserClassDeclarations.

In other, similar situations, the same problem persists. For instance, it turns out that it is still not possible to resolve the call to method `bar(String)` in the following code:

```java
import com.third.party.library.UnknownClass;

public class ClassExtendingUnknownClass extends UnknownClass {

    public void foo(String s) {
        bar(s);
    }

    public void bar(String s) {}
}
```

This is similar to the problem described in that older PR, except that here we attempt to resolve a method call to a local method instead of a field access to a local field.

The current behavior is that an `UnsolvedSymbolException` is thrown because JSS cannot resolve the class's ancestor, and completely gives up.

This PR applies the same logic used in that older PR consistently. Now, symbol resolution is *much more* robust since it can generally ignore ancestors when it cannot resolve them, not only in that particular case. This added robustness comes without any loss or change of functionality. In fact, the method `ResolvedTypeDeclaration#getAncestors()` will still attempt to resolve *all* ancestors and throw an `UnsolvedSymbolException` if *any* ancestor cannot be resolved, just as before. It simply introduces a new method `ResolvedTypeDeclaration#getAncestors(boolean)` which enables the possibility to obtain only those ancestors which are resolvable. PR #1646 already added the same method, but locally restricted to `JavaParserClassDeclaration`. This PR introduces that method in `ResolvedTypeDeclaration` instead.
