### PR TITLE
JUnit test AnalyseJavaParserTest#parseTheRest() hangs on Windows

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
@@ -113,7 +113,7 @@ public class JavaParserTypeSolver implements TypeSolver {
         try {
             return parsedFiles.get(srcFile.toAbsolutePath(), () -> {
                 try {
-                    if (!Files.exists(srcFile)) {
+                    if (!Files.exists(srcFile) || !Files.isRegularFile(srcFile)) {
                         return Optional.empty();
                     }
                     return javaParser.parse(COMPILATION_UNIT, provider(srcFile))


### PR DESCRIPTION
When srcFile is a file with a reserved name on Windows (like 'aux.java' for instance), Files.exists(srcFile) will return true, but opening an InputStream to it will hang forever. To avoid hangs, we check that srcFile is a regular file before trying to parse it.