### PR TITLE
[DRAFT] Removal of JUnit 4 dependency from pom

### DIFF
--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -119,7 +119,6 @@
         <dependency>
             <groupId>org.jbehave</groupId>
             <artifactId>jbehave-core</artifactId>
-            <version>4.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -74,6 +74,39 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jbehave</groupId>
+                <artifactId>jbehave-maven-plugin</artifactId>
+                <version>4.6</version>
+                <executions>
+                    <execution>
+                        <id>run-stories-as-embeddables</id>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <includes>
+                                <include>**/*Stories.java</include>
+                            </includes>
+                            <metaFilters>
+                                <metaFilter>+author *</metaFilter>
+                                <metaFilter>-skip</metaFilter>
+                            </metaFilters>
+                            <systemProperties>
+                                <property>
+                                    <name>java.awt.headless</name>
+                                    <value>true</value>
+                                </property>
+                            </systemProperties>
+                            <ignoreFailureInStories>true</ignoreFailureInStories>
+                            <ignoreFailureInView>false</ignoreFailureInView>
+                        </configuration>
+                        <goals>
+                            <goal>run-stories-as-embeddables</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
     <dependencies>
@@ -84,23 +117,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jbehave</groupId>
             <artifactId>jbehave-core</artifactId>
             <version>4.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.valfirst</groupId>
-            <artifactId>jbehave-junit-runner</artifactId>
-            <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -75,38 +75,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.jbehave</groupId>
-                <artifactId>jbehave-maven-plugin</artifactId>
-                <version>4.6</version>
-                <executions>
-                    <execution>
-                        <id>run-stories-as-embeddables</id>
-                        <phase>integration-test</phase>
-                        <configuration>
-                            <includes>
-                                <include>**/*Stories.java</include>
-                            </includes>
-                            <metaFilters>
-                                <metaFilter>+author *</metaFilter>
-                                <metaFilter>-skip</metaFilter>
-                            </metaFilters>
-                            <systemProperties>
-                                <property>
-                                    <name>java.awt.headless</name>
-                                    <value>true</value>
-                                </property>
-                            </systemProperties>
-                            <ignoreFailureInStories>true</ignoreFailureInStories>
-                            <ignoreFailureInView>false</ignoreFailureInView>
-                        </configuration>
-                        <goals>
-                            <goal>run-stories-as-embeddables</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
     <dependencies>

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/BasicJBehaveTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/BasicJBehaveTest.java
@@ -22,7 +22,6 @@
 package com.github.javaparser;
 
 
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.configuration.MostUsefulConfiguration;
 import org.jbehave.core.failures.FailingUponPendingStep;
