### PR TITLE
Prefer ...ForEachStmt to ...ForeachStmt

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForEachStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForEachStmt.java
@@ -181,6 +181,7 @@ public final class ForEachStmt extends Statement implements NodeWithBody<ForEach
         return super.replace(node, replacementNode);
     }
 
+    /** @deprecated use {@link isForEachStmt}. */
     @Deprecated
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
@@ -188,6 +189,7 @@ public final class ForEachStmt extends Statement implements NodeWithBody<ForEach
         return true;
     }
 
+    /** @deprecated use {@link asForEachStmt}. */
     @Deprecated
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
@@ -195,12 +197,14 @@ public final class ForEachStmt extends Statement implements NodeWithBody<ForEach
         return this;
     }
 
+    /** @deprecated use {@link ifForEachStmt}. */
     @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifForeachStmt(Consumer<ForEachStmt> action) {
         action.accept(this);
     }
 
+    /** @deprecated use {@link toForEachStmt}. */
     @Deprecated
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForEachStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/ForEachStmt.java
@@ -181,23 +181,27 @@ public final class ForEachStmt extends Statement implements NodeWithBody<ForEach
         return super.replace(node, replacementNode);
     }
 
+    @Deprecated
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public boolean isForeachStmt() {
         return true;
     }
 
+    @Deprecated
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public ForEachStmt asForeachStmt() {
         return this;
     }
 
+    @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifForeachStmt(Consumer<ForEachStmt> action) {
         action.accept(this);
     }
 
+    @Deprecated
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<ForEachStmt> toForeachStmt() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
@@ -170,12 +170,14 @@ public abstract class Statement extends Node {
         throw new IllegalStateException(f("%s is not an ForStmt", this));
     }
 
+    /** @deprecated use {@link isForEachStmt}. */
     @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public boolean isForeachStmt() {
         return false;
     }
 
+    /** @deprecated use {@link asForEachStmt}. */
     @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public ForEachStmt asForeachStmt() {
@@ -328,6 +330,7 @@ public abstract class Statement extends Node {
     public void ifForStmt(Consumer<ForStmt> action) {
     }
 
+    /** @deprecated use {@link ifForEachStmt}. */
     @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifForeachStmt(Consumer<ForEachStmt> action) {
@@ -422,6 +425,7 @@ public abstract class Statement extends Node {
         return Optional.empty();
     }
 
+    /** @deprecated use {@link toForEachStmt}. */
     @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<ForEachStmt> toForeachStmt() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
@@ -170,11 +170,13 @@ public abstract class Statement extends Node {
         throw new IllegalStateException(f("%s is not an ForStmt", this));
     }
 
+    @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public boolean isForeachStmt() {
         return false;
     }
 
+    @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public ForEachStmt asForeachStmt() {
         throw new IllegalStateException(f("%s is not an ForEachStmt", this));
@@ -326,6 +328,7 @@ public abstract class Statement extends Node {
     public void ifForStmt(Consumer<ForStmt> action) {
     }
 
+    @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifForeachStmt(Consumer<ForEachStmt> action) {
     }
@@ -419,6 +422,7 @@ public abstract class Statement extends Node {
         return Optional.empty();
     }
 
+    @Deprecated
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<ForEachStmt> toForeachStmt() {
         return Optional.empty();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -639,7 +639,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
     @Test
     void localVariablesExposedToChildWithinEnhancedForeachStmt() {
         ForEachStmt foreachStmt = parse("for (int i: myList) { body(); }",
-                ParseStart.STATEMENT).asForeachStmt();
+                ParseStart.STATEMENT).asForEachStmt();
         assertOneVarExposedToChildInContextNamed(foreachStmt, foreachStmt.getBody(), "i");
         assertNoVarsExposedToChildInContextNamed(foreachStmt, foreachStmt.getVariable(), "i");
         assertNoVarsExposedToChildInContextNamed(foreachStmt, foreachStmt.getIterable(), "i");


### PR DESCRIPTION
In version 3.7.0, the class ForeachStmt was renamed to ForEachStmt.
Several methods have multiple spellings:
```
  asForEachStmt
  asForeachStmt
  ifForEachStmt
  ifForeachStmt
  isForEachStmt
  isForeachStmt
  toForEachStmt
  toForeachStmt
```
This pull request deprecates the version of the method whose capitalization is inconsistent with the argument type and/or return type.
