### PR TITLE
Update javadoc for FieldAccessExpr and MethodCallExpr. The scope coul…

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -45,7 +45,7 @@ import java.util.function.Consumer;
 import com.github.javaparser.ast.Generated;
 
 /**
- * Access of a field of an object.
+ * Access of a field of an object or a class.
  * <br/>In <code>person.name</code> "name" is the name and "person" is the scope.
  *
  * @author Julio Vilmar Gesser

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -46,7 +46,7 @@ import java.util.function.Consumer;
 import com.github.javaparser.ast.Generated;
 
 /**
- * A method call on an object. <br/><code>circle.circumference()</code> <br/>In <code>a.&lt;String&gt;bb(15);</code> a
+ * A method call on an object or a class. <br/><code>circle.circumference()</code> <br/>In <code>a.&lt;String&gt;bb(15);</code> a
  * is the scope, String is a type argument, bb is the name and 15 is an argument.
  *
  * @author Julio Vilmar Gesser


### PR DESCRIPTION
…d be an object or a class (e.g. Enum field access, static field/method access.)

[Issue 1955](https://github.com/javaparser/javaparser/issues/1955)