### PR TITLE
Add SwitchExpr node

### DIFF
--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
@@ -107,6 +107,7 @@ public class MetaModelGenerator {
         add(TypeExpr.class);
         add(UnaryExpr.class);
         add(VariableDeclarationExpr.class);
+        add(SwitchExpr.class);
 
         add(ImportDeclaration.class);
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -1,0 +1,87 @@
+package com.github.javaparser.ast.expr;
+
+import com.github.javaparser.JavaParser;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class SwitchExprTest {
+    @Disabled("to be implemented")
+    @Test
+    void jep325Example1() {
+        JavaParser.parseStatement("switch (day) {\n" +
+                "    case MONDAY, FRIDAY, SUNDAY -> System.out.println(6);\n" +
+                "    case TUESDAY                -> System.out.println(7);\n" +
+                "    case THURSDAY, SATURDAY     -> System.out.println(8);\n" +
+                "    case WEDNESDAY              -> System.out.println(9);\n" +
+                "}};");
+    }
+
+    @Disabled("to be implemented")
+    @Test
+    void jep325Example2() {
+        JavaParser.parseStatement("int numLetters = switch (day) {\n" +
+                "    case MONDAY, FRIDAY, SUNDAY -> 6;\n" +
+                "    case TUESDAY                -> 7;\n" +
+                "    case THURSDAY, SATURDAY     -> 8;\n" +
+                "    case WEDNESDAY              -> 9;\n" +
+                "};");
+    }
+
+    @Disabled("to be implemented")
+    @Test
+    void jep325Example3() {
+        JavaParser.parseBodyDeclaration("static void howMany(int k) {\n" +
+                "    switch (k) {\n" +
+                "        case 1 -> System.out.println(\"one\");\n" +
+                "        case 2 -> System.out.println(\"two\");\n" +
+                "        case 3 -> System.out.println(\"many\");\n" +
+                "    }\n" +
+                "}");
+    }
+
+    @Disabled("to be implemented")
+    @Test
+    void jep325Example4() {
+        JavaParser.parseStatement("T result = switch (arg) {\n" +
+                "    case L1 -> e1;\n" +
+                "    case L2 -> e2;\n" +
+                "    default -> e3;\n" +
+                "};");
+    }
+
+    @Disabled("to be implemented")
+    @Test
+    void jep325Example5() {
+        JavaParser.parseStatement("int j = switch (day) {\n" +
+                "    case MONDAY  -> 0;\n" +
+                "    case TUESDAY -> 1;\n" +
+                "    default      -> {\n" +
+                "        int k = day.toString().length();\n" +
+                "        int result = f(k);\n" +
+                "        break result;\n" +
+                "    }\n" +
+                "};");
+    }
+
+    @Disabled("to be implemented")
+    @Test
+    void jep325Example6() {
+        JavaParser.parseStatement("int result = switch (s) {\n" +
+                "    case \"Foo\": \n" +
+                "        break 1;\n" +
+                "    case \"Bar\":\n" +
+                "        break 2;\n" +
+                "    default:\n" +
+                "        System.out.println(\"Neither Foo nor Bar, hmmm...\");\n" +
+                "        break 0;\n" +
+                "};");
+    }
+
+    @Test
+    void placeholderTest() {
+        JavaParser.parseStatement("int result = switch (s) {\n" +
+                "    case \"Foo\": \n" +
+                "        break;\n" +
+                "};");
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
@@ -733,4 +733,19 @@ public abstract class Expression extends Node {
     public Optional<VariableDeclarationExpr> toVariableDeclarationExpr() {
         return Optional.empty();
     }
+
+    public boolean isSwitchExpr() {
+        return false;
+    }
+
+    public SwitchExpr asSwitchExpr() {
+        throw new IllegalStateException(f("%s is not an SwitchExpr", this));
+    }
+
+    public Optional<SwitchExpr> toSwitchExpr() {
+        return Optional.empty();
+    }
+
+    public void ifSwitchExpr(Consumer<SwitchExpr> action) {
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -38,10 +38,8 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.DerivedProperty;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LambdaExprMetaModel;
-
 import java.util.Optional;
 import java.util.function.Consumer;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -85,7 +83,6 @@ public final class LambdaExpr extends Expression implements NodeWithParameters<L
     public LambdaExpr(NodeList<Parameter> parameters, BlockStmt body) {
         this(null, parameters, body, true);
     }
-
 
     /**
      * Creates a single parameter lambda expression.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SwitchExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SwitchExpr.java
@@ -18,48 +18,49 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-package com.github.javaparser.ast.stmt;
+package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.nodeTypes.SwitchNode;
 import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.stmt.SwitchEntryStmt;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-import static com.github.javaparser.utils.Utils.assertNotNull;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.visitor.CloneVisitor;
-import com.github.javaparser.metamodel.SwitchStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.TokenRange;
-import java.util.function.Consumer;
+import com.github.javaparser.metamodel.SwitchStmtMetaModel;
 import java.util.Optional;
-import com.github.javaparser.ast.Generated;
+import java.util.function.Consumer;
+import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.metamodel.SwitchExprMetaModel;
 
 /**
- * A switch statement.
+ * A switch expression.
  * <br/>In <code>switch(a) { ... }</code> the selector is "a",
  * and the contents of the { ... } are the entries.
  *
  * @author Julio Vilmar Gesser
  * @see SwitchEntryStmt
- * @see com.github.javaparser.ast.expr.SwitchExpr
+ * @see com.github.javaparser.ast.stmt.SwitchStmt
  * @see SwitchNode
  */
-public final class SwitchStmt extends Statement implements SwitchNode {
+public final class SwitchExpr extends Expression implements SwitchNode {
 
     private Expression selector;
 
     private NodeList<SwitchEntryStmt> entries;
 
-    public SwitchStmt() {
+    public SwitchExpr() {
         this(null, new NameExpr(), new NodeList<>());
     }
 
     @AllFieldsConstructor
-    public SwitchStmt(final Expression selector, final NodeList<SwitchEntryStmt> entries) {
+    public SwitchExpr(final Expression selector, final NodeList<SwitchEntryStmt> entries) {
         this(null, selector, entries);
     }
 
@@ -67,7 +68,7 @@ public final class SwitchStmt extends Statement implements SwitchNode {
      * This constructor is used by the parser and is considered private.
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public SwitchStmt(TokenRange tokenRange, Expression selector, NodeList<SwitchEntryStmt> entries) {
+    public SwitchExpr(TokenRange tokenRange, Expression selector, NodeList<SwitchEntryStmt> entries) {
         super(tokenRange);
         setSelector(selector);
         setEntries(entries);
@@ -101,10 +102,10 @@ public final class SwitchStmt extends Statement implements SwitchNode {
     }
 
     @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
-    public SwitchStmt setEntries(final NodeList<SwitchEntryStmt> entries) {
+    public SwitchExpr setEntries(final NodeList<SwitchEntryStmt> entries) {
         assertNotNull(entries);
         if (entries == this.entries) {
-            return (SwitchStmt) this;
+            return (SwitchExpr) this;
         }
         notifyPropertyChange(ObservableProperty.ENTRIES, this.entries, entries);
         if (this.entries != null)
@@ -118,7 +119,7 @@ public final class SwitchStmt extends Statement implements SwitchNode {
      * @deprecated use a method on getEntries instead
      */
     @Deprecated
-    public SwitchStmt setEntry(int i, SwitchEntryStmt entry) {
+    public SwitchExpr setEntry(int i, SwitchEntryStmt entry) {
         getEntries().set(i, entry);
         return this;
     }
@@ -127,16 +128,16 @@ public final class SwitchStmt extends Statement implements SwitchNode {
      * @deprecated use a method on getEntries instead
      */
     @Deprecated
-    public SwitchStmt addEntry(SwitchEntryStmt entry) {
+    public SwitchExpr addEntry(SwitchEntryStmt entry) {
         getEntries().add(entry);
         return this;
     }
 
     @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
-    public SwitchStmt setSelector(final Expression selector) {
+    public SwitchExpr setSelector(final Expression selector) {
         assertNotNull(selector);
         if (selector == this.selector) {
-            return (SwitchStmt) this;
+            return (SwitchExpr) this;
         }
         notifyPropertyChange(ObservableProperty.SELECTOR, this.selector, selector);
         if (this.selector != null)
@@ -162,14 +163,8 @@ public final class SwitchStmt extends Statement implements SwitchNode {
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.CloneGenerator")
-    public SwitchStmt clone() {
-        return (SwitchStmt) accept(new CloneVisitor(), null);
-    }
-
-    @Override
-    @Generated("com.github.javaparser.generator.core.node.GetMetaModelGenerator")
-    public SwitchStmtMetaModel getMetaModel() {
-        return JavaParserMetaModel.switchStmtMetaModel;
+    public SwitchExpr clone() {
+        return (SwitchExpr) accept(new CloneVisitor(), null);
     }
 
     @Override
@@ -191,25 +186,26 @@ public final class SwitchStmt extends Statement implements SwitchNode {
     }
 
     @Override
-    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public boolean isSwitchStmt() {
+    public boolean isSwitchExpr() {
         return true;
     }
 
     @Override
-    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public SwitchStmt asSwitchStmt() {
+    public SwitchExpr asSwitchExpr() {
         return this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public void ifSwitchStmt(Consumer<SwitchStmt> action) {
+    @Override
+    public Optional<SwitchExpr> toSwitchExpr() {
+        return Optional.of(this);
+    }
+
+    public void ifSwitchExpr(Consumer<SwitchExpr> action) {
         action.accept(this);
     }
 
     @Override
-    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public Optional<SwitchStmt> toSwitchStmt() {
-        return Optional.of(this);
+    public SwitchExprMetaModel getMetaModel() {
+        return JavaParserMetaModel.switchExprMetaModel;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/SwitchNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/SwitchNode.java
@@ -1,0 +1,35 @@
+package com.github.javaparser.ast.nodeTypes;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.comments.Comment;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.stmt.SwitchEntryStmt;
+
+import java.util.Optional;
+
+/**
+ * The common interface of {@link com.github.javaparser.ast.expr.SwitchExpr} and {@link com.github.javaparser.ast.stmt.SwitchStmt}
+ */
+public interface SwitchNode {
+    NodeList<SwitchEntryStmt> getEntries();
+
+    SwitchEntryStmt getEntry(int i);
+
+    Expression getSelector();
+
+    SwitchNode setEntries(NodeList<SwitchEntryStmt> entries);
+
+    SwitchNode setSelector(Expression selector);
+
+    boolean remove(Node node);
+
+    SwitchNode clone();
+
+    boolean replace(Node node, Node replacementNode);
+
+    Optional<Comment> getComment();
+    
+    // Too bad Node isn't an interface, or this could have easily inherited all of its methods.
+    // Add more when required.
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -1005,4 +1005,14 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         r.setComment(comment);
         return r;
     }
+
+    @Override
+    public Visitable visit(final SwitchExpr n, final Object arg) {
+        NodeList<SwitchEntryStmt> entries = cloneList(n.getEntries(), arg);
+        Expression selector = cloneNode(n.getSelector(), arg);
+        Comment comment = cloneNode(n.getComment(), arg);
+        SwitchExpr r = new SwitchExpr(n.getTokenRange().orElse(null), selector, entries);
+        r.setComment(comment);
+        return r;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -1303,4 +1303,16 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
             return false;
         return true;
     }
+
+    @Override
+    public Boolean visit(final SwitchExpr n, final Visitable arg) {
+        final SwitchExpr n2 = (SwitchExpr) arg;
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
+            return false;
+        if (!nodeEquals(n.getSelector(), n2.getSelector()))
+            return false;
+        if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        return true;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
@@ -2024,4 +2024,26 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
         }
         return result;
     }
+
+    @Override
+    public List<R> visit(final SwitchExpr n, final A arg) {
+        List<R> result = new ArrayList<>();
+        List<R> tmp;
+        {
+            tmp = n.getEntries().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getSelector().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        return result;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
@@ -227,4 +227,6 @@ public interface GenericVisitor<R, A> {
     R visit(VarType n, A arg);
 
     R visit(Modifier n, A arg);
+
+    R visit(SwitchExpr n, A arg);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -2016,4 +2016,25 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
         }
         return null;
     }
+
+    @Override
+    public R visit(final SwitchExpr n, final A arg) {
+        R result;
+        {
+            result = n.getEntries().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getSelector().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        return null;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaults.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaults.java
@@ -514,4 +514,9 @@ public abstract class GenericVisitorWithDefaults<R, A> implements GenericVisitor
     public R visit(final Modifier n, final A arg) {
         return defaultAction(n, arg);
     }
+
+    @Override
+    public R visit(final SwitchExpr n, final A arg) {
+        return defaultAction(n, arg);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
@@ -429,4 +429,9 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     public Integer visit(final Modifier n, final Void arg) {
         return (n.getKeyword().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
     }
+
+    @Override
+    public Integer visit(final SwitchExpr n, final Void arg) {
+        return (n.getEntries().accept(this, arg)) * 31 + (n.getSelector().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -1228,4 +1228,17 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
         n.setComment(comment);
         return n;
     }
+
+    @Override
+    public Visitable visit(final SwitchExpr n, final A arg) {
+        NodeList<SwitchEntryStmt> entries = modifyList(n.getEntries(), arg);
+        Expression selector = (Expression) n.getSelector().accept(this, arg);
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        if (selector == null)
+            return null;
+        n.setEntries(entries);
+        n.setSelector(selector);
+        n.setComment(comment);
+        return n;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
@@ -1066,4 +1066,14 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
             return false;
         return true;
     }
+
+    @Override
+    public Boolean visit(final SwitchExpr n, final Visitable arg) {
+        final SwitchExpr n2 = (SwitchExpr) arg;
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
+            return false;
+        if (!nodeEquals(n.getSelector(), n2.getSelector()))
+            return false;
+        return true;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
@@ -421,4 +421,9 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     public Integer visit(final Modifier n, final Void arg) {
         return (n.getKeyword().hashCode());
     }
+
+    @Override
+    public Integer visit(final SwitchExpr n, final Void arg) {
+        return (n.getEntries().accept(this, arg)) * 31 + (n.getSelector().accept(this, arg));
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
@@ -507,4 +507,9 @@ public class ObjectIdentityEqualsVisitor implements GenericVisitor<Boolean, Visi
     public Boolean visit(final Modifier n, final Visitable arg) {
         return n == arg;
     }
+
+    @Override
+    public Boolean visit(final SwitchExpr n, final Visitable arg) {
+        return n == arg;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
@@ -421,4 +421,9 @@ public class ObjectIdentityHashCodeVisitor implements GenericVisitor<Integer, Vo
     public Integer visit(final Modifier n, final Void arg) {
         return n.hashCode();
     }
+
+    @Override
+    public Integer visit(final SwitchExpr n, final Void arg) {
+        return n.hashCode();
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
@@ -222,4 +222,6 @@ public interface VoidVisitor<A> {
     void visit(VarType n, A arg);
 
     void visit(Modifier n, A arg);
+
+    void visit(SwitchExpr switchExpr, A arg);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -693,4 +693,11 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     public void visit(final Modifier n, final A arg) {
         n.getComment().ifPresent(l -> l.accept(this, arg));
     }
+
+    @Override
+    public void visit(final SwitchExpr n, final A arg) {
+        n.getEntries().forEach(p -> p.accept(this, arg));
+        n.getSelector().accept(this, arg);
+        n.getComment().ifPresent(l -> l.accept(this, arg));
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaults.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaults.java
@@ -510,4 +510,9 @@ public abstract class VoidVisitorWithDefaults<A> implements VoidVisitor<A> {
     public void visit(final VarType n, final A arg) {
         defaultAction(n, arg);
     }
+
+    @Override
+    public void visit(final SwitchExpr n, final A arg) {
+        defaultAction(n, arg);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -170,6 +170,8 @@ public final class JavaParserMetaModel {
         variableDeclarationExprMetaModel.getConstructorParameters().add(variableDeclarationExprMetaModel.modifiersPropertyMetaModel);
         variableDeclarationExprMetaModel.getConstructorParameters().add(variableDeclarationExprMetaModel.annotationsPropertyMetaModel);
         variableDeclarationExprMetaModel.getConstructorParameters().add(variableDeclarationExprMetaModel.variablesPropertyMetaModel);
+        switchExprMetaModel.getConstructorParameters().add(switchExprMetaModel.selectorPropertyMetaModel);
+        switchExprMetaModel.getConstructorParameters().add(switchExprMetaModel.entriesPropertyMetaModel);
         importDeclarationMetaModel.getConstructorParameters().add(importDeclarationMetaModel.namePropertyMetaModel);
         importDeclarationMetaModel.getConstructorParameters().add(importDeclarationMetaModel.isStaticPropertyMetaModel);
         importDeclarationMetaModel.getConstructorParameters().add(importDeclarationMetaModel.isAsteriskPropertyMetaModel);
@@ -333,6 +335,7 @@ public final class JavaParserMetaModel {
         nodeMetaModels.add(stringLiteralExprMetaModel);
         nodeMetaModels.add(superExprMetaModel);
         nodeMetaModels.add(switchEntryStmtMetaModel);
+        nodeMetaModels.add(switchExprMetaModel);
         nodeMetaModels.add(switchStmtMetaModel);
         nodeMetaModels.add(synchronizedStmtMetaModel);
         nodeMetaModels.add(thisExprMetaModel);
@@ -605,6 +608,10 @@ public final class JavaParserMetaModel {
         variableDeclarationExprMetaModel.getDeclaredPropertyMetaModels().add(variableDeclarationExprMetaModel.variablesPropertyMetaModel);
         variableDeclarationExprMetaModel.maximumCommonTypePropertyMetaModel = new PropertyMetaModel(variableDeclarationExprMetaModel, "maximumCommonType", com.github.javaparser.ast.type.Type.class, Optional.of(typeMetaModel), true, false, false, false);
         variableDeclarationExprMetaModel.getDerivedPropertyMetaModels().add(variableDeclarationExprMetaModel.maximumCommonTypePropertyMetaModel);
+        switchExprMetaModel.entriesPropertyMetaModel = new PropertyMetaModel(switchExprMetaModel, "entries", com.github.javaparser.ast.stmt.SwitchEntryStmt.class, Optional.of(switchEntryStmtMetaModel), false, false, true, false);
+        switchExprMetaModel.getDeclaredPropertyMetaModels().add(switchExprMetaModel.entriesPropertyMetaModel);
+        switchExprMetaModel.selectorPropertyMetaModel = new PropertyMetaModel(switchExprMetaModel, "selector", com.github.javaparser.ast.expr.Expression.class, Optional.of(expressionMetaModel), false, false, false, false);
+        switchExprMetaModel.getDeclaredPropertyMetaModels().add(switchExprMetaModel.selectorPropertyMetaModel);
         importDeclarationMetaModel.isAsteriskPropertyMetaModel = new PropertyMetaModel(importDeclarationMetaModel, "isAsterisk", boolean.class, Optional.empty(), false, false, false, false);
         importDeclarationMetaModel.getDeclaredPropertyMetaModels().add(importDeclarationMetaModel.isAsteriskPropertyMetaModel);
         importDeclarationMetaModel.isStaticPropertyMetaModel = new PropertyMetaModel(importDeclarationMetaModel, "isStatic", boolean.class, Optional.empty(), false, false, false, false);
@@ -891,6 +898,8 @@ public final class JavaParserMetaModel {
     public static final UnaryExprMetaModel unaryExprMetaModel = new UnaryExprMetaModel(Optional.of(expressionMetaModel));
 
     public static final VariableDeclarationExprMetaModel variableDeclarationExprMetaModel = new VariableDeclarationExprMetaModel(Optional.of(expressionMetaModel));
+
+    public static final SwitchExprMetaModel switchExprMetaModel = new SwitchExprMetaModel(Optional.of(expressionMetaModel));
 
     public static final ImportDeclarationMetaModel importDeclarationMetaModel = new ImportDeclarationMetaModel(Optional.of(nodeMetaModel));
 

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/SwitchExprMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/SwitchExprMetaModel.java
@@ -1,0 +1,14 @@
+package com.github.javaparser.metamodel;
+
+import java.util.Optional;
+
+public class SwitchExprMetaModel extends ExpressionMetaModel {
+
+    SwitchExprMetaModel(Optional<BaseNodeMetaModel> superBaseNodeMetaModel) {
+        super(superBaseNodeMetaModel, com.github.javaparser.ast.expr.SwitchExpr.class, "SwitchExpr", "com.github.javaparser.ast.expr", false, false);
+    }
+
+    public PropertyMetaModel entriesPropertyMetaModel;
+
+    public PropertyMetaModel selectorPropertyMetaModel;
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -696,6 +696,19 @@ public class ConcreteSyntaxModel {
                 token(GeneratedJavaParserConstants.RBRACE)
         ));
 
+        concreteSyntaxModelByClass.put(SwitchExpr.class, sequence(
+                comment(),
+                token(GeneratedJavaParserConstants.SWITCH),
+                token(GeneratedJavaParserConstants.LPAREN),
+                child(ObservableProperty.SELECTOR),
+                token(GeneratedJavaParserConstants.RPAREN),
+                space(),
+                token(GeneratedJavaParserConstants.LBRACE),
+                newline(),
+                list(ObservableProperty.ENTRIES, none(), indent(), unindent()),
+                token(GeneratedJavaParserConstants.RBRACE)
+        ));
+
         concreteSyntaxModelByClass.put(SynchronizedStmt.class, sequence(
                 comment(),
                 token(GeneratedJavaParserConstants.SYNCHRONIZED),

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -29,10 +29,7 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
-import com.github.javaparser.ast.nodeTypes.NodeWithName;
-import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
-import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;
-import com.github.javaparser.ast.nodeTypes.NodeWithVariables;
+import com.github.javaparser.ast.nodeTypes.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
 import com.github.javaparser.ast.visitor.Visitable;
@@ -1078,6 +1075,15 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
 
     @Override
     public void visit(final SwitchStmt n, final Void arg) {
+        printSwitchNode(n, arg);
+    }
+
+    @Override
+    public void visit(SwitchExpr n, Void arg) {
+        printSwitchNode(n, arg);
+    }
+
+    private void printSwitchNode(SwitchNode n, Void arg) {
         printComment(n.getComment(), arg);
         printer.print("switch(");
         n.getSelector().accept(this, arg);

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1693,17 +1693,19 @@ Expression UnaryExpressionNotPlusMinus():
 	JavaToken begin = INVALID;
 }
 {
-  (
-	  ( "~" { op = UnaryExpr.Operator.BITWISE_COMPLEMENT; begin=token(); } |
-	    "!" { op = UnaryExpr.Operator.LOGICAL_COMPLEMENT;     begin=token(); }
-	  ) ret = UnaryExpression() { ret = new UnaryExpr(range(begin, token()), ret, op); }
-	|
-	  LOOKAHEAD( CastExpression() )
-	  ret = CastExpression()
-	|
-      ret = PostfixExpression()
-  )
-  { return ret; }
+	(
+		(
+			"~" { op = UnaryExpr.Operator.BITWISE_COMPLEMENT; begin=token(); } |
+			"!" { op = UnaryExpr.Operator.LOGICAL_COMPLEMENT;     begin=token(); }
+		) ret = UnaryExpression() { ret = new UnaryExpr(range(begin, token()), ret, op); }
+		| LOOKAHEAD( CastExpression() )
+			ret = CastExpression()
+		|
+			ret = PostfixExpression()
+		|
+			ret = SwitchExpression()
+	)
+	{ return ret; }
 }
 
 Expression PostfixExpression():
@@ -2225,6 +2227,21 @@ SwitchStmt SwitchStatement():
   "}"
 
   { return new SwitchStmt(range(begin, token()), selector, entries); }
+}
+
+SwitchExpr SwitchExpression():
+{
+	Expression selector;
+	SwitchEntryStmt entry;
+	NodeList<SwitchEntryStmt> entries = emptyList();
+	JavaToken begin;
+}
+{
+  "switch" {begin=token();} "(" selector = Expression() ")" "{"
+    ( entry = SwitchEntry() { entries = add(entries, entry); } )*
+  "}"
+
+  { return new SwitchExpr(range(begin, token()), selector, entries); }
 }
 
 SwitchEntryStmt SwitchEntry():

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/DefaultVisitorAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/DefaultVisitorAdapter.java
@@ -477,4 +477,9 @@ public class DefaultVisitorAdapter implements GenericVisitor<ResolvedType, Boole
     public ResolvedType visit(Modifier node, Boolean arg) {
         throw new UnsupportedOperationException(node.getClass().getCanonicalName());
     }
+
+    @Override
+    public ResolvedType visit(SwitchExpr node, Boolean arg) {
+        throw new UnsupportedOperationException(node.getClass().getCanonicalName());
+    }
 }


### PR DESCRIPTION
Here's the first step towards supporting switch expressions. See #1845.

- a SwitchExpr node now exists.
- a SwitchExpr is created when a `switch` is found as part of an expression, according to the JLS grammar.

This does not enable you to do anything useful. It is only a first step, as can be seen from the test cases (all useful cases are disabled)