### PR TITLE
Sonar issues : squid : S1166 - Exception handlers should preserve the…

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -45,7 +45,8 @@ import java.nio.file.Path;
 import static com.github.javaparser.ParseStart.*;
 import static com.github.javaparser.Problem.PROBLEM_BY_BEGIN_POSITION;
 import static com.github.javaparser.Providers.*;
-import static com.github.javaparser.utils.Utils.assertNotNull;
+import static com.github.javaparser.utils.Utils.assertNotNull;import org.apache.log4j.Logger;
+
 
 /**
  * Parse Java source code and creates Abstract Syntax Trees.
@@ -54,6 +55,9 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * @see StaticJavaParser
  */
 public final class JavaParser {
+    protected static Logger LOG = Logger.getLogger(JavaParser.class.getName());
+    
+
     private final ParserConfiguration configuration;
 
     private GeneratedJavaParser astParser = null;
@@ -128,7 +132,7 @@ public final class JavaParser {
         } finally {
             try {
                 provider.close();
-            } catch (IOException e) {
+            } catch (@SuppressWarnings("squid:S1166") IOException e) {
                 // Since we're done parsing and have our result, we don't care about any errors.
             }
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
@@ -1,12 +1,16 @@
 package com.github.javaparser;
 
-import java.io.IOException;
+import java.io.IOException;import org.apache.log4j.Logger;
+
 
 /**
  * An implementation of interface CharStream, where the stream is assumed to
  * contain only ASCII characters (with java-like unicode escape processing).
  */
 class UnicodeEscapeProcessingProvider implements Provider {
+    protected static Logger LOG = Logger.getLogger(UnicodeEscapeProcessingProvider.class.getName());
+    
+
     private static int hexval(char c) throws java.io.IOException {
         switch (c) {
             case '0':
@@ -110,7 +114,7 @@ class UnicodeEscapeProcessingProvider implements Provider {
                 bufpos -= tokenBegin;
             }
         } catch (Exception t) {
-            throw new RuntimeException(t.getMessage());
+            throw new RuntimeException(t.getMessage(), t);
         }
 
         available = (bufsize += 2048);
@@ -263,7 +267,7 @@ class UnicodeEscapeProcessingProvider implements Provider {
                 column += 4;
             } catch (java.io.IOException e) {
                 throw new RuntimeException("Invalid escape character at line " + line +
-                        " column " + column + ".");
+                        " column " + column + ".", e);
             }
 
             if (backSlashCnt == 1)

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
@@ -27,7 +27,8 @@ import com.github.javaparser.utils.Utils;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.Arrays;
+import java.util.Arrays;import org.apache.log4j.Logger;
+
 
 /**
  * Properties considered by the AstObserver

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/CollectionStrategy.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/CollectionStrategy.java
@@ -9,13 +9,17 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Optional;
 
-import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parse;import org.apache.log4j.Logger;
+
 
 /**
  * A strategy for discovering the structure of a project.
  * Implementations could read a pom.xml, a Gradle build file, a makefile...
  */
 public interface CollectionStrategy {
+    protected static Logger LOG = Logger.getLogger(CollectionStrategy.class.getName());
+    
+
 
     ProjectRoot collect(Path path);
 
@@ -24,9 +28,9 @@ public interface CollectionStrategy {
             return parse(file.toFile()).getStorage()
                     .map(CompilationUnit.Storage::getSourceRoot);
         } catch (ParseProblemException e) {
-            Log.info("Problem parsing file %s", () -> file);
+            Log.info("Problem parsing file %s", () -> file, e);
         } catch (RuntimeException e) {
-            Log.info("Could not parse file %s", () -> file);
+            Log.info("Could not parse file %s", () -> file, e);
         }
         return Optional.empty();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Log.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Log.java
@@ -47,7 +47,7 @@ public class Log {
                 throwable.printStackTrace(pw);
                 trace(sw::toString);
             } catch (IOException e) {
-                throw new AssertionError("Error in logging library");
+                throw new AssertionError("Error in logging library", e);
             }
         }
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/ParserCollectionStrategy.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/ParserCollectionStrategy.java
@@ -6,7 +6,8 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import static java.nio.file.FileVisitResult.*;
+import static java.nio.file.FileVisitResult.*;import org.apache.log4j.Logger;
+
 
 /**
  * A brute force {@link CollectionStrategy} for discovering a project structure.
@@ -17,6 +18,9 @@ import static java.nio.file.FileVisitResult.*;
  * Note that any build artifacts will also be detected: jar files in target directories and so on.
  */
 public class ParserCollectionStrategy implements CollectionStrategy {
+    protected static Logger LOG = Logger.getLogger(ParserCollectionStrategy.class.getName());
+    
+
 
     private final ParserConfiguration parserConfiguration;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -27,7 +27,8 @@ import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.CodeGenerationUtils.*;
 import static com.github.javaparser.utils.Utils.assertNotNull;
-import static java.nio.file.FileVisitResult.*;
+import static java.nio.file.FileVisitResult.*;import org.apache.log4j.Logger;
+
 
 /**
  * A collection of Java source files located in one directory and its subdirectories on the file system. The root directory
@@ -40,6 +41,9 @@ import static java.nio.file.FileVisitResult.*;
  * </ul>
  */
 public class SourceRoot {
+    protected static Logger LOG = Logger.getLogger(SourceRoot.class.getName());
+    
+
     @FunctionalInterface
     public interface Callback {
         enum Result {


### PR DESCRIPTION
Fix sonar issues
squid : S1166 - Exception handlers should preserve the original exception
pmd : EmptyCatchBlock - Catch blocks should not be left empty
This fix was realized with our own product based on javaparser.

