### PR TITLE
Fix: Remove "new ParserConfiguration()" in parallelized parse methods and add encoding parameter to provide()

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -246,7 +246,7 @@ public class SourceRoot {
     private FileVisitResult callback(Path absolutePath, ParserConfiguration configuration, Callback callback) throws IOException {
         Path localPath = root.relativize(absolutePath);
         Log.trace("Parsing %s", () -> localPath);
-        ParseResult<CompilationUnit> result = new JavaParser(configuration).parse(COMPILATION_UNIT, provider(absolutePath));
+        ParseResult<CompilationUnit> result = new JavaParser(configuration).parse(COMPILATION_UNIT, provider(absolutePath, configuration.getCharacterEncoding()));
         result.getResult().ifPresent(cu -> cu.setStorage(absolutePath, configuration.getCharacterEncoding()));
         switch (callback.process(localPath, absolutePath, result)) {
             case SAVE:

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -372,7 +372,7 @@ public class SourceRoot {
      * @param startPackage files in this package and deeper are parsed. Pass "" to parse all files.
      */
     public SourceRoot parseParallelized(String startPackage, Callback callback) throws IOException {
-        return parseParallelized(startPackage, new ParserConfiguration(), callback);
+        return parseParallelized(startPackage, this.parserConfiguration, callback);
     }
 
     /**
@@ -383,7 +383,7 @@ public class SourceRoot {
      * this is much more memory efficient, but saveAll() won't work.
      */
     public SourceRoot parseParallelized(Callback callback) throws IOException {
-        return parseParallelized("", new ParserConfiguration(), callback);
+        return parseParallelized("", this.parserConfiguration, callback);
     }
 
     /**


### PR DESCRIPTION
On "parseParallelized" methods I've removed instantiation of ParserConfiguration in order to make use of internal custom ParserConfiguration instance.

Also, encoding was provided default to UTF8 because the JavaParser was invoked with the provider() method versions without the "encoding" parameter

(No related bugs open)
