### PR TITLE
Run Maven in non-interactive mode to reduce log size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
-install: mvn install -DskipTests=true
-script: mvn test -P AlsoSlowTests
+install: mvn -B install -DskipTests=true
+script: mvn -B test -P AlsoSlowTests
 jdk:
   - openjdk11
 notifications:
@@ -11,5 +11,5 @@ notifications:
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
 after_success:
-  - mvn test jacoco:report coveralls:report
+  - mvn -B test jacoco:report coveralls:report
 # http://lint.travis-ci.org/ validator

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 build_script:
   - echo ignore this
 test_script:
-  - mvn clean install --batch-mode
+  - mvn -B clean install --batch-mode
 cache:
   - C:\maven\
   - C:\Users\appveyor\.m2

--- a/run_core_generators.sh
+++ b/run_core_generators.sh
@@ -7,13 +7,13 @@
 pushd javaparser-core-generators
 
 # Generate code
-mvn clean package -P run-generators -DskipTests
+mvn -B clean package -P run-generators -DskipTests
 
 # Go back to previous directory
 popd
 
 # Fresh code has been generated in core, so rebuild the whole thing again.
-mvn clean install -DskipTests
+mvn -B clean install -DskipTests
 if [ "$?" -ne 0 ]; then
     exit 1
 fi

--- a/run_core_metamodel_generator.sh
+++ b/run_core_metamodel_generator.sh
@@ -3,7 +3,7 @@
 # Rebuilds the metamodel based on the nodes in javaparser-core
 
 # We introspect the nodes in javaparser-core, so we need an update build of it. 
-mvn clean install -DskipTests
+mvn -B clean install -DskipTests
 if [ "$?" -ne 0 ]; then
     exit 1
 fi
@@ -12,13 +12,13 @@ fi
 pushd javaparser-core-metamodel-generator
 
 # Generate code
-mvn clean package -P run-generators -DskipTests
+mvn -B clean package -P run-generators -DskipTests
 
 # Go back to previous directory
 popd
 
 # Fresh code has been generated in core, so rebuild the whole thing again.
-mvn clean install -DskipTests
+mvn -B clean install -DskipTests
 if [ "$?" -ne 0 ]; then
     exit 1
 fi


### PR DESCRIPTION
Passing `-B` to Maven reduces log size by omitting progress messages such as "Progress: 125/150kB".  It also removes control characters from the output.