### PR TITLE
Delegate parent handling to underlying JarTypeSolver in AarTypeSolver

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/AarTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/AarTypeSolver.java
@@ -32,7 +32,6 @@ import java.util.zip.ZipEntry;
  */
 public class AarTypeSolver implements TypeSolver {
 
-    private TypeSolver parent;
     private JarTypeSolver delegate;
 
     public AarTypeSolver(String aarFile) throws IOException {
@@ -54,12 +53,12 @@ public class AarTypeSolver implements TypeSolver {
 
     @Override
     public TypeSolver getParent() {
-        return parent;
+        return delegate.getParent();
     }
 
     @Override
     public void setParent(TypeSolver parent) {
-        this.parent = parent;
+        delegate.setParent(parent);
     }
 
     @Override


### PR DESCRIPTION
Previously if you were to call `getAllAncestors()` you may run into a `UnsolvedSymbolException` if the type originated from an AAR since `getAncestors()` will only search for types within the same AAR rather than other solvers defined in a `CombinedTypeSolver`, this was because we never set the parent for the wrapped `JarTypeSolver`.

