### PR TITLE
Issue2258: NullType must not fail matchTypeParameters

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -357,12 +357,13 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             }
             matchedTypeParameters.put(expectedType.asTypeParameter(), actualType);
         } else if (expectedType.isArray()) {
-            if (!actualType.isArray()) {
+        	// Issue 2258 : NullType must not fail this search
+            if (!(actualType.isArray() || actualType.isNull())) {
                 throw new UnsupportedOperationException(actualType.getClass().getCanonicalName());
             }
             matchTypeParameters(
                     expectedType.asArrayType().getComponentType(),
-                    actualType.asArrayType().getComponentType(),
+                    actualType.isNull() ? actualType : actualType.asArrayType().getComponentType(),
                     matchedTypeParameters);
         } else if (expectedType.isReferenceType()) {
             // avoid cases where the actual type has no type parameters but the expected one has. Such as: "classX extends classY<Integer>"

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
@@ -16,12 +16,17 @@
 
 package com.github.javaparser.symbolsolver.resolution.javaparser.contexts;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.core.resolution.Context;
 import com.github.javaparser.symbolsolver.javaparser.Navigator;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.MethodCallExprContext;
@@ -40,6 +45,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -123,4 +130,21 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
         assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
         assertEquals(Collections.singletonList("java.lang.String"), ref.get().typeParametersMap().getTypes().stream().map(ty -> ty.asReferenceType().describe()).collect(Collectors.toList()));
     }
+	
+	@Test
+	public void test() {
+		ParserConfiguration config = new ParserConfiguration()
+				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
+		JavaParser parser = new JavaParser(config);
+		StaticJavaParser.setConfiguration(config);
+		CompilationUnit cu = parseSample("Issue2258");
+		List<MethodCallExpr> expressions = cu.getChildNodesByType(MethodCallExpr.class);
+		assertTrue(expressions.size() == 2);
+		try {
+		ResolvedType r = expressions.get(1).calculateResolvedType();
+		assertNotNull(r);
+		} catch (Throwable t) {
+			fail();
+		}
+	}
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
@@ -46,8 +46,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -138,16 +136,11 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
 	public void test() {
 		ParserConfiguration config = new ParserConfiguration()
 				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
-		JavaParser parser = new JavaParser(config);
 		StaticJavaParser.setConfiguration(config);
 		CompilationUnit cu = parseSample("Issue2258");
 		List<MethodCallExpr> expressions = cu.getChildNodesByType(MethodCallExpr.class);
 		assertTrue(expressions.size() == 2);
-		try {
-			ResolvedType r = expressions.get(1).calculateResolvedType();
-			assertTrue(ResolvedVoidType.class.isAssignableFrom(r.getClass()));
-		} catch (Throwable t) {
-			fail();
-		}
+		ResolvedType r = expressions.get(1).calculateResolvedType();
+		assertTrue(ResolvedVoidType.class.isAssignableFrom(r.getClass()));
 	}
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/Issue2258.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Issue2258.java.txt
@@ -1,0 +1,11 @@
+
+public class Issue2258 {
+
+	public static void foo(Object[] nullable) {
+		System.out.println("Verify program execution."); // This line is not necessary.
+	}
+
+	public static void main(String[] args) {
+		Issue2258.foo(null);
+	}
+}


### PR DESCRIPTION
Fixes #2258. Accept NullType when trying to match type parameters on MethodCallExpr
