### PR TITLE
support for removal of scope from static methods

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
 
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -214,6 +213,13 @@ public class MethodDeclarationTransformationsTest extends AbstractLexicalPreserv
         MethodDeclaration it = consider("@Override public void A(){}");
         it.setModifiers(EnumSet.noneOf(Modifier.class));
         assertTransformedToString("@Override void A(){}", it);
+    }
+
+    @Test
+    public void removingPublicModifierFromPublicStaticMethod() {
+        MethodDeclaration it = consider("public static void a(){}");
+        it.removeModifier(Modifier.PUBLIC);
+        assertTransformedToString("static void a(){}", it);
     }
 
     @Test
@@ -426,4 +432,5 @@ public class MethodDeclarationTransformationsTest extends AbstractLexicalPreserv
                         "  }\n" +
                         "}\n", result);
     }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -535,12 +535,15 @@ public class Difference {
         Map<Integer, Integer> correspondanceBetweenNextOrderAndPreviousOrder = new HashMap<>();
 
         List<CsmElement> nextOrderElements = elementsFromNextOrder.getElements();
+        List<CsmElement> previousOrderElements = elementsFromPreviousOrder.getElements();
+        WrappingRangeIterator piNext = new WrappingRangeIterator(previousOrderElements.size());
+
         for (int ni = 0; ni< nextOrderElements.size(); ni++) {
             boolean found = false;
             CsmElement ne = nextOrderElements.get(ni);
 
-            List<CsmElement> previousOrderElements = elementsFromPreviousOrder.getElements();
-            for (int pi = 0; pi< previousOrderElements.size() && !found; pi++) {
+            for (int counter = 0; counter< previousOrderElements.size() && !found; counter++) {
+                Integer pi = piNext.next();
                 CsmElement pe = previousOrderElements.get(pi);
                 if (!correspondanceBetweenNextOrderAndPreviousOrder.values().contains(pi)
                         && DifferenceElementCalculator.matching(ne, pe)) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/WrappingRangeIterator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/WrappingRangeIterator.java
@@ -1,0 +1,27 @@
+package com.github.javaparser.printer.lexicalpreservation;
+
+import java.util.Iterator;
+
+public class WrappingRangeIterator implements Iterator<Integer> {
+    private final int limit;
+    private int currentValue = 0;
+
+    public WrappingRangeIterator(int limit) {
+        this.limit = limit;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return true;
+    }
+
+    @Override
+    public Integer next() {
+        int valueToReturn = currentValue;
+        ++currentValue;
+        if (currentValue == limit) {
+            currentValue = 0;
+        }
+        return valueToReturn;
+    }
+}


### PR DESCRIPTION
This fixes #1967.

The idea is, to continue search for a potential match after the last found index to get a longer continuous match.
It still wraps around and has a look at all the elements in case the next one does not match.