### PR TITLE
Allow $ in class-names, use getCanonicalName() instead

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
@@ -34,217 +34,243 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.expr.Name;
-import org.junit.jupiter.api.Test;
 
 class CompilationUnitBuildersTest {
-    private final CompilationUnit cu = new CompilationUnit();
+  private final CompilationUnit cu = new CompilationUnit();
 
-    @Test
-    void testAddImport() {
-        // duplicate imports
-        cu.addImport(Map.class);
-        cu.addImport(Map.class);
-        cu.addImport(Map.class.getName());
-        cu.addImport(List.class);
-        assertEquals(2, cu.getImports().size());
+  @Test
+  void testAddImport() {
+    // duplicate imports
+    cu.addImport(Map.class);
+    cu.addImport(Map.class);
+    cu.addImport(Map.class.getCanonicalName());
+    cu.addImport(List.class);
+    assertEquals(2, cu.getImports().size());
 
-        cu.addImport(com.github.javaparser.StaticJavaParser.class.getName() + ".parseImport", true, false);
-        assertEquals(3, cu.getImports().size());
+    cu.addImport(com.github.javaparser.StaticJavaParser.class.getCanonicalName() + ".parseImport", true, false);
+    assertEquals(3, cu.getImports().size());
 
-        assertEquals("import " + Map.class.getName() + ";" + EOL, cu.getImport(0).toString());
-        assertEquals("import " + List.class.getName() + ";" + EOL, cu.getImport(1).toString());
-        assertEquals("import static " + com.github.javaparser.StaticJavaParser.class.getName() + ".parseImport;" + EOL,
-                cu.getImport(2).toString());
+    assertEquals("import " + Map.class.getCanonicalName() + ";" + EOL, cu.getImport(0).toString());
+    assertEquals("import " + List.class.getCanonicalName() + ";" + EOL, cu.getImport(1).toString());
+    assertEquals("import static " + com.github.javaparser.StaticJavaParser.class.getCanonicalName() + ".parseImport;" + EOL,
+        cu.getImport(2).toString());
+  }
+
+  public class $tartsWith$ {
+  }
+
+  @Test
+  public void test$ImportStarts() {
+    cu.addImport($tartsWith$.class);
+    cu.addImport("my.$tartsWith$");
+    assertEquals(2, cu.getImports().size());
+    assertEquals("import " + $tartsWith$.class.getCanonicalName() + ";" + EOL, cu.getImport(0).toString());
+    assertEquals("import my.$tartsWith$;" + EOL, cu.getImport(1).toString());
+  }
+
+  public class F$F {
+  }
+
+  @Test
+  public void test$Import() {
+    cu.addImport(F$F.class);
+    cu.addImport("my.F$F");
+    // doesnt fail, but imports class "F.F"
+    assertEquals(2, cu.getImports().size());
+    assertEquals("import " + F$F.class.getCanonicalName() + ";" + EOL, cu.getImport(0).toString());
+    assertEquals("import my.F$F;" + EOL, cu.getImport(1).toString());
+  }
+
+  @Test
+  void ignoreJavaLangImports() {
+    cu.addImport("java.lang.Long");
+    cu.addImport("java.lang.*");
+    cu.addImport(String.class);
+    assertEquals(0, cu.getImports().size());
+  }
+
+  @Test
+  void ignoreImportsWithinSamePackage() {
+    cu.setPackageDeclaration(new PackageDeclaration(new Name(new Name("one"), "two")));
+    cu.addImport("one.two.IgnoreImportWithinSamePackage");
+    assertEquals(0, cu.getImports().size());
+    cu.addImport("one.two.three.DoNotIgnoreImportWithinSubPackage");
+    assertEquals(1, cu.getImports().size());
+    assertEquals("import one.two.three.DoNotIgnoreImportWithinSubPackage;" + EOL, cu.getImport(0).toString());
+  }
+
+  @Test
+  void throwIllegalArgumentExceptionOnImportingAnonymousClass() {
+    assertThrows(IllegalArgumentException.class, () -> cu.addImport(new Comparator<Long>() {
+
+      @Override
+      public int compare(Long o1, Long o2) {
+        return o1.compareTo(o2);
+      }
+    }.getClass()));
+  }
+
+  @Test
+  void throwIllegalArgumentExceptionOnImportingLocalClass() {
+    class LocalClass implements Comparator<Long> {
+
+      @Override
+      public int compare(Long o1, Long o2) {
+        return o1.compareTo(o2);
+      }
     }
+    Class<?> localClass = LocalClass.class;
+    assertThrows(IllegalArgumentException.class, () -> cu.addImport(localClass));
+  }
 
-    @Test
-    void ignoreJavaLangImports() {
-        cu.addImport("java.lang.Long");
-        cu.addImport("java.lang.*");
-        cu.addImport(String.class);
-        assertEquals(0, cu.getImports().size());
-    }
+  @Test
+  void ignoreImportsOfDefaultPackageClasses() {
+    cu.addImport("MyImport");
+    assertEquals(0, cu.getImports().size());
+  }
 
-    @Test
-    void ignoreImportsWithinSamePackage() {
-        cu.setPackageDeclaration(new PackageDeclaration(new Name(new Name("one"), "two")));
-        cu.addImport("one.two.IgnoreImportWithinSamePackage");
-        assertEquals(0, cu.getImports().size());
-        cu.addImport("one.two.three.DoNotIgnoreImportWithinSubPackage");
-        assertEquals(1, cu.getImports().size());
-        assertEquals("import one.two.three.DoNotIgnoreImportWithinSubPackage;" + EOL, cu.getImport(0).toString());
-    }
+  @Test
+  void duplicateByAsterisk() {
+    // check asterisk imports
+    cu.addImport("my", false, true);
+    cu.addImport("my.Import");
+    cu.addImport("my.AnotherImport");
+    cu.addImport("my.other.Import");
+    assertEquals(2, cu.getImports().size());
+    assertEquals("import my.*;" + EOL, cu.getImport(0).toString());
+    assertEquals("import my.other.Import;" + EOL, cu.getImport(1).toString());
+    cu.addImport("my.other.*");
+    assertEquals(2, cu.getImports().size());
+    assertEquals("import my.*;" + EOL, cu.getImport(0).toString());
+    assertEquals("import my.other.*;" + EOL, cu.getImport(1).toString());
+  }
 
-    @Test
-    void throwIllegalArgumentExceptionOnImportingAnonymousClass() {
-        assertThrows(IllegalArgumentException.class, () -> cu.addImport(new Comparator<Long>() {
+  @Test
+  void typesInTheJavaLangPackageDoNotNeedExplicitImports() {
+    cu.addImport(String.class);
+    assertEquals(0, cu.getImports().size());
+  }
 
-            @Override
-            public int compare(Long o1, Long o2) {
-                return o1.compareTo(o2);
-            }
-        }.getClass()));
-    }
+  @Test
+  void typesInSubPackagesOfTheJavaLangPackageRequireExplicitImports() {
+    cu.addImport(ElementType.class);
+    assertEquals(1, cu.getImports().size());
+    assertEquals("import java.lang.annotation.ElementType;" + EOL, cu.getImport(0).toString());
+  }
 
-    @Test
-    void throwIllegalArgumentExceptionOnImportingLocalClass() {
-        class LocalClass implements Comparator<Long> {
+  @Test
+  void doNotAddDuplicateImportsByClass() {
+    cu.addImport(Map.class);
+    cu.addImport(Map.class);
+    assertEquals(1, cu.getImports().size());
+  }
 
-            @Override
-            public int compare(Long o1, Long o2) {
-                return o1.compareTo(o2);
-            }
-        }
-        Class<?> localClass = LocalClass.class;
-        assertThrows(IllegalArgumentException.class, () -> cu.addImport(localClass));
-    }
+  @Test
+  void doNotAddDuplicateImportsByString() {
+    cu.addImport(Map.class);
+    cu.addImport("java.util.Map");
+    assertEquals(1, cu.getImports().size());
+  }
 
-    @Test
-    void ignoreImportsOfDefaultPackageClasses() {
-        cu.addImport("MyImport");
-        assertEquals(0, cu.getImports().size());
-    }
+  @Test
+  void doNotAddDuplicateImportsByStringAndFlags() {
+    cu.addImport(Map.class);
+    cu.addImport("java.util.Map", false, false);
+    assertEquals(1, cu.getImports().size());
+  }
 
-    @Test
-    void duplicateByAsterisk() {
-        // check asterisk imports
-        cu.addImport("my", false, true);
-        cu.addImport("my.Import");
-        cu.addImport("my.AnotherImport");
-        cu.addImport("my.other.Import");
-        assertEquals(2, cu.getImports().size());
-        assertEquals("import my.*;" + EOL, cu.getImport(0).toString());
-        assertEquals("import my.other.Import;" + EOL, cu.getImport(1).toString());
-        cu.addImport("my.other.*");
-        assertEquals(2, cu.getImports().size());
-        assertEquals("import my.*;" + EOL, cu.getImport(0).toString());
-        assertEquals("import my.other.*;" + EOL, cu.getImport(1).toString());
-    }
+  @Test
+  void doNotAddDuplicateImportsByImportDeclaration() {
+    cu.addImport(Map.class);
+    cu.addImport(parseImport("import java.util.Map;"));
+    assertEquals(1, cu.getImports().size());
+  }
 
-    @Test
-    void typesInTheJavaLangPackageDoNotNeedExplicitImports() {
-        cu.addImport(String.class);
-        assertEquals(0, cu.getImports().size());
-    }
+  @Test
+  void testAddImportArrayTypes() {
+    cu.addImport(CompilationUnit[][][].class);
+    cu.addImport(int[][][].class);
+    cu.addImport(Integer[][][].class);
+    cu.addImport(List[][][].class);
+    assertEquals(2, cu.getImports().size());
+    assertEquals("com.github.javaparser.ast.CompilationUnit", cu.getImport(0).getNameAsString());
+    assertEquals("java.util.List", cu.getImport(1).getNameAsString());
+  }
 
-    @Test
-    void typesInSubPackagesOfTheJavaLangPackageRequireExplicitImports() {
-        cu.addImport(ElementType.class);
-        assertEquals(1, cu.getImports().size());
-        assertEquals("import java.lang.annotation.ElementType;" + EOL, cu.getImport(0).toString());
-    }
+  class testInnerClass {
 
-    @Test
-    void doNotAddDuplicateImportsByClass() {
-        cu.addImport(Map.class);
-        cu.addImport(Map.class);
-        assertEquals(1, cu.getImports().size());
-    }
+  }
 
-    @Test
-    void doNotAddDuplicateImportsByString() {
-        cu.addImport(Map.class);
-        cu.addImport("java.util.Map");
-        assertEquals(1, cu.getImports().size());
-    }
+  @Test
+  void testAddImportAnonymousClass() {
+    cu.addImport(testInnerClass.class);
+    assertEquals("import " + testInnerClass.class.getCanonicalName().replace("$", ".") + ";" + EOL,
+        cu.getImport(0).toString());
+  }
 
-    @Test
-    void doNotAddDuplicateImportsByStringAndFlags() {
-        cu.addImport(Map.class);
-        cu.addImport("java.util.Map", false, false);
-        assertEquals(1, cu.getImports().size());
-    }
+  @Test
+  void testAddClass() {
+    ClassOrInterfaceDeclaration myClassDeclaration = cu.addClass("testClass", PRIVATE);
+    assertEquals(1, cu.getTypes().size());
+    assertEquals("testClass", cu.getType(0).getNameAsString());
+    assertEquals(ClassOrInterfaceDeclaration.class, cu.getType(0).getClass());
+    assertTrue(myClassDeclaration.isPrivate());
+    assertFalse(myClassDeclaration.isInterface());
+  }
 
-    @Test
-    void doNotAddDuplicateImportsByImportDeclaration() {
-        cu.addImport(Map.class);
-        cu.addImport(parseImport("import java.util.Map;"));
-        assertEquals(1, cu.getImports().size());
-    }
+  @Test
+  void testAddInterface() {
+    ClassOrInterfaceDeclaration myInterfaceDeclaration = cu.addInterface("testInterface");
+    assertEquals(1, cu.getTypes().size());
+    assertEquals("testInterface", cu.getType(0).getNameAsString());
+    assertTrue(myInterfaceDeclaration.isPublic());
+    assertEquals(ClassOrInterfaceDeclaration.class, cu.getType(0).getClass());
+    assertTrue(myInterfaceDeclaration.isInterface());
+  }
 
-    @Test
-    void testAddImportArrayTypes() {
-        cu.addImport(CompilationUnit[][][].class);
-        cu.addImport(int[][][].class);
-        cu.addImport(Integer[][][].class);
-        cu.addImport(List[][][].class);
-        assertEquals(2, cu.getImports().size());
-        assertEquals("com.github.javaparser.ast.CompilationUnit", cu.getImport(0).getNameAsString());
-        assertEquals("java.util.List", cu.getImport(1).getNameAsString());
-    }
+  @Test
+  void testAddEnum() {
+    EnumDeclaration myEnumDeclaration = cu.addEnum("test");
+    assertEquals(1, cu.getTypes().size());
+    assertEquals("test", cu.getType(0).getNameAsString());
+    assertTrue(myEnumDeclaration.isPublic());
+    assertEquals(EnumDeclaration.class, cu.getType(0).getClass());
+  }
 
-    class testInnerClass {
+  @Test
+  void testAddAnnotationDeclaration() {
+    AnnotationDeclaration myAnnotationDeclaration = cu.addAnnotationDeclaration("test");
+    assertEquals(1, cu.getTypes().size());
+    assertEquals("test", cu.getType(0).getNameAsString());
+    assertTrue(myAnnotationDeclaration.isPublic());
+    assertEquals(AnnotationDeclaration.class, cu.getType(0).getClass());
+  }
 
-    }
+  @Test
+  void testGetClassByName() {
+    assertEquals(cu.addClass("test"), cu.getClassByName("test").get());
+  }
 
-    @Test
-    void testAddImportAnonymousClass() {
-        cu.addImport(testInnerClass.class);
-        assertEquals("import " + testInnerClass.class.getName().replace("$", ".") + ";" + EOL,
-                cu.getImport(0).toString());
-    }
+  @Test
+  void testGetInterfaceByName() {
+    assertEquals(cu.addInterface("test"), cu.getInterfaceByName("test").get());
+  }
 
-    @Test
-    void testAddClass() {
-        ClassOrInterfaceDeclaration myClassDeclaration = cu.addClass("testClass", PRIVATE);
-        assertEquals(1, cu.getTypes().size());
-        assertEquals("testClass", cu.getType(0).getNameAsString());
-        assertEquals(ClassOrInterfaceDeclaration.class, cu.getType(0).getClass());
-        assertTrue(myClassDeclaration.isPrivate());
-        assertFalse(myClassDeclaration.isInterface());
-    }
+  @Test
+  void testGetEnumByName() {
+    assertEquals(cu.addEnum("test"), cu.getEnumByName("test").get());
+  }
 
-    @Test
-    void testAddInterface() {
-        ClassOrInterfaceDeclaration myInterfaceDeclaration = cu.addInterface("testInterface");
-        assertEquals(1, cu.getTypes().size());
-        assertEquals("testInterface", cu.getType(0).getNameAsString());
-        assertTrue(myInterfaceDeclaration.isPublic());
-        assertEquals(ClassOrInterfaceDeclaration.class, cu.getType(0).getClass());
-        assertTrue(myInterfaceDeclaration.isInterface());
-    }
-
-    @Test
-    void testAddEnum() {
-        EnumDeclaration myEnumDeclaration = cu.addEnum("test");
-        assertEquals(1, cu.getTypes().size());
-        assertEquals("test", cu.getType(0).getNameAsString());
-        assertTrue(myEnumDeclaration.isPublic());
-        assertEquals(EnumDeclaration.class, cu.getType(0).getClass());
-    }
-
-    @Test
-    void testAddAnnotationDeclaration() {
-        AnnotationDeclaration myAnnotationDeclaration = cu.addAnnotationDeclaration("test");
-        assertEquals(1, cu.getTypes().size());
-        assertEquals("test", cu.getType(0).getNameAsString());
-        assertTrue(myAnnotationDeclaration.isPublic());
-        assertEquals(AnnotationDeclaration.class, cu.getType(0).getClass());
-    }
-
-    @Test
-    void testGetClassByName() {
-        assertEquals(cu.addClass("test"), cu.getClassByName("test").get());
-    }
-
-    @Test
-    void testGetInterfaceByName() {
-        assertEquals(cu.addInterface("test"), cu.getInterfaceByName("test").get());
-    }
-
-    @Test
-    void testGetEnumByName() {
-        assertEquals(cu.addEnum("test"), cu.getEnumByName("test").get());
-    }
-
-    @Test
-    void testGetAnnotationDeclarationByName() {
-        assertEquals(cu.addAnnotationDeclaration("test"), cu.getAnnotationDeclarationByName("test").get());
-    }
+  @Test
+  void testGetAnnotationDeclarationByName() {
+    assertEquals(cu.addAnnotationDeclaration("test"), cu.getAnnotationDeclarationByName("test").get());
+  }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -379,6 +379,9 @@ public class CompilationUnit extends Node {
      * @return this, the {@link CompilationUnit}
      */
     public CompilationUnit addImport(String name, boolean isStatic, boolean isAsterisk) {
+        if (name == null) {
+          return this;
+        }
         final StringBuilder i = new StringBuilder("import ");
         if (isStatic) {
             i.append("static ");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -366,7 +366,7 @@ public class CompilationUnit extends Node {
         else if (clazz.isAnonymousClass() || clazz.isLocalClass())
             throw new IllegalArgumentException(
                     clazz.getName() + " is an anonymous or local class therefore it can't be added with addImport");
-        return addImport(clazz.getName());
+        return addImport(clazz.getCanonicalName());
     }
 
     /**
@@ -383,7 +383,7 @@ public class CompilationUnit extends Node {
         if (isStatic) {
             i.append("static ");
         }
-        i.append(name.replace("$", "."));
+        i.append(name);
         if (isAsterisk) {
             i.append(".*");
         }


### PR DESCRIPTION
Fixes #2391. 
* allow $ in class-names, use getCanonicalName() instead of replacing $ of getName() for inner classes
* ignore null-names (getCanonicalName could return null)


