### PR TITLE
Use the encoding from the config in tryParse()

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -102,7 +102,7 @@ public class SourceRoot {
         final Path path = root.resolve(relativePath);
         Log.trace("Parsing %s", () -> path);
         final ParseResult<CompilationUnit> result = new JavaParser(configuration)
-                .parse(COMPILATION_UNIT, provider(path));
+                .parse(COMPILATION_UNIT, provider(path, configuration.getCharacterEncoding()));
         result.getResult().ifPresent(cu -> cu.setStorage(path, configuration.getCharacterEncoding()));
         cache.put(relativePath, result);
         return result;


### PR DESCRIPTION
I only changed the methods related to save() in my PR yesterday, but today i realised,
that the Parser should also use the configured encoding in the parse Method.
With this change, it is now possible to parse statements like 'int äöü = 0' and save them
with the same encoding used in the original file.
