### PR TITLE
Make a shortcut to set the type of all variables declared in a variable declaration

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithVariablesTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithVariablesTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.type.PrimitiveType;
 import org.junit.jupiter.api.Test;
@@ -51,19 +52,19 @@ class NodeWithVariablesTest {
     void getCommonTypeFailsOnDodgySetterUsage() {
         assertThrows(AssertionError.class, () -> {
             VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a,b");
-        declaration.getVariable(1).setType(String.class);
-        declaration.getCommonType();
-    });
-        }
+            declaration.getVariable(1).setType(String.class);
+            declaration.getCommonType();
+        });
+    }
 
     @Test
     void getCommonTypeFailsOnInvalidEmptyVariableList() {
         assertThrows(AssertionError.class, () -> {
             VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a");
-        declaration.getVariables().clear();
-        declaration.getCommonType();
-    });
-        }
+            declaration.getVariables().clear();
+            declaration.getCommonType();
+        });
+    }
 
     @Test
     void getElementTypeWorksForNormalVariables() {
@@ -86,18 +87,24 @@ class NodeWithVariablesTest {
     void getElementTypeFailsOnDodgySetterUsage() {
         assertThrows(AssertionError.class, () -> {
             VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a,b");
-        declaration.getVariable(1).setType(String.class);
-        declaration.getElementType();
-    });
-        }
+            declaration.getVariable(1).setType(String.class);
+            declaration.getElementType();
+        });
+    }
 
     @Test
     void getElementTypeFailsOnInvalidEmptyVariableList() {
         assertThrows(AssertionError.class, () -> {
             VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a");
-        declaration.getVariables().clear();
-        declaration.getElementType();
-    });
-        }
+            declaration.getVariables().clear();
+            declaration.getElementType();
+        });
+    }
 
+    @Test
+    void setAllTypesWorks() {
+        VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int[] a[],b[][]");
+        declaration.setAllTypes(StaticJavaParser.parseType("Dog"));
+        assertEquals("Dog a, b", declaration.toString());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
@@ -101,6 +101,19 @@ public interface NodeWithVariables<N extends Node> {
     }
 
     /**
+     * Sets the type of all variables.
+     * Erases any existing type.
+     * This is a shortcut for setting a type on all variable declarators separately.
+     */
+    @SuppressWarnings("unchecked")
+    default N setAllTypes(Type newType) {
+        for (VariableDeclarator variable : getVariables()) {
+            variable.setType(newType);
+        }
+        return (N) this;
+    }
+
+    /**
      * Returns the type that maximum shared type between all variables.
      * The minimum common type does never include annotations on the array level.
      * <p>


### PR DESCRIPTION
Fixes #1362.
