### PR TITLE
removing unused dependencies

### DIFF
--- a/javaparser-symbol-solver-logic/pom.xml
+++ b/javaparser-symbol-solver-logic/pom.xml
@@ -32,17 +32,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-symbol-solver-model</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Hello, I noticed that javassist and guava are declared in the pom of module javaparser-symbol-solver-logic. However, they are not used in this module. 
