### PR TITLE
Fix resolving methods with generic return types

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -28,7 +28,6 @@ import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.*;
-import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.core.resolution.Context;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
@@ -79,6 +78,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
 
     @Override
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
+        ResolvedType typeOfScope;
         if (wrappedNode.getScope().isPresent()) {
             Expression scope = wrappedNode.getScope().get();
             // Consider static method calls
@@ -99,30 +99,26 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                 }
             }
 
-            ResolvedType typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
-            // we can replace the parameter types from the scope into the typeParametersValues
-
-            Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes = new HashMap<>();
-            for (int i = 0; i < argumentsTypes.size(); i++) {
-                // by replacing types I can also find new equivalences
-                // for example if I replace T=U with String because I know that T=String I can derive that also U equal String
-                ResolvedType originalArgumentType = argumentsTypes.get(i);
-                ResolvedType updatedArgumentType = usingParameterTypesFromScope(typeOfScope, originalArgumentType, inferredTypes);
-                argumentsTypes.set(i, updatedArgumentType);
-            }
-            for (int i = 0; i < argumentsTypes.size(); i++) {
-                ResolvedType updatedArgumentType = applyInferredTypes(argumentsTypes.get(i), inferredTypes);
-                argumentsTypes.set(i, updatedArgumentType);
-            }
-
-            return solveMethodAsUsage(typeOfScope, name, argumentsTypes, this);
+            typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
         } else {
-            Context parentContext = getParent();
-            while (parentContext instanceof MethodCallExprContext || parentContext instanceof ObjectCreationContext) {
-                parentContext = parentContext.getParent();
-            }
-            return parentContext.solveMethodAsUsage(name, argumentsTypes);
+            typeOfScope = JavaParserFacade.get(typeSolver).getTypeOfThisIn(wrappedNode);
         }
+
+        // we can replace the parameter types from the scope into the typeParametersValues
+        Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes = new HashMap<>();
+        for (int i = 0; i < argumentsTypes.size(); i++) {
+            // by replacing types I can also find new equivalences
+            // for example if I replace T=U with String because I know that T=String I can derive that also U equal String
+            ResolvedType originalArgumentType = argumentsTypes.get(i);
+            ResolvedType updatedArgumentType = usingParameterTypesFromScope(typeOfScope, originalArgumentType, inferredTypes);
+            argumentsTypes.set(i, updatedArgumentType);
+        }
+        for (int i = 0; i < argumentsTypes.size(); i++) {
+            ResolvedType updatedArgumentType = applyInferredTypes(argumentsTypes.get(i), inferredTypes);
+            argumentsTypes.set(i, updatedArgumentType);
+        }
+
+        return solveMethodAsUsage(typeOfScope, name, argumentsTypes, this);
     }
 
     private MethodUsage resolveMethodTypeParametersFromExplicitList(TypeSolver typeSolver, MethodUsage methodUsage) {
@@ -211,7 +207,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             for (int i = 0; i < methodUsage.getParamTypes().size(); i++) {
                 ResolvedParameterDeclaration parameter = methodUsage.getDeclaration().getParam(i);
                 ResolvedType parameterType = parameter.getType();
-                if (parameter.isVariadic()) {
+                if (!argumentsTypes.get(i).isArray() && parameter.isVariadic()) {
                 	parameterType = parameterType.asArrayType().getComponentType();
                 }
                 inferTypes(argumentsTypes.get(i), parameterType, derivedValues);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -305,6 +305,10 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             mappings.put(target.asTypeParameter(), source);
             return;
         }
+        if (source.isTypeVariable()) {
+            inferTypes(target, source, mappings);
+            return;
+        }
         if (source.isPrimitive() || target.isPrimitive()) {
             return;
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
@@ -203,6 +203,19 @@ class GenericsResolutionTest extends AbstractResolutionTest {
     }
 
     @Test
+    void resolveUsageOfMethodOfGenericClassWithGenericReturnType() {
+        CompilationUnit cu = parseSample("Generics");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "GenericMethodCalls.Derived");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "caller");
+        MethodCallExpr expression = Navigator.findMethodCall(method, "get").get();
+
+        MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(expression);
+
+        assertEquals("get", methodUsage.getName());
+        assertEquals("java.lang.String", methodUsage.returnType().describe());
+    }
+
+    @Test
     void resolveUsageOfMethodOfGenericClassWithUnboundedWildcard() {
         CompilationUnit cu = parseSample("GenericsWildcard");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "GenericsWildcard");

--- a/javaparser-symbol-solver-testing/src/test/resources/Generics.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Generics.java.txt
@@ -33,12 +33,17 @@ public final class GenericMethodCalls {
         public void callee(T data) {
         }
 
+        public T get() {
+            return null;
+        }
+
     }
 
     public class Derived extends Base<String> {
 
         public void caller() {
             callee("test");
+            get();
         }
 
     }


### PR DESCRIPTION
Fix an issue with resolving generic return types.

Consider the example below, when resolving the `foo()` methodcall in the Bar class, the return type was not resolved to `String`, but was still `T`.

```
public class Foo <T> {
    public T foo() {
        return null;
    }
}

public class Bar extends Foo<String> {
    public void bar() {
        foo();
    }
}
```
