### PR TITLE
Performance improvement getting all methods

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -382,9 +382,7 @@ public abstract class ResolvedReferenceType implements ResolvedType,
      * that have been overwritten.
      */
     public List<ResolvedMethodDeclaration> getAllMethods() {
-        List<ResolvedMethodDeclaration> allMethods = new LinkedList<>();
-        allMethods.addAll(this.getDeclaredMethods().stream().map(MethodUsage::getDeclaration)
-                .collect(Collectors.toList()));
+        List<ResolvedMethodDeclaration> allMethods = new LinkedList<>(this.getTypeDeclaration().getDeclaredMethods());
         getDirectAncestors().forEach(a ->
                 allMethods.addAll(a.getAllMethods()));
         return allMethods;
@@ -406,18 +404,9 @@ public abstract class ResolvedReferenceType implements ResolvedType,
     }
 
     public List<ResolvedMethodDeclaration> getAllMethodsVisibleToInheritors() {
-        List<ResolvedMethodDeclaration> res = new LinkedList<>(this.getDeclaredMethods().stream()
-                .map(m -> m.getDeclaration())
+        return this.getAllMethods().stream()
                 .filter(m -> m.accessSpecifier() != PRIVATE)
-                .collect(Collectors.toList()));
-
-        // We want to avoid infinite recursion in case of Object having Object as ancestor
-        if (!(Object.class.getCanonicalName().equals(getQualifiedName()))) {
-            getDirectAncestors().forEach(a ->
-                    res.addAll(a.getAllMethodsVisibleToInheritors()));
-        }
-
-        return res;
+                .collect(Collectors.toList());
     }
 
     //


### PR DESCRIPTION
Avoid unnecessary conversion ResolvedMethodDeclaration -> MethodUsage -> ResolvedMethodDeclaration. The MethodUsage constructor does type solving of paramters and return type, which can be time consuming, especially if there are a lot of generified methods. 

This change made type resolving of some big classes 2x or 3x faster.

Maarten