### PR TITLE
[DISCUSSION] Issue 2032 - add string output interface

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -111,6 +111,7 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
     /**
      * @return the complete qualified name. Only the identifiers and the dots, so no comments or whitespace.
      */
+    @Override
     public String asString() {
         if (qualifier != null) {
             return qualifier.asString() + "." + identifier;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/SimpleName.java
@@ -100,6 +100,7 @@ public class SimpleName extends Node implements NodeWithIdentifier<SimpleName> {
         return super.remove(node);
     }
 
+    @Override
     public String asString() {
         return identifier;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -104,6 +104,7 @@ public class StringLiteralExpr extends LiteralStringValueExpr {
     /**
      * @return the unescaped literal value
      */
+    @Override
     public String asString() {
         return unescapeJava(value);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TextBlockLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TextBlockLiteralExpr.java
@@ -172,6 +172,7 @@ public class TextBlockLiteralExpr extends LiteralStringValueExpr {
     /**
      * @return the final string value of this text block after all processing.
      */
+    @Override
     public String asString() {
         return translateEscapes();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeAsString.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeAsString.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.nodeTypes;
+
+import com.github.javaparser.printer.PrettyPrinterConfiguration;
+
+/**
+ * This interface describes the different ways in which a node can be converted to a string.
+ *
+ * See this blog post for additional details: https://javaparser.org/making-strings-in-javaparser/
+ */
+public interface NodeAsString {
+
+    /**
+     * Description mostly from <a href="https://javaparser.org/making-strings-in-javaparser/">https://javaparser.org/making-strings-in-javaparser/</a>
+     * <p>
+     * We noticed that many people were using the output of the pretty printer
+     * for comparisons, like <pre>name.toString.equals("a.b.C")</pre>
+     *
+     * This can easily lead to bugs, since the pretty printer will also output
+     * comments and annotations associated with the node, so its output could be
+     * easily be <pre>\/*hello*\/a.b.C</pre>! Oops!
+     * <p>
+     * {@link #asString()} is defined as "the output you probably want when you
+     * want to represent this node as a string."
+     * It is quite arbitrary, but mostly means "what toString does, but without
+     * formatting, comments, or annotations."
+     *
+     * @return The node as a code string, normalised to not include the "fluff" that doesn't necessarily
+     * affect meaning or execution of the code, such as comments and annotations.
+     */
+    String asString();
+
+
+    /**
+     * @return The pretty printer that will be used by {@link #toString()} and {@link #toPrettyString()} if no parameter is provided.
+     */
+    PrettyPrinterConfiguration getDefaultPrinterConfiguration();
+
+
+    /**
+     * This just delegates to {@link #toPrettyString()}.
+     * <p>
+     * Use of {@link #toString()} and {@link #toString(PrettyPrinterConfiguration)} is discouraged, in favour of:
+     * <ul>
+     *      <li>{@link #asString()} if you want a stable string representation that doesn't alter due to comments and similar volatile attributes</li>
+     *      <li>{@link #toPrettyString()} if you want a formatted version of the node, using the default pretty-printer</li>
+     *      <li>{@link #toString(PrettyPrinterConfiguration)} ()} if you want a formatted version of the node, using the default pretty-printer</li>
+     * </ul>
+     *
+     * @return The output of {@link #toPrettyString()}
+     */
+    @Override
+    String toString();
+
+    /**
+     * This just delegates to {@link #toPrettyString(PrettyPrinterConfiguration)}.
+     * <p>
+     * Use of {@link #toString()} and {@link #toString(PrettyPrinterConfiguration)} is discouraged, in favour of:
+     * <ul>
+     *      <li>{@link #asString()} if you want a stable string representation that doesn't alter due to comments and similar volatile attributes</li>
+     *      <li>{@link #toPrettyString()} if you want a formatted version of the node, using the default pretty-printer</li>
+     *      <li>{@link #toString(PrettyPrinterConfiguration)} ()} if you want a formatted version of the node, using the default pretty-printer</li>
+     * </ul>
+     *
+     * @param prettyPrinterConfiguration A custom configuration describing the pretty-printing rules.
+     * @return the output of {@link #toPrettyString(PrettyPrinterConfiguration)}
+     */
+    String toString(PrettyPrinterConfiguration prettyPrinterConfiguration);
+
+
+    /**
+     * This method calls {@link #toString(PrettyPrinterConfiguration)} with the default pretty printer.
+     * @return This node as a pretty-printed String.
+     */
+    String toPrettyString();
+
+    /**
+     * See {@link #toPrettyString()} ()} for an overloaded equivalent which uses the default pretty-printer.
+     *
+     * @param prettyPrinterConfiguration A custom configuration describing the pretty-printing rules.
+     * @return This node as a pretty-printed String.
+     */
+    String toPrettyString(PrettyPrinterConfiguration prettyPrinterConfiguration);
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeAsString.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeAsString.java
@@ -31,7 +31,12 @@ import com.github.javaparser.printer.PrettyPrinterConfiguration;
 public interface NodeAsString {
 
     /**
-     * Description mostly from <a href="https://javaparser.org/making-strings-in-javaparser/">https://javaparser.org/making-strings-in-javaparser/</a>
+     * Description from <a href="https://github.com/javaparser/javaparser/issues/2032#issuecomment-456201113">https://github.com/javaparser/javaparser/issues/2032#issuecomment-456201113</a>
+     * <p>
+     * "asString is the opposite of a print function: it gives you something you can use programmatically, as a key in a hashmap, or to compare to something in a configuration file. "
+     * <p>
+     * <p>
+     * Additional description from <a href="https://javaparser.org/making-strings-in-javaparser/">https://javaparser.org/making-strings-in-javaparser/</a>
      * <p>
      * We noticed that many people were using the output of the pretty printer
      * for comparisons, like <pre>name.toString.equals("a.b.C")</pre>

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/Type.java
@@ -126,8 +126,6 @@ public abstract class Type extends Node implements Resolvable<ResolvedType> {
         return super.remove(node);
     }
 
-    public abstract String asString();
-
     @Override
     @Generated("com.github.javaparser.generator.core.node.CloneGenerator")
     public Type clone() {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -17,7 +17,6 @@
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
-import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedTypeVariable;
@@ -33,7 +32,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparing;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
@@ -418,8 +417,12 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
     @Test
     void testGetAllInterfacesWithoutParameters() {
         ReflectionClassDeclaration compilationUnit = (ReflectionClassDeclaration) typeResolver.solveType("com.github.javaparser.ast.CompilationUnit");
-        assertEquals(ImmutableSet.of("java.lang.Cloneable", "com.github.javaparser.ast.visitor.Visitable", "com.github.javaparser.ast.observer.Observable",
-                "com.github.javaparser.HasParentNode", "com.github.javaparser.ast.nodeTypes.NodeWithRange",
+        assertEquals(ImmutableSet.of("java.lang.Cloneable",
+                "com.github.javaparser.ast.visitor.Visitable",
+                "com.github.javaparser.ast.observer.Observable",
+                "com.github.javaparser.HasParentNode",
+                "com.github.javaparser.ast.nodeTypes.NodeAsString",
+                "com.github.javaparser.ast.nodeTypes.NodeWithRange",
                 "com.github.javaparser.ast.nodeTypes.NodeWithTokenRange").stream().sorted().collect(Collectors.toList()),
                 compilationUnit.getAllInterfaces().stream().map(i -> i.getQualifiedName()).sorted().collect(Collectors.toList()));
 
@@ -429,6 +432,7 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
                 "java.lang.Cloneable",
                 "com.github.javaparser.HasParentNode",
                 "com.github.javaparser.ast.visitor.Visitable",
+                "com.github.javaparser.ast.nodeTypes.NodeAsString",
                 "com.github.javaparser.ast.nodeTypes.NodeWithImplements",
                 "com.github.javaparser.ast.nodeTypes.NodeWithSimpleName",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers",
@@ -453,7 +457,8 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
     void testGetAllInterfacesWithParameters() {
         ReflectionClassDeclaration constructorDeclaration = (ReflectionClassDeclaration) typeResolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
         List<ResolvedReferenceType> interfaces = constructorDeclaration.getAllInterfaces();
-        assertEquals(34, interfaces.size());
+        int expcetedInterfaceCount = 35;
+        assertEquals(expcetedInterfaceCount, interfaces.size());
 
         ResolvedReferenceType interfaze;
         int i = 0;
@@ -504,6 +509,9 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
 
         interfaze = constructorDeclaration.getAllInterfaces().get(i++);
         assertEquals("com.github.javaparser.resolution.Resolvable", interfaze.getQualifiedName());
+
+        interfaze = constructorDeclaration.getAllInterfaces().get(i++);
+        assertEquals("com.github.javaparser.ast.nodeTypes.NodeAsString", interfaze.getQualifiedName());
 
         interfaze = constructorDeclaration.getAllInterfaces().get(i++);
         assertEquals("java.lang.Cloneable", interfaze.getQualifiedName());
@@ -641,7 +649,8 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
     void testGetAllAncestorsWithoutTypeParameters() {
         ReflectionClassDeclaration cu = (ReflectionClassDeclaration) typeResolver.solveType("com.github.javaparser.ast.CompilationUnit");
         assertEquals(ImmutableSet.of("java.lang.Cloneable", "com.github.javaparser.ast.visitor.Visitable",
-                "com.github.javaparser.ast.observer.Observable", "com.github.javaparser.ast.Node",
+                "com.github.javaparser.ast.observer.Observable",
+                "com.github.javaparser.ast.Node", "com.github.javaparser.ast.nodeTypes.NodeAsString",
                 "com.github.javaparser.ast.nodeTypes.NodeWithTokenRange", "java.lang.Object", "com.github.javaparser.HasParentNode",
                 "com.github.javaparser.ast.nodeTypes.NodeWithRange"), cu.getAllAncestors().stream().map(i -> i.getQualifiedName()).collect(Collectors.toSet()));
     }
@@ -668,6 +677,9 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         ancestor = ancestors.remove(0);
         assertEquals("com.github.javaparser.ast.body.CallableDeclaration", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.body.CallableDeclaration.T").get().asReferenceType().getQualifiedName());
+
+        ancestor = ancestors.remove(0);
+        assertEquals("com.github.javaparser.ast.nodeTypes.NodeAsString", ancestor.getQualifiedName());
 
         ancestor = ancestors.remove(0);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithAnnotations", ancestor.getQualifiedName());
@@ -788,7 +800,8 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
 
     public static class ClassWithSyntheticConstructor {
 
-        private ClassWithSyntheticConstructor() {}
+        private ClassWithSyntheticConstructor() {
+        }
 
         public static ClassWithSyntheticConstructor newInstance() {
             return ClassWithSyntheticConstructorHelper.create();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -588,6 +588,8 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         interfaze = constructorDeclaration.getAllInterfaces().get(i++);
         assertEquals("com.github.javaparser.ast.nodeTypes.modifiers.NodeWithStrictfpModifier", interfaze.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", interfaze.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.modifiers.NodeWithStrictfpModifier.N").get().asReferenceType().getQualifiedName());
+
+        assertEquals(expcetedInterfaceCount, i);
     }
 
     @Test


### PR DESCRIPTION
Ref: #2032 

My understanding is that the `asString` method is to be used to give a representation of a declaration/definition that remains stable following changes to meta-data such as comments and annotations.

Regardless, for code that handles arbitrary nodes, it is not currently possible to determine which nodes has an `asString` representation other than searching the codebase and maintaining a local list (which may then go out of date thus must be reviewed each release).

For that reason I am strongly in favour of introducing an interface to describe this behaviour/contract. 

A nice and simple approach _(the one taken in this PR)_ is to attach such an interface to `Node` and delegate to `toString` by default. This doesn't break anything or change existing behaviour, and avoids having to make hard decisions.

An acceptable but slightly harder-work alternative would be to have the interface applied to specific nodes/node typess (this would allow `instanceof` checks to verify if it has an `asString` method), but in this case I am a little less clear _where_ to place it, and what the criteria would be for its use/inclusion. 

---- 

Long-term, my preference would be to deprecate all usage of `toString` in favour of:

- `toPrettyString` (or `toPrettyPrintString`) - this applies the pretty printer to the node (overloaded with an optional config as `toString` currently does), and then have `toString` delegate to `toPrettyString` to maintain backwards compatability.

- `toNormalisedString` - this is what `asString` is currently trying to be, but in need of a better name to describe a node which is "stable" in that it is unaffected by changes to meta-data (such as comments and annotations and position in file). Also worth explicitly noting in the interface contract that this is not long-term stable thus is subject to change and human change over time. 

Perhaps something that could be added to the definition of `asString` is that it refers to the "definition" of something -- e.g in the case of a class/method, it's the class/method header. Similarly, in the case of a loop, it's the loop "header" (i.e. omitting the body), with two string representations of "loop from 1 to 10" being roughly equivalent even if the body of the loop differs. In the case of variables we would have a declaration/assignment/combined representation. Not sure about the rest!


I did consider suggesting that a config could be used re: the `asString`/`toNormalisedString` behaviour (optionally include/exclude: comments, annotations, children), but then having it programmatically/algorithmically defined brings it closer to just a variation of a pretty printer, and limits any scope for manual intervention to override it (as is the case with current examples of the `asString` method.

----

Anyhow, this has turned into somewhat an essay! Going forward I suggest we introduce an interface of some kind now per this pr (perhaps flag it as alpha/pre-release/unstable/subject to change/whatever?) until things have firmed up a bit more? 