### PR TITLE
perform duplicate checking on all addImport methods

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
@@ -31,6 +31,7 @@ import java.lang.annotation.ElementType;
 import java.util.List;
 import java.util.Map;
 
+import static com.github.javaparser.JavaParser.parseImport;
 import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.*;
@@ -63,6 +64,34 @@ class CompilationUnitBuildersTest {
         cu.addImport(ElementType.class);
         assertEquals(1, cu.getImports().size());
         assertEquals("import java.lang.annotation.ElementType;"+ EOL, cu.getImport(0).toString());
+    }
+
+    @Test
+    void doNotAddDuplicateImportsByClass() {
+        cu.addImport(Map.class);
+        cu.addImport(Map.class);
+        assertEquals(1, cu.getImports().size());
+    }
+
+    @Test
+    void doNotAddDuplicateImportsByString() {
+        cu.addImport(Map.class);
+        cu.addImport("java.util.Map");
+        assertEquals(1, cu.getImports().size());
+    }
+
+    @Test
+    void doNotAddDuplicateImportsByStringAndFlags() {
+        cu.addImport(Map.class);
+        cu.addImport("java.util.Map", false, false);
+        assertEquals(1, cu.getImports().size());
+    }
+
+    @Test
+    void doNotAddDuplicateImportsByImportDeclaration() {
+        cu.addImport(Map.class);
+        cu.addImport(parseImport("import java.util.Map;"));
+        assertEquals(1, cu.getImports().size());
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -58,8 +58,6 @@ import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 import static com.github.javaparser.utils.CodeGenerationUtils.subtractPaths;
 import static com.github.javaparser.utils.Utils.assertNotNull;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.Generated;
 
 /**
  * <p>
@@ -220,8 +218,10 @@ public final class CompilationUnit extends Node {
         return this;
     }
 
-    public CompilationUnit addImport(ImportDeclaration imports) {
-        getImports().add(imports);
+    public CompilationUnit addImport(ImportDeclaration importDeclaration) {
+        if (getImports().stream().noneMatch(im -> im.toString().equals(importDeclaration.toString()))) {
+            getImports().add(importDeclaration);
+        }
         return this;
     }
 
@@ -338,13 +338,7 @@ public final class CompilationUnit extends Node {
             i.append(".*");
         }
         i.append(";");
-        ImportDeclaration importDeclaration = JavaParser.parseImport(i.toString());
-        if (getImports().stream().anyMatch(im -> im.toString().equals(importDeclaration.toString())))
-            return this;
-        else {
-            getImports().add(importDeclaration);
-            return this;
-        }
+        return addImport(JavaParser.parseImport(i.toString()));
     }
 
     /**


### PR DESCRIPTION
before this there was no duplicate checking for addImport(ImportDeclaration). This came as a surprise to me.