### PR TITLE
Filter synthetic constructors

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
@@ -47,6 +47,7 @@ public class JavassistTypeDeclarationAdapter {
 
   public List<ResolvedConstructorDeclaration> getConstructors() {
     return Arrays.stream(ctClass.getConstructors())
+        .filter(m -> (m.getMethodInfo().getAccessFlags() & AccessFlag.SYNTHETIC) == 0)
         .map(m -> new JavassistConstructorDeclaration(m, typeSolver)).collect(Collectors.toList());
   }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
@@ -177,6 +177,7 @@ class ReflectionClassAdapter {
 
     public List<ResolvedConstructorDeclaration> getConstructors() {
         return Arrays.stream(clazz.getDeclaredConstructors())
+                .filter(m -> !m.isSynthetic())
                 .map(m -> new ReflectionConstructorDeclaration(m, typeSolver))
                 .collect(Collectors.toList());
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -201,6 +201,13 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
     }
 
     @Test
+    void testGetConstructors() {
+        TypeSolver typeResolver = new ReflectionTypeSolver();
+        ResolvedReferenceTypeDeclaration locale = new ReflectionClassDeclaration(ClassWithSyntheticConstructor.class, typeResolver);
+        assertEquals(1, locale.getConstructors().size());
+    }
+
+    @Test
     void testGetInterfaces() {
         TypeSolver typeResolver = new ReflectionTypeSolver();
         ResolvedClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
@@ -778,4 +785,20 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
 
         assertTrue(ancestors.isEmpty());
     }
+
+    public static class ClassWithSyntheticConstructor {
+
+        private ClassWithSyntheticConstructor() {}
+
+        public static ClassWithSyntheticConstructor newInstance() {
+            return ClassWithSyntheticConstructorHelper.create();
+        }
+
+        private static class ClassWithSyntheticConstructorHelper {
+            public static ClassWithSyntheticConstructor create() {
+                return new ClassWithSyntheticConstructor();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
The method ResolvedReferenceTypeDeclaration#getConstructors() shouldn't return synthetic constructors, just like the getDeclaredMethods() method already filters the synthetic methods.
