### PR TITLE
Correct positions with unicode escape processing

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
@@ -51,6 +51,7 @@ public class PositionMappingTest {
 		String outputText = process(provider);
 		assertEquals(inputText, outputText);
 		PositionMapping mapping = provider.getPositionMapping();
+		assertTrue(mapping.isEmpty());
 		assertEquals(4, provider.getInputCounter().getLine());
 		assertEquals(4, provider.getOutputCounter().getLine());
 		assertSame(PositionMapping.PositionUpdate.NONE, mapping.lookup(new Position(10000, 1)));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
@@ -1,5 +1,21 @@
 /*
- * Copyright (c) 2019 Business Operation Systems GmbH. All Rights Reserved.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  */
 package com.github.javaparser;
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.javaparser.UnicodeEscapeProcessingProvider.Pos;
 import com.github.javaparser.UnicodeEscapeProcessingProvider.PositionMapping;
 
 /**
@@ -54,7 +53,7 @@ public class PositionMappingTest {
 		PositionMapping mapping = provider.getPositionMapping();
 		assertEquals(4, provider.getInputCounter().getLine());
 		assertEquals(4, provider.getOutputCounter().getLine());
-		assertSame(PositionMapping.PositionUpdate.NONE, mapping.lookup(new Pos(10000, 1)));
+		assertSame(PositionMapping.PositionUpdate.NONE, mapping.lookup(new Position(10000, 1)));
 	}
 
 	@Test
@@ -111,9 +110,9 @@ public class PositionMappingTest {
 			for (String inPart : inLine) {
 				assertFalse(outFinished);
 				
-				Pos inPos = new Pos(inPosLine, inPosColumn);
-				Pos outPos = new Pos(outPosLine, outPosColumn);
-				Pos transfomedOutPos = mapping.transform(outPos);
+				Position inPos = new Position(inPosLine, inPosColumn);
+				Position outPos = new Position(outPosLine, outPosColumn);
+				Position transfomedOutPos = mapping.transform(outPos);
 
 				assertEquals(inPos, transfomedOutPos, 
 					"Position mismatch at '" + outPart + "' " + outPos + " -> '" + inPart + "' " + inPos + ".");

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 Business Operation Systems GmbH. All Rights Reserved.
+ */
+package com.github.javaparser;
+
+import static com.github.javaparser.UnicodeEscapeProcessingProviderTest.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.UnicodeEscapeProcessingProvider.Pos;
+import com.github.javaparser.UnicodeEscapeProcessingProvider.PositionMapping;
+
+/**
+ * Test case for {@link PositionMapping}.
+ *
+ * @author <a href="mailto:bhu@top-logic.com">Bernhard Haumacher</a>
+ */
+@SuppressWarnings("javadoc")
+public class PositionMappingTest {
+
+	@Test
+	public void testNoMapping() throws IOException {
+		List<List<String>> input = lines(
+			line("Hello World !\n"), 
+			line("Next Line\r"), 
+			line("Third Line\r\n"), 
+			line("Fourth Line."));
+		String inputText = text(input);
+		UnicodeEscapeProcessingProvider provider = provider(inputText);
+		String outputText = process(provider);
+		assertEquals(inputText, outputText);
+		PositionMapping mapping = provider.getPositionMapping();
+		assertEquals(4, provider.getInputCounter().getLine());
+		assertEquals(4, provider.getOutputCounter().getLine());
+		assertSame(PositionMapping.PositionUpdate.NONE, mapping.lookup(new Pos(10000, 1)));
+	}
+
+	@Test
+	public void testEncodedLineFeed() throws IOException {
+		List<List<String>> input = lines(
+			line("B", "\\u000A", "C"));
+		List<List<String>> output = lines(
+			line("B", "\n"), 
+			line("C"));
+		
+		checkConvert(input, output);
+	}
+	
+	@Test
+	public void testComplexMapping() throws IOException {
+		List<List<String>> input = lines(
+			// Character positions:
+			//                      111    1 11111    1222    2 2222     2
+			//    1    2 34567    89012    3 45678    9012    3 45678    9
+			line("H", "\\u00E4", "llo W", "\\u00F6", "rld!", "\\u000A", "123 N", "\\u00E4", "xt Line", "\\u000D", "Third Line", "\r\n"), 
+			line("Fo", "\\u00FC", "rth Line."));
+		List<List<String>> output = lines(
+			line("H", "ä", "llo W", "ö", "rld!", "\n"), 
+			line("123 N", "ä", "xt Line", "\r"), 
+			line("Third Line", "\r\n"), 
+			line("Fo", "ü", "rth Line."));
+
+		checkConvert(input, output);
+	}
+
+	private void checkConvert(List<List<String>> input,
+			List<List<String>> output) throws IOException {
+		UnicodeEscapeProcessingProvider provider = provider(text(input));
+		String decoded = process(provider);
+		assertEquals(text(output), decoded);
+		
+		PositionMapping mapping = provider.getPositionMapping();
+		
+		// Coarse grained test.
+		assertEquals(input.size(), provider.getInputCounter().getLine());
+		assertEquals(output.size(), provider.getOutputCounter().getLine());
+		
+		// Fine grained test.
+		int inPosLine = 1;
+		int inPosColumn = 1;
+		int outPosLine = 1;
+		int outPosColumn = 1;
+		Iterator<List<String>> outLineIt = output.iterator();
+		List<String> outLine = outLineIt.next();
+		Iterator<String> outPartIt = outLine.iterator();
+		String outPart = outPartIt.next();
+		boolean outFinished = false;
+		for (List<String> inLine : input) {
+			for (String inPart : inLine) {
+				assertFalse(outFinished);
+				
+				Pos inPos = new Pos(inPosLine, inPosColumn);
+				Pos outPos = new Pos(outPosLine, outPosColumn);
+				Pos transfomedOutPos = mapping.transform(outPos);
+
+				assertEquals(inPos, transfomedOutPos, 
+					"Position mismatch at '" + outPart + "' " + outPos + " -> '" + inPart + "' " + inPos + ".");
+
+				outPosColumn += outPart.length();
+				inPosColumn += inPart.length();
+				
+				if (!outPartIt.hasNext()) {
+					if (outLineIt.hasNext()) {
+						outPartIt = outLineIt.next().iterator();
+						outPosLine ++;
+						outPosColumn = 1;
+
+						outPart = outPartIt.next();
+					} else {
+						outFinished = true;
+					}
+				} else {
+					outPart = outPartIt.next();
+				}
+			}
+			
+			inPosColumn = 1;
+			inPosLine++;
+		}
+	}
+	
+	private static String text(List<List<String>> input) {
+		StringBuilder result = new StringBuilder();
+		for (List<String> line : input) {
+			for (String part : line) {
+				result.append(part);
+			}
+		}
+		return result.toString();
+	}
+
+	@SafeVarargs
+	private static List<String> line(String ...parts) {
+		return Arrays.asList(parts);
+	}
+
+	@SafeVarargs
+	private static List<List<String>> lines(List<String> ...lines) {
+		return Arrays.asList(lines);
+	}
+	
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/UnicodeEscapeProcessingProviderTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/UnicodeEscapeProcessingProviderTest.java
@@ -120,10 +120,18 @@ public class UnicodeEscapeProcessingProviderTest {
 		assertEquals("12345678\\uuxx", new String(read("12345678\\uuxx")));
 	}
 	
-	private String read(String source) throws IOException {
+	static String read(String source) throws IOException {
+		return process(provider(source));
+	}
+
+	static UnicodeEscapeProcessingProvider provider(String source) {
 		UnicodeEscapeProcessingProvider provider = new UnicodeEscapeProcessingProvider(10, 
 				new StringProvider(source));
-	
+		return provider;
+	}
+
+	static String process(UnicodeEscapeProcessingProvider provider)
+			throws IOException {
 		StringBuilder result = new StringBuilder();
 		char[] buffer = new char[10];
 		while (true) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -174,9 +174,11 @@ public class ParserConfiguration {
 					result.getResult().ifPresent(
 						root -> {
 							PositionMapping mapping = _unicodeDecoder.getPositionMapping();
-							root.walk(
-								node -> node.getRange().ifPresent(
-									range -> node.setRange(mapping.transform(range))));
+							if (!mapping.isEmpty()) {
+								root.walk(
+									node -> node.getRange().ifPresent(
+										range -> node.setRange(mapping.transform(range))));
+							}
 						}
 					);
 				}

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -170,24 +170,15 @@ public class ParserConfiguration {
 			@Override
 			public void process(ParseResult<? extends Node> result,
 					ParserConfiguration configuration) {
-				if (configuration.isPreprocessUnicodeEscapes()) {
-					Optional<? extends Node> nodeHandle = result.getResult();
-					if (nodeHandle.isPresent()) {
-						PositionMapping positionMapping = _unicodeDecoder.getPositionMapping();
-						adjustPositions(positionMapping, result.getResult().get());
-					}
-				}
-			}
-
-			private void adjustPositions(PositionMapping positionMapping, Node node) {
-				Optional<Range> rangeHandle = node.getRange();
-				if (rangeHandle.isPresent()) {
-					Range range = rangeHandle.get();
-					node.setRange(positionMapping.transform(range));
-				}
-				
-				for (Node child : node.getChildNodes()) {
-					adjustPositions(positionMapping, child);
+				if (isPreprocessUnicodeEscapes()) {
+					result.getResult().ifPresent(
+						root -> {
+							PositionMapping mapping = _unicodeDecoder.getPositionMapping();
+							root.walk(
+								node -> node.getRange().ifPresent(
+									range -> node.setRange(mapping.transform(range))));
+						}
+					);
 				}
 			}
     	}

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -21,22 +21,39 @@
 
 package com.github.javaparser;
 
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.validator.*;
-import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
-import com.github.javaparser.resolution.SymbolResolver;
-import com.github.javaparser.version.Java10PostProcessor;
-import com.github.javaparser.version.Java11PostProcessor;
-import com.github.javaparser.version.Java12PostProcessor;
+import static com.github.javaparser.ParserConfiguration.LanguageLevel.*;
+import static com.github.javaparser.utils.Utils.*;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.github.javaparser.ParserConfiguration.LanguageLevel.*;
-import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ParseResult.PostProcessor;
+import com.github.javaparser.Providers.PreProcessor;
+import com.github.javaparser.UnicodeEscapeProcessingProvider.PositionMapping;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.validator.Java10Validator;
+import com.github.javaparser.ast.validator.Java11Validator;
+import com.github.javaparser.ast.validator.Java12Validator;
+import com.github.javaparser.ast.validator.Java1_0Validator;
+import com.github.javaparser.ast.validator.Java1_1Validator;
+import com.github.javaparser.ast.validator.Java1_2Validator;
+import com.github.javaparser.ast.validator.Java1_3Validator;
+import com.github.javaparser.ast.validator.Java1_4Validator;
+import com.github.javaparser.ast.validator.Java5Validator;
+import com.github.javaparser.ast.validator.Java6Validator;
+import com.github.javaparser.ast.validator.Java7Validator;
+import com.github.javaparser.ast.validator.Java8Validator;
+import com.github.javaparser.ast.validator.Java9Validator;
+import com.github.javaparser.ast.validator.ProblemReporter;
+import com.github.javaparser.ast.validator.Validator;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import com.github.javaparser.resolution.SymbolResolver;
+import com.github.javaparser.version.Java10PostProcessor;
+import com.github.javaparser.version.Java11PostProcessor;
+import com.github.javaparser.version.Java12PostProcessor;
 
 /**
  * The configuration that is used by the parser.
@@ -138,12 +155,45 @@ public class ParserConfiguration {
     private final List<ParseResult.PostProcessor> postProcessors = new ArrayList<>();
 
     public ParserConfiguration() {
-        preProcessors.add(innerProvider -> {
-            if (preprocessUnicodeEscapes) {
-                return new UnicodeEscapeProcessingProvider(innerProvider);
-            }
-            return innerProvider;
-        });
+    	class UnicodeEscapeProcessor implements PreProcessor, PostProcessor {
+    		private UnicodeEscapeProcessingProvider _unicodeDecoder;
+
+			@Override
+    		public Provider process(Provider innerProvider) {
+	            if (isPreprocessUnicodeEscapes()) {
+	                _unicodeDecoder = new UnicodeEscapeProcessingProvider(innerProvider);
+					return _unicodeDecoder;
+	            }
+	            return innerProvider;
+    		}
+    		
+			@Override
+			public void process(ParseResult<? extends Node> result,
+					ParserConfiguration configuration) {
+				if (configuration.isPreprocessUnicodeEscapes()) {
+					Optional<? extends Node> nodeHandle = result.getResult();
+					if (nodeHandle.isPresent()) {
+						PositionMapping positionMapping = _unicodeDecoder.getPositionMapping();
+						adjustPositions(positionMapping, result.getResult().get());
+					}
+				}
+			}
+
+			private void adjustPositions(PositionMapping positionMapping, Node node) {
+				Optional<Range> rangeHandle = node.getRange();
+				if (rangeHandle.isPresent()) {
+					Range range = rangeHandle.get();
+					node.setRange(positionMapping.transform(range));
+				}
+				
+				for (Node child : node.getChildNodes()) {
+					adjustPositions(positionMapping, child);
+				}
+			}
+    	}
+    	UnicodeEscapeProcessor unicodeProcessor = new UnicodeEscapeProcessor();
+    	preProcessors.add(unicodeProcessor);
+		postProcessors.add(unicodeProcessor);
         postProcessors.add((result, configuration) -> {
             if (configuration.isLexicalPreservationEnabled()) {
                 result.ifSuccessful(LexicalPreservingPrinter::setup);

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -329,14 +329,9 @@ public class ParserConfiguration {
     /**
      * When set to true, unicode escape handling is done by preprocessing the whole input,
      * meaning that all unicode escapes are turned into unicode characters before parsing.
-     * That means the AST will never contain literal unicode escapes,
-     * and that positions will point to where a token was found in the *processed input*, not in the original input,
-     * which is mostly not what you want.
-     * That's why the default is false, which is not the correct way to parse a Java file according to the Java Language Specification,
-     * but it works for almost any input, since unicode escapes are mostly used in comments, strings and characters,
-     * and the parser will understand them in those locations.
-     * The unicode escapes will not be processed and are transfered intact to the AST,
-     * and the locations will point to the original stream.
+     * That means the AST will never contain literal unicode escapes. However,
+     * positions in the AST will point to the original input, which is exactly the same as without this option.
+     * Without this option enabled, the unicode escapes will not be processed and are transfered intact to the AST.
      */
     public ParserConfiguration setPreprocessUnicodeEscapes(boolean preprocessUnicodeEscapes) {
         this.preprocessUnicodeEscapes = preprocessUnicodeEscapes;

--- a/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
@@ -327,6 +327,13 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 		public PositionMapping() {
 			super();
 		}
+		
+		/**
+		 * Whether this is the identity transformation.
+		 */
+		public boolean isEmpty() {
+			return _deltas.isEmpty();
+		}
 
 		void add(int line, int column, int lineDelta, int columnDelta) {
 			_deltas.add(new DeltaInfo(line, column, lineDelta, columnDelta));

--- a/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
@@ -20,12 +20,19 @@
 package com.github.javaparser;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * {@link Provider} un-escaping unicode escape sequences in the input sequence.
  */
 public class UnicodeEscapeProcessingProvider implements Provider {
 	
+	private static final char LF = '\n';
+
+	private static final char CR = '\r';
+
 	private static final char BACKSLASH = '\\';
 
 	private static final int EOF = -1;
@@ -43,7 +50,13 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 	private int _pos = 0;
 
 	private boolean _backslashSeen;
+	
+	private final LineCounter _inputLine = new LineCounter();
 
+	private final LineCounter _outputLine = new LineCounter();
+	
+	private final PositionMappingBuilder _mappingBuilder = new PositionMappingBuilder(_outputLine, _inputLine);
+	
 	private Provider _input;
 
 	/** 
@@ -60,13 +73,27 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 		_input = input;
 		_data = new char[bufferSize];
 	}
+	
+	/**
+	 * The {@link LineCounter} of the input file.
+	 */
+	public LineCounter getInputCounter() {
+		return _inputLine;
+	}
+	
+	/**
+	 * The {@link LineCounter} of the output file.
+	 */
+	public LineCounter getOutputCounter() {
+		return _outputLine;
+	}
 
 	@Override
 	public int read(char[] buffer, final int offset, int len) throws IOException {
 		int pos = offset;
 		int stop = offset + len;
 		while (pos < stop) {
-			int ch = nextOutputChar();
+			int ch = _outputLine.process(nextOutputChar());
 			if (ch < 0) {
 				if (pos == offset) {
 					// Nothing read yet, this is the end of the stream.
@@ -75,6 +102,7 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 					break;
 				}
 			} else {
+				_mappingBuilder.update();
 				buffer[pos++] = (char) ch;
 			}
 		}
@@ -98,19 +126,21 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 				return EOF;
 			case BACKSLASH: {
 				if (_backslashSeen) {
-					// This is a backslash in an odd position. It is not eligible to form an unicode escape sequence.
-					_backslashSeen = false;
-					return next;
+					return clearBackSlashSeen(next);
 				} else {
 					return backSlashSeen();
 				}
 			}
 			default: {
 				// An arbitrary character.
-				_backslashSeen = false;
-				return next;
+				return clearBackSlashSeen(next);
 			}
 		}
+	}
+
+	private int clearBackSlashSeen(int next) {
+		_backslashSeen = false;
+		return next;
 	}
 
 	private int backSlashSeen() throws IOException {
@@ -190,8 +220,7 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 		}
 
 		int ch = digit3 << 12 | digit2 << 8 | digit1 << 4 | digit0;
-		_backslashSeen = false;
-		return ch;
+		return clearBackSlashSeen(ch);
 	}
 
 	private void pushBackUs(int cnt) {
@@ -214,11 +243,21 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 	}
 
 	/** 
-	 * Retrieves the next un-escaped character from the buffered {@link #_input}.
+	 * Processes column/line information from the input file.
 	 * 
-	 * @return The next character to output or <code>-1</code> if no more input is available.
+	 * @return The next character or <code>-1</code> if no more input is available.
 	 */
 	private int nextInputChar() throws IOException {
+		int result = nextBufferedChar();
+		return _inputLine.process(result);
+	}
+
+	/** 
+	 * Retrieves the next un-escaped character from the buffered {@link #_input}.
+	 * 
+	 * @return The next character or <code>-1</code> if no more input is available.
+	 */
+	private int nextBufferedChar() throws IOException {
 		while (isBufferEmpty()) {
 			int direct = fillBuffer();
 			if (direct < 0) {
@@ -266,6 +305,340 @@ public class UnicodeEscapeProcessingProvider implements Provider {
 			}
 		}
 		_data[--_pos] = (char) ch;
+	}
+	
+	/**
+	 * The {@link PositionMapping} being built during processing the file.
+	 */
+	public PositionMapping getPositionMapping() {
+		return _mappingBuilder.getMapping();
+	}
+	
+	/**
+	 * An algorithm mapping {@link Position} form two corresponding files.
+	 */
+	public static final class PositionMapping {
+		
+		private final List<DeltaInfo> _deltas = new ArrayList<>();
+		
+		/** 
+		 * Creates a {@link UnicodeEscapeProcessingProvider.PositionMapping}.
+		 */
+		public PositionMapping() {
+			super();
+		}
+
+		void add(int line, int column, int lineDelta, int columnDelta) {
+			_deltas.add(new DeltaInfo(line, column, lineDelta, columnDelta));
+		}
+		
+		/**
+		 * Looks up the {@link PositionUpdate} for the given Position.
+		 */
+		public PositionUpdate lookup(Pos position) {
+			int result = Collections.binarySearch(_deltas, position);
+			if (result >= 0) {
+				return _deltas.get(result);
+			} else {
+				int insertIndex = -result - 1;
+				if (insertIndex == 0) {
+					// Before the first delta info, identity mapping.
+					return PositionUpdate.NONE;
+				} else {
+					// The relevant update is the one with the position smaller
+					// than the requested position.
+					return _deltas.get(insertIndex - 1);
+				}
+			}
+		}
+		
+		/**
+		 * Algorithm updating a {@link Position} from one file to a
+		 * {@link Position} in a corresponding file.
+		 */
+		public static interface PositionUpdate {
+			
+			/**
+			 * The identity position mapping.
+			 */
+			PositionUpdate NONE = new PositionUpdate() {
+				@Override
+				public int transformLine(int line) {
+					return line;
+				}
+				
+				@Override
+				public int transformColumn(int column) {
+					return column;
+				}
+			};
+
+			/** 
+			 * Maps the given line to an original line.
+			 */
+			int transformLine(int line);
+
+			/** 
+			 * Maps the given column to an original column.
+			 */
+			int transformColumn(int column);
+
+			/**
+			 * The transformed position.
+			 */
+			default Pos transform(Pos pos) {
+				return new Pos(transformLine(pos.getLine()), transformColumn(pos.getColumn()));
+			}
+			
+		}
+		
+		private static final class DeltaInfo extends Pos implements PositionUpdate {
+
+			/**
+			 * The offset to add to the {@link #getLine()} and all following source
+			 * positions up to the next {@link PositionUpdate}.
+			 */
+			private final int _lineDelta;
+			
+			/**
+			 * The offset to add to the {@link #getColumn()} and all following
+			 * source positions up to the next {@link PositionUpdate}.
+			 */
+			private final int _columnDelta;
+
+			/** 
+			 * Creates a {@link PositionUpdate}.
+			 */
+			public DeltaInfo(int line, int column, int lineDelta,
+					int columnDelta) {
+				super(line, column);
+				_lineDelta = lineDelta;
+				_columnDelta = columnDelta;
+			}
+			
+			@Override
+			public int transformLine(int line) {
+				return line + _lineDelta;
+			}
+			
+			@Override
+			public int transformColumn(int column) {
+				return column + _columnDelta;
+			}
+			
+			@Override
+			public String toString() {
+				return "(" + getLine() + ", " + getColumn() + ": " + _lineDelta + ", " + _columnDelta + ")";
+			}
+
+		}
+
+		/** 
+		 * The transformed position.
+		 */
+		public Pos transform(Pos pos) {
+			return lookup(pos).transform(pos);
+		}
+	}
+	
+	private static final class PositionMappingBuilder {
+		
+		private LineCounter _left;
+		
+		private LineCounter _right;
+		
+		private final PositionMapping _mapping = new PositionMapping();
+		
+		private int _lineDelta = 0;
+		private int _columnDelta = 0;
+		
+		/** 
+		 * Creates a {@link PositionMappingBuilder}.
+		 *
+		 * @param left The source {@link LineCounter}.
+		 * @param right The target {@link LineCounter}.
+		 */
+		public PositionMappingBuilder(LineCounter left, LineCounter right) {
+			_left = left;
+			_right = right;
+			update();
+		}
+		
+		/**
+		 * The built {@link PositionMapping}.
+		 */
+		public PositionMapping getMapping() {
+			return _mapping;
+		}
+		
+		public void update() {
+			int lineDelta = _right.getLine() - _left.getLine();
+			int columnDelta = _right.getColumn() - _left.getColumn();
+			
+			if (lineDelta != _lineDelta || columnDelta != _columnDelta) {
+				_mapping.add(_left.getLine(), _left.getColumn(), lineDelta, columnDelta);
+				
+				_lineDelta = lineDelta;
+				_columnDelta = columnDelta;
+			}
+		}
+		
+	}
+	
+	/**
+	 * A position in a file (consisting of line and column).
+	 */
+	public static class Pos implements Comparable<Pos> {
+		
+		private final int _line;
+		private final int _column;
+		
+		/** 
+		 * Creates a {@link Position}.
+		 *
+		 * @param line See {@link #getLine()}.
+		 * @param column See {@link #getColumn()}.
+		 */
+		public Pos(int line, int column) {
+			_line = line;
+			_column = column;
+		}
+		
+		/**
+		 * Line in a file.
+		 */
+		public int getLine() {
+			return _line;
+		}
+
+		/**
+		 * Column in a file.
+		 */
+		public int getColumn() {
+			return _column;
+		}
+
+		@Override
+		public int compareTo(Pos other) {
+			int lineCompare = Integer.compare(getLine(), other.getLine());
+			if (lineCompare != 0) {
+				return lineCompare;
+			}
+			return Integer.compare(getColumn(), other.getColumn());
+		}
+		
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + _column;
+			result = prime * result + _line;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Pos other = (Pos) obj;
+			if (_column != other._column)
+				return false;
+			if (_line != other._line)
+				return false;
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return "(" + getLine() + ", " + getColumn() + ")";
+		}
+	
+	}
+	
+	/**
+	 * Processor keeping track of the current line and column in a stream of
+	 * incoming characters.
+	 * 
+	 * @see #process(int)
+	 */
+	public static final class LineCounter {
+		
+		/**
+		 * Whether {@link #CR} has been seen on the input as last character.
+		 */
+		private boolean _crSeen;
+
+		private int _line = 1;
+
+		private int _column = 1;
+
+		/** 
+		 * Creates a {@link UnicodeEscapeProcessingProvider.LineCounter}.
+		 */
+		public LineCounter() {
+			super();
+		}
+		
+		/**
+		 * The line of the currently processed input character.
+		 */
+		public int getLine() {
+			return _line;
+		}
+		
+		/**
+		 * The column of the currently processed input character.
+		 */
+		public int getColumn() {
+			return _column;
+		}
+		
+		/** 
+		 * The current position.
+		 */
+		public Pos getPosition() {
+			return new Pos(getLine(), getColumn());
+		}
+
+		/** 
+		 * Analyzes the given character for line feed.
+		 */
+		public int process(int ch) {
+			switch (ch) {
+				case EOF: {
+					break;
+				}
+				case CR: {
+					incLine();
+					_crSeen = true;
+					break;
+				}
+				case LF: {
+					// CR LF does only count as a single line terminator.
+					if (_crSeen) {
+						_crSeen = false;
+					} else {
+						incLine();
+					}
+					break;
+				}
+				default: {
+					_crSeen = false;
+					_column++;
+				}
+			}
+			return ch;
+		}
+
+		private void incLine() {
+			_line++;
+			_column = 1;
+		}
+
 	}
 	
 }


### PR DESCRIPTION
Fixes #2270.

A known problem in the position mapping so far is that when the unicode decoder encounters a broken unicode escape sequence it does not adjust the internal position after pushing back the already read chars. This would result in incorrect positions if the parse operation continues after the broken unicode escape. Currently, the scanner immediately aborts after seeing a broken unicode escape, therefore, the problem cannot be observed in a complete parse test.