### PR TITLE
Returning from type search earlier if matching non-asterisk import was found unresolvable 

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -197,6 +197,8 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                         SymbolReference<ResolvedReferenceTypeDeclaration> ref = typeSolver.tryToSolveType(qName);
                         if (ref != null && ref.isSolved()) {
                             return SymbolReference.adapt(ref, ResolvedTypeDeclaration.class);
+                        } else {
+                            return SymbolReference.unsolved(ResolvedTypeDeclaration.class);
                         }
                     }
                 }
@@ -260,8 +262,8 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
         for (ImportDeclaration importDecl : wrappedNode.getImports()) {
-            if(importDecl.isStatic()){
-                if(importDecl.isAsterisk()){
+            if (importDecl.isStatic()) {
+                if (importDecl.isAsterisk()) {
                     String importString = importDecl.getNameAsString();
 
                     if (this.wrappedNode.getPackageDeclaration().isPresent()
@@ -278,7 +280,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                     if (method.isSolved()) {
                         return method;
                     }
-                } else{
+                } else {
                     String qName = importDecl.getNameAsString();
 
                     if (qName.equals(name) || qName.endsWith("." + name)) {
@@ -287,6 +289,8 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                         SymbolReference<ResolvedMethodDeclaration> method = MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true);
                         if (method.isSolved()) {
                             return method;
+                        } else {
+                            return SymbolReference.unsolved(ResolvedMethodDeclaration.class);
                         }
                     }
                 }


### PR DESCRIPTION
If an import for e.g. `a.b.Foo` is found while searching for the type `Foo` then we can stop looking any further, even if we cannot resolve `a.b.Foo`. Even if we were to find a `Foo` in e.g. `java.lang` later on, that result would be incorrect. This change hence improves performance and resolution accuracy in some edge cases.