### PR TITLE
Fix indent of added comments

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1124,8 +1124,8 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                 .setBlockComment("block");
         assertEqualsNoEol("public class Foo {" + EOL +
                           "    /*block*/" + EOL +
-                          "void mymethod() {" + EOL +
-                          "}" + EOL +
+                          "    void mymethod() {" + EOL +
+                          "    }" + EOL +
                           "}", LexicalPreservingPrinter.print(cu));
     }
 
@@ -1140,8 +1140,8 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                 .setLineComment("line");
         assertEqualsNoEol("public class Foo {" + EOL +
                           "    //line" + EOL +
-                          "void mymethod() {" + EOL +
-                          "}" + EOL +
+                          "    void mymethod() {" + EOL +
+                          "    }" + EOL +
                           "}", LexicalPreservingPrinter.print(cu));
     }
     

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -8,6 +8,7 @@ import static com.github.javaparser.utils.TestUtils.assertEqualsNoEol;
 import static com.github.javaparser.utils.Utils.EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -1197,6 +1198,29 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                           "void mymethod() {" + EOL +
                           "}" + EOL +
                           "}", LexicalPreservingPrinter.print(cu));        
+    }
+
+    @Test
+    void testFixIndentOfMovedNode() {
+        try {
+            CompilationUnit compilationUnit = parse(readExample("FixIndentOfMovedNode"));
+            LexicalPreservingPrinter.setup(compilationUnit);
+
+            compilationUnit.getClassByName("ThisIsASampleClass").get()
+                    .getMethodsByName("longerMethod")
+                    .get(0)
+                    .setBlockComment("Lorem ipsum dolor sit amet, consetetur sadipscing elitr.");
+
+            compilationUnit.getClassByName("Foo").get()
+                    .getFieldByName("myFoo")
+                    .get()
+                    .setLineComment("sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat");
+
+            String expectedCode = readExample("FixIndentOfMovedNodeExpected");
+            assertEquals(expectedCode, LexicalPreservingPrinter.print(compilationUnit));
+        } catch (IOException ex) {
+            fail("Could not read test code", ex);
+        }
     }
 
     @Test

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/FixIndentOfMovedNode.java.txt
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/FixIndentOfMovedNode.java.txt
@@ -1,0 +1,202 @@
+/*
+ * This is a sample file.
+ */
+public class ThisIsASampleClass extends C1 implements I1, I2, I3, I4, I5 {
+    private int f1 = 1;
+    private String field2 = "";
+
+    public void foo1(int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
+    }
+
+    public static void longerMethod() throws Exception1, Exception2, Exception3 {
+        // todo something
+        int
+                i = 0;
+        int[] a = new int[]{1, 2, 0x0052, 0x0053, 0x0054};
+        int[] empty = new int[]{};
+        int var1 = 1;
+        int var2 = 2;
+        foo1(0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057);
+        int x = (3 + 4 + 5 + 6) * (7 + 8 + 9 + 10) * (11 + 12 + 13 + 14 + 0xFFFFFFFF);
+        String s1, s2, s3;
+        s1 = s2 = s3 = "012345678901456";
+        assert i + j + k + l + n + m <= 2 : "assert description";
+        int y = 2 > 3 ? 7 + 8 + 9 : 11 + 12 + 13;
+        super.getFoo().foo().getBar().bar();
+
+        label:
+        if (2 < 3) {
+            return;
+        } else if (2 > 3) return;
+        else return;
+        for (int i = 0; i < 0xFFFFFF; i += 2)
+            System.out.println(i);
+        while (x < 50000) x++;
+        do x++; while (x < 10000);
+        switch (a) {
+            case 0:
+            case 1:
+                doCase0();
+                break;
+            case 2:
+            case 3:
+                return;
+            default:
+                doDefault();
+        }
+        try (MyResource r1 = getResource(); MyResource r2 = null) {
+            doSomething();
+        } catch (Exception e) {
+            processException(e);
+        } finally {
+            processFinally();
+        }
+        do {
+            x--;
+        } while (x > 10);
+        try (MyResource r1 = getResource();
+             MyResource r2 = null) {
+            doSomething();
+        }
+        Runnable r = () -> {
+        };
+    }
+
+    public static void test()
+            throws Exception {
+        foo.foo().bar("arg1",
+                "arg2");
+        new Object() {
+        };
+    }
+
+    class TestInnerClass {
+    }
+
+    interface TestInnerInterface {
+    }
+}
+/*
+ * This is a sample file.
+ */
+
+public class ThisIsASampleClass extends C1 implements I1, I2, I3, I4, I5 {
+    private int f1 = 1;
+    private String field2 = "";
+
+    public void foo1(int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
+    }
+
+    public static void longerMethod() throws Exception1, Exception2, Exception3 {
+        // todo something
+        int
+                i = 0;
+        int[] a = new int[]{1, 2, 0x0052, 0x0053, 0x0054};
+        int[] empty = new int[]{};
+        int var1 = 1;
+        int var2 = 2;
+        foo1(0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057);
+        int x = (3 + 4 + 5 + 6) * (7 + 8 + 9 + 10) * (11 + 12 + 13 + 14 + 0xFFFFFFFF);
+        String s1, s2, s3;
+        s1 = s2 = s3 = "012345678901456";
+        assert i + j + k + l + n + m <= 2 : "assert description";
+        int y = 2 > 3 ? 7 + 8 + 9 : 11 + 12 + 13;
+        super.getFoo().foo().getBar().bar();
+
+        label:
+        if (2 < 3) {
+            return;
+        } else if (2 > 3) return;
+        else return;
+        for (int i = 0; i < 0xFFFFFF; i += 2)
+            System.out.println(i);
+        while (x < 50000) x++;
+        do x++; while (x < 10000);
+        switch (a) {
+            case 0:
+            case 1:
+                doCase0();
+                break;
+            case 2:
+            case 3:
+                return;
+            default:
+                doDefault();
+        }
+        try (MyResource r1 = getResource(); MyResource r2 = null) {
+            doSomething();
+        } catch (Exception e) {
+            processException(e);
+        } finally {
+            processFinally();
+        }
+        do {
+            x--;
+        } while (x > 10);
+        try (MyResource r1 = getResource();
+             MyResource r2 = null) {
+            doSomething();
+        }
+        Runnable r = () -> {
+        };
+    }
+
+    public static void test()
+            throws Exception {
+        foo.foo().bar("arg1",
+                "arg2");
+        new Object() {
+        };
+    }
+
+    class TestInnerClass {
+    }
+
+    interface TestInnerInterface {
+    }
+}
+
+enum Breed {
+    Dalmatian(), Labrador(), Dachshund()
+}
+
+@Annotation1
+@Annotation2
+@Annotation3(param1 = "value1", param2 = "value2")
+@Annotation4
+class Foo {
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static void foo() {
+    }
+
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static int myFoo;
+
+    public void method(@Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int param) {
+        @Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int localVariable;
+    }
+}
+enum Breed {
+    Dalmatian(), Labrador(), Dachshund()
+}
+
+@Annotation1
+@Annotation2
+@Annotation3(param1 = "value1", param2 = "value2")
+@Annotation4
+class Foo {
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static void foo() {
+    }
+
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static int myFoo;
+
+    public void method(@Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int param) {
+        @Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int localVariable;
+    }
+}

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/FixIndentOfMovedNodeExpected.java.txt
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/FixIndentOfMovedNodeExpected.java.txt
@@ -1,0 +1,204 @@
+/*
+ * This is a sample file.
+ */
+public class ThisIsASampleClass extends C1 implements I1, I2, I3, I4, I5 {
+    private int f1 = 1;
+    private String field2 = "";
+
+    public void foo1(int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
+    }
+
+    /*Lorem ipsum dolor sit amet, consetetur sadipscing elitr.*/
+    public static void longerMethod() throws Exception1, Exception2, Exception3 {
+        // todo something
+        int
+                i = 0;
+        int[] a = new int[]{1, 2, 0x0052, 0x0053, 0x0054};
+        int[] empty = new int[]{};
+        int var1 = 1;
+        int var2 = 2;
+        foo1(0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057);
+        int x = (3 + 4 + 5 + 6) * (7 + 8 + 9 + 10) * (11 + 12 + 13 + 14 + 0xFFFFFFFF);
+        String s1, s2, s3;
+        s1 = s2 = s3 = "012345678901456";
+        assert i + j + k + l + n + m <= 2 : "assert description";
+        int y = 2 > 3 ? 7 + 8 + 9 : 11 + 12 + 13;
+        super.getFoo().foo().getBar().bar();
+
+        label:
+        if (2 < 3) {
+            return;
+        } else if (2 > 3) return;
+        else return;
+        for (int i = 0; i < 0xFFFFFF; i += 2)
+            System.out.println(i);
+        while (x < 50000) x++;
+        do x++; while (x < 10000);
+        switch (a) {
+            case 0:
+            case 1:
+                doCase0();
+                break;
+            case 2:
+            case 3:
+                return;
+            default:
+                doDefault();
+        }
+        try (MyResource r1 = getResource(); MyResource r2 = null) {
+            doSomething();
+        } catch (Exception e) {
+            processException(e);
+        } finally {
+            processFinally();
+        }
+        do {
+            x--;
+        } while (x > 10);
+        try (MyResource r1 = getResource();
+             MyResource r2 = null) {
+            doSomething();
+        }
+        Runnable r = () -> {
+        };
+    }
+
+    public static void test()
+            throws Exception {
+        foo.foo().bar("arg1",
+                "arg2");
+        new Object() {
+        };
+    }
+
+    class TestInnerClass {
+    }
+
+    interface TestInnerInterface {
+    }
+}
+/*
+ * This is a sample file.
+ */
+
+public class ThisIsASampleClass extends C1 implements I1, I2, I3, I4, I5 {
+    private int f1 = 1;
+    private String field2 = "";
+
+    public void foo1(int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
+    }
+
+    public static void longerMethod() throws Exception1, Exception2, Exception3 {
+        // todo something
+        int
+                i = 0;
+        int[] a = new int[]{1, 2, 0x0052, 0x0053, 0x0054};
+        int[] empty = new int[]{};
+        int var1 = 1;
+        int var2 = 2;
+        foo1(0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057);
+        int x = (3 + 4 + 5 + 6) * (7 + 8 + 9 + 10) * (11 + 12 + 13 + 14 + 0xFFFFFFFF);
+        String s1, s2, s3;
+        s1 = s2 = s3 = "012345678901456";
+        assert i + j + k + l + n + m <= 2 : "assert description";
+        int y = 2 > 3 ? 7 + 8 + 9 : 11 + 12 + 13;
+        super.getFoo().foo().getBar().bar();
+
+        label:
+        if (2 < 3) {
+            return;
+        } else if (2 > 3) return;
+        else return;
+        for (int i = 0; i < 0xFFFFFF; i += 2)
+            System.out.println(i);
+        while (x < 50000) x++;
+        do x++; while (x < 10000);
+        switch (a) {
+            case 0:
+            case 1:
+                doCase0();
+                break;
+            case 2:
+            case 3:
+                return;
+            default:
+                doDefault();
+        }
+        try (MyResource r1 = getResource(); MyResource r2 = null) {
+            doSomething();
+        } catch (Exception e) {
+            processException(e);
+        } finally {
+            processFinally();
+        }
+        do {
+            x--;
+        } while (x > 10);
+        try (MyResource r1 = getResource();
+             MyResource r2 = null) {
+            doSomething();
+        }
+        Runnable r = () -> {
+        };
+    }
+
+    public static void test()
+            throws Exception {
+        foo.foo().bar("arg1",
+                "arg2");
+        new Object() {
+        };
+    }
+
+    class TestInnerClass {
+    }
+
+    interface TestInnerInterface {
+    }
+}
+
+enum Breed {
+    Dalmatian(), Labrador(), Dachshund()
+}
+
+@Annotation1
+@Annotation2
+@Annotation3(param1 = "value1", param2 = "value2")
+@Annotation4
+class Foo {
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static void foo() {
+    }
+
+    //sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static int myFoo;
+
+    public void method(@Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int param) {
+        @Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int localVariable;
+    }
+}
+enum Breed {
+    Dalmatian(), Labrador(), Dachshund()
+}
+
+@Annotation1
+@Annotation2
+@Annotation3(param1 = "value1", param2 = "value2")
+@Annotation4
+class Foo {
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static void foo() {
+    }
+
+    @Annotation1
+    @Annotation3(param1 = "value1", param2 = "value2")
+    public static int myFoo;
+
+    public void method(@Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int param) {
+        @Annotation1 @Annotation3(param1 = "value1", param2 = "value2") final int localVariable;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -135,6 +135,10 @@ public class LexicalPreservingPrinter {
                 if (oldValue == null) {
                     // Find the position of the comment node and put in front of it the comment and a newline
                     int index = nodeText.findChild(observedNode);
+
+                    // Add the same indent depth of the comment to the following node
+                    fixIndentOfMovedNode(nodeText, index);
+
                     nodeText.addChild(index, (Comment) newValue);
                     nodeText.addToken(index + 1, eolTokenKind(), Utils.EOL);
                 } else if (newValue == null) {
@@ -249,13 +253,27 @@ public class LexicalPreservingPrinter {
             return matchingTokens;
         }
 
-
         private boolean isEqualRange(Optional<Range> range1, Optional<Range> range2) {
             if (range1.isPresent() && range2.isPresent()) {
                 return range1.get().equals(range2.get());
             }
 
             return false;
+        }
+
+        private void fixIndentOfMovedNode(NodeText nodeText, int index) {
+            for (int i = index - 1; i >= 0; i--) {
+                TextElement spaceCandidate = nodeText.getTextElement(i);
+                if (!spaceCandidate.isSpaceOrTab()) {
+                    if (spaceCandidate.isNewline() && i != index - 1) {
+                        for (int j = 0; j < (index - 1) - i; j++) {
+                            nodeText.addElement(index, new TokenTextElement(JavaToken.Kind.SPACE.getKind()));
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
         }
 
         @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -261,6 +261,12 @@ public class LexicalPreservingPrinter {
             return false;
         }
 
+        /**
+         * This method inserts new space tokens at the given {@code index}. If a new comment is added to the node
+         * at the position of {@code index}, the new comment and the node will have the same indent.
+         * @param nodeText The text of the node
+         * @param index The position where a new comment will be added to
+         */
         private void fixIndentOfMovedNode(NodeText nodeText, int index) {
             if(index <= 0) {
                 return;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -262,6 +262,10 @@ public class LexicalPreservingPrinter {
         }
 
         private void fixIndentOfMovedNode(NodeText nodeText, int index) {
+            if(index <= 0) {
+                return;
+            }
+
             for (int i = index - 1; i >= 0; i--) {
                 TextElement spaceCandidate = nodeText.getTextElement(i);
                 if (!spaceCandidate.isSpaceOrTab()) {
@@ -269,9 +273,8 @@ public class LexicalPreservingPrinter {
                         for (int j = 0; j < (index - 1) - i; j++) {
                             nodeText.addElement(index, new TokenTextElement(JavaToken.Kind.SPACE.getKind()));
                         }
-                    } else {
-                        break;
                     }
+                    break;
                 }
             }
         }


### PR DESCRIPTION
After adding a comment to an existing node of an AST, the node after the comment loses it's indent when printing it with the `LexicalPreservingPrinter`.
Given this example
```java
public class Foo {
    void mymethod() {
    }
}
```
the resulting string would look like this:
```java
public class Foo {
    //line
void mymethod() {
}
}
```
I fixed the LPP so the result looks like this
```java
public class Foo {
    //line
    void mymethod() {
    }
}
```

I've added the indents to the LPPTest. Should I add another test or is it fine?