### PR TITLE
Update JavadocBlockTag

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/JavadocBlockTag.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/JavadocBlockTag.java
@@ -66,7 +66,7 @@ public class JavadocBlockTag {
         private String keyword;
 
         boolean hasName() {
-            return this == PARAM;
+            return this == PARAM || this == EXCEPTION || this == THROWS;
         }
 
         static Type fromName(String tagName) {


### PR DESCRIPTION
to capture the type of exception documented by ```@throws``` and ```@exception``` in ```JavadocBlockTag.name``` similar to ```@param```.