### PR TITLE
UnsupportedOperationException when resolving method invocations on unbounded/extends generic types.

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -402,9 +402,9 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             if (wildcardUsage.isSuper()) {
                 return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext);
             } else if (wildcardUsage.isExtends()) {
-                throw new UnsupportedOperationException("extends wildcard");
+                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext);
             } else {
-                throw new UnsupportedOperationException("unbounded wildcard");
+                return solveMethodAsUsage(new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver), name, argumentsTypes, invokationContext);
             }
         } else if (type instanceof ResolvedLambdaConstraintType){
             ResolvedLambdaConstraintType constraintType = (ResolvedLambdaConstraintType) type;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
@@ -198,6 +198,32 @@ public class GenericsResolutionTest extends AbstractResolutionTest {
     }
 
     @Test
+    public void resolveUsageOfMethodOfGenericClassWithUnboundedWildcard() {
+        CompilationUnit cu = parseSample("GenericsWildcard");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "GenericsWildcard");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "unbounded");
+        MethodCallExpr expression = Navigator.findMethodCall(method, "toString").get();
+
+        MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(expression);
+
+        assertEquals("toString", methodUsage.getName());
+        assertEquals("java.lang.Object", methodUsage.declaringType().getQualifiedName());
+    }
+
+    @Test
+    public void resolveUsageOfMethodOfGenericClassWithExtendsWildcard() {
+        CompilationUnit cu = parseSample("GenericsWildcard");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "GenericsWildcard");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "bounded");
+        MethodCallExpr expression = Navigator.findMethodCall(method, "bar").get();
+
+        MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(expression);
+
+        assertEquals("bar", methodUsage.getName());
+        assertEquals("GenericsWildcard.Foo", methodUsage.declaringType().getQualifiedName());
+    }
+
+    @Test
     public void resolveElementOfList() {
         CompilationUnit cu = parseSample("ElementOfList");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ElementOfList");

--- a/javaparser-symbol-solver-testing/src/test/resources/GenericsWildcard.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/GenericsWildcard.java.txt
@@ -1,0 +1,19 @@
+import java.util.Map;
+
+public class GenericsWildcard {
+
+    public static class Foo {
+        public String bar() {
+            return "";
+        }
+    }
+
+    public String unbounded(Map<String, ?> map) {
+        return map.get("").toString();
+    }
+
+    public String bounded(Map<String, ? extends Foo> map) {
+        return map.get("").bar();
+    }
+
+}


### PR DESCRIPTION
This PR fixed exceptions when resolving methods calls like:

```
Map<String, ?> map = ...;
map.get("").toString();

Map<String, ? extends Foo> map = ...;
map.get("").toString();
```

thanks,
Maarten