### PR TITLE
Return early when searching for a method without parameters

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -203,7 +203,13 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration implemen
             boolean isSynthetic = method.getMethodInfo().getAttribute(SyntheticAttribute.tag) != null;
             boolean isNotBridge = (method.getMethodInfo().getAccessFlags() & AccessFlag.BRIDGE) == 0;
             if (method.getName().equals(name) && !isSynthetic && isNotBridge && staticOnlyCheck.test(method)) {
-                candidates.add(new JavassistMethodDeclaration(method, typeSolver));
+                ResolvedMethodDeclaration candidate = new JavassistMethodDeclaration(method, typeSolver);
+                candidates.add(candidate);
+
+                // no need to search for overloaded/inherited methods if the method has no parameters
+                if (argumentsTypes.isEmpty() && candidate.getNumberOfParams() == 0) {
+                    return SymbolReference.solved(candidate);
+                }
             }
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistUtils.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistUtils.java
@@ -50,6 +50,11 @@ class JavassistUtils {
                     methodUsage = methodUsage.replaceTypeParameter(tpToReplace, newValue);
                 }
                 methods.add(methodUsage);
+
+                // no need to search for overloaded/inherited methods if the method has no parameters
+                if (argumentsTypes.isEmpty() && methodUsage.getNoParams() == 0) {
+                    return Optional.of(methodUsage);
+                }
             }
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -192,6 +192,11 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration impleme
                 methodUsage = methodUsage.replaceTypeParameter(tpToReplace, newValue);
             }
             methods.add(methodUsage);
+
+            // no need to search for overloaded/inherited methods if the method has no parameters
+            if (argumentsTypes.isEmpty() && methodUsage.getNoParams() == 0) {
+                return Optional.of(methodUsage);
+            }
         }
         if (getSuperClass() != null) {
             ResolvedClassDeclaration superClass = (ResolvedClassDeclaration) getSuperClass().getTypeDeclaration();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -144,6 +144,11 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration impleme
             if (method.isBridge() || method.isSynthetic()) continue;
             ResolvedMethodDeclaration methodDeclaration = new ReflectionMethodDeclaration(method, typeSolver);
             methods.add(methodDeclaration);
+
+            // no need to search for overloaded/inherited methods if the method has no parameters
+            if (argumentsTypes.isEmpty() && methodDeclaration.getNumberOfParams() == 0) {
+                return SymbolReference.solved(methodDeclaration);
+            }
         }
         if (getSuperClass() != null) {
             ResolvedClassDeclaration superClass = (ResolvedClassDeclaration) getSuperClass().getTypeDeclaration();


### PR DESCRIPTION
When searching for methods without parameters, you can stop searching when you find one in the given class. 

Although this PR shouldn't change the behaviour of the method, it fixes an issue I encounter when trying to resolve a method without having the full class hierarchy in my classpath. As an extra benefit, it should make method-resolution a little bit faster for methods without parameters :)