### PR TITLE
Use File.isSameFile instead of Path.equals in SymbolSolverCollectionStrategy

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/utils/SymbolSolverCollectionStrategy.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/utils/SymbolSolverCollectionStrategy.java
@@ -64,8 +64,8 @@ public class SymbolSolverCollectionStrategy implements CollectionStrategy {
                 }
 
                 @Override
-                public FileVisitResult postVisitDirectory(Path dir, IOException e) {
-                    if (dir.equals(current_root)) {
+                public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+                    if (current_root != null && Files.isSameFile(dir, current_root)) {
                         projectRoot.addSourceRoot(dir);
                         typeSolver.add(new JavaParserTypeSolver(current_root.toFile()));
                         current_root = null;


### PR DESCRIPTION
Similar change as done for ParserCollectionStrategy in #2041.
Fixes problems with different separators and relative paths on Windows.