### PR TITLE
Should containsWithin() compare files as well?

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithRangeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithRangeTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.nodeTypes;
+
+import com.github.javaparser.*;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.Statement;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NodeWithRangeTest {
+
+    @Test
+    void nodeContainsItself() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider provider = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(provider);
+        ParseResult<CompilationUnit> parse = parser.parse(ParseStart.COMPILATION_UNIT, provider);
+        assertTrue(parse.isSuccessful());
+
+        VariableDeclarationExpr node = parse.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        assertTrue(node.containsWithin(node));
+    }
+
+    @Test
+    void subNodeInSameFileIsContained() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider provider = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(provider);
+        ParseResult<CompilationUnit> parse = parser.parse(ParseStart.COMPILATION_UNIT, provider);
+        assertTrue(parse.isSuccessful());
+
+        VariableDeclarationExpr superNode = parse.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        Expression subNode = superNode.getVariable(0).getInitializer().get(); // 42
+
+        assertTrue(superNode.containsWithin(subNode));
+    }
+
+    @Test
+    void nodesInTwoDifferentFilesDoNotContainEachOther() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider providerA = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(providerA);
+        ParseResult<CompilationUnit> parseA = parser.parse(ParseStart.COMPILATION_UNIT, providerA);
+        assertTrue(parseA.isSuccessful());
+
+        Provider providerB = Providers.resourceProvider("com/github/javaparser/range/B.java");
+        assertNotNull(providerB);
+        ParseResult<CompilationUnit> parseB = parser.parse(ParseStart.COMPILATION_UNIT, providerB);
+        assertTrue(parseB.isSuccessful());
+
+        VariableDeclarationExpr superNodeA = parseA.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        Expression subNodeA = superNodeA.getVariable(0).getInitializer().get(); // 42
+
+        VariableDeclarationExpr superNodeB = parseB.getResult().get()
+                .getType(0) // class B
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int b = 42;
+                .getExpression().asVariableDeclarationExpr(); // b = 42
+
+        Expression subNodeB = superNodeB.getVariable(0).getInitializer().get(); // 42
+
+        assertFalse(superNodeA.containsWithin(superNodeB));
+        assertFalse(superNodeA.containsWithin(subNodeB));
+        assertFalse(superNodeB.containsWithin(superNodeA));
+        assertFalse(superNodeB.containsWithin(subNodeA));
+    }
+
+    @Test
+    void nodesWithAndWithoutFileDoNotContainEachOther() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider providerA = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(providerA);
+        ParseResult<CompilationUnit> parseA = parser.parse(ParseStart.COMPILATION_UNIT, providerA);
+        assertTrue(parseA.isSuccessful());
+
+        ParseResult<Statement> parseB = parser.parse(ParseStart.STATEMENT, new StringProvider("int b = 42;"));
+        assertTrue(parseB.isSuccessful());
+
+        VariableDeclarationExpr superNodeA = parseA.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        Expression subNodeA = superNodeA.getVariable(0).getInitializer().get(); // 42
+
+        VariableDeclarationExpr superNodeB = parseB.getResult().get()
+                .asExpressionStmt() // int b = 42;
+                .getExpression().asVariableDeclarationExpr(); // b = 42
+
+        Expression subNodeB = superNodeB.getVariable(0).getInitializer().get(); // 42
+
+        assertNotNull(superNodeA.findCompilationUnit().orElse(null));
+        assertNull(superNodeB.findCompilationUnit().orElse(null));
+        assertFalse(superNodeA.containsWithin(superNodeB));
+        assertFalse(superNodeA.containsWithin(subNodeB));
+        assertFalse(superNodeB.containsWithin(superNodeA));
+        assertFalse(superNodeB.containsWithin(subNodeA));
+    }
+
+    @Test
+    void subNodeWithoutFileIsContained() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        ParseResult<Statement> parseA = parser.parse(ParseStart.STATEMENT, new StringProvider("int a = 42;"));
+        assertTrue(parseA.isSuccessful());
+
+        ParseResult<Statement> parseB = parser.parse(ParseStart.STATEMENT, new StringProvider("int b = 42;"));
+        assertTrue(parseB.isSuccessful());
+
+        VariableDeclarationExpr superNodeA = parseA.getResult().get()
+                .asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        Expression subNodeA = superNodeA.getVariable(0).getInitializer().get(); // 42
+
+        VariableDeclarationExpr superNodeB = parseB.getResult().get()
+                .asExpressionStmt() // int b = 42;
+                .getExpression().asVariableDeclarationExpr(); // b = 42
+
+        Expression subNodeB = superNodeB.getVariable(0).getInitializer().get(); // 42
+
+        assertNull(superNodeA.findCompilationUnit().orElse(null));
+        assertNull(superNodeB.findCompilationUnit().orElse(null));
+        assertTrue(superNodeA.containsWithin(subNodeA));
+        assertTrue(superNodeA.containsWithin(subNodeB));
+        assertTrue(superNodeB.containsWithin(subNodeA));
+        assertTrue(superNodeB.containsWithin(subNodeB));
+    }
+}

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/range/A.java
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/range/A.java
@@ -1,0 +1,7 @@
+package com.github.javaparser.range;
+
+public class A {
+    public void foo() {
+        int a = 42;
+    }
+}

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/range/B.java
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/range/B.java
@@ -1,0 +1,7 @@
+package com.github.javaparser.range;
+
+public class B {
+    public void foo() {
+        int b = 42;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithRange.java
@@ -2,18 +2,20 @@ package com.github.javaparser.ast.nodeTypes;
 
 import com.github.javaparser.Position;
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 
 import java.util.Optional;
 
 /**
  * A node that has a Range, which is every Node.
- * 
  */
 public interface NodeWithRange<N> {
     Optional<Range> getRange();
 
     N setRange(Range range);
+
+    Optional<CompilationUnit> findCompilationUnit();
 
     /**
      * The begin position of this node in the source file.
@@ -30,7 +32,8 @@ public interface NodeWithRange<N> {
     }
 
     default boolean containsWithin(Node other) {
-        if (getRange().isPresent() && other.getRange().isPresent()) {
+        if (findCompilationUnit().orElse(null) == other.findCompilationUnit().orElse(null) &&
+                getRange().isPresent() && other.getRange().isPresent()) {
             return getRange().get().contains(other.getRange().get());
         }
         return false;


### PR DESCRIPTION
_Please note that some tests are failing in this PR. Therefore it's not an actual pull request, but more of an issue accompanied by some code. :)_

I recently had a weird bug where some node sayed it contained some other node, even though the two nodes were in completely different files. I had used `Node#containsWithin()` for checking whether one node contained the other.

I then realized that `containsWithin()` compares _only the ranges_, but _not the files_ that these nodes are contained in. At first I thought it was a bug, which is why I starting writing a fix to prepare a pull request. I then realized this may not be a bug at all, because:

1. In order to compare the files as well, we need to find the compilation unit, and thus we need to add an abstract method `findCompilationUnit()` to the interface `NodeWithRange`, which is a bit ugly maybe (see changes in this PR)
2. Also, once I had changed `NodeWithRange` as described, various tests started failing (well, 12 tests, actually), especially the PrettyPrintVisitorTests and the LexicalPreservingPrinterTests.

So I'm not sure now... is it intentional that `containsWithin()` compares based on ranges only, but not based on files? If so, I would suggest:

1. at least making that clear in a Javadoc, because it can be confusing. The name `containsWithin()` suggests that one node is contained within the other, so perhaps the method name is not ideal, though I'll admit I have no better idea on the spot. ;-)
2. providing a method (perhaps in `Node` rather than in `NodeWithRange`) that _actually_ checks whether some node is a descendant node of another node. This would be a pretty generic and useful method I think, and it can be implemented in a straightforward way by using `findFirst()` behind the scenes.

I could take care of that, if you agree.