### PR TITLE
Make input character encoding a configuration option

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -59,8 +59,7 @@ public final class JavaParser {
     private GeneratedJavaParser astParser = null;
 
     /**
-     * Instantiate the parser with default configuration. Note that parsing can also be done with the static methods on
-     * this class.
+     * Instantiate the parser with default configuration. Note that parsing can also be done with the static methods {@link StaticJavaParser}.
      * Creating an instance will reduce setup time between parsing files.
      */
     public JavaParser() {
@@ -68,7 +67,7 @@ public final class JavaParser {
     }
 
     /**
-     * Instantiate the parser. Note that parsing can also be done with the static methods on this class.
+     * Instantiate the parser. Note that parsing can also be done with the static methods {@link StaticJavaParser}.
      * Creating an instance will reduce setup time between parsing files.
      */
     public JavaParser(ParserConfiguration configuration) {
@@ -151,14 +150,13 @@ public final class JavaParser {
     /**
      * Parses the Java code contained in the {@link InputStream} and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param in {@link InputStream} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<CompilationUnit> parse(final InputStream in) {
-        return parse(in, UTF8);
+        return parse(in, configuration.getCharacterEncoding());
     }
 
     /**
@@ -170,7 +168,9 @@ public final class JavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      * @throws FileNotFoundException the file was not found
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public ParseResult<CompilationUnit> parse(final File file, final Charset encoding) throws FileNotFoundException {
         ParseResult<CompilationUnit> result = parse(COMPILATION_UNIT, provider(file, encoding));
         result.getResult().ifPresent(cu -> cu.setStorage(file.toPath()));
@@ -180,7 +180,6 @@ public final class JavaParser {
     /**
      * Parses the Java code contained in a {@link File} and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param file {@link File} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
@@ -188,7 +187,7 @@ public final class JavaParser {
      * @throws FileNotFoundException the file was not found
      */
     public ParseResult<CompilationUnit> parse(final File file) throws FileNotFoundException {
-        ParseResult<CompilationUnit> result = parse(COMPILATION_UNIT, provider(file));
+        ParseResult<CompilationUnit> result = parse(COMPILATION_UNIT, provider(file, configuration.getCharacterEncoding()));
         result.getResult().ifPresent(cu -> cu.setStorage(file.toPath()));
         return result;
     }
@@ -202,7 +201,9 @@ public final class JavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws IOException the path could not be accessed
      * @throws ParseProblemException if the source code has parser errors
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public ParseResult<CompilationUnit> parse(final Path path, final Charset encoding) throws IOException {
         ParseResult<CompilationUnit> result = parse(COMPILATION_UNIT, provider(path, encoding));
         result.getResult().ifPresent(cu -> cu.setStorage(path));
@@ -212,7 +213,6 @@ public final class JavaParser {
     /**
      * Parses the Java code contained in a file and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param path path to a file containing Java source code
      * @return CompilationUnit representing the Java source code
@@ -220,7 +220,7 @@ public final class JavaParser {
      * @throws IOException the path could not be accessed
      */
     public ParseResult<CompilationUnit> parse(final Path path) throws IOException {
-        ParseResult<CompilationUnit> result = parse(COMPILATION_UNIT, provider(path));
+        ParseResult<CompilationUnit> result = parse(COMPILATION_UNIT, provider(path, configuration.getCharacterEncoding()));
         result.getResult().ifPresent(cu -> cu.setStorage(path));
         return result;
     }
@@ -228,7 +228,6 @@ public final class JavaParser {
     /**
      * Parses the Java code contained in a resource and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param path path to a resource containing Java source code. As resource is accessed through a class loader, a
      * leading "/" is not allowed in pathToResource
@@ -237,7 +236,7 @@ public final class JavaParser {
      * @throws IOException the path could not be accessed
      */
     public ParseResult<CompilationUnit> parseResource(final String path) throws IOException {
-        return parse(COMPILATION_UNIT, resourceProvider(path));
+        return parse(COMPILATION_UNIT, resourceProvider(path, configuration.getCharacterEncoding()));
     }
 
     /**
@@ -250,7 +249,9 @@ public final class JavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public ParseResult<CompilationUnit> parseResource(final String path, Charset encoding) throws IOException {
         return parse(COMPILATION_UNIT, resourceProvider(path, encoding));
     }
@@ -265,7 +266,9 @@ public final class JavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public ParseResult<CompilationUnit> parseResource(final ClassLoader classLoader, final String path, Charset encoding) throws IOException {
         return parse(COMPILATION_UNIT, resourceProvider(classLoader, path, encoding));
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -30,6 +30,7 @@ import com.github.javaparser.version.Java10PostProcessor;
 import com.github.javaparser.version.Java11PostProcessor;
 import com.github.javaparser.version.Java12PostProcessor;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -44,39 +45,73 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  */
 public class ParserConfiguration {
     public enum LanguageLevel {
-        /** Does no post processing or validation. Only for people wanting the fastest parsing. */
+        /**
+         * Does no post processing or validation. Only for people wanting the fastest parsing.
+         */
         RAW(null, null),
-        /** The most used Java version. */
+        /**
+         * The most used Java version.
+         */
         POPULAR(new Java8Validator(), null),
-        /** The latest Java version that is available. */
+        /**
+         * The latest Java version that is available.
+         */
         CURRENT(new Java8Validator(), null),
-        /** The newest Java features supported. */
+        /**
+         * The newest Java features supported.
+         */
         BLEEDING_EDGE(new Java12Validator(), new Java12PostProcessor()),
-        /** Java 1.0 */
+        /**
+         * Java 1.0
+         */
         JAVA_1_0(new Java1_0Validator(), null),
-        /** Java 1.1 */
+        /**
+         * Java 1.1
+         */
         JAVA_1_1(new Java1_1Validator(), null),
-        /** Java 1.2 */
+        /**
+         * Java 1.2
+         */
         JAVA_1_2(new Java1_2Validator(), null),
-        /** Java 1.3 */
+        /**
+         * Java 1.3
+         */
         JAVA_1_3(new Java1_3Validator(), null),
-        /** Java 1.4 */
+        /**
+         * Java 1.4
+         */
         JAVA_1_4(new Java1_4Validator(), null),
-        /** Java 5 */
+        /**
+         * Java 5
+         */
         JAVA_5(new Java5Validator(), null),
-        /** Java 6 */
+        /**
+         * Java 6
+         */
         JAVA_6(new Java6Validator(), null),
-        /** Java 7 */
+        /**
+         * Java 7
+         */
         JAVA_7(new Java7Validator(), null),
-        /** Java 8 */
+        /**
+         * Java 8
+         */
         JAVA_8(new Java8Validator(), null),
-        /** Java 9 */
+        /**
+         * Java 9
+         */
         JAVA_9(new Java9Validator(), null),
-        /** Java 10 */
+        /**
+         * Java 10
+         */
         JAVA_10(new Java10Validator(), new Java10PostProcessor()),
-        /** Java 11 */
+        /**
+         * Java 11
+         */
         JAVA_11(new Java11Validator(), new Java11PostProcessor()),
-        /** Java 12 */
+        /**
+         * Java 12
+         */
         JAVA_12(new Java12Validator(), new Java12PostProcessor());
 
         final Validator validator;
@@ -97,6 +132,7 @@ public class ParserConfiguration {
     private SymbolResolver symbolResolver = null;
     private int tabSize = 1;
     private LanguageLevel languageLevel = CURRENT;
+    private Charset characterEncoding = Providers.UTF8;
 
     private final List<Providers.PreProcessor> preProcessors = new ArrayList<>();
     private final List<ParseResult.PostProcessor> postProcessors = new ArrayList<>();
@@ -110,9 +146,7 @@ public class ParserConfiguration {
         });
         postProcessors.add((result, configuration) -> {
             if (configuration.isLexicalPreservationEnabled()) {
-                if (configuration.isLexicalPreservationEnabled()) {
-                    result.ifSuccessful(LexicalPreservingPrinter::setup);
-                }
+                result.ifSuccessful(LexicalPreservingPrinter::setup);
             }
         });
         postProcessors.add((result, configuration) -> {
@@ -262,4 +296,17 @@ public class ParserConfiguration {
     public boolean isPreprocessUnicodeEscapes() {
         return preprocessUnicodeEscapes;
     }
+
+    public Charset getCharacterEncoding() {
+        return characterEncoding;
+    }
+
+    /**
+     * The character encoding used for reading input from files and streams. By default UTF8 is used.
+     */
+    public ParserConfiguration setCharacterEncoding(Charset characterEncoding) {
+        this.characterEncoding = characterEncoding;
+        return this;
+    }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -79,7 +79,9 @@ public final class StaticJavaParser {
      * @param encoding encoding of the source code
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public static CompilationUnit parse(final InputStream in, Charset encoding) {
         return handleResult(newParser().parse(in, encoding));
     }
@@ -87,7 +89,6 @@ public final class StaticJavaParser {
     /**
      * Parses the Java code contained in the {@link InputStream} and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param in {@link InputStream} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
@@ -106,7 +107,9 @@ public final class StaticJavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      * @throws FileNotFoundException the file was not found
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public static CompilationUnit parse(final File file, final Charset encoding) throws FileNotFoundException {
         return handleResult(newParser().parse(file, encoding));
     }
@@ -114,7 +117,6 @@ public final class StaticJavaParser {
     /**
      * Parses the Java code contained in a {@link File} and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param file {@link File} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
@@ -134,7 +136,9 @@ public final class StaticJavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws IOException the path could not be accessed
      * @throws ParseProblemException if the source code has parser errors
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public static CompilationUnit parse(final Path path, final Charset encoding) throws IOException {
         return handleResult(newParser().parse(path, encoding));
     }
@@ -142,7 +146,6 @@ public final class StaticJavaParser {
     /**
      * Parses the Java code contained in a file and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param path path to a file containing Java source code
      * @return CompilationUnit representing the Java source code
@@ -156,7 +159,6 @@ public final class StaticJavaParser {
     /**
      * Parses the Java code contained in a resource and returns a
      * {@link CompilationUnit} that represents it.<br>
-     * Note: Uses UTF-8 encoding
      *
      * @param path path to a resource containing Java source code. As resource is accessed through a class loader, a
      * leading "/" is not allowed in pathToResource
@@ -178,7 +180,9 @@ public final class StaticJavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public static CompilationUnit parseResource(final String path, Charset encoding) throws IOException {
         return handleResult(newParser().parseResource(path, encoding));
     }
@@ -193,7 +197,9 @@ public final class StaticJavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
+     * @deprecated set the encoding in the {@link ParserConfiguration}
      */
+    @Deprecated
     public static CompilationUnit parseResource(final ClassLoader classLoader, final String path, Charset encoding) throws IOException {
         return handleResult(newParser().parseResource(classLoader, path, encoding));
     }


### PR DESCRIPTION
Fixes #2129.

@songyunseok - you can tell `SourceRoot` which configuration to use, so now you can set the character encoding on the configuration and use that configuration with `SourceRoot`.