### PR TITLE
Fix findRootNode() and associated methods for comment nodes

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -307,6 +307,37 @@ class NodeTest {
     }
 
     @Test
+    void findCompilationUnitOfCommentNode() {
+        CompilationUnit cu = parse("class X {\n" +
+                "  void x() {\n" +
+                "    // this is a comment\n" +
+                "    foo();\n" +
+                "  }\n" +
+                "}\n");
+
+        Comment comment = cu.getType(0).getMember(0)
+                .asMethodDeclaration().getBody().get()
+                .getStatement(0).getComment().get();
+
+        assertTrue(comment.findCompilationUnit().isPresent());
+    }
+
+    @Test
+    void findCompilationUnitOfOrphanCommentNode() {
+        CompilationUnit cu = parse("class X {\n" +
+                "  void x() {\n" +
+                "    // this is a comment\n" +
+                "  }\n" +
+                "}\n");
+
+        Comment comment = cu.getType(0).getMember(0)
+                .asMethodDeclaration().getBody().get()
+                .getOrphanComments().get(0);
+
+        assertTrue(comment.findCompilationUnit().isPresent());
+    }
+
+    @Test
     void removeAllOnRequiredProperty() {
         CompilationUnit cu = parse("class X{ void x(){}}");
         MethodDeclaration methodDeclaration = cu.getType(0).getMethods().get(0);
@@ -401,7 +432,7 @@ class NodeTest {
         Optional<IntegerLiteralExpr> ints = e.findFirst(IntegerLiteralExpr.class);
         assertEquals("Optional[1]", ints.toString());
     }
-    
+
     @Test
     void stream() {
         Expression e = parseExpression("1+2+3");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -239,12 +239,9 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      *
      * @param comment to be set
      */
-    public final Node setComment(final Comment comment) {
+    public Node setComment(final Comment comment) {
         if (this.comment == comment) {
             return this;
-        }
-        if (comment != null && (this instanceof Comment)) {
-            throw new RuntimeException("A comment can not be commented");
         }
         notifyPropertyChange(ObservableProperty.COMMENT, this.comment, comment);
         if (this.comment != null) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -694,10 +694,6 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      */
     public Node findRootNode() {
         Node n = this;
-        // (Non-orphan) comments are not integrated into the normal AST; we need to get the commented node first.
-        if (this instanceof Comment && ((Comment) this).getCommentedNode().isPresent()) {
-            n = ((Comment) this).getCommentedNode().get();
-        }
         while (n.getParentNode().isPresent()) {
             n = n.getParentNode().get();
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -694,6 +694,10 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      */
     public Node findRootNode() {
         Node n = this;
+        // (Non-orphan) comments are not integrated into the normal AST; we need to get the commented node first.
+        if (this instanceof Comment && ((Comment) this).getCommentedNode().isPresent()) {
+            n = ((Comment) this).getCommentedNode().get();
+        }
         while (n.getParentNode().isPresent()) {
             n = n.getParentNode().get();
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -143,6 +143,16 @@ public abstract class Comment extends Node {
         }
     }
 
+   @Override
+    public Node findRootNode() {
+       // (Non-orphan) comments are not integrated into the normal AST; we need to get the commented node first.
+        Node n = getCommentedNode().orElse(this);
+        while (n.getParentNode().isPresent()) {
+            n = n.getParentNode().get();
+        }
+        return n;
+    }
+
     @Override
     @Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")
     public boolean remove(Node node) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -131,6 +131,15 @@ public abstract class Comment extends Node {
     }
 
     @Override
+    public Node setComment(final Comment comment) {
+        // comments on comments are not allowed, so we override setComment(Comment) here
+        if (comment != null) {
+            throw new IllegalArgumentException("A comment cannot be commented.");
+        }
+        return super.setComment(comment);
+    }
+
+    @Override
     public boolean remove() {
         // the other are orphan comments and remove should work with them
         if (this.commentedNode != null) {


### PR DESCRIPTION
See #2152. This PR does not yet change the whole architecture of comments to take _all_ comments (including orphan comments) out of the AST, as discussed in that issue. But it already fixes `findRootNode()` (and methods which use `findRootNode()`, such as `findCompilationUnit()`) for comments nodes for the time being, as discussed at the very beginning of that issue. :-)
