### PR TITLE
to solve getTypeParametersMap method bug

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -276,7 +276,7 @@ public abstract class ResolvedReferenceType implements ResolvedType,
         List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap = new ArrayList<>();
         if (!isRawType()) {
             for (int i = 0; i < typeDeclaration.getTypeParameters().size(); i++) {
-                typeParametersMap.add(new Pair<>(typeDeclaration.getTypeParameters().get(0), typeParametersValues().get(i)));
+                typeParametersMap.add(new Pair<>(typeDeclaration.getTypeParameters().get(i), typeParametersValues().get(i)));
             }
         }
         return typeParametersMap;


### PR DESCRIPTION
to solve getTypeParametersMap method pair object first parameter always is class fist typeArugment

Fixes #2144.
