### PR TITLE
Fix and test for issue #2367, resolving NameExpr when it represents a private field name

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
@@ -70,8 +70,8 @@ public class ClassOrInterfaceDeclarationContext extends AbstractJavaParserContex
     public Optional<Value> solveSymbolAsValue(String name) {
         if (typeSolver == null) throw new IllegalArgumentException();
 
-        if (this.getDeclaration().hasVisibleField(name)) {
-            return Optional.of(Value.from(this.getDeclaration().getVisibleField(name)));
+        if (this.getDeclaration().hasField(name)) {
+            return Optional.of(Value.from(this.getDeclaration().getField(name)));
         }
 
         // then to parent

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2367Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2367Test.java
@@ -1,0 +1,40 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseStart;
+import com.github.javaparser.StreamProvider;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+
+class Issue2367Test extends AbstractSymbolResolutionTest {
+
+    @Test
+    void issue2367() throws IOException {
+        Path dir = adaptPath("src/test/resources/issue2367");
+        Path file = adaptPath("src/test/resources/issue2367/Issue2367.java");
+
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+        typeSolver.add(new JavaParserTypeSolver(dir));
+
+        JavaParser javaParser = new JavaParser();
+        javaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+
+        CompilationUnit unit = javaParser.parse(ParseStart.COMPILATION_UNIT,
+                new StreamProvider(Files.newInputStream(file))).getResult().get();
+
+        NameExpr nameExpr = unit.findFirst(NameExpr.class, m -> m.getName().getIdentifier().equals("privateField")).get();
+        ResolvedValueDeclaration resolvedValueDeclaration = nameExpr.resolve();
+        assertEquals("double", resolvedValueDeclaration.getType().describe());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue2367/Issue2367.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue2367/Issue2367.java
@@ -1,0 +1,8 @@
+public class Issue2367 {
+
+    private double privateField;
+
+    public Issue2367(double localField) {
+        privateField = localField;
+    }
+}


### PR DESCRIPTION
Fixes #2367. When solving a symbol as value, private members should also be considered.
