### PR TITLE
Fix indent of inserted code blocks

### DIFF
--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/IndentOfInsertedCodeBlocks.java.txt
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/IndentOfInsertedCodeBlocks.java.txt
@@ -1,0 +1,5 @@
+public class Example1 {
+    public void foo() {
+        System.out.println("Hello World!");
+    }
+}

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/IndentOfInsertedCodeBlocksExpected.java.txt
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/lexical_preservation_samples/IndentOfInsertedCodeBlocksExpected.java.txt
@@ -1,0 +1,15 @@
+public class Example1 {
+    public void foo() {
+        System.out.println("Hello World!");
+        if (name.equals("foo")) {
+            int i = 0;
+            System.out.println(i);
+            if (i < 0) {
+                i = 0;
+            }
+            new Object() {
+            };
+        } else {
+        }
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -501,9 +501,24 @@ public class LexicalPreservingPrinter {
 
         boolean pendingIndentation = false;
         for (CsmElement element : calculatedSyntaxModel.elements) {
+            if (element instanceof CsmIndent) {
+                int indexCurrentElement = calculatedSyntaxModel.elements.indexOf(element);
+                if(calculatedSyntaxModel.elements.size() > indexCurrentElement &&
+                        !(calculatedSyntaxModel.elements.get(indexCurrentElement + 1) instanceof CsmUnindent)) {
+                    for (int i = 0; i < Difference.STANDARD_INDENTATION_SIZE; i++) {
+                        indentation.add(new TokenTextElement(SPACE, " "));
+                    }
+                }
+            } else if (element instanceof CsmUnindent) {
+                for (int i = 0; i < Difference.STANDARD_INDENTATION_SIZE && indentation.size() > 0; i++) {
+                    indentation.remove(indentation.size() - 1);
+                }
+            }
+
             if (pendingIndentation && !(element instanceof CsmToken && ((CsmToken) element).isNewLine())) {
                 indentation.forEach(nodeText::addElement);
             }
+
             pendingIndentation = false;
             if (element instanceof LexicalDifferenceCalculator.CsmChild) {
                 nodeText.addChild(((LexicalDifferenceCalculator.CsmChild) element).getChild());
@@ -516,22 +531,12 @@ public class LexicalPreservingPrinter {
             } else if (element instanceof CsmMix) {
                 CsmMix csmMix = (CsmMix) element;
                 csmMix.getElements().forEach(e -> interpret(node, e, nodeText));
-
-            // Indentation should probably be dealt with before because an indentation has effects also on the
-            // following lines
-
-            } else if (element instanceof CsmIndent) {
-                for (int i = 0; i < Difference.STANDARD_INDENTATION_SIZE; i++) {
-                    nodeText.addToken(SPACE, " ");
-                }
-            } else if (element instanceof CsmUnindent) {
-                for (int i = 0; i < Difference.STANDARD_INDENTATION_SIZE; i++) {
-                    if (nodeText.endWithSpace()) {
-                        nodeText.removeLastElement();
-                    }
-                }
             } else {
-                throw new UnsupportedOperationException(element.getClass().getSimpleName());
+                // Indentation should probably be dealt with before because an indentation has effects also on the
+                // following lines
+                if(!(element instanceof CsmIndent) && !(element instanceof CsmUnindent)) {
+                    throw new UnsupportedOperationException(element.getClass().getSimpleName());
+                }
             }
         }
         // Array brackets are a pain... we do not have a way to represent them explicitly in the AST


### PR DESCRIPTION
Concidering the following example with LPP setup
```java
public class Example1 {
    public void foo() {
        System.out.println("Hello World!");
    }
}
```
adding code blocks and if statments results in
```java
public class Example1 {
    public void foo() {
        System.out.println("Hello World!");
        if (name.equals("foo")) {
            int i = 0;
        System.out.println(i);
        if (i < 0) {
            i = 0;
    }
        new Object() {
        };
    } else {
    }
    }
}
```
but I would expect
```java
public class Example1 {
    public void foo() {
        System.out.println("Hello World!");
        if (name.equals("foo")) {
            int i = 0;
            System.out.println(i);
            if (i < 0) {
                i = 0;
            }
            new Object() {
            };
        } else {
        }
    }
}
```
I've fixed this problem by applying the indention modifications of `CsmIndent` and `CsmUnindent` to the current indention modifier. There is also a test including the example above.