### PR TITLE
fix the remove modifier implementation

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiersTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -31,7 +32,10 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
+import static com.github.javaparser.ast.Modifier.Keyword.STATIC;
+import static com.github.javaparser.ast.Modifier.Keyword.SYNCHRONIZED;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -61,4 +65,32 @@ class NodeWithModifiersTest {
         assertEquals("property MODIFIERS is changed to [public ]", changes.get(0));
     }
 
+    @Test
+    void removeExistingModifier() {
+        NodeWithModifiers node = anythingWithModifiers(PUBLIC);
+        node.removeModifier(PUBLIC);
+        assertEquals(0, node.getModifiers().size());
+    }
+
+    @Test
+    void ignoreNotExistingModifiersOnRemove() {
+        NodeWithModifiers node = anythingWithModifiers(PUBLIC);
+        node.removeModifier(PRIVATE);
+
+        assertEquals(createModifierList(PUBLIC), node.getModifiers());
+    }
+
+    @Test
+    void keepModifiersThatShouldNotBeRemoved() {
+        NodeWithModifiers node = anythingWithModifiers(PUBLIC, STATIC, SYNCHRONIZED);
+        node.removeModifier(PUBLIC, PRIVATE, STATIC);
+
+        assertEquals(createModifierList(SYNCHRONIZED), node.getModifiers());
+    }
+
+    private NodeWithModifiers anythingWithModifiers(Modifier.Keyword ... keywords) {
+        ClassOrInterfaceDeclaration foo = new ClassOrInterfaceDeclaration(new NodeList<>(), false, "Foo");
+        foo.addModifier(keywords);
+        return foo;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
@@ -26,6 +26,9 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.github.javaparser.ast.NodeList.toNodeList;
 
@@ -61,15 +64,11 @@ public interface NodeWithModifiers<N extends Node> {
 
     @SuppressWarnings("unchecked")
     default N removeModifier(Modifier.Keyword... modifiersToRemove) {
-        NodeList<Modifier> existingModifiers = new NodeList<>(getModifiers());
-        for (Modifier.Keyword modifierToRemove : modifiersToRemove) {
-            for (Modifier existingModifier : existingModifiers) {
-                if (existingModifier.getKeyword() == modifierToRemove) {
-                    existingModifiers.remove(existingModifier);
-                }
-            }
-        }
-        setModifiers(existingModifiers);
+        List<Modifier.Keyword> modifiersToRemoveAsList = Arrays.asList(modifiersToRemove);
+        NodeList<Modifier> remaining = getModifiers().stream()
+                .filter(existingModifier -> !modifiersToRemoveAsList.contains(existingModifier.getKeyword()))
+                .collect(toNodeList());
+        setModifiers(remaining);
         return (N) this;
     }
 


### PR DESCRIPTION
The current one throws a ConcurrentModificationException if the modifier
that should be removed exists on the node