### PR TITLE
Update Generics to make Type a NodeWithAnnotations

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/TypeNodeWithAnnotations
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/TypeNodeWithAnnotations
@@ -1,0 +1,27 @@
+package com.github.javaparser.ast.type;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import org.junit.jupiter.api.Test;
+
+import static com.github.javaparser.ast.NodeList.nodeList;
+import static com.github.javaparser.ast.type.PrimitiveType.Primitive.BOOLEAN;
+
+public class TypeNodeWithAnnotations {
+
+    @Test
+    public void testPrimitive(){
+        PrimitiveType pt = new PrimitiveType()
+            .setAnnotations(nodeList())
+            .setType(BOOLEAN);
+        System.out.println( pt );
+
+        PrimitiveType pt2 = new PrimitiveType(PrimitiveType.Primitive.BOOLEAN);
+        NodeList<AnnotationExpr> as = new NodeList<>();
+        //as.add(Ast.anno("@A"));
+        PrimitiveType anotherPrimitive = null;
+        anotherPrimitive = pt2.setAnnotations(as); //works, its a
+        Type t = pt2;
+        PrimitiveType pt3 = t.asPrimitiveType();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithAnnotations.java
@@ -37,12 +37,12 @@ import static com.github.javaparser.StaticJavaParser.parseName;
  * @author Federico Tomassetti
  * @since July 2014
  */
-public interface NodeWithAnnotations<N extends Node> {
+public interface NodeWithAnnotations<N extends Node & NodeWithAnnotations> {
     NodeList<AnnotationExpr> getAnnotations();
 
     N setAnnotations(NodeList<AnnotationExpr> annotations);
 
-    void tryAddImportToParentCompilationUnit(Class<?> clazz);
+    //void tryAddImportToParentCompilationUnit(Class<?> clazz);
 
     default AnnotationExpr getAnnotation(int i) {
         return getAnnotations().get(i);
@@ -95,7 +95,7 @@ public interface NodeWithAnnotations<N extends Node> {
      * @return this
      */
     default N addAnnotation(Class<? extends Annotation> clazz) {
-        tryAddImportToParentCompilationUnit(clazz);
+        ((Node)this).tryAddImportToParentCompilationUnit(clazz);
         return addAnnotation(clazz.getSimpleName());
     }
 
@@ -106,7 +106,7 @@ public interface NodeWithAnnotations<N extends Node> {
      * @return the {@link NormalAnnotationExpr} added
      */
     default NormalAnnotationExpr addAndGetAnnotation(Class<? extends Annotation> clazz) {
-        tryAddImportToParentCompilationUnit(clazz);
+        ((Node)this).tryAddImportToParentCompilationUnit(clazz);
         return addAndGetAnnotation(clazz.getSimpleName());
     }
 
@@ -131,7 +131,7 @@ public interface NodeWithAnnotations<N extends Node> {
      * @return this
      */
     default N addMarkerAnnotation(Class<? extends Annotation> clazz) {
-        tryAddImportToParentCompilationUnit(clazz);
+        ((Node)this).tryAddImportToParentCompilationUnit(clazz);
         return addMarkerAnnotation(clazz.getSimpleName());
     }
 
@@ -157,7 +157,7 @@ public interface NodeWithAnnotations<N extends Node> {
      * @return this
      */
     default N addSingleMemberAnnotation(Class<? extends Annotation> clazz, Expression expression) {
-        tryAddImportToParentCompilationUnit(clazz);
+        ((Node)this).tryAddImportToParentCompilationUnit(clazz);
         return addSingleMemberAnnotation(clazz.getSimpleName(), expression);
     }
 
@@ -181,7 +181,7 @@ public interface NodeWithAnnotations<N extends Node> {
      */
     default N addSingleMemberAnnotation(Class<? extends Annotation> clazz,
                                         String value) {
-        tryAddImportToParentCompilationUnit(clazz);
+        ((Node)this).tryAddImportToParentCompilationUnit(clazz);
         return addSingleMemberAnnotation(clazz.getSimpleName(), value);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -46,7 +46,7 @@ import com.github.javaparser.ast.Generated;
  * To indicate that a type is an array, it gets wrapped in an ArrayType for every array level it has.
  * So, int[][] becomes ArrayType(ArrayType(int)).
  */
-public class ArrayType extends ReferenceType implements NodeWithAnnotations<ArrayType> {
+public class ArrayType extends ReferenceType<ArrayType> {
 
     @Override
     public ResolvedArrayType resolve() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -55,7 +55,8 @@ import com.github.javaparser.ast.Generated;
  *
  * @author Julio Vilmar Gesser
  */
-public class ClassOrInterfaceType extends ReferenceType implements NodeWithSimpleName<ClassOrInterfaceType>, NodeWithAnnotations<ClassOrInterfaceType>, NodeWithTypeArguments<ClassOrInterfaceType> {
+public class ClassOrInterfaceType extends ReferenceType<ClassOrInterfaceType>
+        implements NodeWithSimpleName<ClassOrInterfaceType>, NodeWithTypeArguments<ClassOrInterfaceType> {
 
     @OptionalProperty
     private ClassOrInterfaceType scope;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -52,7 +52,7 @@ import com.github.javaparser.ast.Generated;
  *
  * @since 3.0.0
  */
-public class IntersectionType extends Type implements NodeWithAnnotations<IntersectionType> {
+public class IntersectionType extends Type<IntersectionType>{
 
     @NonEmptyProperty
     private NodeList<ReferenceType> elements;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -48,7 +48,7 @@ import com.github.javaparser.ast.Generated;
  *
  * @author Julio Vilmar Gesser
  */
-public class PrimitiveType extends Type implements NodeWithAnnotations<PrimitiveType> {
+public class PrimitiveType extends Type<PrimitiveType>{
 
     public static PrimitiveType booleanType() {
         return new PrimitiveType(Primitive.BOOLEAN);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ReferenceType.java
@@ -37,7 +37,7 @@ import java.util.Optional;
  *
  * @author Julio Vilmar Gesser
  */
-public abstract class ReferenceType extends Type {
+public abstract class ReferenceType<T extends ReferenceType> extends Type<T> {
 
     public ReferenceType() {
         this(null, new NodeList<>());

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
@@ -42,7 +43,8 @@ import java.util.Optional;
  *
  * @author Julio Vilmar Gesser
  */
-public abstract class Type extends Node implements Resolvable<ResolvedType> {
+public abstract class Type<T extends Type> extends Node
+        implements Resolvable<ResolvedType>, NodeWithAnnotations<T> {
 
     private NodeList<AnnotationExpr> annotations;
 
@@ -79,17 +81,17 @@ public abstract class Type extends Node implements Resolvable<ResolvedType> {
     }
 
     @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
-    public Type setAnnotations(final NodeList<AnnotationExpr> annotations) {
+    public T setAnnotations(final NodeList<AnnotationExpr> annotations) {
         assertNotNull(annotations);
         if (annotations == this.annotations) {
-            return (Type) this;
+            return (T) this;
         }
         notifyPropertyChange(ObservableProperty.ANNOTATIONS, this.annotations, annotations);
         if (this.annotations != null)
             this.annotations.setParentNode(null);
         this.annotations = annotations;
         setAsParentNodeOf(annotations);
-        return this;
+        return (T)this;
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
@@ -54,7 +54,7 @@ import com.github.javaparser.ast.Generated;
  * @author Julio Vilmar Gesser
  * @see com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters
  */
-public class TypeParameter extends ReferenceType implements NodeWithSimpleName<TypeParameter>, NodeWithAnnotations<TypeParameter> {
+public class TypeParameter extends ReferenceType<TypeParameter> implements NodeWithSimpleName<TypeParameter>  {
 
     private SimpleName name;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -57,7 +57,7 @@ import com.github.javaparser.ast.Generated;
  *
  * The types that make up the union type are its "elements"
  */
-public class UnionType extends Type implements NodeWithAnnotations<UnionType> {
+public class UnionType extends Type<UnionType> {
 
     @NonEmptyProperty
     private NodeList<ReferenceType> elements;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -45,7 +45,7 @@ import com.github.javaparser.ast.Generated;
  *
  * @author Didier Villevalois
  */
-public class UnknownType extends Type {
+public class UnknownType extends Type<UnknownType> {
 
     @AllFieldsConstructor
     public UnknownType() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VarType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VarType.java
@@ -43,7 +43,7 @@ import com.github.javaparser.ast.Generated;
  * <li><b>var</b> a = new ArrayList&lt;String>();</li>
  * </ol>
  */
-public class VarType extends Type {
+public class VarType extends Type<VarType> {
 
     @AllFieldsConstructor
     public VarType() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -43,7 +43,7 @@ import com.github.javaparser.ast.Generated;
  *
  * @author Julio Vilmar Gesser
  */
-public class VoidType extends Type implements NodeWithAnnotations<VoidType> {
+public class VoidType extends Type<VoidType> {
 
     @AllFieldsConstructor
     public VoidType() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -46,7 +46,7 @@ import java.util.function.Consumer;
  *
  * @author Julio Vilmar Gesser
  */
-public class WildcardType extends Type implements NodeWithAnnotations<WildcardType> {
+public class WildcardType extends Type<WildcardType> {
 
     @OptionalProperty
     private ReferenceType extendedType;


### PR DESCRIPTION
Made some changes to NodeWithAnnotations interface and the Type abstract class to implement NodeWithAnnotations directly, rather than having selective implementations (subclasses) to manually implement NodeWithAnnotations


