### PR TITLE
Copy orphan comments.

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
@@ -54,6 +54,7 @@ public class CloneVisitorGenerator extends VisitorGenerator {
 
         body.addStatement(builder.toString());
         body.addStatement("r.setComment(comment);");
+        body.addStatement("n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);");
         body.addStatement("copyData(n, r);");
         body.addStatement("return r;");
     }


### PR DESCRIPTION
Copy all orphan comments on cloning a node.

Fixes #2277.
