### PR TITLE
Rename QuickJavaParser to StaticJavaParser

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/CoreGenerator.java
@@ -1,7 +1,7 @@
 package com.github.javaparser.generator.core;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.generator.core.node.*;
 import com.github.javaparser.generator.core.other.TokenKindGenerator;
 import com.github.javaparser.generator.core.visitor.*;
@@ -35,7 +35,7 @@ public class CoreGenerator {
         final SourceRoot sourceRoot = new SourceRoot(root, parserConfiguration)
 //                .setPrinter(LexicalPreservingPrinter::print)
                 ;
-        QuickJavaParser.setConfiguration(parserConfiguration);
+        StaticJavaParser.setConfiguration(parserConfiguration);
 
         final Path generatedJavaCcRoot = Paths.get(args[0], "..", "javaparser-core", "target", "generated-sources", "javacc");
         final SourceRoot generatedJavaCcSourceRoot = new SourceRoot(generatedJavaCcRoot, parserConfiguration)

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/AcceptGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/AcceptGenerator.java
@@ -9,7 +9,7 @@ import com.github.javaparser.generator.NodeGenerator;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.utils.SourceRoot;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 
 public class AcceptGenerator extends NodeGenerator {
     private final MethodDeclaration genericAccept;

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/CloneGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/CloneGenerator.java
@@ -8,7 +8,7 @@ import com.github.javaparser.generator.NodeGenerator;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.utils.SourceRoot;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
 public class CloneGenerator extends NodeGenerator {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetMetaModelGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/GetMetaModelGenerator.java
@@ -8,7 +8,7 @@ import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.utils.SourceRoot;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
 public class GetMetaModelGenerator extends NodeGenerator {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/MainConstructorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/MainConstructorGenerator.java
@@ -12,7 +12,7 @@ import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.utils.SourceRoot;
 
-import static com.github.javaparser.QuickJavaParser.parseExplicitConstructorInvocationStmt;
+import static com.github.javaparser.StaticJavaParser.parseExplicitConstructorInvocationStmt;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
 public class MainConstructorGenerator extends NodeGenerator {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/PropertyGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/PropertyGenerator.java
@@ -18,7 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.javaparser.QuickJavaParser.parseType;
+import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.ast.Modifier.Keyword.FINAL;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/RemoveMethodGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/RemoveMethodGenerator.java
@@ -10,7 +10,7 @@ import com.github.javaparser.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 import static com.github.javaparser.utils.Utils.capitalize;
 

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/ReplaceMethodGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/ReplaceMethodGenerator.java
@@ -10,7 +10,7 @@ import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SourceRoot;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
 public class ReplaceMethodGenerator extends NodeGenerator {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/TypeCastingGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/node/TypeCastingGenerator.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 import static com.github.javaparser.utils.Utils.set;
 

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/HashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/HashCodeVisitorGenerator.java
@@ -11,7 +11,7 @@ import com.github.javaparser.metamodel.PropertyMetaModel;
 
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 
 /**
  * Generates JavaParser's HashCodeVisitor.

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
@@ -33,7 +33,7 @@ import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.utils.SourceRoot;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 
 public class NoCommentHashCodeVisitorGenerator extends VisitorGenerator {
 

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/InitializeConstructorParametersStatementsGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/InitializeConstructorParametersStatementsGenerator.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.generator.metamodel.MetaModelGenerator.nodeMetaModelFieldName;
 import static com.github.javaparser.generator.metamodel.MetaModelGenerator.propertyMetaModelFieldName;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/InitializePropertyMetaModelsStatementsGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/InitializePropertyMetaModelsStatementsGenerator.java
@@ -9,7 +9,7 @@ import com.github.javaparser.metamodel.OptionalProperty;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.generator.metamodel.MetaModelGenerator.isNode;
 import static com.github.javaparser.generator.metamodel.MetaModelGenerator.nodeMetaModelName;

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
@@ -1,8 +1,7 @@
 package com.github.javaparser.generator.metamodel;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
@@ -165,7 +164,7 @@ public class MetaModelGenerator {
                 .setStoreTokens(false);
         final SourceRoot sourceRoot = new SourceRoot(root, parserConfiguration);
         sourceRoot.setPrinter(new PrettyPrinter(new PrettyPrinterConfiguration().setEndOfLineCharacter("\n"))::print);
-        QuickJavaParser.setConfiguration(parserConfiguration);
+        StaticJavaParser.setConfiguration(parserConfiguration);
 
         new MetaModelGenerator().run(sourceRoot);
 

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/NodeMetaModelGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/NodeMetaModelGenerator.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.ast.Modifier.Keyword.*;
 import static com.github.javaparser.generator.metamodel.MetaModelGenerator.*;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;

--- a/javaparser-core-serialization/src/main/java/com/github/javaparser/serialization/JavaParserJsonDeserializer.java
+++ b/javaparser-core-serialization/src/main/java/com/github/javaparser/serialization/JavaParserJsonDeserializer.java
@@ -192,9 +192,9 @@ public class JavaParserJsonDeserializer {
      * @see com.github.javaparser.ParserConfiguration#ParserConfiguration()
      */
     private void setSymbolResolverIfCompilationUnit(Node node) {
-        if (node instanceof CompilationUnit && QuickJavaParser.getConfiguration().getSymbolResolver().isPresent()) {
+        if (node instanceof CompilationUnit && StaticJavaParser.getConfiguration().getSymbolResolver().isPresent()) {
             CompilationUnit cu = (CompilationUnit)node;
-            cu.setData(Node.SYMBOL_RESOLVER_KEY, QuickJavaParser.getConfiguration().getSymbolResolver().get());
+            cu.setData(Node.SYMBOL_RESOLVER_KEY, StaticJavaParser.getConfiguration().getSymbolResolver().get());
         }
     }
 

--- a/javaparser-core-serialization/src/test/java/com/github/javaparser/serialization/JavaParserJsonDeserializerTest.java
+++ b/javaparser-core-serialization/src/test/java/com/github/javaparser/serialization/JavaParserJsonDeserializerTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import javax.json.Json;
 import java.io.StringReader;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.serialization.JavaParserJsonSerializerTest.serialize;
 import static com.github.javaparser.utils.Utils.EOL;
 import static com.github.javaparser.utils.Utils.normalizeEolInTextBlock;
@@ -197,7 +197,7 @@ class JavaParserJsonDeserializerTest {
                 return null;
             }
         };
-        QuickJavaParser.getConfiguration().setSymbolResolver(stubResolver);
+        StaticJavaParser.getConfiguration().setSymbolResolver(stubResolver);
         CompilationUnit cu = parse("public class X{} class Z{}");
         String serialized = serialize(cu, false);
 
@@ -208,7 +208,7 @@ class JavaParserJsonDeserializerTest {
 
     @AfterAll
     static void clearConfiguration() {
-        QuickJavaParser.setConfiguration(new ParserConfiguration());
+        StaticJavaParser.setConfiguration(new ParserConfiguration());
     }
 
     /**

--- a/javaparser-core-serialization/src/test/java/com/github/javaparser/serialization/JavaParserJsonSerializerTest.java
+++ b/javaparser-core-serialization/src/test/java/com/github/javaparser/serialization/JavaParserJsonSerializerTest.java
@@ -20,7 +20,6 @@
  */
 package com.github.javaparser.serialization;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import org.junit.jupiter.api.Test;
@@ -32,7 +31,7 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JavaParserJsonSerializerTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseResource;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseResource;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/GeneratedJavaParserTokenManagerTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/GeneratedJavaParserTokenManagerTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static com.github.javaparser.QuickJavaParser.parseResource;
+import static com.github.javaparser.StaticJavaParser.parseResource;
 
 class GeneratedJavaParserTokenManagerTest {
     private String makeFilename(String sampleName) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -42,7 +42,7 @@ import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.BLEEDING_EDGE;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.CURRENT;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.Range.range;
 import static com.github.javaparser.utils.CodeGenerationUtils.mavenModuleRoot;
 import static com.github.javaparser.utils.TestUtils.assertInstanceOf;
@@ -54,12 +54,12 @@ class JavaParserTest {
 
     @BeforeEach
     void setToLatestJava() {
-        QuickJavaParser.getConfiguration().setLanguageLevel(BLEEDING_EDGE);
+        StaticJavaParser.getConfiguration().setLanguageLevel(BLEEDING_EDGE);
     }
 
     @AfterEach
     void resetJavaLevel() {
-        QuickJavaParser.getConfiguration().setLanguageLevel(CURRENT);
+        StaticJavaParser.getConfiguration().setLanguageLevel(CURRENT);
     }
 
     @Test
@@ -271,21 +271,21 @@ class JavaParserTest {
 
     @Test
     void parseModuleDeclaration() {
-        QuickJavaParser.parseModuleDeclaration("module X {}");
+        StaticJavaParser.parseModuleDeclaration("module X {}");
     }
 
     @Test
     void parseModuleDirective() {
-        QuickJavaParser.parseModuleDirective("opens C;");
+        StaticJavaParser.parseModuleDirective("opens C;");
     }
 
     @Test
     void parseTypeParameter() {
-        QuickJavaParser.parseTypeParameter("T extends Serializable & AttachableListener");
+        StaticJavaParser.parseTypeParameter("T extends Serializable & AttachableListener");
     }
 
     @Test
     void parseTypeDeclaration() {
-        QuickJavaParser.parseTypeDeclaration("enum Z {A, B}");
+        StaticJavaParser.parseTypeDeclaration("enum Z {A, B}");
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/TokenRangeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/TokenRangeTest.java
@@ -3,7 +3,7 @@ package com.github.javaparser;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TokenRangeTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
@@ -21,14 +21,13 @@
 
 package com.github.javaparser.ast;
 
-import com.github.javaparser.JavaParser;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.CodeGenerationUtils.mavenModuleRoot;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/FindNodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/FindNodeTest.java
@@ -5,7 +5,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.ast;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.expr.Name;
@@ -35,7 +34,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.ast.NodeList.nodeList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -42,8 +42,8 @@ import org.junit.jupiter.api.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
@@ -2,8 +2,8 @@ package com.github.javaparser.ast;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parsePackageDeclaration;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parsePackageDeclaration;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
@@ -3,8 +3,8 @@ package com.github.javaparser.ast.body;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
@@ -3,7 +3,7 @@ package com.github.javaparser.ast.body;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FieldDeclarationTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
@@ -2,7 +2,7 @@ package com.github.javaparser.ast.body;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
@@ -30,7 +30,7 @@ import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.*;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/CharLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/CharLiteralExprTest.java
@@ -6,7 +6,7 @@ import com.github.javaparser.ParserConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CharLiteralExprTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/DoubleLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/DoubleLiteralExprTest.java
@@ -3,7 +3,7 @@ package com.github.javaparser.ast.expr;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 
 class DoubleLiteralExprTest {
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/InstanceOfExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/InstanceOfExprTest.java
@@ -2,7 +2,7 @@ package com.github.javaparser.ast.expr;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 class InstanceOfExprTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LambdaExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LambdaExprTest.java
@@ -7,8 +7,8 @@ import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.type.UnknownType;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseBlock;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseBlock;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
@@ -23,7 +23,7 @@ package com.github.javaparser.ast.expr;
 import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("OctalInteger")

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/MethodCallExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/MethodCallExprTest.java
@@ -2,7 +2,7 @@ package com.github.javaparser.ast.expr;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static java.util.Optional.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
@@ -27,7 +27,7 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
@@ -23,7 +23,7 @@ package com.github.javaparser.ast.expr;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseSimpleName;
+import static com.github.javaparser.StaticJavaParser.parseSimpleName;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
@@ -2,7 +2,7 @@ package com.github.javaparser.ast.expr;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.*;
 
 class StringLiteralExprTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SuperExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SuperExprTest.java
@@ -3,7 +3,7 @@ package com.github.javaparser.ast.expr;
 import com.github.javaparser.ParseProblemException;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -5,7 +5,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.SwitchEntry;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/ThisExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/ThisExprTest.java
@@ -2,7 +2,7 @@ package com.github.javaparser.ast.expr;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ThisExprTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
@@ -21,11 +21,10 @@
 
 package com.github.javaparser.ast.imports;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.ImportDeclaration;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseImport;
+import static com.github.javaparser.StaticJavaParser.parseImport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ImportDeclarationTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithTraversableScopeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithTraversableScopeTest.java
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithVariablesTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithVariablesTest.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.type.PrimitiveType;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseVariableDeclarationExpr;
+import static com.github.javaparser.StaticJavaParser.parseVariableDeclarationExpr;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.ast.observer;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -31,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PropagatingAstObserverTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/BreakStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/BreakStmtTest.java
@@ -3,7 +3,7 @@ package com.github.javaparser.ast.stmt;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/ForEachStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/ForEachStmtTest.java
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.PrimitiveType;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ForEachStmtTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/IfElseStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/IfElseStmtTest.java
@@ -2,7 +2,7 @@ package com.github.javaparser.ast.stmt;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
@@ -3,9 +3,7 @@ package com.github.javaparser.ast.stmt;
 import com.github.javaparser.ast.NodeList;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.EXPRESSION;
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.STATEMENT_GROUP;
 import static org.junit.jupiter.api.Assertions.*;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
@@ -31,7 +31,7 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/TypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/TypeTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import static com.github.javaparser.ParseStart.VARIABLE_DECLARATION_EXPR;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.*;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.QuickJavaParser.parseType;
-import static com.github.javaparser.QuickJavaParser.parseVariableDeclarationExpr;
+import static com.github.javaparser.StaticJavaParser.parseType;
+import static com.github.javaparser.StaticJavaParser.parseVariableDeclarationExpr;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/CloneVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/CloneVisitorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
-import static com.github.javaparser.QuickJavaParser.parseType;
+import static com.github.javaparser.StaticJavaParser.parseType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CloneVisitorTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
@@ -1,10 +1,9 @@
 package com.github.javaparser.ast.visitor;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ModifierVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ModifierVisitorTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.ast.visitor;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -30,8 +29,8 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseBodyDeclaration;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitorTest.java
@@ -24,7 +24,7 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
@@ -1,10 +1,9 @@
 package com.github.javaparser.ast.visitor;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/TreeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/TreeVisitorTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.ast.visitor;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.ArrayInitializerExpr;
@@ -30,8 +29,8 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/ComparingSteps.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/ComparingSteps.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/ManipulationSteps.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.bdd.steps;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
@@ -43,7 +42,7 @@ import org.jbehave.core.annotations.When;
 
 import java.util.Map;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 import static com.github.javaparser.ast.Modifier.staticModifier;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/PrettyPrintingSteps.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/PrettyPrintingSteps.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.Utils.readerToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/bdd/steps/SharedSteps.java
@@ -36,7 +36,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
@@ -31,7 +31,7 @@ import java.lang.annotation.ElementType;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.javaparser.QuickJavaParser.parseImport;
+import static com.github.javaparser.StaticJavaParser.parseImport;
 import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.*;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithMembersBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithMembersBuildersTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.ast.Modifier.Keyword.*;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithThrownExceptionsBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithThrownExceptionsBuildersTest.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
@@ -31,7 +31,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 
 class JavadocExtractorTest {
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.javadoc;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
@@ -32,8 +31,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseJavadoc;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseJavadoc;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import static com.github.javaparser.GeneratedJavaParserConstants.IDENTIFIER;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_9;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelAcceptanceTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelAcceptanceTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.printer;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.utils.CodeGenerationUtils;
@@ -31,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ConcreteSyntaxModelAcceptanceTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.ClassExpr;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DotPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DotPrinterTest.java
@@ -21,13 +21,12 @@
 
 package com.github.javaparser.printer;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.printer;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -33,7 +32,7 @@ import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.type.Type;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_9;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.QuickJavaParser.*;
+import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.printer.PrettyPrinterConfiguration.IndentType.TABS;
 import static com.github.javaparser.printer.PrettyPrinterConfiguration.IndentType.TABS_WITH_SPACE_ALIGN;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
@@ -3,7 +3,7 @@ package com.github.javaparser.printer;
 import com.github.javaparser.ast.expr.Expression;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class XmlPrinterTest {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
@@ -21,13 +21,12 @@
 
 package com.github.javaparser.printer;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static com.github.javaparser.utils.TestUtils.readTextResource;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/AbstractLexicalPreservingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/AbstractLexicalPreservingTest.java
@@ -21,15 +21,14 @@
 
 package com.github.javaparser.printer.lexicalpreservation;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
 import java.io.IOException;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.readResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -17,8 +17,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.github.javaparser.QuickJavaParser.parse;
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
 import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
@@ -30,7 +30,7 @@ import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -40,8 +39,8 @@ import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinte
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
@@ -25,14 +25,13 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 
 /**
  * Transforming Statement and verifying the LexicalPreservation works as expected.

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorListTest.java
@@ -21,7 +21,7 @@
 
 package com.github.javaparser.utils;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.utils;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.visitor.ObjectIdentityEqualsVisitor;
 import com.github.javaparser.ast.visitor.ObjectIdentityHashCodeVisitor;
@@ -9,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
@@ -21,7 +21,7 @@
 
 package com.github.javaparser.utils;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,7 +33,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.visitor.ObjectIdentityEqualsVisitor;
 import com.github.javaparser.ast.visitor.ObjectIdentityHashCodeVisitor;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/ClassCreator.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/ClassCreator.java
@@ -35,8 +35,8 @@ import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.type.VoidType;
 
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.Keyword.STATIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/CuPrinter.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/CuPrinter.java
@@ -21,8 +21,7 @@
 
 package com.github.javaparser.wiki_samples;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 
 import java.io.FileInputStream;
@@ -34,7 +33,7 @@ public class CuPrinter {
         FileInputStream in = new FileInputStream("test.java");
 
         // parse the file
-        CompilationUnit cu = QuickJavaParser.parse(in);
+        CompilationUnit cu = StaticJavaParser.parse(in);
 
         // prints the resulting compilation unit to default system output
         System.out.println(cu.toString());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/MethodChanger_1.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/MethodChanger_1.java
@@ -27,7 +27,7 @@ import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
 import java.io.File;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 
 public class MethodChanger_1 {
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/MethodChanger_2.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/MethodChanger_2.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.wiki_samples;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
@@ -30,7 +29,7 @@ import com.github.javaparser.ast.body.TypeDeclaration;
 
 import java.io.FileInputStream;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.ast.type.PrimitiveType.intType;
 
 public class MethodChanger_2 {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/MethodPrinter.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/MethodPrinter.java
@@ -21,8 +21,7 @@
 
 package com.github.javaparser.wiki_samples;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
@@ -36,7 +35,7 @@ public class MethodPrinter {
         FileInputStream in = new FileInputStream("test.java");
 
         // parse it
-        CompilationUnit cu = QuickJavaParser.parse(in);
+        CompilationUnit cu = StaticJavaParser.parse(in);
 
         // visit and print the methods names
         cu.accept(new MethodVisitor(), null);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/removenode/ModifierVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/wiki_samples/removenode/ModifierVisitorTest.java
@@ -21,7 +21,7 @@
 
 package com.github.javaparser.wiki_samples.removenode;
 
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -35,7 +35,7 @@ public class ModifierVisitorTest {
 
     public static void main(String... args) throws Exception {
         // parse the file
-        CompilationUnit cu = QuickJavaParser.parse(new FileInputStream("forGitHubTest.java"));
+        CompilationUnit cu = StaticJavaParser.parse(new FileInputStream("forGitHubTest.java"));
 
         // The visitor should remove all a=20 variable declarations.
         cu.accept(new MyVisitor(), null);

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -51,7 +51,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * Parse Java source code and creates Abstract Syntax Trees.
  *
  * @author Júlio Vilmar Gesser
- * @see QuickJavaParser
+ * @see StaticJavaParser
  */
 public final class JavaParser {
     private final ParserConfiguration configuration;

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -46,11 +46,11 @@ import java.nio.file.Path;
 /**
  * A simpler, static API than {@link JavaParser}.
  */
-public final class QuickJavaParser {
+public final class StaticJavaParser {
     private static ParserConfiguration configuration = new ParserConfiguration();
     private static JavaParser parser = new JavaParser(configuration);
 
-    private QuickJavaParser() {
+    private StaticJavaParser() {
     }
 
     /**
@@ -65,7 +65,7 @@ public final class QuickJavaParser {
      * This is a STATIC field, so modifying it will directly change how all static parse... methods work!
      */
     public static void setConfiguration(ParserConfiguration configuration) {
-        QuickJavaParser.configuration = configuration;
+        StaticJavaParser.configuration = configuration;
         parser = new JavaParser(configuration);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -54,13 +54,11 @@ import java.util.Optional;
 import java.util.function.Function;
 import static com.github.javaparser.Providers.UTF8;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.QuickJavaParser.parseImport;
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseImport;
+import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 import static com.github.javaparser.utils.CodeGenerationUtils.subtractPaths;
 import static com.github.javaparser.utils.Utils.assertNotNull;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.Generated;
 
 /**
  * <p>

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/ImportDeclaration.java
@@ -25,14 +25,12 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.ImportDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.TokenRange;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.Generated;
 
 /**
  * An import declaration.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -20,7 +20,6 @@
  */
 package com.github.javaparser.ast.comments;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -34,7 +33,7 @@ import java.util.function.Consumer;
 import java.util.Optional;
 import com.github.javaparser.ast.Generated;
 
-import static com.github.javaparser.QuickJavaParser.parseJavadoc;
+import static com.github.javaparser.StaticJavaParser.parseJavadoc;
 
 /**
  * A Javadoc comment. <code>/&#42;&#42; a comment &#42;/</code>

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -20,7 +20,6 @@
  */
 package com.github.javaparser.ast.expr;
 
-import com.github.javaparser.Range;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.ArrayType;
@@ -34,7 +33,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.NonEmptyProperty;
 import java.util.Optional;
 
-import static com.github.javaparser.QuickJavaParser.parseType;
+import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
 import java.util.Optional;
 import com.github.javaparser.ast.Generated;
 
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseName;
 
 /**
  * An annotation that uses only the annotation type name.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -20,7 +20,6 @@
  */
 package com.github.javaparser.ast.expr;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Node;
@@ -34,11 +33,8 @@ import com.github.javaparser.metamodel.NonEmptyProperty;
 import com.github.javaparser.metamodel.OptionalProperty;
 import java.util.Optional;
 
-import static com.github.javaparser.QuickJavaParser.parseName;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 import com.github.javaparser.ast.visitor.CloneVisitor;
-import com.github.javaparser.metamodel.NameMetaModel;
-import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.ast.Generated;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleDeclaration.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.ast.modules;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
@@ -15,7 +14,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.ModuleDeclarationMetaModel;
 
-import static com.github.javaparser.QuickJavaParser.parseModuleDirective;
+import static com.github.javaparser.StaticJavaParser.parseModuleDirective;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.Generated;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleExportsDirective.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/modules/ModuleExportsDirective.java
@@ -10,7 +10,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.TokenRange;
 import java.util.function.Consumer;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
@@ -28,8 +28,8 @@ import com.github.javaparser.ast.expr.*;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseName;
 
 /**
  * A node that can be annotated.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 
 /**
  * A node with arguments.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExpression.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExpression.java
@@ -24,7 +24,7 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 
 /**
  * A node that has an expression in it.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 
 /**
  * A node that extends other types.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithImplements.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithImplements.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 
 /**
  * A node that implements other types.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -32,7 +32,7 @@ import com.github.javaparser.ast.type.VoidType;
 import java.util.List;
 import java.util.Optional;
 
-import static com.github.javaparser.QuickJavaParser.parseType;
+import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.ast.Modifier.Keyword;
 import static com.github.javaparser.ast.Modifier.Keyword.*;
 import static com.github.javaparser.ast.Modifier.createModifierList;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithName.java
@@ -24,7 +24,7 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Name;
 
-import static com.github.javaparser.QuickJavaParser.parseName;
+import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
@@ -29,7 +29,7 @@ import com.github.javaparser.ast.type.Type;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static com.github.javaparser.QuickJavaParser.parseType;
+import static com.github.javaparser.StaticJavaParser.parseType;
 import static java.util.stream.Collectors.toSet;
 
 public interface NodeWithParameters<N extends Node> {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithStatements.java
@@ -29,7 +29,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 
-import static com.github.javaparser.QuickJavaParser.parseStatement;
+import static com.github.javaparser.StaticJavaParser.parseStatement;
 
 /**
  * A node that contains a list of statements.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrownExceptions.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithThrownExceptions.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.ReferenceType;
 
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 
 /**
  * A node that declares the types of exception it throws.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithType.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.type.Type;
 
-import static com.github.javaparser.QuickJavaParser.parseType;
+import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeParameters.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithTypeParameters.java
@@ -25,7 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.type.TypeParameter;
 
-import static com.github.javaparser.QuickJavaParser.parseTypeParameter;
+import static com.github.javaparser.StaticJavaParser.parseTypeParameter;
 
 /**
  * A node that can have type parameters.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -29,7 +29,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import java.util.HashMap;
 
-import static com.github.javaparser.QuickJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.CloneVisitor;

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/CollectionStrategy.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/CollectionStrategy.java
@@ -9,7 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Optional;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 
 /**
  * A strategy for discovering the structure of a project.

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/SourceFileInfoExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/SourceFileInfoExtractor.java
@@ -45,7 +45,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.symbolsolver.javaparser.Navigator.requireParentNode;
 import static java.util.Comparator.comparing;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue113.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue113.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
@@ -18,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class Issue113 extends AbstractSymbolResolutionTest {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1491.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1491.java
@@ -1,7 +1,7 @@
 package com.github.javaparser.symbolsolver;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 
 class Issue1491 {
 
@@ -34,7 +34,7 @@ class Issue1491 {
         localCts.add(new JavaParserTypeSolver(aJava.getAbsoluteFile().getParentFile()));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        QuickJavaParser.setConfiguration(parserConfiguration);
+        StaticJavaParser.setConfiguration(parserConfiguration);
 
         CompilationUnit cu = parse(aJava);
         cu.accept(new VoidVisitorAdapter() {
@@ -58,7 +58,7 @@ class Issue1491 {
         localCts.add(new JavaParserTypeSolver(aJava.getAbsoluteFile().getParentFile()));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        QuickJavaParser.setConfiguration(parserConfiguration);
+        StaticJavaParser.setConfiguration(parserConfiguration);
 
         CompilationUnit cu = parse(aJava);
         cu.accept(new VoidVisitorAdapter() {
@@ -82,7 +82,7 @@ class Issue1491 {
         localCts.add(new JavaParserTypeSolver(aJava.getAbsoluteFile().getParentFile()));
 
         ParserConfiguration parserConfiguration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(localCts));
-        QuickJavaParser.setConfiguration(parserConfiguration);
+        StaticJavaParser.setConfiguration(parserConfiguration);
 
         CompilationUnit cu = parse(aJava);
         cu.accept(new VoidVisitorAdapter<Void>() {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue185.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue185.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.symbolsolver.javaparser.Navigator;
@@ -15,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue228.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue228.java
@@ -8,7 +8,7 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class Issue228 extends AbstractResolutionTest{

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue276.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue276.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 
 class Issue276 extends AbstractResolutionTest{
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue300.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue300.java
@@ -16,7 +16,6 @@
 
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -35,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue314.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue314.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -14,7 +13,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class Issue314 extends AbstractResolutionTest{

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
@@ -10,7 +9,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue347.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue347.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -12,7 +11,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -16,9 +16,8 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.MethodUsage;
@@ -875,9 +874,9 @@ class JavaParserInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
     void issue1528() {
         try {
             TypeSolver typeSolver = new ReflectionTypeSolver();
-            QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+            StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
             JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
-            CompilationUnit compilationUnit = QuickJavaParser.parse("public interface Foo extends Comparable { }");
+            CompilationUnit compilationUnit = StaticJavaParser.parse("public interface Foo extends Comparable { }");
             ClassOrInterfaceDeclaration foo = (ClassOrInterfaceDeclaration) compilationUnit.getType(0);
             ResolvedInterfaceDeclaration interfaceDeclaration = javaParserFacade.getTypeDeclaration(foo).asInterface();
 
@@ -885,7 +884,7 @@ class JavaParserInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
 
             assertEquals("java.lang.Comparable", extendedInterface.getQualifiedName());
         } finally {
-            QuickJavaParser.setConfiguration(new ParserConfiguration());
+            StaticJavaParser.setConfiguration(new ParserConfiguration());
         }
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/Issue257.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/Issue257.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.symbolsolver.javassistmodel;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -17,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 
 class Issue257 extends AbstractSymbolResolutionTest {
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AbstractResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AbstractResolutionTest.java
@@ -16,8 +16,7 @@
 
 package com.github.javaparser.symbolsolver.resolution;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.symbolsolver.AbstractSymbolResolutionTest;
 
@@ -41,6 +40,6 @@ public abstract class AbstractResolutionTest extends AbstractSymbolResolutionTes
         if (is == null) {
             throw new RuntimeException("Unable to find sample " + sampleName);
         }
-        return QuickJavaParser.parse(is);
+        return StaticJavaParser.parse(is);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseNewJavaParserHelpersTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseNewJavaParserHelpersTest.java
@@ -16,8 +16,7 @@
 
 package com.github.javaparser.symbolsolver.resolution;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
@@ -54,7 +53,7 @@ class AnalyseNewJavaParserHelpersTest extends AbstractResolutionTest {
 
     private CompilationUnit parse(String fileName) throws IOException {
         Path sourceFile = src.resolve(fileName + ".java");
-        return QuickJavaParser.parse(sourceFile);
+        return StaticJavaParser.parse(sourceFile);
     }
 
 //    @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -1,7 +1,6 @@
 package com.github.javaparser.symbolsolver.resolution;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -41,13 +40,13 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
         CombinedTypeSolver typeSolver = new CombinedTypeSolver();
         typeSolver.add(new ReflectionTypeSolver());
         typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
     }
 
     @AfterAll
     static void unConfigureSymbolSolver() {
         // unconfigure symbol solver so as not to potentially disturb tests in other classes
-        QuickJavaParser.getConfiguration().setSymbolResolver(null);
+        StaticJavaParser.getConfiguration().setSymbolResolver(null);
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnonymousClassesResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnonymousClassesResolutionTest.java
@@ -1,7 +1,6 @@
 package com.github.javaparser.symbolsolver.resolution;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
@@ -34,13 +33,13 @@ class AnonymousClassesResolutionTest extends AbstractResolutionTest {
                 cd);
 
         typeSolver.add(memoryTypeSolver);
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
     }
 
     @AfterAll
     static void unConfigureSymbolSolver() {
         // unconfigure symbol solver so as not to potentially disturb tests in other classes
-        QuickJavaParser.getConfiguration().setSymbolResolver(null);
+        StaticJavaParser.getConfiguration().setSymbolResolver(null);
     }
 
     // See #1703

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ArrayExprTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ArrayExprTest.java
@@ -15,7 +15,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ConstructorsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ConstructorsResolutionTest.java
@@ -1,7 +1,7 @@
 package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
@@ -26,7 +26,7 @@ class ConstructorsResolutionTest extends AbstractResolutionTest {
 
     @AfterEach
     void resetConfiguration() {
-        QuickJavaParser.setConfiguration(new ParserConfiguration());
+        StaticJavaParser.setConfiguration(new ParserConfiguration());
     }
 
     @Test
@@ -108,7 +108,7 @@ class ConstructorsResolutionTest extends AbstractResolutionTest {
     @Test
     void solveEnumConstructor() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         CompilationUnit cu = parseSample("ConstructorCallsEnum");
         EnumDeclaration enumDeclaration = Navigator.demandEnum(cu, "ConstructorCallsEnum");
@@ -124,7 +124,7 @@ class ConstructorsResolutionTest extends AbstractResolutionTest {
 
     @Test
     void solveNonPublicParentConstructorReflection() {
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         CompilationUnit cu = parseSample("ReflectionTypeSolverConstructorResolution");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ReflectionTypeSolverConstructionResolution");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -60,7 +60,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
 
     private CompilationUnit parseSample(String sampleName) {
         InputStream is = ContextTest.class.getClassLoader().getResourceAsStream(sampleName + ".java.txt");
-        return QuickJavaParser.parse(is);
+        return StaticJavaParser.parse(is);
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
@@ -1,6 +1,5 @@
 package com.github.javaparser.symbolsolver.resolution;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
@@ -19,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
@@ -17,7 +17,7 @@
 package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -68,7 +68,7 @@ class EnumResolutionTest extends AbstractResolutionTest {
     void resolveEnumConstantAccess() {
         try {
             // configure symbol solver before parsing
-            QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+            StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
             // parse compilation unit and get field access expression
             CompilationUnit cu = parseSample("EnumFieldAccess");
@@ -88,7 +88,7 @@ class EnumResolutionTest extends AbstractResolutionTest {
             assertTrue(resolvedEnumConstantDeclaration.isEnumConstant());
             assertTrue(resolvedEnumConstantDeclaration.hasName());
         } finally {
-            QuickJavaParser.setConfiguration(new ParserConfiguration());
+            StaticJavaParser.setConfiguration(new ParserConfiguration());
         }
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ExprResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ExprResolutionTest.java
@@ -16,7 +16,6 @@
 
 package com.github.javaparser.symbolsolver.resolution;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -29,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.resolution.types.ResolvedPrimitiveType.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
@@ -17,7 +17,7 @@
 package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
@@ -49,7 +49,7 @@ class FieldsResolutionTest extends AbstractResolutionTest {
 
     @AfterEach
     void resetConfiguration() {
-        QuickJavaParser.setConfiguration(new ParserConfiguration());
+        StaticJavaParser.setConfiguration(new ParserConfiguration());
     }
 
     @Test
@@ -121,7 +121,7 @@ class FieldsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveClassFieldThroughThis() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get field access expression
         CompilationUnit cu = parseSample("AccessClassMemberThroughThis");
@@ -143,7 +143,7 @@ class FieldsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveClassFieldThroughSuper() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get field access expression
         CompilationUnit cu = parseSample("AccessThroughSuper");
@@ -166,7 +166,7 @@ class FieldsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveClassFieldOfClassExtendingUnknownClass1() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get field access expression
         CompilationUnit cu = parseSample("ClassExtendingUnknownClass");
@@ -188,7 +188,7 @@ class FieldsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveClassFieldOfClassExtendingUnknownClass2() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get field access expression
         CompilationUnit cu = parseSample("ClassExtendingUnknownClass");
@@ -210,7 +210,7 @@ class FieldsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveInheritedFieldFromInterface() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get field access expression
         CompilationUnit cu = parseSample("ReflectionTypeSolverFieldFromInterfaceResolution");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
@@ -39,7 +39,7 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionTest.java
@@ -16,7 +16,7 @@
 
 package com.github.javaparser.symbolsolver.resolution;
 
-import com.github.javaparser.QuickJavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -454,7 +454,7 @@ class MethodsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveLocalMethodInClassExtendingUnknownClass() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get field access expression
         CompilationUnit cu = parseSample("ClassExtendingUnknownClass");
@@ -473,7 +473,7 @@ class MethodsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveCorrectMethodWithComplexOverloading1() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get method call expression
         CompilationUnit cu = parseSample("OverloadedMethods");
@@ -491,7 +491,7 @@ class MethodsResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveCorrectMethodWithComplexOverloading2() {
         // configure symbol solver before parsing
-        QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
         // parse compilation unit and get method call expression
         CompilationUnit cu = parseSample("OverloadedMethods");
@@ -509,7 +509,7 @@ class MethodsResolutionTest extends AbstractResolutionTest {
 	@Test
 	void resolveCorrectMethodWithComplexOverloading3() {
 		// configure symbol solver before parsing
-		QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+		StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
 		// parse compilation unit and get method call expression
 		CompilationUnit cu = parseSample("OverloadedMethods");
@@ -527,7 +527,7 @@ class MethodsResolutionTest extends AbstractResolutionTest {
 	@Test
 	void resolveCorrectMethodWithComplexOverloading4() {
 		// configure symbol solver before parsing
-		QuickJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+		StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
 
 		// parse compilation unit and get method call expression
 		CompilationUnit cu = parseSample("OverloadedMethods");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTest.java
@@ -389,7 +389,7 @@ class NameLogicTest extends AbstractNameLogicTest {
     @Test
     void identifyNamesInSimpleExamples() {
         String code = "package a.b.c; class A { void foo(int param) { return a.b.c.D.e; } }";
-        CompilationUnit cu = QuickJavaParser.parse(code);
+        CompilationUnit cu = StaticJavaParser.parse(code);
 
         assertEquals(false, NameLogic.isAName(cu));
         assertEquals(false, NameLogic.isAName(cu.getPackageDeclaration().get()));
@@ -434,7 +434,7 @@ class NameLogicTest extends AbstractNameLogicTest {
     @Test
     void identifyNameRolesInSimpleExamples() {
         String code = "package a.b.c; class A { void foo(int param) { return a.b.c.D.e; } }";
-        CompilationUnit cu = QuickJavaParser.parse(code);
+        CompilationUnit cu = StaticJavaParser.parse(code);
 
         Name packageName = cu.getPackageDeclaration().get().getName();
         assertEquals(DECLARATION, NameLogic.classifyRole(packageName));

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTestingJss060Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogicTestingJss060Test.java
@@ -14,7 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.github.javaparser.QuickJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;
 
 @SlowTest
 class NameLogicTestingJss060Test extends AbstractResolutionTest {


### PR DESCRIPTION
After some discussion this came up as a good name for the static parse methods class.