### PR TITLE
Add synchronized to toNode method

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -265,6 +265,8 @@ class LexicalDifferenceCalculator {
                 return GeneratedJavaParserConstants.ABSTRACT;
             case TRANSIENT:
                 return GeneratedJavaParserConstants.TRANSIENT;
+            case SYNCHRONIZED:
+                return GeneratedJavaParserConstants.SYNCHRONIZED;
             default:
                 throw new UnsupportedOperationException(modifier.getKeyword().name());
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -267,6 +267,14 @@ class LexicalDifferenceCalculator {
                 return GeneratedJavaParserConstants.TRANSIENT;
             case SYNCHRONIZED:
                 return GeneratedJavaParserConstants.SYNCHRONIZED;
+            case VOLATILE:
+                return GeneratedJavaParserConstants.VOLATILE;
+            case NATIVE:
+                return GeneratedJavaParserConstants.NATIVE;
+            case STRICTFP:
+                return GeneratedJavaParserConstants.STRICTFP;
+            case TRANSITIVE:
+                return GeneratedJavaParserConstants.TRANSITIVE;
             default:
                 throw new UnsupportedOperationException(modifier.getKeyword().name());
         }


### PR DESCRIPTION
I ran into an `java.lang.UnsupportedOperationException: SYNCHRONIZED` Exception.
My change should fix this exception. 

```
java.lang.UnsupportedOperationException: SYNCHRONIZED
	at com.github.javaparser.printer.lexicalpreservation.LexicalDifferenceCalculator.toToken(LexicalDifferenceCalculator.java:269)
	at com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.prettyPrintingTextNode(LexicalPreservingPrinter.java:460)
	at com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.getOrCreateNodeText(LexicalPreservingPrinter.java:532)
	at com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.print(LexicalPreservingPrinter.java:403)
	at com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.print(LexicalPreservingPrinter.java:391)
	at com.github.javaparser.printer.lexicalpreservation.ChildTextElement.expand(ChildTextElement.java:41)
	at com.github.javaparser.printer.lexicalpreservation.NodeText.lambda$expand$0(NodeText.java:196)
...
```