### PR TITLE
Add an exception filter to the CombinedTypeSolver

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/CombinedTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/CombinedTypeSolverTest.java
@@ -33,7 +33,7 @@ import org.junit.runners.Parameterized.Parameters;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver.ExceptionFilters;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver.ExceptionHandlers;
 
 @RunWith(Parameterized.class)
 public class CombinedTypeSolverTest {
@@ -41,14 +41,14 @@ public class CombinedTypeSolverTest {
     @Parameters
     public static List<Object[]> parameters() {
         // Why these classes? NFE is a subclass, IOOBE is a superclass and ISE is a class without children (by default)
-        Predicate<Exception> whitelistTestFilter = ExceptionFilters.getTypeBasedWhitelist(NumberFormatException.class,
+        Predicate<Exception> whitelistTestFilter = ExceptionHandlers.getTypeBasedWhitelist(NumberFormatException.class,
                 IndexOutOfBoundsException.class, IllegalStateException.class);
-        Predicate<Exception> blacklistTestFilter = ExceptionFilters.getTypeBasedBlacklist(NumberFormatException.class,
+        Predicate<Exception> blacklistTestFilter = ExceptionHandlers.getTypeBasedBlacklist(NumberFormatException.class,
                 IndexOutOfBoundsException.class, IllegalStateException.class);
 
         return Arrays.asList(new Object[][] {
-                { new RuntimeException(), ExceptionFilters.IGNORE_ALL, true }, // 0
-                { new RuntimeException(), ExceptionFilters.IGNORE_NONE, false }, // 1
+                { new RuntimeException(), ExceptionHandlers.IGNORE_ALL, true }, // 0
+                { new RuntimeException(), ExceptionHandlers.IGNORE_NONE, false }, // 1
 
                 { new RuntimeException(), whitelistTestFilter, false }, // 2
                 { new IllegalStateException(), whitelistTestFilter, true }, // 3

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/CombinedTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/CombinedTypeSolverTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Federico Tomassetti
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.javaparser.symbolsolver.resolution.typesolvers;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver.ExceptionFilters;
+
+@RunWith(Parameterized.class)
+public class CombinedTypeSolverTest {
+
+    @Parameters
+    public static List<Object[]> parameters() {
+        // Why these classes? NFE is a subclass, IOOBE is a superclass and ISE is a class without children (by default)
+        Predicate<Exception> whitelistTestFilter = ExceptionFilters.getTypeBasedWhitelist(NumberFormatException.class,
+                IndexOutOfBoundsException.class, IllegalStateException.class);
+        Predicate<Exception> blacklistTestFilter = ExceptionFilters.getTypeBasedBlacklist(NumberFormatException.class,
+                IndexOutOfBoundsException.class, IllegalStateException.class);
+
+        return Arrays.asList(new Object[][] {
+                { new RuntimeException(), ExceptionFilters.IGNORE_ALL, true }, // 0
+                { new RuntimeException(), ExceptionFilters.IGNORE_NONE, false }, // 1
+
+                { new RuntimeException(), whitelistTestFilter, false }, // 2
+                { new IllegalStateException(), whitelistTestFilter, true }, // 3
+
+                { new NumberFormatException(), whitelistTestFilter, true }, // 4
+                { new IllegalArgumentException(), whitelistTestFilter, false }, // 5
+
+                { new IndexOutOfBoundsException(), whitelistTestFilter, true }, // 6
+                { new ArrayIndexOutOfBoundsException(), whitelistTestFilter, true }, // 7
+
+                { new RuntimeException(), blacklistTestFilter, true }, // 8
+                { new NullPointerException(), blacklistTestFilter, true }, // 9
+                { new IllegalStateException(), blacklistTestFilter, false }, // 10
+
+                { new NumberFormatException(), blacklistTestFilter, false }, // 11
+                { new IllegalArgumentException(), blacklistTestFilter, true }, // 12
+
+                { new IndexOutOfBoundsException(), blacklistTestFilter, false }, // 13
+                { new ArrayIndexOutOfBoundsException(), blacklistTestFilter, false }, // 14
+        });
+    }
+
+    @Parameter(0)
+    public Exception toBeThrownException;
+
+    @Parameter(1)
+    public Predicate<Exception> filter;
+
+    @Parameter(2)
+    public boolean expectForward;
+
+    @Test
+    public void testExceptionFilter() {
+        TypeSolver erroringTypeSolver = mock(TypeSolver.class);
+        doThrow(toBeThrownException).when(erroringTypeSolver).tryToSolveType(any(String.class));
+
+        TypeSolver secondaryTypeSolver = mock(TypeSolver.class);
+        when(secondaryTypeSolver.tryToSolveType(any(String.class)))
+                .thenReturn(SymbolReference.unsolved(ResolvedReferenceTypeDeclaration.class));
+
+        try {
+            new CombinedTypeSolver(filter, erroringTypeSolver, secondaryTypeSolver)
+                    .tryToSolveType("an uninteresting string");
+            assertTrue("Forwarded, but we expected an exception", expectForward);
+        } catch (Exception e) {
+            assertFalse("Exception, but we expected forwarding", expectForward); // if we expected the error to be
+                                                                                 // forwarded there shouldn't be an
+                                                                                 // exception
+        }
+
+        verify(secondaryTypeSolver, times(expectForward ? 1 : 0)).tryToSolveType(any(String.class));
+    }
+
+}


### PR DESCRIPTION
Actually fixes the "overlying" problem of #1946.
In that issue we concluded that ignoring exceptions and forwarding the solve to the next solver was undesirable, because we don't want any exceptions to go unnoticed. This makes a lot of sense from a development perspective, but while using JSS to parse real-world code it can lead to nasty roadblocks (which were #1942, #1945, #1946, #1948 and #1949 for me, and I still haven't been able to successfully parse the full codebase). I'm not trying to insult the stability of JSS, I'm the idiot for trying to use an incomplete piece of software 😉 

To solve this problem I have added an opt-in filter to the `CombinedTypeSolver`, allowing users to circumvent some shortcomings of JSS at their own peril. It simply consists of a `Predicate<Exception>` to which all thrown exceptions are tested. If the predicate returns `true`, the exception is ignored and the solve forwarded to the next solver. I also added some convenience filter implementations (black & white lists and some implementations thereof) for use-cases which I deemed "likely to happen to other people". I of course also added a test for this.

I'm not used to contributing to big projects like this one, so I'm pretty sure there's plenty of things to improve in this PR. Some things I think could be better with some help/suggestions:
- Variable names could be better I think.
- Some of the code wrapping seems a bit unfortunate to me, is it correct? (I just formatted the code using the provided eclipse template.)
- I often add a lot of whitespace to break up large blocks of code for readability. Not sure if that's wanted here.
- Given my very limited knowledge of the code this might be in the completely wrong place.
- Not sure if the `ExceptionFilters` class should be an inner-class

I would love to hear your feedback!