### PR TITLE
Fix for issue #1963

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
@@ -104,8 +104,12 @@ class ReflectionClassAdapter {
                 return true;
             }
         }
-        ReferenceTypeImpl superclass = getSuperClass();
-        return superclass != null && superclass.getTypeDeclaration().hasField(name);
+        for (ResolvedReferenceType ancestor : typeDeclaration.getAllAncestors()) {
+            if (ancestor.getTypeDeclaration().hasField(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public List<ResolvedFieldDeclaration> getAllFields() {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
@@ -201,4 +201,20 @@ public class FieldsResolutionTest extends AbstractResolutionTest {
         assertEquals(variableDeclarator, ((JavaParserFieldDeclaration) resolvedValueDeclaration).getVariableDeclarator());
     }
 
+    @Test
+    public void resolveInheritedFieldFromInterface() {
+        // configure symbol solver before parsing
+        JavaParser.getStaticConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get field access expression
+        CompilationUnit cu = parseSample("ReflectionTypeSolverFieldFromInterfaceResolution");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Test");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "foo");
+        ReturnStmt returnStmt = (ReturnStmt) method.getBody().get().getStatements().get(0);
+        Expression expression = returnStmt.getExpression().get();
+
+        ResolvedType ref = JavaParserFacade.get(new ReflectionTypeSolver()).getType(expression);
+        assertEquals("int", ref.describe());
+    }
+
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/ReflectionTypeSolverFieldFromInterfaceResolution.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/ReflectionTypeSolverFieldFromInterfaceResolution.java.txt
@@ -1,0 +1,7 @@
+import javax.swing.JDialog;
+
+public class Test {
+    public int foo() {
+        return JDialog.DISPOSE_ON_CLOSE;
+    }
+}


### PR DESCRIPTION
The ReflectionClassAdapter#hasField() method should also check fields from implemented interfaces. The implementation is now consistent with the getField() method. This fixes issue #1963.