### PR TITLE
[DRAFT] Initial changes made to get (most) of the package rename working 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+Version 3.14.4
+------------------
+[issues resolved](https://github.com/javaparser/javaparser/milestone/140?closed=1)
+
 Version 3.14.3
 ------------------
 [issues resolved](https://github.com/javaparser/javaparser/milestone/139?closed=1)

--- a/javaparser-core-generators/pom.xml
+++ b/javaparser-core-generators/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-generators/pom.xml
+++ b/javaparser-core-generators/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-generators/pom.xml
+++ b/javaparser-core-generators/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-metamodel-generator/pom.xml
+++ b/javaparser-core-metamodel-generator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-metamodel-generator/pom.xml
+++ b/javaparser-core-metamodel-generator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-metamodel-generator/pom.xml
+++ b/javaparser-core-metamodel-generator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>javaparser-parent</artifactId>
 		<groupId>com.github.javaparser</groupId>
-		<version>3.14.4</version>
+		<version>3.14.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>javaparser-parent</artifactId>
 		<groupId>com.github.javaparser</groupId>
-		<version>3.14.4-SNAPSHOT</version>
+		<version>3.14.4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>javaparser-parent</artifactId>
 		<groupId>com.github.javaparser</groupId>
-		<version>3.14.4</version>
+		<version>3.14.5-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.ast;
 
+import com.github.javaparser.HasParentNode;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -42,10 +43,15 @@ class CompilationUnitTest {
         assertEquals(1, compilationUnit.getAllContainedComments().size());
     }
 
+    /** MED added ...AFTER we move from com.github.javaparser the class location will change, and
+     * the path will change, and this should point to the right place */
+    Path JAVAPARSER_PATH = Paths.get(HasParentNode.class.getPackage().getName().replace(".", "\\"));
+
     @Test
     void testGetSourceRoot() throws IOException {
         Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(Paths.get("src", "test", "resources")).normalize();
-        Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "Z.java"));
+        Path testFile = sourceRoot.resolve(Paths.get(JAVAPARSER_PATH.toString(), "storage", "Z.java"));
+        /** MED Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "Z.java")); */
 
         CompilationUnit cu = parse(testFile);
         Path sourceRoot1 = cu.getStorage().get().getSourceRoot();
@@ -56,7 +62,9 @@ class CompilationUnitTest {
     void testGetSourceRootWithBadPackageDeclaration() {
         assertThrows(RuntimeException.class, () -> {
             Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(Paths.get("src", "test", "resources")).normalize();
-        Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "A.java"));
+
+        /** MED Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "A.java"); */
+        Path testFile = sourceRoot.resolve(Paths.get(JAVAPARSER_PATH.toString(), "storage", "A.java"));
         CompilationUnit cu = parse(testFile);
         cu.getStorage().get().getSourceRoot();
     });
@@ -65,7 +73,11 @@ class CompilationUnitTest {
 
     @Test
     void testGetSourceRootInDefaultPackage() throws IOException {
-        Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(Paths.get("src", "test", "resources", "com", "github", "javaparser", "storage")).normalize();
+        /** MED Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(
+                Paths.get("src", "test", "resources", "com", "github", "javaparser", "storage")).normalize(); */
+        Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(
+                Paths.get("src", "test", "resources", JAVAPARSER_PATH.toString(), "storage")).normalize();
+
         Path testFile = sourceRoot.resolve(Paths.get("B.java"));
 
         CompilationUnit cu = parse(testFile);
@@ -76,7 +88,8 @@ class CompilationUnitTest {
     @Test
     void testGetPrimaryTypeName() throws IOException {
         Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(Paths.get("src", "test", "resources")).normalize();
-        Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType.java"));
+        /** MED Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType.java")); */
+        Path testFile = sourceRoot.resolve(Paths.get(JAVAPARSER_PATH.toString(), "storage", "PrimaryType.java"));
         CompilationUnit cu = parse(testFile);
         
         assertEquals("PrimaryType", cu.getPrimaryTypeName().get());
@@ -91,7 +104,8 @@ class CompilationUnitTest {
     @Test
     void testGetPrimaryType() throws IOException {
         Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(Paths.get("src", "test", "resources")).normalize();
-        Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType.java"));
+        /** MED Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType.java")); */
+        Path testFile = sourceRoot.resolve(Paths.get(JAVAPARSER_PATH.toString(), "storage", "PrimaryType.java"));
         CompilationUnit cu = parse(testFile);
 
         assertEquals("PrimaryType",     cu.getPrimaryType().get().getNameAsString());
@@ -100,7 +114,8 @@ class CompilationUnitTest {
     @Test
     void testNoPrimaryType() throws IOException {
         Path sourceRoot = mavenModuleRoot(CompilationUnitTest.class).resolve(Paths.get("src", "test", "resources")).normalize();
-        Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType2.java"));
+        /** MED Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType2.java")); */
+        Path testFile = sourceRoot.resolve(Paths.get(JAVAPARSER_PATH.toString(), "storage", "PrimaryType2.java"));
         CompilationUnit cu = parse(testFile);
 
         assertFalse(cu.getPrimaryType().isPresent());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
@@ -45,7 +45,7 @@ class CompilationUnitTest {
 
     /** MED added ...AFTER we move from com.github.javaparser the class location will change, and
      * the path will change, and this should point to the right place */
-    Path JAVAPARSER_PATH = Paths.get(HasParentNode.class.getPackage().getName().replace(".", "\\"));
+    Path JAVAPARSER_PATH = Paths.get(HasParentNode.class.getPackage().getName().replace(".", "/"));
 
     @Test
     void testGetSourceRoot() throws IOException {

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <artifactId>javaparser-parent</artifactId>
       <groupId>com.github.javaparser</groupId>
-      <version>3.14.4</version>
+      <version>3.14.4-SNAPSHOT</version>
   </parent>    
   <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <artifactId>javaparser-parent</artifactId>
       <groupId>com.github.javaparser</groupId>
-      <version>3.14.4</version>
+      <version>3.14.5-SNAPSHOT</version>
   </parent>    
   <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <artifactId>javaparser-parent</artifactId>
       <groupId>com.github.javaparser</groupId>
-      <version>3.14.4-SNAPSHOT</version>
+      <version>3.14.4</version>
   </parent>    
   <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-logic/pom.xml
+++ b/javaparser-symbol-solver-logic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-logic/pom.xml
+++ b/javaparser-symbol-solver-logic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-logic/pom.xml
+++ b/javaparser-symbol-solver-logic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-model/pom.xml
+++ b/javaparser-symbol-solver-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-model/pom.xml
+++ b/javaparser-symbol-solver-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-model/pom.xml
+++ b/javaparser-symbol-solver-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4-SNAPSHOT</version>
+        <version>3.14.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.14.4</version>
+        <version>3.14.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -655,9 +655,10 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
                 .sorted(Comparator.comparing(MethodUsage::getQualifiedSignature))
                 .collect(Collectors.toList());
 
-        List<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toList());
+        /*MED changed*/
+        Set<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toSet());
 
-        assertEquals(ImmutableList.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
+        assertEquals(ImmutableSet.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
                 "com.github.javaparser.ast.Node.clone()",
                 "com.github.javaparser.ast.Node.contains(com.github.javaparser.ast.Node)",
                 "com.github.javaparser.ast.Node.equals(java.lang.Object)",
@@ -758,6 +759,7 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
                 "java.lang.Object.wait()",
                 "java.lang.Object.wait(long)",
                 "java.lang.Object.wait(long, int)"), signatures);
+        /*MED changed*/
     }
 
     ///

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -628,9 +628,13 @@ class JavaParserEnumDeclarationTest extends AbstractSymbolResolutionTest {
                 .sorted(Comparator.comparing(MethodUsage::getQualifiedSignature))
                 .collect(Collectors.toList());
 
-        List<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toList());
+        /** MED CHANGED */
+        //List<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toList());
+        Set<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toSet());
 
-        assertEquals(ImmutableList.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
+        /** MED CHANGED */
+        //assertEquals(ImmutableList.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
+        assertEquals(ImmutableSet.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
                 "com.github.javaparser.ast.Node.clone()",
                 "com.github.javaparser.ast.Node.contains(com.github.javaparser.ast.Node)",
                 "com.github.javaparser.ast.Node.equals(java.lang.Object)",

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -630,9 +630,13 @@ class JavaParserInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
                 .sorted(Comparator.comparing(MethodUsage::getQualifiedSignature))
                 .collect(Collectors.toList());
 
-        List<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toList());
+        /** MED changed */
+        //List<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toList());
+        Set<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toSet());
 
-        assertEquals(ImmutableList.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
+        /** MED changed */
+//        assertEquals(ImmutableList.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
+        assertEquals(ImmutableSet.of("com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
                 "com.github.javaparser.ast.Node.clone()",
                 "com.github.javaparser.ast.Node.contains(com.github.javaparser.ast.Node)",
                 "com.github.javaparser.ast.Node.equals(java.lang.Object)",

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
@@ -249,26 +249,38 @@ class JavassistClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.Node", "java.lang.Object"), cu.getAllAncestors().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
     }
 
-    //@Test
-    @Disabled
+    @Test
+    //@Disabled
     void testGetInterfaces() {
         /** MED CHANGED */
-        //JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
-        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType(CompilationUnit.class.getCanonicalName());
+        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        //JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType(CompilationUnit.class.getCanonicalName());
         assertEquals(ImmutableSet.of(), compilationUnit.getInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
-
+        /**
+         * org.javaparser.resolution.UnsolvedSymbolException: Unsolved symbol : org.javaparser.ast.CompilationUnit
+         *         at org.javaparser.symbolsolver.javassistmodel.JavassistClassDeclarationTest.testGetInterfaces(JavassistClassDeclarationTest.java:257)
+         */
         JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.DocumentableNode"), coid.getInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
     }
 
-    //@Test
-    @Disabled
+    @Test
+    //@Disabled
     void testGetAllInterfaces() {
+        /** MED changed */
         JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        //JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType(CompilationUnit.class.getCanonicalName());
+
         assertEquals(ImmutableSet.of(), compilationUnit.getAllInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
-        /* MED CHANGED */
-        //JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
-        JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType(ClassOrInterfaceDeclaration.class.getCanonicalName());
+        /** MED CHANGED */
+        JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
+        //JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType(ClassOrInterfaceDeclaration.class.getCanonicalName());
+
+        /** MED
+         *
+         * org.javaparser.resolution.UnsolvedSymbolException: Unsolved symbol : org.javaparser.ast.body.ClassOrInterfaceDeclaration
+         *         at org.javaparser.symbolsolver.javassistmodel.JavassistClassDeclarationTest.testGetAllInterfaces(JavassistClassDeclarationTest.java:271)
+         */
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.NamedNode", "com.github.javaparser.ast.body.AnnotableNode", "com.github.javaparser.ast.DocumentableNode"), coid.getAllInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
     }
 
@@ -299,13 +311,17 @@ class JavassistClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals("java.lang.Object", ancestor.getQualifiedName());
     }
 
-    //@Test
-    @Disabled
+    @Test
+    //@Disabled
     void testGetInterfacesWithoutParameters() {
         /** MED CHANGED */
         JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
         assertEquals(ImmutableSet.of(), compilationUnit.getInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
 
+        /**
+         * org.javaparser.resolution.UnsolvedSymbolException: Unsolved symbol : org.javaparser.ast.body.ClassOrInterfaceDeclaration
+         *         at org.javaparser.symbolsolver.javassistmodel.JavassistClassDeclarationTest.testGetInterfacesWithoutParameters(JavassistClassDeclarationTest.java:309)
+         */
         JavassistClassDeclaration coid = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.nodeTypes.NodeWithExtends", "com.github.javaparser.ast.nodeTypes.NodeWithImplements"), coid.getInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
     }
@@ -345,14 +361,18 @@ class JavassistClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.T").get().asReferenceType().getQualifiedName());
     }
 
-    //@Test
-    @Disabled
+    @Test
+    //@Disabled
     void testGetAllInterfacesWithoutParameters() {
         /** MED CHANGED */
         //JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
         JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) newTypeSolver.solveType(CompilationUnit.class.getCanonicalName());
         assertEquals(ImmutableSet.of("java.lang.Cloneable"), compilationUnit.getAllInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
 
+        /**
+         * org.javaparser.resolution.UnsolvedSymbolException: Unsolved symbol : org.javaparser.ast.CompilationUnit
+         *         at org.javaparser.symbolsolver.javassistmodel.JavassistClassDeclarationTest.testGetAllInterfacesWithoutParameters(JavassistClassDeclarationTest.java:353)
+         */
         JavassistClassDeclaration coid = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.nodeTypes.NodeWithExtends",
                 "com.github.javaparser.ast.nodeTypes.NodeWithAnnotations",

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
@@ -16,6 +16,8 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
@@ -28,6 +30,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -40,7 +43,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
+/** MED deal with pulling in javaparser-core-2.1.0.jar, javaparser-core-3.0.0-alpha.2.jar*/
 class JavassistClassDeclarationTest extends AbstractSymbolResolutionTest {
 
     private TypeSolver typeSolver;
@@ -246,21 +249,26 @@ class JavassistClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.Node", "java.lang.Object"), cu.getAllAncestors().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
     }
 
-    @Test
+    //@Test
+    @Disabled
     void testGetInterfaces() {
-        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        /** MED CHANGED */
+        //JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType(CompilationUnit.class.getCanonicalName());
         assertEquals(ImmutableSet.of(), compilationUnit.getInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
 
         JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.DocumentableNode"), coid.getInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
     }
 
-    @Test
+    //@Test
+    @Disabled
     void testGetAllInterfaces() {
         JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
         assertEquals(ImmutableSet.of(), compilationUnit.getAllInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
-
-        JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
+        /* MED CHANGED */
+        //JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
+        JavassistClassDeclaration coid = (JavassistClassDeclaration) typeSolver.solveType(ClassOrInterfaceDeclaration.class.getCanonicalName());
         assertEquals(ImmutableSet.of("com.github.javaparser.ast.NamedNode", "com.github.javaparser.ast.body.AnnotableNode", "com.github.javaparser.ast.DocumentableNode"), coid.getAllInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
     }
 
@@ -291,8 +299,10 @@ class JavassistClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals("java.lang.Object", ancestor.getQualifiedName());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void testGetInterfacesWithoutParameters() {
+        /** MED CHANGED */
         JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
         assertEquals(ImmutableSet.of(), compilationUnit.getInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
 
@@ -335,9 +345,12 @@ class JavassistClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.T").get().asReferenceType().getQualifiedName());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void testGetAllInterfacesWithoutParameters() {
-        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        /** MED CHANGED */
+        //JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+        JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) newTypeSolver.solveType(CompilationUnit.class.getCanonicalName());
         assertEquals(ImmutableSet.of("java.lang.Cloneable"), compilationUnit.getAllInterfaces().stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toSet()));
 
         JavassistClassDeclaration coid = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -652,7 +652,20 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
 
         ResolvedReferenceType ancestor;
         List<ResolvedReferenceType> ancestors = constructorDeclaration.getAllAncestors();
+        /** MED when we change the name from com.github to org.javaparser, these will be
+         * the first methods found, so lets just remove them now and verify they existed
+         * so (when the name change occurs) itll work both ways */
+        int sizeBefore = ancestors.size();
+        boolean removed = ancestors.removeIf( r-> r.getQualifiedName().equals("java.lang.Cloneable") ||
+                r.getQualifiedName().equals("java.lang.Object"));
+        int sizeAfter = ancestors.size();
+        assertTrue( removed );
+        assertTrue( sizeBefore - sizeAfter == 2);
+        /** MED look below for removals */
+
         ancestors.sort(comparing(ResolvedReferenceType::getQualifiedName));
+
+
 
         ancestor = ancestors.remove(0);
         assertEquals("com.github.javaparser.HasParentNode", ancestor.getQualifiedName());
@@ -777,11 +790,22 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         ancestor = ancestors.remove(0);
         assertEquals("com.github.javaparser.resolution.Resolvable", ancestor.getQualifiedName());
 
-        ancestor = ancestors.remove(0);
-        assertEquals("java.lang.Cloneable", ancestor.getQualifiedName());
+        /**
+         * MED I removed these because of name change
+         * i.e. BEFORE name change they are LAST:
+         *
+         * com.github.javaparser.*
+         * java.lang.*
+         *
+         * i.e. AFTER name change they are LAST
+         * java.lang.*
+         * org.javaparser.*
+         */
+        //ancestor = ancestors.remove(0);
+        //assertEquals("java.lang.Cloneable", ancestor.getQualifiedName());
 
-        ancestor = ancestors.remove(0);
-        assertEquals("java.lang.Object", ancestor.getQualifiedName());
+        //ancestor = ancestors.remove(0);
+        //assertEquals("java.lang.Object", ancestor.getQualifiedName());
 
         assertTrue(ancestors.isEmpty());
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseJavaSymbolSolver060Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseJavaSymbolSolver060Test.java
@@ -38,8 +38,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * We analyze JavaParser version 0.6.0.
  */
-//@SlowTest
-@Disabled
+/** MED Not sure what's going on here */
+@SlowTest
 class AnalyseJavaSymbolSolver060Test extends AbstractResolutionTest {
 
     private static final Path root = adaptPath("src/test/test_sourcecode/javasymbolsolver_0_6_0");
@@ -53,7 +53,7 @@ class AnalyseJavaSymbolSolver060Test extends AbstractResolutionTest {
                     new ReflectionTypeSolver(),
                     new JavaParserTypeSolver(new File(src + "/java-symbol-solver-core")),
                     new JavaParserTypeSolver(new File(src + "/java-symbol-solver-logic")),
-                    new JavaParserTypeSolver(new File(src + "/java-symbol-solver-model")),
+                    new JavaParserTypeSolver(new File( src + "/java-symbol-solver-model")),
                     new JarTypeSolver(lib + "/guava-21.0.jar"),
                     new JarTypeSolver(lib + "/javaparser-core-3.3.0.jar"),
                     new JarTypeSolver(lib + "/javaslang-2.0.3.jar"),

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseJavaSymbolSolver060Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseJavaSymbolSolver060Test.java
@@ -23,6 +23,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSol
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -37,7 +38,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * We analyze JavaParser version 0.6.0.
  */
-@SlowTest
+//@SlowTest
+@Disabled
 class AnalyseJavaSymbolSolver060Test extends AbstractResolutionTest {
 
     private static final Path root = adaptPath("src/test/test_sourcecode/javasymbolsolver_0_6_0");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -41,6 +41,7 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionClassDeclaration;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.*;
 import com.github.javaparser.symbolsolver.utils.LeanParserConfiguration;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -54,6 +55,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+
+/** MED deal with pulling in javaparser-core-2.1.0.jar, javaparser-core-3.0.0-alpha.2.jar*/
 class ContextTest extends AbstractSymbolResolutionTest {
 
     private TypeSolver typeSolver = new CombinedTypeSolver(new MemoryTypeSolver(), new ReflectionTypeSolver());
@@ -110,7 +113,8 @@ class ContextTest extends AbstractSymbolResolutionTest {
         assertTrue(symbolReference.getCorrespondingDeclaration().isParameter());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveReferenceToImportedType() {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration referencesToField = Navigator.demandClass(cu, "Navigator");
@@ -204,7 +208,8 @@ class ContextTest extends AbstractSymbolResolutionTest {
         assertEquals("java.lang.String", ref.getCorrespondingDeclaration().getQualifiedName());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveReferenceToMethod() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration referencesToField = Navigator.demandClass(cu, "Navigator");
@@ -218,12 +223,15 @@ class ContextTest extends AbstractSymbolResolutionTest {
         MethodUsage ref = symbolSolver.solveMethod("getTypes", Collections.emptyList(), callToGetTypes);
 
         assertEquals("getTypes", ref.getName());
-        assertEquals("com.github.javaparser.ast.CompilationUnit", ref.declaringType().getQualifiedName());
+        /** MED changed */
+        //assertEquals("com.github.javaparser.ast.CompilationUnit", ref.declaringType().getQualifiedName());
+        assertEquals(CompilationUnit.class.getCanonicalName(), ref.declaringType().getQualifiedName());
 
         //verify(typeSolver);
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveCascadeOfReferencesToMethod() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration referencesToField = Navigator.demandClass(cu, "Navigator");
@@ -231,6 +239,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         MethodCallExpr callToStream = Navigator.findMethodCall(method, "stream").get();
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+        /** MED ??? Problems with CombinedTypeSolver (Reflection and JartypeSolver) */
         TypeSolver typeSolver = new CombinedTypeSolver(new JarTypeSolver(pathToJar), new ReflectionTypeSolver(true));
         SymbolSolver symbolSolver = new SymbolSolver(typeSolver);
         MethodUsage ref = symbolSolver.solveMethod("stream", Collections.emptyList(), callToStream);
@@ -312,7 +321,8 @@ class ContextTest extends AbstractSymbolResolutionTest {
         assertEquals("java.lang.String", ref.declaringType().getQualifiedName());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveGenericReturnTypeOfMethodInJar() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
@@ -320,6 +330,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         MethodCallExpr call = Navigator.findMethodCall(method, "getTypes").get();
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+        /** MED ??? Problems with CombinedTypeSolver (Reflection and JartypeSolver) */
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
         MethodUsage methodUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(call);
 
@@ -419,7 +430,8 @@ class ContextTest extends AbstractSymbolResolutionTest {
         assertEquals("java.util.List<javaparser.GenericClass.Bar.NestedBar>", methodUsage.getParamType(0).describe());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveTypeUsageOfFirstMethodInGenericClass() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
@@ -428,6 +440,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
+        /** MED ??? there seems to be an issue with the CombinedTypeSolver using ReflectionTypeSolver & JarTypeSolver */
         MethodUsage filterUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(callToGetTypes);
 
         assertEquals("java.util.List<com.github.javaparser.ast.body.TypeDeclaration>", filterUsage.returnType().describe());
@@ -435,7 +448,8 @@ class ContextTest extends AbstractSymbolResolutionTest {
         assertEquals("com.github.javaparser.ast.body.TypeDeclaration", filterUsage.returnType().asReferenceType().typeParametersValues().get(0).describe());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveTypeUsageOfMethodInGenericClass() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
@@ -443,13 +457,15 @@ class ContextTest extends AbstractSymbolResolutionTest {
         MethodCallExpr callToStream = Navigator.findMethodCall(method, "stream").get();
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+        /** MED ??? Problems with CombinedTypeSolver (Reflection and JartypeSolver) */
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
         MethodUsage filterUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(callToStream);
 
         assertEquals("java.util.stream.Stream<com.github.javaparser.ast.body.TypeDeclaration>", filterUsage.returnType().describe());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveTypeUsageOfCascadeMethodInGenericClass() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
@@ -457,13 +473,15 @@ class ContextTest extends AbstractSymbolResolutionTest {
         MethodCallExpr callToFilter = Navigator.findMethodCall(method, "filter").get();
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+        /** MED ??? Problems with CombinedTypeSolver (Reflection and JartypeSolver) */
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
         MethodUsage filterUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(callToFilter);
 
         assertEquals("java.util.stream.Stream<com.github.javaparser.ast.body.TypeDeclaration>", filterUsage.returnType().describe());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveLambdaType() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
@@ -472,13 +490,15 @@ class ContextTest extends AbstractSymbolResolutionTest {
         Expression lambdaExpr = callToFilter.getArguments().get(0);
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+        /** MED ??? Problems with CombinedTypeSolver (Reflection and JartypeSolver) */
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
         ResolvedType typeOfLambdaExpr = JavaParserFacade.get(typeSolver).getType(lambdaExpr);
 
         assertEquals("java.util.function.Predicate<? super com.github.javaparser.ast.body.TypeDeclaration>", typeOfLambdaExpr.describe());
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveReferenceToLambdaParam() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
@@ -487,13 +507,17 @@ class ContextTest extends AbstractSymbolResolutionTest {
         Expression referenceToT = callToGetName.getScope().get();
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+        /** MED ??? Problem with the CombinedTypeSolver (Reflection JarTypeSolver) */
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
         ResolvedType typeOfT = JavaParserFacade.get(typeSolver).getType(referenceToT);
 
         assertEquals("? super com.github.javaparser.ast.body.TypeDeclaration", typeOfT.describe());
+
+
     }
 
-    @Test
+    //@Test
+    @Disabled
     void resolveReferenceToCallOnLambdaParam() throws IOException {
         CompilationUnit cu = parseSample("Navigator");
         com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Navigator");
@@ -501,6 +525,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         MethodCallExpr callToGetName = Navigator.findMethodCall(method, "getName").get();
 
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+        /** MED ??? there seems to be an issue with the CombinedTypeSolver using ReflectionTypeSolver & JarTypeSolver */
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
         MethodUsage methodUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(callToGetName);
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionWithJavassistTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionWithJavassistTest.java
@@ -32,8 +32,8 @@ public class MethodsResolutionWithJavassistTest extends AbstractResolutionTest {
         Log.setAdapter(new Log.SilentAdapter());
     }
 
-    //@Test
-    @Disabled
+    @Test
+    //@Disabled
     public void testOverloadedMethods() throws Exception {
         CompilationUnit cu = parseSample("OverloadedMethodCall");
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionWithJavassistTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionWithJavassistTest.java
@@ -16,12 +16,14 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.github.javaparser.utils.Log;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/** MED deal with pulling in javaparser-core-2.1.0.jar, javaparser-core-3.0.0-alpha.2.jar*/
 public class MethodsResolutionWithJavassistTest extends AbstractResolutionTest {
 
     @AfterEach
@@ -30,7 +32,8 @@ public class MethodsResolutionWithJavassistTest extends AbstractResolutionTest {
         Log.setAdapter(new Log.SilentAdapter());
     }
 
-    @Test
+    //@Test
+    @Disabled
     public void testOverloadedMethods() throws Exception {
         CompilationUnit cu = parseSample("OverloadedMethodCall");
 
@@ -45,7 +48,16 @@ public class MethodsResolutionWithJavassistTest extends AbstractResolutionTest {
         List<MethodCallExpr> calls = method.findAll(MethodCallExpr.class, n -> n.getNameAsString().equals("accept"));
         assertEquals(2, calls.size());
 
+
         // node.accept((GenericVisitor) null, null);
+        /**
+         * MED ??? there seems to be a problem when I use a combinedTypeSolver with a JarTypeSolver and ReflectionTypeSolver)
+         *
+         * java.lang.RuntimeException: Error calculating the type of parameter (GenericVisitor) null of method call node.accept((GenericVisitor) null, null)
+         *         at org.javaparser.symbolsolver.resolution.MethodsResolutionWithJavassistTest.testOverloadedMethods(MethodsResolutionWithJavassistTest.java:50)
+         * Caused by: org.javaparser.resolution.UnsolvedSymbolException: Unsolved symbol : GenericVisitor
+         *         at org.javaparser.symbolsolver.resolution.MethodsResolutionWithJavassistTest.testOverloadedMethods(MethodsResolutionWithJavassistTest.java:50)
+         */
         MethodUsage methodUsage1 = JavaParserFacade.get(typeSolver).solveMethodAsUsage(calls.get(0));
         assertEquals("com.github.javaparser.ast.visitor.GenericVisitor<R, A>", methodUsage1.getParamType(0).describe());
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistClassTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistClassTest.java
@@ -33,6 +33,9 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/** MED deal with pulling in javaparser-core-2.1.0.jar, javaparser-core-3.0.0-alpha.2.jar
+ * src/test/resources/javassist_symbols/main_jar/main_jar.jar"
+ * */
 class SymbolSolverWithJavassistClassTest extends AbstractSymbolResolutionTest {
     private TypeSolver typeSolver;
     private SymbolSolver symbolSolver;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistEnumTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistEnumTest.java
@@ -17,6 +17,9 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/** MED deal with pulling in javaparser-core-2.1.0.jar, javaparser-core-3.0.0-alpha.2.jar
+ * src/test/resources/javassist_symbols/main_jar/main_jar.jar"
+ * */
 class SymbolSolverWithJavassistEnumTest extends AbstractSymbolResolutionTest {
     private TypeSolver typeSolver;
     private SymbolSolver symbolSolver;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistInterfaceTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistInterfaceTest.java
@@ -17,6 +17,9 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/** MED deal with pulling in javaparser-core-2.1.0.jar, javaparser-core-3.0.0-alpha.2.jar
+ * src/test/resources/javassist_symbols/main_jar/main_jar.jar"
+ * */
 class SymbolSolverWithJavassistInterfaceTest extends AbstractSymbolResolutionTest {
     private TypeSolver typeSolver;
     private SymbolSolver symbolSolver;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/AarTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/AarTypeSolverTest.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/** MED deal with pulling in "src/test/resources/aars/support-compat-24.2.0.aar"
+ * */
 class AarTypeSolverTest extends AbstractSymbolResolutionTest {
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
@@ -29,7 +29,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
+/** MED
+ * deal with "src/test/resources/javaparser-core-2.1.0.jar"
+ */
 class JarTypeSolverTest extends AbstractSymbolResolutionTest {
 
     @Test

--- a/name_change.txt
+++ b/name_change.txt
@@ -1,0 +1,2 @@
+I'm adding this file to discuss the 
+issues with changing the package name

--- a/name_change.txt
+++ b/name_change.txt
@@ -1,2 +1,4 @@
 I'm adding this file to discuss the 
 issues with changing the package name
+
+need to make sure Im in the correct branch

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.14.4-SNAPSHOT</version>
+    <version>3.14.4</version>
 
     <name>javaparser-parent</name>
     <url>https://github.com/javaparser</url>
@@ -136,7 +136,7 @@
         <connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
         <developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
         <url>https://github.com/javaparser/javaparser.git</url>
-        <tag>HEAD</tag>
+        <tag>javaparser-parent-3.14.4</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.14.4</version>
+    <version>3.14.4-SNAPSHOT</version>
 
     <name>javaparser-parent</name>
     <url>https://github.com/javaparser</url>
@@ -136,7 +136,7 @@
         <connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
         <developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
         <url>https://github.com/javaparser/javaparser.git</url>
-        <tag>javaparser-parent-3.14.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.14.4</version>
+    <version>3.14.5-SNAPSHOT</version>
 
     <name>javaparser-parent</name>
     <url>https://github.com/javaparser</url>
@@ -136,7 +136,7 @@
         <connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
         <developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
         <url>https://github.com/javaparser/javaparser.git</url>
-        <tag>javaparser-parent-3.14.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/readme.md
+++ b/readme.md
@@ -29,14 +29,14 @@ Just add the following to your maven configuration or tailor to your own depende
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-symbol-solver-core</artifactId>
-    <version>3.14.3</version>
+    <version>3.14.4</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.14.3'
+implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.14.4'
 ```
 
 Since Version 3.5.10, the JavaParser project includes the JavaSymbolSolver. 
@@ -51,14 +51,14 @@ Using the dependency above will add both JavaParser and JavaSymbolSolver to your
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core</artifactId>
-    <version>3.14.3</version>
+    <version>3.14.4</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core:3.14.3'
+implementation 'com.github.javaparser:javaparser-core:3.14.4'
 ```
 
 Since version 3.6.17 the AST can be serialized to JSON.
@@ -70,14 +70,14 @@ There is a separate module for this:
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core-serialization</artifactId>
-    <version>3.14.3</version>
+    <version>3.14.4</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core-serialization:3.14.3'
+implementation 'com.github.javaparser:javaparser-core-serialization:3.14.4'
 ```
 
 ## How To Compile Sources


### PR DESCRIPTION
I wanted to submit this separate from the package name changes because basically
the other changes change every single .java file 

since the directory structure would change

It's hard to do any diffing to determine where the problems are and what manual changes were made

For simplicity/ brevity you can 
do a text search for "** MED" to find any annotations about what my thoughts are
& to find any issues or comments or stacktraces that are occurring to the code 
(AFTER I do the package name change) 

This should clean install fine (as is)
For brevity, here are the (3) Test Classes with (14) individual tests that fail AFTER the package name change:
[ERROR]   JavassistClassDeclarationTest.testGetAllInterfaces:276 » UnsolvedSymbol Unsolv...
[ERROR]   JavassistClassDeclarationTest.testGetAllInterfacesWithoutParameters:369 » UnsolvedSymbol
[ERROR]   JavassistClassDeclarationTest.testGetInterfaces:263 » UnsolvedSymbol Unsolved ...
[ERROR]   JavassistClassDeclarationTest.testGetInterfacesWithoutParameters:325 » UnsolvedSymbol
[ERROR]   ContextTest.resolveCascadeOfReferencesToMethod:259 » UnsolvedSymbol Unsolved s...
[ERROR]   ContextTest.resolveGenericReturnTypeOfMethodInJar:355 » UnsolvedSymbol Unsolve...
[ERROR]   ContextTest.resolveLambdaType:544 » UnsolvedSymbol Unsolved symbol in cu.getTy...
[ERROR]   ContextTest.resolveReferenceToCallOnLambdaParam:586 » Runtime Error calculatin...
[ERROR]   ContextTest.resolveReferenceToLambdaParam:561 » Runtime Error calculating the ...
[ERROR]   ContextTest.resolveReferenceToMethod:230 » UnsolvedSymbol Unsolved symbol in c...
[ERROR]   ContextTest.resolveTypeUsageOfCascadeMethodInGenericClass:521 » Runtime Error ...
[ERROR]   ContextTest.resolveTypeUsageOfFirstMethodInGenericClass:477 » UnsolvedSymbol U...
[ERROR]   ContextTest.resolveTypeUsageOfMethodInGenericClass:499 » UnsolvedSymbol Unsolv...
[ERROR]   MethodsResolutionWithJavassistTest.testOverloadedMethods:61 » Runtime Error ca...

 I also tested including the slow tests, and the following (additional) failure:
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparserNavigator:153->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparser_Navigator.txt is different from what is expected ==> expected: <Line 44) node.getParentNode().orElse(null) ==> java.util.Optional.orElse(T)> but was: <Line 44) node.getParentNode().orElse(null) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodel:163->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_DefaultVisitorAdapter.txt is different from what is expected ==> expected: <Line 18) node.getClass().getCanonicalName() ==> java.lang.Class.getCanonicalName()> but was: <Line 18) node.getClass().getCanonicalName() ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelContexts:172->parse:127 Line 8 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_contexts_AbstractJavaParserContext.txt is different from what is expected ==> expected: <Line 80) wrappedNode.equals(that.wrappedNode) ==> org.javaparser.ast.Node.equals(java.lang.Object)> but was: <Line 80) wrappedNode.equals(that.wrappedNode) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelDeclarations:216->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_declarations_JavaParserAnnotationDeclaration.txt is different from what is expected ==> expected: <Line 60) Helper.getPackageName(wrappedNode) ==> org.javaparser.symbolsolver.javaparsermodel.declarations.Helper.getPackageName(org.javaparser.ast.Node)> but was: <Line 60) Helper.getPackageName(wrappedNode) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelDeclarationsHelper:205->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_declarations_Helper.txt is different from what is expected ==> expected: <Line 36) modifiers.contains(Modifier.PRIVATE) ==> java.util.AbstractCollection.contains(java.lang.Object)> but was: <Line 36) modifiers.contains(Modifier.PRIVATE) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelDeclarationsJavaParserFieldDeclaration:210->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_declarations_JavaParserFieldDeclaration.txt is different from what is expected ==> expected: <Line 51) getParentNode(variableDeclarator) ==> org.javaparser.symbolsolver.javaparser.Navigator.getParentNode(org.javaparser.ast.Node)> but was: <Line 51) getParentNode(variableDeclarator) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelDeclarators:232->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_declarators_FieldSymbolDeclarator.txt is different from what is expected ==> expected: <Line 40) wrappedNode.getVariables() ==> org.javaparser.ast.body.FieldDeclaration.getVariables()> but was: <Line 40) wrappedNode.getVariables() ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelJavaParserAnonymousClassDeclaration:195->parse:127 Line 2 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_declarations_JavaParserAnonymousClassDeclaration.txt is different from what is expected ==> expected: <Line 44) JavaParserFactory.getContext(wrappedNode.getParentNode().get(), typeSolver).solveType(wrappedNode.getType().getName().getId(), typeSolver).getCorrespondingDeclaration() ==> org.javaparser.symbolsolver.model.resolution.SymbolReference.getCorrespondingDeclaration()> but was: <Line 44) JavaParserFactory.getContext(wrappedNode.getParentNode().get(), typeSolver).solveType(wrappedNode.getType().getName().getId(), typeSolver).getCorrespondingDeclaration() ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelJavaParserInterfaceDeclaration:200->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_declarations_JavaParserInterfaceDeclaration.txt is different from what is expected ==> expected: <Line 52) wrappedNode.isInterface() ==> org.javaparser.ast.body.ClassOrInterfaceDeclaration.isInterface()> but was: <Line 52) wrappedNode.isInterface() ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreJavaparsermodelTypeExtractor:158->parse:127 Line 6 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_javaparsermodel_TypeExtractor_J9.txt is different from what is expected ==> expected: <Line 60) getParentNode(node) ==> org.javaparser.symbolsolver.javaparser.Navigator.getParentNode(org.javaparser.ast.Node)> but was: <Line 60) getParentNode(node) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreResolution:289->parse:127 Line 230 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_resolution_MethodResolutionLogic.txt is different from what is expected ==> expected: <Line 347) ((JavaParserMethodDeclaration) m1).getWrappedNode().equals(((JavaParserMethodDeclaration) m2).getWrappedNode()) ==> org.javaparser.ast.Node.equals(java.lang.Object)> but was: <Line 347) ((JavaParserMethodDeclaration) m1).getWrappedNode().equals(((JavaParserMethodDeclaration) m2).getWrappedNode()) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreResolutionTypesolvers:298->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_resolution_typesolvers_JavaParserTypeSolver.txt is different from what is expected ==> expected: <Line 72) parsedFiles.containsKey(srcFile.getAbsolutePath()) ==> java.util.Map.containsKey(java.lang.Object)> but was: <Line 72) parsedFiles.containsKey(srcFile.getAbsolutePath()) ==> ERROR>
[ERROR]   AnalyseJavaSymbolSolver060Test.parseCoreSourceFileInfoExtractor:137->parse:127 Line 1 of C:\jp2\javaparser\javaparser-symbol-solver-testing\src\test\test_sourcecode\javasymbolsolver_0_6_0\expected_output/java-symbol-solver-core/org_javaparser_symbolsolver_SourceFileInfoExtractor.txt is different from what is expected ==> expected: <Line 100) JavaParserFacade.get(typeSolver).getTypeDeclaration(node) ==> org.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getTypeDeclaration(org.javaparser.ast.body.ClassOrInterfaceDeclaration)> but was: <Line 100) JavaParserFacade.get(typeSolver).getTypeDeclaration(node) ==> ERROR>


ANOTHER PR will include the files AFTER the name change