### PR TITLE
Add TRANSIENT case to toToken() method

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -263,6 +263,8 @@ class LexicalDifferenceCalculator {
                 return GeneratedJavaParserConstants.FINAL;
             case ABSTRACT:
                 return GeneratedJavaParserConstants.ABSTRACT;
+            case TRANSIENT:
+                return GeneratedJavaParserConstants.TRANSIENT;
             default:
                 throw new UnsupportedOperationException(modifier.getKeyword().name());
         }


### PR DESCRIPTION
The TRANSIENT case was missing at LexicalDifferenceCalculator toToken() method