### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - $HOME/.ivy2
 jdk:
-  - openjdk12
+  - openjdk11
 notifications:
   webhooks:
     urls:

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,10 @@
 Version 3.13.9
 ------------------
+[issues resolved](https://github.com/javaparser/javaparser/milestone/134?closed=1)
 
 Version 3.13.8 (failed)
 ------------------
 (release failed)
-[issues resolved](https://github.com/javaparser/javaparser/milestone/134?closed=1)
 
 Version 3.13.7
 ------------------


### PR DESCRIPTION
https://stackoverflow.com/questions/55878548/travis-ci-couldnt-install-openjdk11

I thought it was outdated and set it to 12, but that wasn't the fix.