### PR TITLE
resolve dependency in the install phase and cache them between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: java
-install: mvn dependency:resolve
+install: mvn package -DskipTests dependency:resolve dependency:resolve-plugins
 cache:
   directories:
     - $HOME/.m2/repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: java
-install: mvn install -DskipTests=true
+install: mvn dependency:resolve
+cache:
+  directories:
+    - $HOME/.m2/repository
 script: mvn test -P AlsoSlowTests
 jdk:
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: mvn dependency:resolve
 cache:
   directories:
     - $HOME/.m2/repository
-script: mvn test -P AlsoSlowTests
+script: mvn verify -P AlsoSlowTests
 jdk:
   - openjdk11
 notifications:


### PR DESCRIPTION
As far as I understand the travis documentation install should only resolve dependencies.
With the current `mvn install` command you do way more, `dependency:resolve` should be enough.