### PR TITLE
Introduce the toAST method

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/AssociableToAST.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/AssociableToAST.java
@@ -1,0 +1,21 @@
+package com.github.javaparser.resolution.declarations;
+
+import com.github.javaparser.ast.Node;
+
+import java.util.Optional;
+
+/**
+ * A declaration that can be potentially associated with an AST node.
+ * @param <N> type of AST Node that can be associated
+ */
+public interface AssociableToAST<N extends Node> {
+
+    /**
+     * If the declaration is associated to an AST node return it, otherwise it return empty.
+     * Declaration based on source code have an AST node associated while others don't. Example
+     * of other declarations are declarations coming from reflection or JARs.
+     */
+    default Optional<N> toAST() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/AssociableToAST.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/AssociableToAST.java
@@ -15,7 +15,7 @@ public interface AssociableToAST<N extends Node> {
      * Declaration based on source code have an AST node associated while others don't. Example
      * of other declarations are declarations coming from reflection or JARs.
      */
-    default Optional<N> toAST() {
+    default Optional<N> toAst() {
         throw new UnsupportedOperationException();
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/AssociableToAST.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/AssociableToAST.java
@@ -14,6 +14,22 @@ public interface AssociableToAST<N extends Node> {
      * If the declaration is associated to an AST node return it, otherwise it return empty.
      * Declaration based on source code have an AST node associated while others don't. Example
      * of other declarations are declarations coming from reflection or JARs.
+     *
+     * You may wonder how this method is different from the various getWrappedNode.
+     * The difference is that toAst is present in all Resolved* declarations (such as
+     * ResolvedAnnotationDeclaration), while getWrappedNode is present
+     * only on the subclasses of the Resolved* declarations that derive from JP AST nodes (such as
+     * JavaParserClassDeclaration). Therefore one
+     * which has a Resolved* declaration need to do a downcast before being able to use getWrappedNode.
+     *
+     * Now, this means that toAst could potentially replace getWrappedNode (but not the other way around!).
+     * However toAst return an Optional, which is less convenient than getting the direct node. Also,
+     * toAst sometimes have to return a more generic node. This is the case for subclasses of
+     * ResolvedClassDeclaration. In those cases toAst return a Node. Why? Because both anonymous
+     * class declarations and standard class declarations are subclasses of that. In one case the
+     * underlying AST node is an ObjectCreationExpr, while in the other case it is ClassOrInterfaceDeclaration.
+     * In these cases getWrappedNode is particularly nice because it returns the right type of AST node,
+     * not just a Node.
      */
     default Optional<N> toAst() {
         throw new UnsupportedOperationException();

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedAnnotationDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedAnnotationDeclaration.java
@@ -21,12 +21,15 @@
 
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+
 import java.util.List;
 
 /**
  * @author Federico Tomassetti
  */
-public interface ResolvedAnnotationDeclaration extends ResolvedReferenceTypeDeclaration {
+public interface ResolvedAnnotationDeclaration extends ResolvedReferenceTypeDeclaration,
+        AssociableToAST<AnnotationDeclaration> {
 
     List<ResolvedAnnotationMemberDeclaration> getAnnotationMembers();
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedClassDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedClassDeclaration.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 
@@ -29,10 +30,13 @@ import java.util.List;
 /**
  * Declaration of a Class (not an interface or an enum).
  *
+ * Note that it can be associated to a Node AST because anonymous class declarations return an incompatible
+ * node type, compared to classic class declarations.
+ *
  * @author Federico Tomassetti
  */
 public interface ResolvedClassDeclaration extends ResolvedReferenceTypeDeclaration,
-        ResolvedTypeParametrizable, HasAccessSpecifier, AssociableToAST<ClassOrInterfaceDeclaration> {
+        ResolvedTypeParametrizable, HasAccessSpecifier, AssociableToAST<Node> {
 
     /**
      * This method should always return true.

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedClassDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedClassDeclaration.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 
 import java.util.List;
@@ -31,7 +32,7 @@ import java.util.List;
  * @author Federico Tomassetti
  */
 public interface ResolvedClassDeclaration extends ResolvedReferenceTypeDeclaration,
-        ResolvedTypeParametrizable, HasAccessSpecifier {
+        ResolvedTypeParametrizable, HasAccessSpecifier, AssociableToAST<ClassOrInterfaceDeclaration> {
 
     /**
      * This method should always return true.

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedConstructorDeclaration.java
@@ -21,12 +21,15 @@
 
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+
 /**
  * A declaration of a constructor.
  *
  * @author Federico Tomassetti
  */
-public interface ResolvedConstructorDeclaration extends ResolvedMethodLikeDeclaration {
+public interface ResolvedConstructorDeclaration extends ResolvedMethodLikeDeclaration,
+        AssociableToAST<ConstructorDeclaration> {
 
     /**
      * A constructor can be declared in a class or an enum.

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedInterfaceDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedInterfaceDeclaration.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ import java.util.List;
  * @author Federico Tomassetti
  */
 public interface ResolvedInterfaceDeclaration extends ResolvedReferenceTypeDeclaration,
-        ResolvedTypeParametrizable, HasAccessSpecifier {
+        ResolvedTypeParametrizable, HasAccessSpecifier, AssociableToAST<ClassOrInterfaceDeclaration> {
 
     @Override
     default boolean isInterface() {

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 
 /**
@@ -28,7 +29,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
  *
  * @author Federico Tomassetti
  */
-public interface ResolvedMethodDeclaration extends ResolvedMethodLikeDeclaration {
+public interface ResolvedMethodDeclaration extends ResolvedMethodLikeDeclaration, AssociableToAST<MethodDeclaration> {
 
     /**
      * The type of the value returned by the current method. This method can also be invoked

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/DefaultConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/DefaultConstructorDeclaration.java
@@ -81,7 +81,7 @@ public class DefaultConstructorDeclaration<N extends ResolvedReferenceTypeDeclar
     }
 
     @Override
-    public Optional<ConstructorDeclaration> toAST() {
+    public Optional<ConstructorDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/DefaultConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/DefaultConstructorDeclaration.java
@@ -17,11 +17,14 @@
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedType;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This represents the default constructor added by the compiler for objects not declaring one.
@@ -75,5 +78,10 @@ public class DefaultConstructorDeclaration<N extends ResolvedReferenceTypeDeclar
     @Override
     public ResolvedType getSpecifiedException(int index) {
         throw new UnsupportedOperationException("The default constructor does not throw exceptions");
+    }
+
+    @Override
+    public Optional<ConstructorDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -110,4 +110,9 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
     public List<ResolvedConstructorDeclaration> getConstructors() {
         return Collections.emptyList();
     }
+
+    @Override
+    public Optional<AnnotationDeclaration> toAST() {
+        return Optional.of(wrappedNode);
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -112,7 +112,7 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
     }
 
     @Override
-    public Optional<AnnotationDeclaration> toAST() {
+    public Optional<AnnotationDeclaration> toAst() {
         return Optional.of(wrappedNode);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -207,7 +207,7 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
   }
 
   @Override
-  public Optional<Node> toAST() {
+  public Optional<Node> toAst() {
     return Optional.of(wrappedNode);
   }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -2,6 +2,7 @@ package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
@@ -201,5 +202,9 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
     throw new UnsupportedOperationException("containerType is not supported for " + this.getClass().getCanonicalName());
   }
 
+  @Override
+  public Optional<Node> toAST() {
+    return Optional.of(wrappedNode);
+  }
 
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -347,6 +347,11 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
         return AstResolutionUtils.toAccessLevel(wrappedNode.getModifiers());
     }
 
+    @Override
+    public Optional<Node> toAST() {
+        return Optional.of(wrappedNode);
+    }
+
     ///
     /// Protected methods
     ///

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -348,7 +348,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
-    public Optional<Node> toAST() {
+    public Optional<Node> toAst() {
         return Optional.of(wrappedNode);
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserConstructorDeclaration.java
@@ -17,12 +17,15 @@
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -96,5 +99,10 @@ public class JavaParserConstructorDeclaration<N extends ResolvedReferenceTypeDec
         }
         return JavaParserFacade.get(typeSolver)
                 .convert(wrappedNode.getThrownExceptions().get(index), wrappedNode);
+    }
+
+    @Override
+    public Optional<ConstructorDeclaration> toAST() {
+        return Optional.of(wrappedNode);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserConstructorDeclaration.java
@@ -102,7 +102,7 @@ public class JavaParserConstructorDeclaration<N extends ResolvedReferenceTypeDec
     }
 
     @Override
-    public Optional<ConstructorDeclaration> toAST() {
+    public Optional<ConstructorDeclaration> toAst() {
         return Optional.of(wrappedNode);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -20,6 +20,7 @@ import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
@@ -325,6 +326,11 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
         @Override
         public ResolvedType getSpecifiedException(int index) {
             throw new UnsupportedOperationException("The values method of an enum does not throw any exception");
+        }
+
+        @Override
+        public Optional<MethodDeclaration> toAST() {
+            return Optional.empty();
         }
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -329,7 +329,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
         }
 
         @Override
-        public Optional<MethodDeclaration> toAST() {
+        public Optional<MethodDeclaration> toAst() {
             return Optional.empty();
         }
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -318,7 +318,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
-    public Optional<ClassOrInterfaceDeclaration> toAST() {
+    public Optional<ClassOrInterfaceDeclaration> toAst() {
         return Optional.of(wrappedNode);
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -317,6 +317,11 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
         return Collections.emptyList();
     }
 
+    @Override
+    public Optional<ClassOrInterfaceDeclaration> toAST() {
+        return Optional.of(wrappedNode);
+    }
+
     ///
     /// Private methods
     ///

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -168,7 +168,7 @@ public class JavaParserMethodDeclaration implements ResolvedMethodDeclaration {
     }
 
     @Override
-    public Optional<MethodDeclaration> toAST() {
+    public Optional<MethodDeclaration> toAst() {
         return Optional.of(wrappedNode);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -18,6 +18,7 @@ package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
@@ -32,6 +33,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.github.javaparser.symbolsolver.javaparser.Navigator.requireParentNode;
@@ -163,5 +165,10 @@ public class JavaParserMethodDeclaration implements ResolvedMethodDeclaration {
         }
         return JavaParserFacade.get(typeSolver).convert(wrappedNode.getThrownExceptions()
                 .get(index), wrappedNode);
+    }
+
+    @Override
+    public Optional<MethodDeclaration> toAST() {
+        return Optional.of(wrappedNode);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -16,6 +16,7 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
+import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -138,5 +139,10 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
         return Stream.of(ctClass.getDeclaredMethods())
                 .map(m -> new JavassistAnnotationMemberDeclaration(m, typeSolver))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<AnnotationDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -142,7 +142,7 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
-    public Optional<AnnotationDeclaration> toAST() {
+    public Optional<AnnotationDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -394,7 +394,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
-    public Optional<Node> toAST() {
+    public Optional<Node> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -392,4 +392,9 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration {
          */
         return this.internalTypes().stream().anyMatch(f -> f.getName().endsWith(name));
     }
+
+    @Override
+    public Optional<Node> toAST() {
+        return Optional.empty();
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
@@ -18,6 +18,7 @@ package com.github.javaparser.symbolsolver.javassistmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
@@ -146,5 +147,10 @@ public class JavassistConstructorDeclaration implements ResolvedConstructorDecla
         } catch (NotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public Optional<ConstructorDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
@@ -150,7 +150,7 @@ public class JavassistConstructorDeclaration implements ResolvedConstructorDecla
     }
 
     @Override
-    public Optional<ConstructorDeclaration> toAST() {
+    public Optional<ConstructorDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -288,7 +288,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration imple
     }
 
     @Override
-    public Optional<ClassOrInterfaceDeclaration> toAST() {
+    public Optional<ClassOrInterfaceDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -17,6 +17,7 @@
 package com.github.javaparser.symbolsolver.javassistmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
@@ -284,5 +285,10 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration imple
     @Override
     public List<ResolvedConstructorDeclaration> getConstructors() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<ClassOrInterfaceDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodDeclaration.java
@@ -18,6 +18,7 @@ package com.github.javaparser.symbolsolver.javassistmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
@@ -201,5 +202,10 @@ public class JavassistMethodDeclaration implements ResolvedMethodDeclaration {
         } catch (NotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public Optional<MethodDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodDeclaration.java
@@ -205,7 +205,7 @@ public class JavassistMethodDeclaration implements ResolvedMethodDeclaration {
     }
 
     @Override
-    public Optional<MethodDeclaration> toAST() {
+    public Optional<MethodDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -16,6 +16,7 @@
 
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
+import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
@@ -167,5 +168,10 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
         return Stream.of(clazz.getDeclaredMethods())
                        .map(m -> new ReflectionAnnotationMemberDeclaration(m, typeSolver))
                        .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<AnnotationDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -171,7 +171,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
     }
 
     @Override
-    public Optional<AnnotationDeclaration> toAST() {
+    public Optional<AnnotationDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -341,6 +341,11 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
                 .collect(Collectors.toSet());
     }
 
+    @Override
+    public Optional<Node> toAST() {
+        return Optional.empty();
+    }
+
     ///
     /// Protected methods
     ///

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -342,7 +342,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
     }
 
     @Override
-    public Optional<Node> toAST() {
+    public Optional<Node> toAst() {
         return Optional.empty();
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionConstructorDeclaration.java
@@ -17,6 +17,7 @@
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedClassDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
@@ -27,6 +28,7 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -93,5 +95,10 @@ public class ReflectionConstructorDeclaration implements ResolvedConstructorDecl
             throw new IllegalArgumentException();
         }
         return ReflectionFactory.typeUsageFor(this.constructor.getExceptionTypes()[index], typeSolver);
+    }
+
+    @Override
+    public Optional<ConstructorDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionConstructorDeclaration.java
@@ -98,7 +98,7 @@ public class ReflectionConstructorDeclaration implements ResolvedConstructorDecl
     }
 
     @Override
-    public Optional<ConstructorDeclaration> toAST() {
+    public Optional<ConstructorDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -18,6 +18,7 @@ package com.github.javaparser.symbolsolver.reflectionmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
@@ -310,5 +311,10 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
     @Override
     public List<ResolvedConstructorDeclaration> getConstructors() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<ClassOrInterfaceDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -314,7 +314,7 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
     }
 
     @Override
-    public Optional<ClassOrInterfaceDeclaration> toAST() {
+    public Optional<ClassOrInterfaceDeclaration> toAst() {
         return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
@@ -17,6 +17,7 @@
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
@@ -31,6 +32,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -148,5 +150,10 @@ public class ReflectionMethodDeclaration implements ResolvedMethodDeclaration {
             throw new IllegalArgumentException();
         }
         return ReflectionFactory.typeUsageFor(this.method.getExceptionTypes()[index], typeSolver);
+    }
+
+    @Override
+    public Optional<MethodDeclaration> toAST() {
+        return Optional.empty();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
@@ -153,7 +153,7 @@ public class ReflectionMethodDeclaration implements ResolvedMethodDeclaration {
     }
 
     @Override
-    public Optional<MethodDeclaration> toAST() {
+    public Optional<MethodDeclaration> toAst() {
         return Optional.empty();
     }
 }


### PR DESCRIPTION
Frequently users want to go from resolved declarations back to source code. Currently they have to do a downcast. This PR introduce a method for that, which should make the thing much more obvious (so maybe more intuitive usage and less questions)