### PR TITLE
[Bugfix] Fixed bug where the symbol solver can't resolve types in classes that…

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/Context.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/Context.java
@@ -192,7 +192,7 @@ public interface Context {
                 methodUsage = ((TypeVariableResolutionCapability) methodDeclaration)
                                       .resolveTypeVariables(this, argumentsTypes);
             } else {
-                return Optional.empty();
+                throw new UnsupportedOperationException();
             }
 
             return Optional.of(methodUsage);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/Context.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/Context.java
@@ -192,7 +192,7 @@ public interface Context {
                 methodUsage = ((TypeVariableResolutionCapability) methodDeclaration)
                                       .resolveTypeVariables(this, argumentsTypes);
             } else {
-                throw new UnsupportedOperationException();
+                return Optional.empty();
             }
 
             return Optional.of(methodUsage);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/Context.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/Context.java
@@ -192,7 +192,8 @@ public interface Context {
                 methodUsage = ((TypeVariableResolutionCapability) methodDeclaration)
                                       .resolveTypeVariables(this, argumentsTypes);
             } else {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("Resolved method declarations should have the " +
+                                                        TypeVariableResolutionCapability.class.getName() + ".");
             }
 
             return Optional.of(methodUsage);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -86,10 +86,15 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
         return wrappedNode.getName().getId();
     }
 
+    /**
+     * Annotation declarations cannot have type parameters and hence this method always returns an empty list.
+     *
+     * @return An empty list.
+     */
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
-        // TODO #1840
-        throw new UnsupportedOperationException();
+        // Annotation declarations cannot have type parameters - i.e. we can always return an empty list.
+        return Collections.emptyList();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -117,10 +117,15 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
         return getClassName();
     }
 
+    /**
+     * Annotation declarations cannot have type parameters and hence this method always returns an empty list.
+     *
+     * @return An empty list.
+     */
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
-        // TODO #1840
-        throw new UnsupportedOperationException();
+        // Annotation declarations cannot have type parameters - i.e. we can always return an empty list.
+        return Collections.emptyList();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -25,10 +25,7 @@ import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 import java.lang.annotation.Annotation;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -154,8 +151,8 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
-        // TODO #1840
-        throw new UnsupportedOperationException();
+        // Annotation declarations cannot have type parameters - i.e. we can always return an empty list.
+        return Collections.emptyList();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -149,6 +149,11 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
         throw new UnsupportedOperationException("containerType() is not supported for " + this.getClass().getCanonicalName());
     }
 
+    /**
+     * Annotation declarations cannot have type parameters and hence this method always returns an empty list.
+     *
+     * @return An empty list.
+     */
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
         // Annotation declarations cannot have type parameters - i.e. we can always return an empty list.

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
@@ -31,10 +31,8 @@ import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparser.Navigator;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.resolution.Value;
-import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.Test;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/TypeInClassWithAnnotationAncestorTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/TypeInClassWithAnnotationAncestorTest.java
@@ -1,0 +1,27 @@
+package com.github.javaparser.symbolsolver.resolution;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class TypeInClassWithAnnotationAncestorTest extends AbstractResolutionTest {
+
+	@Test
+	public void resolveStringReturnType() {
+		CompilationUnit cu = parseSample("ClassWithAnnotationAncestor");
+		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ClassWithAnnotationAncestor");
+		MethodDeclaration method = Navigator.demandMethod(clazz, "testMethod");
+		ResolvedType type = JavaParserFacade.get(new ReflectionTypeSolver())
+				                    .convertToUsage(method.getType(), method.getType());
+		assertFalse(type.isTypeVariable());
+		assertEquals("java.lang.String", type.describe());
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/ClassWithAnnotationAncestor.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/ClassWithAnnotationAncestor.java.txt
@@ -1,0 +1,16 @@
+public class ClassWithAnnotationAncestor implements SuppressWarnings {
+
+    public String testMethod() {
+        return "result";
+    }
+
+    @Override
+    public String[] value() {
+        return new String[0];
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return null;
+    }
+}


### PR DESCRIPTION
… have an annotation as ancestor. The symbol solver tries to get the type parameters of parents which previously failed with an `UnsupportedOperationException`. The pull request includes both test and fix. Relates to #1833.