### PR TITLE
Introduced isDescendantOf(Node) and isAncestorOf(Node) methods

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/AncestorDescendantTests.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/AncestorDescendantTests.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class AncestorDescendantTests {
 
     @Test
-    void nodeIsAncestorOfItself() throws IOException {
+    void nodeIsNotAncestorOfItself() throws IOException {
         JavaParser parser = new JavaParser();
 
         Provider provider = Providers.resourceProvider("com/github/javaparser/range/A.java");
@@ -26,11 +26,11 @@ public class AncestorDescendantTests {
                 .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
                 .getExpression().asVariableDeclarationExpr(); // a = 42
 
-        assertTrue(node.isAncestorOf(node));
+        assertFalse(node.isAncestorOf(node));
     }
 
     @Test
-    void nodeIsDescendantOfItself() throws IOException {
+    void nodeIsNotDescendantOfItself() throws IOException {
         JavaParser parser = new JavaParser();
 
         Provider provider = Providers.resourceProvider("com/github/javaparser/range/A.java");
@@ -44,7 +44,7 @@ public class AncestorDescendantTests {
                 .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
                 .getExpression().asVariableDeclarationExpr(); // a = 42
 
-        assertTrue(node.isDescendantOf(node));
+        assertFalse(node.isDescendantOf(node));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class AncestorDescendantTests {
 
         assertTrue(superNode.isAncestorOf(subNode));
         assertFalse(subNode.isAncestorOf(superNode));
-        assertTrue(subNode.isDescendantOf(subNode));
+        assertTrue(subNode.isDescendantOf(superNode));
         assertFalse(superNode.isDescendantOf(subNode));
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/AncestorDescendantTests.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/AncestorDescendantTests.java
@@ -1,0 +1,108 @@
+package com.github.javaparser.ast;
+
+import com.github.javaparser.*;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AncestorDescendantTests {
+
+    @Test
+    void nodeIsAncestorOfItself() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider provider = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(provider);
+        ParseResult<CompilationUnit> parse = parser.parse(ParseStart.COMPILATION_UNIT, provider);
+        assertTrue(parse.isSuccessful());
+
+        VariableDeclarationExpr node = parse.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        assertTrue(node.isAncestorOf(node));
+    }
+
+    @Test
+    void nodeIsDescendantOfItself() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider provider = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(provider);
+        ParseResult<CompilationUnit> parse = parser.parse(ParseStart.COMPILATION_UNIT, provider);
+        assertTrue(parse.isSuccessful());
+
+        VariableDeclarationExpr node = parse.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        assertTrue(node.isDescendantOf(node));
+    }
+
+    @Test
+    void nodeInSameFileIsDescendantOfAncestor() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider provider = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(provider);
+        ParseResult<CompilationUnit> parse = parser.parse(ParseStart.COMPILATION_UNIT, provider);
+        assertTrue(parse.isSuccessful());
+
+        VariableDeclarationExpr superNode = parse.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        Expression subNode = superNode.getVariable(0).getInitializer().get(); // 42
+
+        assertTrue(superNode.isAncestorOf(subNode));
+        assertFalse(subNode.isAncestorOf(superNode));
+        assertTrue(subNode.isDescendantOf(subNode));
+        assertFalse(superNode.isDescendantOf(subNode));
+    }
+
+    @Test
+    void nodesInTwoDifferentFilesAreNotDescendantOrAncestorOfEachOther() throws IOException {
+        JavaParser parser = new JavaParser();
+
+        Provider providerA = Providers.resourceProvider("com/github/javaparser/range/A.java");
+        assertNotNull(providerA);
+        ParseResult<CompilationUnit> parseA = parser.parse(ParseStart.COMPILATION_UNIT, providerA);
+        assertTrue(parseA.isSuccessful());
+
+        Provider providerB = Providers.resourceProvider("com/github/javaparser/range/B.java");
+        assertNotNull(providerB);
+        ParseResult<CompilationUnit> parseB = parser.parse(ParseStart.COMPILATION_UNIT, providerB);
+        assertTrue(parseB.isSuccessful());
+
+        VariableDeclarationExpr superNodeA = parseA.getResult().get()
+                .getType(0) // class A
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int a = 42;
+                .getExpression().asVariableDeclarationExpr(); // a = 42
+
+        Expression subNodeA = superNodeA.getVariable(0).getInitializer().get(); // 42
+
+        VariableDeclarationExpr superNodeB = parseB.getResult().get()
+                .getType(0) // class B
+                .getMember(0).asMethodDeclaration() // method foo()
+                .getBody().get().getStatement(0).asExpressionStmt() // int b = 42;
+                .getExpression().asVariableDeclarationExpr(); // b = 42
+
+        Expression subNodeB = superNodeB.getVariable(0).getInitializer().get(); // 42
+
+        assertFalse(superNodeA.isAncestorOf(superNodeB));
+        assertFalse(superNodeA.isDescendantOf(subNodeB));
+        assertFalse(superNodeB.isAncestorOf(superNodeA));
+        assertFalse(superNodeB.isDescendantOf(subNodeA));
+    }
+}

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/range/A.java
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/range/A.java
@@ -1,0 +1,7 @@
+package com.github.javaparser.range;
+
+public class A {
+    public void foo() {
+        int a = 42;
+    }
+}

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/range/B.java
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/range/B.java
@@ -1,0 +1,7 @@
+package com.github.javaparser.range;
+
+public class B {
+    public void foo() {
+        int b = 42;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
@@ -79,4 +79,16 @@ public interface HasParentNode<T> extends Observable {
         return Optional.empty();
     }
 
+    /**
+     * Determines whether this {@code HasParentNode} node is a descendant of the given node. Any node is a descendant of
+     * itself.
+     *
+     * @param ancestor the node for which to determine whether it has this node as an ancestor.
+     * @return {@code true} if this node is a descendant of the given node, and {@code false} otherwise.
+     * @see Node#isAncestorOf(Node)
+     */
+    default boolean isDescendantOf(Node ancestor) {
+        return this == ancestor || findAncestor(Node.class, n -> n == ancestor).isPresent();
+    }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
@@ -80,15 +80,15 @@ public interface HasParentNode<T> extends Observable {
     }
 
     /**
-     * Determines whether this {@code HasParentNode} node is a descendant of the given node. Any node is a descendant of
-     * itself.
+     * Determines whether this {@code HasParentNode} node is a descendant of the given node. A node is <i>not</i> a
+     * descendant of itself.
      *
      * @param ancestor the node for which to determine whether it has this node as an ancestor.
      * @return {@code true} if this node is a descendant of the given node, and {@code false} otherwise.
      * @see Node#isAncestorOf(Node)
      */
     default boolean isDescendantOf(Node ancestor) {
-        return this == ancestor || findAncestor(Node.class, n -> n == ancestor).isPresent();
+        return findAncestor(Node.class, n -> n == ancestor).isPresent();
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -858,14 +858,14 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     }
 
     /**
-     * Determines whether this node is an ancestor of the given node. Any node is an ancestor of itself.
+     * Determines whether this node is an ancestor of the given node. A node is <i>not</i> an ancestor of itself.
      *
      * @param descendant the node for which to determine whether it has this node as an ancestor.
      * @return {@code true} if this node is an ancestor of the given node, and {@code false} otherwise.
      * @see HasParentNode#isDescendantOf(Node)
      */
     public boolean isAncestorOf(Node descendant) {
-        return findFirst(Node.class, n -> n == descendant).isPresent();
+        return this != descendant && findFirst(Node.class, n -> n == descendant).isPresent();
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -40,21 +40,20 @@ import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.resolution.types.ResolvedType;
+
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
 import static com.github.javaparser.ast.Node.Parsedness.PARSED;
 import static com.github.javaparser.ast.Node.TreeTraversal.PREORDER;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Spliterator.DISTINCT;
 import static java.util.Spliterator.NONNULL;
-import com.github.javaparser.metamodel.NodeMetaModel;
-import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.ast.Node;
 
 /**
  * Base class for all nodes of the abstract syntax tree.
@@ -223,7 +222,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
 
     /**
      * @param range the range of characters in the source code that this node covers. null can be used to indicate that
-     * no range information is known, or that it is not of interest.
+     *              no range information is known, or that it is not of interest.
      */
     public Node setRange(Range range) {
         if (this.range == range) {
@@ -476,8 +475,8 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      * Sets data for this node using the given key.
      * For information on creating DataKey, see {@link DataKey}.
      *
-     * @param <M> The type of data
-     * @param key The singleton key for the data
+     * @param <M>    The type of data
+     * @param key    The singleton key for the data
      * @param object The data object
      * @see DataKey
      */
@@ -585,7 +584,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
         if (mode == null) {
             throw new IllegalArgumentException("Mode should be not null");
         }
-        switch(mode) {
+        switch (mode) {
             case JUST_THIS_NODE:
                 register(observer);
                 break;
@@ -731,7 +730,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     }
 
     private Iterator<Node> treeIterator(TreeTraversal traversal) {
-        switch(traversal) {
+        switch (traversal) {
             case BREADTHFIRST:
                 return new BreadthFirstIterator(this);
             case POSTORDER:
@@ -856,6 +855,17 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
             }
             return Optional.empty();
         });
+    }
+
+    /**
+     * Determines whether this node is an ancestor of the given node. Any node is an ancestor of itself.
+     *
+     * @param descendant the node for which to determine whether it has this node as an ancestor.
+     * @return {@code true} if this node is an ancestor of the given node, and {@code false} otherwise.
+     * @see HasParentNode#isDescendantOf(Node)
+     */
+    public boolean isAncestorOf(Node descendant) {
+        return findFirst(Node.class, n -> n == descendant).isPresent();
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithRange.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 /**
  * A node that has a Range, which is every Node.
- * 
  */
 public interface NodeWithRange<N> {
     Optional<Range> getRange();
@@ -29,7 +28,28 @@ public interface NodeWithRange<N> {
         return getRange().map(r -> r.end);
     }
 
+    /**
+     * @deprecated use {@link #containsWithinRange(Node)} instead.
+     */
+    @Deprecated
     default boolean containsWithin(Node other) {
+        return containsWithinRange(other);
+    }
+
+    /**
+     * Checks whether the range of the given {@code Node} is contained within the range of this {@code NodeWithRange}.
+     * Note that any range contains itself, i.e., for any node {@code n}, we have that
+     * {@code n.containsWithinRange(n) == true}.
+     *
+     * <b>Notice:</b> This method compares two nodes based on their ranges <i>only</i>, but <i>not</i> based on the
+     * storage unit of the two nodes. Therefore, this method may return {@code true} for a node that is contained in a
+     * different file than this {@code NodeWithRange}. You may wish to use {@link Node#isAncestorOf(Node)} instead.
+     *
+     * @param other the node whose range should be compared with this node's range.
+     * @return {@code true} if the given node's range is contained within this node's range, and {@code false}
+     * otherwise.
+     */
+    default boolean containsWithinRange(Node other) {
         if (getRange().isPresent() && other.getRange().isPresent()) {
             return getRange().get().contains(other.getRange().get());
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/PositionUtils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/PositionUtils.java
@@ -131,9 +131,9 @@ public final class PositionUtils {
         final Range containedRange = contained.getRange().get();
         final Range containerRange = container.getRange().get();
         if (!ignoringAnnotations || PositionUtils.getLastAnnotation(container) == null) {
-            return container.containsWithin(contained);
+            return container.containsWithinRange(contained);
         }
-        if (!container.containsWithin(contained)) {
+        if (!container.containsWithinRange(contained)) {
             return false;
         }
         // if the node is contained, but it comes immediately after the annotations,


### PR DESCRIPTION
See #2302.

This PR introduces new `isDescendantOf(Node)` and `isAncestorOf(Node)` convenience methods. Without them, users (myself included) may accidentally use `containsWithin(Node)`, which does something a bit different. :)

Also, `containsWithin(Node)` has been deprecated in favor of a new method `containsWithinRange(Node)`.

There is one thing that slightly bugs me still. There's an inconsistency that currently already exists in JavaParser and that became particularly obvious when I implemented the new methods. Namely, the method `findFirst()` starts walking the tree downwards from the _current_ node, whereas the method `findAncestor()` does not start walking the tree upwards from the _current_ node, but starts walking the tree upwards from the _parent_ node.

The new `isDescendantOf()` and `isAncestorOf()` methods are just straightforward implementations based on `findAncestor()` and `findFirst()`, respectively. The problem is that I wanted to be able to consistently say "a node is a descendant of itself" and "a node is an ancestor of itself" (either both, or neither; but we can't say one, but not the other, that would just be inconsistent). So the implementation of `isDescendantOf(Node)`, which uses `findAncestor()`, has to use an additional check whether the given node is equal to the current object, whereas the method `isAncestorOf()`, which uses `findFirst()`, doesn't have to do that check.

I think it would be more consistent to rewrite `findAncestor()` in such a way that it also starts from the _current_ node instead of the _parent_ node, what do you think? I didn't want to do that now, though, because that would be a change in behavior of an existing method which may surprise users... so at best, it'd be a story for another PR. What do you think?