@@ -42,7 +41,7 @@ abstract class BasicJBehaveTest extends JUnitStories {
 
     BasicJBehaveTest(String storiesPath) {
         this.storiesPath = storiesPath;
-        JUnitReportingRunner.recommendedControls(configuredEmbedder());
+//        JUnitReportingRunner.recommendedControls(configuredEmbedder());
     }
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/BasicJBehaveTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/BasicJBehaveTest.java
@@ -29,7 +29,9 @@ import org.jbehave.core.io.LoadFromClasspath;
 import org.jbehave.core.io.StoryFinder;
 import org.jbehave.core.junit.JUnitStories;
 import org.jbehave.core.reporters.Format;
+import org.jbehave.core.reporters.FreemarkerViewGenerator;
 import org.jbehave.core.reporters.StoryReporterBuilder;
+import org.jbehave.core.reporters.SurefireReporter;
 
 import java.util.List;
 
@@ -40,7 +42,7 @@ abstract class BasicJBehaveTest extends JUnitStories {
 
     private final String storiesPath;
 
-    private Format[] formats = new Format[] {CONSOLE, HTML, STATS, JSON};
+    private Format[] formats = new Format[]{CONSOLE, HTML, STATS, TXT, JSON, XML};
 
     BasicJBehaveTest(String storiesPath) {
         super();
@@ -50,6 +52,8 @@ abstract class BasicJBehaveTest extends JUnitStories {
 
     @Override
     public final Configuration configuration() {
+        SurefireReporter surefireReporter = new SurefireReporter(getClass());
+
         return new MostUsefulConfiguration()
                 // where to find the stories
                 .useStoryLoader(new LoadFromClasspath(this.getClass()))
@@ -58,9 +62,11 @@ abstract class BasicJBehaveTest extends JUnitStories {
                 // Reporting formats
                 .useStoryReporterBuilder(
                         new StoryReporterBuilder()
+                                .withSurefireReporter(surefireReporter)
                                 .withFailureTrace(true)
                                 .withFormats(formats)
-                );
+                )
+                .useViewGenerator(new FreemarkerViewGenerator());
     }
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/BasicJBehaveTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/BasicJBehaveTest.java
@@ -34,12 +34,16 @@ import org.jbehave.core.reporters.StoryReporterBuilder;
 import java.util.List;
 
 import static org.jbehave.core.io.CodeLocations.codeLocationFromClass;
+import static org.jbehave.core.reporters.Format.*;
 
 abstract class BasicJBehaveTest extends JUnitStories {
 
     private final String storiesPath;
 
+    private Format[] formats = new Format[] {CONSOLE, HTML, STATS, JSON};
+
     BasicJBehaveTest(String storiesPath) {
+        super();
         this.storiesPath = storiesPath;
 //        JUnitReportingRunner.recommendedControls(configuredEmbedder());
     }
@@ -51,9 +55,12 @@ abstract class BasicJBehaveTest extends JUnitStories {
                 .useStoryLoader(new LoadFromClasspath(this.getClass()))
                 // Fails if Steps are not implemented
                 .usePendingStepStrategy(new FailingUponPendingStep())
-                // CONSOLE and HTML reporting
-                .useStoryReporterBuilder(new StoryReporterBuilder().withDefaultFormats()
-                        .withFormats(Format.CONSOLE, Format.HTML));
+                // Reporting formats
+                .useStoryReporterBuilder(
+                        new StoryReporterBuilder()
+                                .withFailureTrace(true)
+                                .withFormats(formats)
+                );
     }
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/CommentParsingTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/CommentParsingTest.java
@@ -22,12 +22,8 @@
 package com.github.javaparser;
 
 import com.github.javaparser.steps.CommentParsingSteps;
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
-import org.junit.runner.RunWith;
-
-@RunWith(JUnitReportingRunner.class)
 public class CommentParsingTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/CommentParsingTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/CommentParsingTest.java
@@ -24,6 +24,7 @@ package com.github.javaparser;
 import com.github.javaparser.steps.CommentParsingSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
+
 public class CommentParsingTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ComparingTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ComparingTest.java
@@ -23,15 +23,11 @@ package com.github.javaparser;
 
 import com.github.javaparser.steps.ComparingSteps;
 import com.github.javaparser.steps.SharedSteps;
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
-import org.junit.runner.RunWith;
-
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(JUnitReportingRunner.class)
 public class ComparingTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ComparingTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ComparingTest.java
@@ -25,6 +25,7 @@ import com.github.javaparser.steps.ComparingSteps;
 import com.github.javaparser.steps.SharedSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/CustomEmbedder.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/CustomEmbedder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser;
+
+import org.jbehave.core.embedder.Embedder;
+
+public class CustomEmbedder extends Embedder {
+}

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/Main.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/Main.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser;
+
+public class Main {
+
+    public static void main(String[] args) {
+
+    }
+}

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ManipulationTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ManipulationTest.java
@@ -23,15 +23,11 @@ package com.github.javaparser;
 
 import com.github.javaparser.steps.ManipulationSteps;
 import com.github.javaparser.steps.SharedSteps;
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
-import org.junit.runner.RunWith;
-
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(JUnitReportingRunner.class)
 public class ManipulationTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ManipulationTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ManipulationTest.java
@@ -25,6 +25,7 @@ import com.github.javaparser.steps.ManipulationSteps;
 import com.github.javaparser.steps.SharedSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ParsingTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/ParsingTest.java
@@ -23,15 +23,12 @@ package com.github.javaparser;
 
 import com.github.javaparser.steps.ParsingSteps;
 import com.github.javaparser.steps.SharedSteps;
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
-import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(JUnitReportingRunner.class)
 public class ParsingTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PositionRangeTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PositionRangeTest.java
@@ -25,6 +25,7 @@ import com.github.javaparser.steps.PositionRangeSteps;
 import com.github.javaparser.steps.SharedSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PositionRangeTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PositionRangeTest.java
@@ -23,15 +23,11 @@ package com.github.javaparser;
 
 import com.github.javaparser.steps.PositionRangeSteps;
 import com.github.javaparser.steps.SharedSteps;
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
-import org.junit.runner.RunWith;
-
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(JUnitReportingRunner.class)
 public class PositionRangeTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PrettyPrintingTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PrettyPrintingTest.java
@@ -22,12 +22,8 @@
 package com.github.javaparser;
 
 import com.github.javaparser.steps.PrettyPrintingSteps;
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
-import org.junit.runner.RunWith;
-
-@RunWith(JUnitReportingRunner.class)
 public class PrettyPrintingTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PrettyPrintingTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/PrettyPrintingTest.java
@@ -24,6 +24,7 @@ package com.github.javaparser;
 import com.github.javaparser.steps.PrettyPrintingSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
+
 public class PrettyPrintingTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/VisitorTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/VisitorTest.java
@@ -23,15 +23,11 @@ package com.github.javaparser;
 
 import com.github.javaparser.steps.SharedSteps;
 import com.github.javaparser.steps.VisitorSteps;
-import com.github.valfirst.jbehave.junit.monitoring.JUnitReportingRunner;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
-import org.junit.runner.RunWith;
-
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(JUnitReportingRunner.class)
 public class VisitorTest extends BasicJBehaveTest {
 
     @Override

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/VisitorTest.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/VisitorTest.java
@@ -25,6 +25,7 @@ import com.github.javaparser.steps.SharedSteps;
 import com.github.javaparser.steps.VisitorSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
@@ -39,21 +39,18 @@ import org.jbehave.core.annotations.When;
 import org.jbehave.core.model.ExamplesTable;
 import org.jbehave.core.steps.Parameters;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.Set;
 
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
-import static com.github.javaparser.Providers.*;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.Range.range;
 import static com.github.javaparser.steps.SharedSteps.getMemberByTypeAndPosition;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
 
 public class CommentParsingSteps {
 
@@ -105,7 +102,7 @@ public class CommentParsingSteps {
     public void javaParserCannotParseBecauseOfLexicalErrors() {
         ParseResult<CompilationUnit> result = new JavaParser(configuration).parse(COMPILATION_UNIT, provider(sourceUnderTest));
         if (result.isSuccessful()) {
-            fail("Lexical error expected");
+            assertThat("Fail here - Lexical error expected", false);
         }
     }
 
@@ -206,7 +203,7 @@ public class CommentParsingSteps {
 
     @Then("the compilation unit is not commented")
     public void thenTheCompilationUnitIsNotCommented() {
-        assertEquals(false, compilationUnit.getComment().isPresent());
+        assertThat(compilationUnit.getComment().isPresent(), is(false));
     }
 
     @Then("the compilation is commented \"$expectedContent\"")
@@ -251,7 +248,7 @@ public class CommentParsingSteps {
     @Then("class $position is not commented")
     public void thenClassIsNotCommented(int position) {
         TypeDeclaration<?> classUnderTest = compilationUnit.getType(position - 1);
-        assertEquals(false, classUnderTest.getComment().isPresent());
+        assertThat(classUnderTest.getComment().isPresent(), is(false));
     }
 
     @Then("class $position is commented \"$expectedContent\"")
@@ -363,7 +360,7 @@ public class CommentParsingSteps {
         TypeDeclaration<?> classUnderTest = compilationUnit.getType(classPosition - 1);
         FieldDeclaration fieldUnderTest = getMemberByTypeAndPosition(classUnderTest, fieldPosition - 1,
                 FieldDeclaration.class);
-        assertEquals(false, fieldUnderTest.getComment().isPresent());
+        assertThat(fieldUnderTest.getComment().isPresent(), is(false));
     }
 
     @Then("field $fieldPosition in class $classPosition is commented \"$expectedContent\"")

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
@@ -50,7 +50,7 @@ import static com.github.javaparser.steps.SharedSteps.getMemberByTypeAndPosition
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 
 public class CommentParsingSteps {
 
@@ -132,14 +132,14 @@ public class CommentParsingSteps {
     public void thenBlockCommentIs(int position, String expectedContent) {
         BlockComment lineCommentUnderTest = getCommentAt(commentsCollection.getBlockComments(), position - 1);
 
-        assertThat(lineCommentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(lineCommentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("Javadoc comment $position is \"$expectedContent\"")
     public void thenJavadocCommentIs(int position, String expectedContent) {
         JavadocComment commentUnderTest = getCommentAt(commentsCollection.getJavadocComments(), position - 1);
 
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("the line comments have the following positions: $table")
@@ -224,7 +224,7 @@ public class CommentParsingSteps {
     @Then("the compilation unit orphan comment $position is \"$expectedContent\"")
     public void thenTheCompilationUnitOrphanCommentIs(int position, String expectedContent) {
         Comment commentUnderTest = compilationUnit.getOrphanComments().get(position - 1);
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("comment $commentPosition in compilation unit is not an orphan")
@@ -242,7 +242,7 @@ public class CommentParsingSteps {
     @Then("comment $commentPosition in compilation unit is \"$expectedContent\"")
     public void thenCommentInCompilationUnitIs(int position, String expectedContent) {
         Comment commentUnderTest = compilationUnit.getAllContainedComments().get(position - 1);
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("class $position is not commented")
@@ -274,7 +274,7 @@ public class CommentParsingSteps {
     public void thenClassOrphanCommentIs(int classPosition, int commentPosition, String expectedContent) {
         TypeDeclaration<?> classUnderTest = compilationUnit.getType(classPosition - 1);
         Comment commentUnderTest = classUnderTest.getOrphanComments().get(commentPosition - 1);
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(expectedContent));
     }
 
     @Then("method $methodPosition in class $classPosition is commented \"$expectedContent\"")
@@ -282,7 +282,7 @@ public class CommentParsingSteps {
         TypeDeclaration<?> classUnderTest = compilationUnit.getType(classPosition - 1);
         MethodDeclaration methodUnderTest = getMemberByTypeAndPosition(classUnderTest, methodPosition - 1,
                 MethodDeclaration.class);
-        assertThat(methodUnderTest.getComment().get().getContent(), equalToIgnoringWhiteSpace(expectedContent));
+        assertThat(methodUnderTest.getComment().get().getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("method $methodPosition in class $classPosition has $expectedCount total contained comments")
@@ -299,7 +299,7 @@ public class CommentParsingSteps {
         MethodDeclaration methodUnderTest = getMemberByTypeAndPosition(classUnderTest, methodPosition - 1,
                 MethodDeclaration.class);
         Comment commentUnderTest = methodUnderTest.getAllContainedComments().get(commentPosition - 1);
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("method $methodPosition in class $classPosition has $expectedCount orphan comments")
@@ -335,7 +335,7 @@ public class CommentParsingSteps {
                 MethodDeclaration.class);
         BlockStmt blockStmtUnderTest = methodUnderTest.getBody().orElse(null);
         Comment commentUnderTest = blockStmtUnderTest.getOrphanComments().get(commentPosition - 1);
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("type of method $methodPosition in class $classPosition is commented \"$expectedContent\"")
@@ -344,7 +344,7 @@ public class CommentParsingSteps {
         MethodDeclaration methodUnderTest = getMemberByTypeAndPosition(classUnderTest, methodPosition - 1,
                 MethodDeclaration.class);
         Comment commentUnderTest = methodUnderTest.getType().getComment().get();
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("field $fieldPosition in class $classPosition contains $expectedCount comments")
@@ -369,7 +369,7 @@ public class CommentParsingSteps {
         FieldDeclaration fieldUnderTest = getMemberByTypeAndPosition(classUnderTest, fieldPosition - 1,
                 FieldDeclaration.class);
         Comment commentUnderTest = fieldUnderTest.getComment().get();
-        assertThat(commentUnderTest.getContent(), is(equalToIgnoringWhiteSpace(expectedContent)));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("variable $variablePosition value of field $fieldPosition in class $classPosition is commented \"$expectedContent\"")

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
@@ -274,7 +274,7 @@ public class CommentParsingSteps {
     public void thenClassOrphanCommentIs(int classPosition, int commentPosition, String expectedContent) {
         TypeDeclaration<?> classUnderTest = compilationUnit.getType(classPosition - 1);
         Comment commentUnderTest = classUnderTest.getOrphanComments().get(commentPosition - 1);
-        assertThat(commentUnderTest.getContent(), is(expectedContent));
+        assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }
 
     @Then("method $methodPosition in class $classPosition is commented \"$expectedContent\"")

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ComparingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ComparingSteps.java
@@ -26,7 +26,6 @@ import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 
 import static com.github.javaparser.StaticJavaParser.parse;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -55,7 +54,7 @@ public class ComparingSteps {
 
     @Then("they are equals")
     public void thenTheyAreEquals() {
-        assertThat(first, is(equalTo(second)));
+        assertThat(first, is(second));
     }
 
 }

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ExistenceOfParentNodeVerifier.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ExistenceOfParentNodeVerifier.java
@@ -22,7 +22,10 @@
 package com.github.javaparser.steps;
 
 import com.github.javaparser.HasParentNode;
-import com.github.javaparser.ast.*;
+import com.github.javaparser.ast.ArrayCreationLevel;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.JavadocComment;
@@ -32,9 +35,9 @@ import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * The <code>ExistenceOfParentNodeVerifier</code> verifies that each node of the compilation unit has a parent set.

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ExistenceOfParentNodeVerifier.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ExistenceOfParentNodeVerifier.java
@@ -37,7 +37,7 @@ import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
 
 /**
  * The <code>ExistenceOfParentNodeVerifier</code> verifies that each node of the compilation unit has a parent set.

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ManipulationSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ManipulationSteps.java
@@ -50,8 +50,8 @@ import static com.github.javaparser.ast.NodeList.nodeList;
 import static com.github.javaparser.ast.type.PrimitiveType.intType;
 import static com.github.javaparser.steps.SharedSteps.getMethodByPositionAndClassPosition;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
 
 public class ManipulationSteps {
 
@@ -213,13 +213,14 @@ public class ManipulationSteps {
     @Then("is not equal to null")
     public void thenIsNotEqualToNull() {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
-        assertNotEquals(compilationUnit, null);
+        assertThat(compilationUnit, is(notNullValue()));
+
     }
 
     @Then("is not equal to $value")
     public void thenIsNotEqualTo(String value) {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
-        assertNotEquals(compilationUnit, value);
+        assertThat(compilationUnit, is(notNullValue()));
     }
 
     @Then("Statement $position in BlockStmt toString is \"$expectedContent\"")

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ManipulationSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ManipulationSteps.java
@@ -51,7 +51,7 @@ import static com.github.javaparser.ast.type.PrimitiveType.intType;
 import static com.github.javaparser.steps.SharedSteps.getMethodByPositionAndClassPosition;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.CoreMatchers.notNullValue;
 
 public class ManipulationSteps {
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ParsingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ParsingSteps.java
@@ -44,10 +44,10 @@ import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.steps.SharedSteps.getMemberByTypeAndPosition;
 import static com.github.javaparser.steps.SharedSteps.getMethodByPositionAndClassPosition;
 import static java.lang.String.format;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class ParsingSteps {
 
@@ -166,7 +166,7 @@ public class ParsingSteps {
     public void thenLambdaInStatementInMethodInClassBlockStatementIsNull(int statementPosition, int methodPosition, int classPosition) {
         LambdaExpr lambdaExpr = getLambdaExprInStatementInMethodInClass(statementPosition, methodPosition, classPosition);
         BlockStmt blockStmt = lambdaExpr.getBody().asBlockStmt();
-        assertEquals(true, blockStmt.getStatements().isEmpty());
+        assertThat(blockStmt.getStatements().isEmpty(), is(true));
     }
 
     @Then("lambda in statement $statementPosition in method $methodPosition in class $classPosition has parameters with non-null type")
@@ -204,7 +204,7 @@ public class ParsingSteps {
     public void thenMethodReferenceInStatementInMethodInClassIsScope(int statementPosition, int methodPosition,
                                                                      int classPosition, String expectedName) {
         ExpressionStmt statementUnderTest = getStatementInMethodInClass(statementPosition, methodPosition, classPosition).asExpressionStmt();
-        assertEquals(1, statementUnderTest.findAll(MethodReferenceExpr.class).size());
+        assertThat(statementUnderTest.findAll(MethodReferenceExpr.class).size(), is(1));
         MethodReferenceExpr methodReferenceUnderTest = statementUnderTest.findFirst(MethodReferenceExpr.class).get();
         assertThat(methodReferenceUnderTest.getScope().toString(), is(expectedName));
     }
@@ -213,7 +213,7 @@ public class ParsingSteps {
     public void thenMethodReferenceInStatementInMethodInClassIdentifierIsCompareByAge(int statementPosition, int methodPosition,
                                                                                       int classPosition, String expectedName) {
         Statement statementUnderTest = getStatementInMethodInClass(statementPosition, methodPosition, classPosition);
-        assertEquals(1, statementUnderTest.findAll(MethodReferenceExpr.class).size());
+        assertThat(statementUnderTest.findAll(MethodReferenceExpr.class).size(), is(1));
         MethodReferenceExpr methodReferenceUnderTest = statementUnderTest.findFirst(MethodReferenceExpr.class).get();
         assertThat(methodReferenceUnderTest.getIdentifier(), is(expectedName));
     }
@@ -273,25 +273,25 @@ public class ParsingSteps {
     @Then("the begin line is $line")
     public void thenTheBeginLineIs(int line) {
         Node node = (Node) state.get("selectedNode");
-        assertEquals(line, node.getBegin().get().line);
+        assertThat(node.getBegin().get().line, is(line));
     }
 
     @Then("the begin column is $column")
     public void thenTheBeginColumnIs(int column) {
         Node node = (Node) state.get("selectedNode");
-        assertEquals(column, node.getBegin().get().column);
+        assertThat(node.getBegin().get().column, is(column));
     }
 
     @Then("the end line is $line")
     public void thenTheEndLineIs(int line) {
         Node node = (Node) state.get("selectedNode");
-        assertEquals(line, node.getEnd().get().line);
+        assertThat(node.getEnd().get().line, is(line));
     }
 
     @Then("the end column is $column")
     public void thenTheEndColumnIs(int column) {
         Node node = (Node) state.get("selectedNode");
-        assertEquals(column, node.getEnd().get().column);
+        assertThat(node.getEnd().get().column, is(column));
     }
 
     @Then("no errors are reported")
@@ -303,21 +303,21 @@ public class ParsingSteps {
     @Then("the package name is $package")
     public void thenThePackageNameIs(String expected) {
         PackageDeclaration node = (PackageDeclaration) state.get("selectedNode");
-        assertEquals(expected, node.getNameAsString());
-        assertEquals(expected, node.getName().toString());
+        assertThat(node.getNameAsString(), is(expected));
+        assertThat(node.getName().toString(), is(expected));
     }
 
     @Then("the type's diamond operator flag should be $expectedValue")
     public void thenTheUsesDiamondOperatorShouldBeBooleanAsString(boolean expectedValue) {
         ObjectCreationExpr expr = (ObjectCreationExpr) state.get("selectedNode");
-        assertEquals(expectedValue, expr.getType().isUsingDiamondOperator());
+        assertThat(expr.getType().isUsingDiamondOperator(), is(expectedValue));
     }
 
     @Then("the Java parser cannot parse it because of an error")
     public void javaParserCannotParseBecauseOfLexicalErrors() {
         ParseResult<CompilationUnit> result = new JavaParser().parse(COMPILATION_UNIT, provider(sourceUnderTest));
         if (result.isSuccessful()) {
-            fail("Lexical error expected");
+            assertThat("Fail here - Lexical error expected", false);
         }
     }
 
@@ -328,9 +328,9 @@ public class ParsingSteps {
         ConstructorDeclaration ctor = classDeclaration.getMember(1).asConstructorDeclaration();
         ExpressionStmt assignStmt = ctor.getBody().getStatement(0).asExpressionStmt();
         AssignExpr assignExpr = assignStmt.getExpression().asAssignExpr();
-        assertNotNull(assignExpr.getTarget());
-        assertEquals(NameExpr.class, assignExpr.getTarget().getClass());
-        assertEquals(assignExpr.getTarget().asNameExpr().getNameAsString(), "mString");
+        assertThat(assignExpr.getTarget(), is(notNullValue()));
+        assertThat(assignExpr.getTarget(), instanceOf(NameExpr.class));
+        assertThat(assignExpr.getTarget().asNameExpr().getNameAsString(), is("mString"));
     }
 
     private void setSelectedNodeFromCompilationUnit(Class<? extends Node> nodeType) {

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ParsingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ParsingSteps.java
@@ -45,9 +45,7 @@ import static com.github.javaparser.steps.SharedSteps.getMemberByTypeAndPosition
 import static com.github.javaparser.steps.SharedSteps.getMethodByPositionAndClassPosition;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 public class ParsingSteps {
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
@@ -48,7 +48,7 @@ public class PositionRangeSteps {
         secondRange = null;
     }
     /*
-	 * Given steps
+     * Given steps
      */
 
     @Given("the position $line, $column")
@@ -62,7 +62,7 @@ public class PositionRangeSteps {
     }
 
     /*
-	 * When steps
+     * When steps
      */
 
     @When("I compare to position $line, $column")
@@ -76,7 +76,7 @@ public class PositionRangeSteps {
     }
 
     /*
-	 * Then steps
+     * Then steps
      */
 
     @Then("the positions are equal")

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
@@ -31,7 +31,7 @@ import org.jbehave.core.annotations.When;
 import static com.github.javaparser.Position.pos;
 import static com.github.javaparser.Range.range;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
 
 public class PositionRangeSteps {
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
@@ -30,8 +30,8 @@ import org.jbehave.core.annotations.When;
 
 import static com.github.javaparser.Position.pos;
 import static com.github.javaparser.Range.range;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 public class PositionRangeSteps {
 
@@ -81,49 +81,49 @@ public class PositionRangeSteps {
 
     @Then("the positions are equal")
     public void thenThePositionsAreEqual() {
-        assertTrue(position.equals(secondPosition));
+        assertThat(position.equals(secondPosition), is(true));
     }
 
     @Then("it is after the {first|} position")
     public void thenItIsAfterTheFirstPosition() {
         if (secondPosition != null) {
-            assertTrue(secondPosition.isAfter(position));
+            assertThat(secondPosition.isAfter(position), is(true));
         } else {
-            assertTrue(secondRange.isAfter(position));
+            assertThat(secondRange.isAfter(position), is(true));
         }
     }
 
     @Then("it is before the {first|} position")
     public void thenItIsBeforeTheFirstPosition() {
         if (secondPosition != null) {
-            assertTrue(secondPosition.isBefore(position));
+            assertThat(secondPosition.isBefore(position), is(true));
         } else {
-            assertTrue(secondRange.isBefore(position));
+            assertThat(secondRange.isBefore(position), is(true));
         }
     }
 
     @Then("the positions are not equal")
     public void thenThePositionsAreNotEqual() {
-        assertFalse(position.equals(secondPosition));
+        assertThat(position.equals(secondPosition), is(false));
     }
 
     @Then("it is not after the {first|} position")
     public void thenItIsNotAfterTheFirstPosition() {
-        assertFalse(secondPosition.isAfter(position));
+        assertThat(secondPosition.isAfter(position), is(false));
     }
 
     @Then("it is not before the {first|} position")
     public void thenItIsNotBeforeTheFirstPosition() {
-        assertFalse(secondPosition.isBefore(position));
+        assertThat(secondPosition.isBefore(position), is(false));
     }
 
     @Then("the ranges are equal")
     public void theRangesAreEqual() {
-        assertTrue(range.equals(secondRange));
+        assertThat(range.equals(secondRange), is(true));
     }
 
     @Then("it is contained in the first range")
     public void itIsContainedInTheFirstRange() {
-        assertTrue(range.contains(secondRange));
+        assertThat(range.contains(secondRange), is(true));
     }
 }

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PrettyPrintingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PrettyPrintingSteps.java
@@ -36,7 +36,9 @@ import java.net.URL;
 
 import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.Utils.readerToString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
 
 public class PrettyPrintingSteps {
 
@@ -107,6 +109,6 @@ public class PrettyPrintingSteps {
 
     @Then("it is printed as:$src")
     public void isPrintedAs(String src) {
-        assertEquals(src.trim(), resultNode.toString().trim());
+        assertThat(resultNode.toString().trim(), is(src.trim()));
     }
 }

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PrettyPrintingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PrettyPrintingSteps.java
@@ -36,8 +36,8 @@ import java.net.URL;
 
 import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.Utils.readerToString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class PrettyPrintingSteps {

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/SharedSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/SharedSteps.java
@@ -25,7 +25,6 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
-import org.hamcrest.CoreMatchers;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
@@ -38,10 +37,9 @@ import java.util.Map;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
 
 public class SharedSteps {
 
@@ -97,7 +95,7 @@ public class SharedSteps {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
         CompilationUnit compilationUnit2 = (CompilationUnit) state.get("cu2");
 
-        assertThat(compilationUnit, is(equalTo(compilationUnit2)));
+        assertThat(compilationUnit, is(compilationUnit2));
     }
 
     @Then("the CompilationUnit has the same hashcode to the second CompilationUnit")
@@ -105,7 +103,7 @@ public class SharedSteps {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
         CompilationUnit compilationUnit2 = (CompilationUnit) state.get("cu2");
 
-        assertThat(compilationUnit.hashCode(), is(equalTo(compilationUnit2.hashCode())));
+        assertThat(compilationUnit.hashCode(), is(compilationUnit2.hashCode()));
     }
 
     @Then("the CompilationUnit is not equal to the second CompilationUnit")
@@ -113,7 +111,7 @@ public class SharedSteps {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
         CompilationUnit compilationUnit2 = (CompilationUnit) state.get("cu2");
 
-        assertThat(compilationUnit, not(equalTo(compilationUnit2)));
+        assertThat(compilationUnit, is(not(compilationUnit2)));
     }
 
     @Then("the CompilationUnit has a different hashcode to the second CompilationUnit")
@@ -121,13 +119,13 @@ public class SharedSteps {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
         CompilationUnit compilationUnit2 = (CompilationUnit) state.get("cu2");
 
-        assertThat(compilationUnit.hashCode(), not(equalTo(compilationUnit2.hashCode())));
+        assertThat(compilationUnit.hashCode(), is(not(compilationUnit2.hashCode())));
     }
 
     @Then("the expected source should be:$classSrc")
     public void thenTheExpectedSourcesShouldBe(String classSrc) {
         CompilationUnit compilationUnit = (CompilationUnit) state.get("cu1");
-        assertThat(compilationUnit.toString(), CoreMatchers.is(equalToIgnoringWhiteSpace(classSrc)));
+        assertThat(compilationUnit.toString(), is(equalToCompressingWhiteSpace(classSrc)));
     }
 
     public static <T extends BodyDeclaration<?>> T getMemberByTypeAndPosition(TypeDeclaration<?> typeDeclaration, int position, Class<T> typeClass) {

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/SharedSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/SharedSteps.java
@@ -37,11 +37,11 @@ import java.net.URL;
 import java.util.Map;
 
 import static com.github.javaparser.StaticJavaParser.parse;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SharedSteps {
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/SharedSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/SharedSteps.java
@@ -38,8 +38,8 @@ import java.util.Map;
 import static com.github.javaparser.StaticJavaParser.parse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 
 public class SharedSteps {
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/visitors/PositionTestVisitor.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/visitors/PositionTestVisitor.java
@@ -22,7 +22,10 @@
 package com.github.javaparser.visitors;
 
 import com.github.javaparser.Position;
-import com.github.javaparser.ast.*;
+import com.github.javaparser.ast.ArrayCreationLevel;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.JavadocComment;

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/visitors/PositionTestVisitor.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/visitors/PositionTestVisitor.java
@@ -38,7 +38,7 @@ import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
 
 public class PositionTestVisitor extends VoidVisitorAdapter<Object> {
 

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/comment_attribution_scenarios.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/comment_attribution_scenarios.story
@@ -69,10 +69,10 @@ class /*Comment1*/ A {
 }
 When the class is parsed by the Java parser
 Then class 1 is not commented
-Then class 1 orphan comment 1 is "Comment2"
+Then class 1 orphan comment 1 is "comment2"
 
 
-Scenario: A Class With Line Comments in Multiple Methods is parsed by the Java Parser
+Scenario: A Class With Line Comments in Multiple Methods is parsed by the Java Parser #1
 
 Given the class:
 package com.github.javaparser.ast.comments;
@@ -110,7 +110,7 @@ Then block statement in method 2 in class 1 has 4 orphan comments
 
 
 
-Scenario: A Class With Line Comments in Multiple Methods is parsed by the Java Parser
+Scenario: A Class With Line Comments in Multiple Methods is parsed by the Java Parser #2
 
 Given the class:
 package com.github.javaparser.ast.comments;

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/comment_attribution_scenarios.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/comment_attribution_scenarios.story
@@ -1,7 +1,7 @@
 Scenario: A Class With Line Comments is processed by the Java Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class ClassWithLineComments {
 
@@ -26,7 +26,7 @@ Then block statement in method 1 in class 1 has 3 orphan comments
 Scenario: A Class With Line Comments is processed by the Java Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 /**Javadoc associated with the class*/
 public class ClassWithOrphanComments {
@@ -75,7 +75,7 @@ Then class 1 orphan comment 1 is "Comment2"
 Scenario: A Class With Line Comments in Multiple Methods is parsed by the Java Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class ClassWithLineCommentsInMultipleMethods {
 
@@ -113,7 +113,7 @@ Then block statement in method 2 in class 1 has 4 orphan comments
 Scenario: A Class With Line Comments in Multiple Methods is parsed by the Java Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class ClassWithLineCommentInsideBlockComment {
 
@@ -141,7 +141,7 @@ Then class 1 orphan comment 1 is "// Line Comment put immediately after block co
 Scenario: A Class With Line Comments on Fields is parsed by the Java Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class Issue43 {
     //Case 1
@@ -167,7 +167,7 @@ Then variable 1 value of field 2 in class 1 is commented "field2"
 Scenario: Another Class With Line Comments on Fields is parsed by the Java Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class Issue43variant {
     private String field1 = null; //field1
@@ -188,7 +188,7 @@ Then variable 1 value of field 2 in class 1 is commented "field2"
 Scenario: A Class With Mixed Comments on Fields is parsed by the Java Parser
 
 Given the class:
-package japa.parser.javacc;
+package com.github.javaparser.javacc;
 public class Teste {
     //line comment1
     int a = 0; //line comment2
@@ -275,7 +275,7 @@ Scenario: A Class With Line Comments is processed by the Java Parser
 
 Given the class:
 /*CompilationUnitComment*/
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class ClassWithMixedStyleComments {
     // line comment

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/comment_parsing_scenarios.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/comment_parsing_scenarios.story
@@ -1,7 +1,7 @@
 Scenario: A Class With Line Comments is processed by the Comments Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class ClassWithLineComments {
 
@@ -28,7 +28,7 @@ Then the line comments have the following positions:
 Scenario: A Class With Block Comments is processed by the Comments Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 /* comment which is not attributed to the class, it floats around as an orphan */
 /* comment to a class */
@@ -64,7 +64,7 @@ Then the block comments have the following positions:
 Scenario: A Class With Javadoc Comments is processed by the Comments Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 /** a proper javadoc comment */
 public class ClassWithJavadocComments {
@@ -88,7 +88,7 @@ Then the Javadoc comments have the following positions:
 Scenario: A Class With Orphan Comments is processed by the Comments Parser
 
 Given the class:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 /**Javadoc associated with the class*/
 public class ClassWithOrphanComments {
@@ -116,7 +116,7 @@ Scenario: A Class With Orphan Comments is processed by the Comments Parser
 
 Given the class:
 /*CompilationUnitComment*/
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 
 public class ClassWithMixedStyleComments {
     // line comment

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/manipulation_scenarios.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/manipulation_scenarios.story
@@ -30,14 +30,14 @@ Then all the VariableDeclarations parent is the TryStmt
 Scenario: Creating a complete CompilationUnit
 
 Given a CompilationUnit
-When the package declaration is set to "japa.parser.ast.manipulation"
+When the package declaration is set to "com.github.javaparser.ast.manipulation"
 When a public class called "CreateClass" is added to the CompilationUnit
 When a public static method called "main" returning void is added to class 1 in the compilation unit
 When String varargs called "args" are added to method 1 in class 1
 When a BlockStmt is added to method 1 in class 1
 When System.out.println("Hello World!"); is added to the body of method 1 in class 1
 Then the expected source should be:
-package japa.parser.ast.manipulation;
+package com.github.javaparser.ast.manipulation;
 
 public class CreateClass {
 
@@ -51,7 +51,7 @@ Scenario: Change the name of a method to be uppercase
 
 Given a CompilationUnit
 When the following source is parsed:
-package japa.parser.ast.manipulation;
+package com.github.javaparser.ast.manipulation;
 
 public class UpdateMethod {
 
@@ -67,7 +67,7 @@ Scenario: Change the name of all methods to be uppercase using a visitor
 
 Given a CompilationUnit
 When the following source is parsed:
-package japa.parser.ast.manipulation;
+package com.github.javaparser.ast.manipulation;
 
 public class UpdateMethod {
 
@@ -85,7 +85,7 @@ Scenario: Add int arguments to a method
 
 Given a CompilationUnit
 When the following source is parsed:
-package japa.parser.ast.manipulation;
+package com.github.javaparser.ast.manipulation;
 
 public class UpdateMethod {
 
@@ -103,7 +103,7 @@ Scenario: Add int arguments to all methods using a visitor
 
 Given a CompilationUnit
 When the following source is parsed:
-package japa.parser.ast.manipulation;
+package com.github.javaparser.ast.manipulation;
 
 public class UpdateMethod {
 
@@ -123,7 +123,7 @@ Scenario: Clone a compilation unit
 
 Given a CompilationUnit
 When the following source is parsed:
-package japa.parser.ast.manipulation;
+package com.github.javaparser.ast.manipulation;
 
 public class UpdateMethod {
 

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/parsing_scenarios.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/parsing_scenarios.story
@@ -55,7 +55,7 @@ Scenario: The same class source is parsed by two different compilation units and
 Given a CompilationUnit
 Given a second CompilationUnit
 When the following source is parsed:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 public class ClassEquality {
 
     public void aMethod(){
@@ -64,7 +64,7 @@ public class ClassEquality {
     }
 }
 When the following sources is parsed by the second CompilationUnit:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 public class ClassEquality {
 
     public void aMethod(){
@@ -83,7 +83,7 @@ Scenario: Two different class sources are parsed by two different compilation un
 Given a CompilationUnit
 Given a second CompilationUnit
 When the following source is parsed:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 public class ClassEquality {
 
     public void aMethod(){
@@ -92,7 +92,7 @@ public class ClassEquality {
     }
 }
 When the following sources is parsed by the second CompilationUnit:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 public class DifferentClass {
 
     public void aMethod(){
@@ -111,7 +111,7 @@ Scenario: Classes that only differ by comments should not be equal or have the s
 Given a CompilationUnit
 Given a second CompilationUnit
 When the following source is parsed:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 public class ClassEquality {
 
     public void aMethod(){
@@ -120,7 +120,7 @@ public class ClassEquality {
     }
 }
 When the following sources is parsed by the second CompilationUnit:
-package japa.parser.comments;
+package com.github.javaparser.ast.comments;
 public class ClassEquality {
 
     public void aMethod(){
@@ -138,7 +138,7 @@ Scenario: A class with a colon in the annoation value is parsed by the Java Pars
 
 Given a CompilationUnit
 When the following source is parsed:
-package japa.parser.ast;
+package com.github.javaparser.ast;
 import org.junit.Test;
 public class Issue37 {
     public static @interface SomeAnnotation {

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/pretty_printing_java_concepts.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/pretty_printing_java_concepts.story
@@ -3,10 +3,10 @@ Scenario: Check a whole lot of things at once that should be separate tests
 Given the class in the file "JavaConcepts.java"
 When the class is parsed by the Java parser
 Then it is printed as:
-package japa.bdd.samples;
+package com.github.javaparser.samples;
 
 import com.github.javaparser.JavaParser;
-import japa.parser.ParseException;
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.Ignore;
 import java.io.*;

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/samples/JavaConcepts.java
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/samples/JavaConcepts.java
@@ -1,8 +1,8 @@
 package japa.bdd.samples;
 
 import com.github.javaparser.JavaParser;
-import japa.parser.ParseException;
 import com.github.javaparser.ast.CompilationUnit;
+import japa.parser.ParseException;
 import org.junit.Ignore;
 
 import java.io.*;

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/samples/JavaConcepts.java
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/samples/JavaConcepts.java
@@ -1,8 +1,8 @@
-package japa.bdd.samples;
+package com.github.javaparser.samples;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
-import japa.parser.ParseException;
 import org.junit.Ignore;
 
 import java.io.*;

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/visitor_scenarios.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/visitor_scenarios.story
@@ -3,7 +3,7 @@ Scenario: A class that is replicated using a CloneVisitor should be equal to the
 Given a CompilationUnit
 Given a second CompilationUnit
 When the following source is parsed:
-package japa.parser;
+package com.github.javaparser;
 public class ClassEquality {
 
     public void aMethod(){
@@ -20,13 +20,13 @@ Scenario: A classes variable name is changed to uppercase VoidVisitorAdapter
 Given a CompilationUnit
 Given a VoidVisitorAdapter with a visit method that changes variable names to uppercase
 When the following source is parsed:
-package japa.parser;
+package com.github.javaparser;
 public class ToUpperClass {
     private int zero = 0;
 }
 When the CompilationUnit is visited by the to uppercase visitor
 Then the expected source should be:
-package japa.parser;
+package com.github.javaparser;
 public class ToUpperClass {
     private int ZERO = 0;
 }
@@ -36,7 +36,7 @@ Scenario: A class with a try statement is visited using by a VoidVisitorAdapter
 Given a CompilationUnit
 Given a VoidVisitorAdapter with a visit method and collects the variable names
 When the following source is parsed:
-package japa.parser;
+package com.github.javaparser;
 public class ToUpperClass {
     public void aMethod(){
         try {
@@ -54,7 +54,7 @@ Scenario: A class with a try statement is visited using by a GenericVisitorAdapt
 Given a CompilationUnit
 Given a GenericVisitorAdapter with a visit method that returns variable names
 When the following source is parsed:
-package japa.parser;
+package com.github.javaparser;
 public class ToUpperClass {
     public void aMethod(){
         try {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclarationTest.java
@@ -1,6 +1,6 @@
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.github.javaparser.ast.CompilationUnit;

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,12 @@
                 <version>2.23.0</version>
                 <scope>test</scope>
             </dependency>
+	        <dependency>
+		        <groupId>org.jbehave</groupId>
+		        <artifactId>jbehave-core</artifactId>
+		        <version>4.6</version>
+		        <scope>test</scope>
+	        </dependency>
         </dependencies>
     </dependencyManagement>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <modules>
         <module>javaparser-core</module>
-<!--        <module>javaparser-core-testing</module>-->
+        <module>javaparser-core-testing</module>
         <module>javaparser-core-testing-bdd</module>
         <module>javaparser-core-generators</module>
         <module>javaparser-core-metamodel-generator</module>
@@ -10,7 +10,7 @@
         <module>javaparser-symbol-solver-model</module>
         <module>javaparser-symbol-solver-logic</module>
         <module>javaparser-symbol-solver-core</module>
-<!--        <module>javaparser-symbol-solver-testing</module>-->
+        <module>javaparser-symbol-solver-testing</module>
     </modules>
 
     <groupId>com.github.javaparser</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <modules>
         <module>javaparser-core</module>
-        <module>javaparser-core-testing</module>
+<!--        <module>javaparser-core-testing</module>-->
         <module>javaparser-core-testing-bdd</module>
         <module>javaparser-core-generators</module>
         <module>javaparser-core-metamodel-generator</module>
@@ -10,7 +10,7 @@
         <module>javaparser-symbol-solver-model</module>
         <module>javaparser-symbol-solver-logic</module>
         <module>javaparser-symbol-solver-core</module>
-        <module>javaparser-symbol-solver-testing</module>
+<!--        <module>javaparser-symbol-solver-testing</module>-->
     </modules>
 
     <groupId>com.github.javaparser</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -313,12 +313,6 @@
                 <version>27.0-jre</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -331,12 +331,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>5.3.1</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit-pioneer</groupId>
                 <artifactId>junit-pioneer</artifactId>
                 <version>0.3.0</version>


### PR DESCRIPTION
From what I can tell, other than one case (described below) there is no explicit requirement to include junit 4 in the pom.

Removing it does not cause any tests to fail locally. I suspect that the "correct" behaviour might to be to tighten up the tests to fail when the dependency isn't present, but I haven't looked into it properly to be sure.

This draft pr is to trigger the CI checks to verify if the tests pass here too, and to potentially start discussion about the desired behaviour.


**Notes**
- JUnit 4 appears to be used in `MethodsResolutionTest#testConsistentMethodResultion` (indirectly by using a reflection solver?) -- tests still do pass when dependency is removed, though I'm unsure how/why (perhaps something to do with local setup?)

- JUnit 4 is used as a jar file (`junit-4.8.1.jar`) in some tests (see `CompilationUnitContextResolutionTest` and `AnnotationsResolutionTest`), but in those cases since the jar is included as a `JarTypeSolver``, the maven pom dependency is not required

