### PR TITLE
Allow var in try-with-resources statements

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/TryStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/TryStmtTest.java
@@ -25,21 +25,18 @@ class TryStmtTest {
     void multipleTest() {
         TryStmt tryStmt = parse9("try(Reader x = new FileReader(); Reader x = new FileReader()){}");
         assertInstanceOf(VariableDeclarationExpr.class, tryStmt.getResources().get(0));
-
     }
 
     @Test
     void modifiersTest() {
         TryStmt tryStmt = parse9("try(final @A Reader x = new FileReader()){}");
         assertInstanceOf(VariableDeclarationExpr.class, tryStmt.getResources().get(0));
-
     }
 
     @Test
     void simpleVariable() {
         TryStmt tryStmt = parse9("try(a){}");
         assertInstanceOf(NameExpr.class, tryStmt.getResources().get(0));
-
     }
 
     @Test
@@ -47,32 +44,54 @@ class TryStmtTest {
         TryStmt tryStmt = parse9("try(a;b){}");
         assertInstanceOf(NameExpr.class, tryStmt.getResources().get(0));
         assertInstanceOf(NameExpr.class, tryStmt.getResources().get(1));
-
     }
 
     @Test
     void complexVariable() {
         TryStmt tryStmt = parse9("try(a.b.c){}");
         assertInstanceOf(FieldAccessExpr.class, tryStmt.getResources().get(0));
-
     }
 
     @Test
     void superAccess() {
         TryStmt tryStmt = parse9("try(super.a){}");
         assertInstanceOf(FieldAccessExpr.class, tryStmt.getResources().get(0));
-
     }
 
     @Test
     void outerClassAccess() {
         TryStmt tryStmt = parse9("try(X.this.a){}");
         assertInstanceOf(FieldAccessExpr.class, tryStmt.getResources().get(0));
+    }
 
+    @Test
+    void varTestJava10() {
+        TryStmt tryStmt = parse10("try(var x = new FileReader()){}");
+        assertInstanceOf(VariableDeclarationExpr.class, tryStmt.getResources().get(0));
+    }
+
+    @Test
+    void varTestJava11() {
+        TryStmt tryStmt = parse11("try(var x = new FileReader()){}");
+        assertInstanceOf(VariableDeclarationExpr.class, tryStmt.getResources().get(0));
     }
 
     private <T> T parse9(String code) {
         JavaParser parser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_9));
+        ParseResult<Statement> result = parser.parse(ParseStart.STATEMENT, provider(code));
+        assertTrue(result.isSuccessful(), result.toString());
+        return (T) result.getResult().get();
+    }
+
+    private <T> T parse10(String code) {
+        JavaParser parser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_10));
+        ParseResult<Statement> result = parser.parse(ParseStart.STATEMENT, provider(code));
+        assertTrue(result.isSuccessful(), result.toString());
+        return (T) result.getResult().get();
+    }
+
+    private <T> T parse11(String code) {
+        JavaParser parser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_11));
         ParseResult<Statement> result = parser.parse(ParseStart.STATEMENT, provider(code));
         assertTrue(result.isSuccessful(), result.toString());
         return (T) result.getResult().get();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java10ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java10ValidatorTest.java
@@ -37,15 +37,15 @@ class Java10ValidatorTest {
     }
 
     @Test
-    void varNotAllowedInCast() {
-        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int a = (var)20;"));
+    void varAllowedInTryWithResources() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("try(var f = new FileReader(\"\")){ }catch (Exception e){ }"));
         assertNoProblems(result);
     }
 
     @Test
-    void varNotAllowedInTryWithResources() {
-        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("try(var f = new FileReader(\"\")){ }catch (Exception e){ }"));
-        assertProblems(result, "(line 1,col 5) \"var\" is not allowed here.");
+    void varNotAllowedInCast() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int a = (var)20;"));
+        assertNoProblems(result);
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java10Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java10Validator.java
@@ -8,11 +8,11 @@ import com.github.javaparser.ast.validator.chunks.VarValidator;
  */
 public class Java10Validator extends Java9Validator {
 
-    final Validator varOnlyOnLocalVariableDefinitionAndFor = new SingleNodeTypeValidator<>(VarType.class, new VarValidator(false));
+    final Validator varOnlyOnLocalVariableDefinitionAndForAndTry = new SingleNodeTypeValidator<>(VarType.class, new VarValidator(false));
 
     public Java10Validator() {
         super();
-        add(varOnlyOnLocalVariableDefinitionAndFor);
+        add(varOnlyOnLocalVariableDefinitionAndForAndTry);
         /* There is no validator that validates that "var" is not used in Java 9 and lower, since the parser will never create a VarType node,
            because that is done by the Java10 postprocessor. You can add it by hand, but that is obscure enough to ignore. */
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java11Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/Java11Validator.java
@@ -11,6 +11,6 @@ public class Java11Validator extends Java10Validator {
 
     public Java11Validator() {
         super();
-        replace(varOnlyOnLocalVariableDefinitionAndFor, varAlsoInLambdaParameters);
+        replace(varOnlyOnLocalVariableDefinitionAndForAndTry, varAlsoInLambdaParameters);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/chunks/VarValidator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/chunks/VarValidator.java
@@ -10,6 +10,7 @@ import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ForStmt;
 import com.github.javaparser.ast.stmt.ForEachStmt;
+import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.ast.type.VarType;
 import com.github.javaparser.ast.validator.ProblemReporter;
 import com.github.javaparser.ast.validator.TypedValidator;
@@ -65,7 +66,8 @@ public class VarValidator implements TypedValidator<VarType> {
                     return;
                 }
                 container.ifPresent(c -> {
-                    boolean positionIsFine = c instanceof ForStmt || c instanceof ForEachStmt || c instanceof ExpressionStmt;
+                    boolean positionIsFine = c instanceof ForStmt || c instanceof ForEachStmt ||
+                            c instanceof ExpressionStmt || c instanceof TryStmt;
                     if (!positionIsFine) {
                         reportIllegalPosition(node, reporter);
                     }


### PR DESCRIPTION
I believe there is currently a small bug in the post-validators for Java 10.

Namely, the post-validator ensures that the keyword `var` _cannot_ occur within a try-with-resources statement. However, I believe this is incorrect: It is perfectly fine to use `var` within a try-with-resources statement.

- I tried to compile a simple `.java` file that uses `var` within a try-with-resources statement using Java 10, and it worked fine.
- My IDE (IntelliJ) does not complain when I try to use `var` within a try-with-resources statement.
- The JLS does not appear to forbid `var` within a try-with-resources statement.
   - In [JLS 14.20.3](https://docs.oracle.com/javase/specs/jls/se10/html/jls-14.html#jls-14.20.3), the given syntax rules allow to construct a try-with-resources with the `var` keyword. That possibility is even mentioned later on:
      > The type of a variable declared in a resource specification is determined as follows:
      > - If LocalVariableType is an UnannType, then (...)
      > - If LocalVariableType is var, then (...)
   - In [JLS 14.4](https://docs.oracle.com/javase/specs/jls/se10/html/jls-14.html#jls-14.4), a bunch of restrictions is given where a local variable declaration may not use `var`. A try-with-resources statement is _not_ among those restrictions.
- Try-with-resources statements with `var` exist in practice. I stumbled over this bug while parsing a file that used this. As proof, I managed to find some article where `var` is explicitly used within a try-with-resources statement: https://dzone.com/articles/finally-java-10-has-var-to-declare-local-variables

This PR fixes the post-validator for Java 10 (and up) to allow `var` within try-with-resource statements. It also fixes a test accordingly and introduces two new tests.


