### PR TITLE
Improving Symbol-Solving of Method References

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -132,8 +132,7 @@ public class JavaParserFacade {
     }
 
     public SymbolReference<ResolvedMethodDeclaration> solve(MethodReferenceExpr methodReferenceExpr) {
-        MethodUsage methodUsage = toMethodUsage(methodReferenceExpr);
-        return solved(methodUsage.getDeclaration());
+        return solve(methodReferenceExpr, true);
     }
 
     public SymbolReference<ResolvedConstructorDeclaration> solve(ObjectCreationExpr objectCreationExpr) {
@@ -263,6 +262,15 @@ public class JavaParserFacade {
             placeholder.setMethod(res);
         }
         return res;
+    }
+
+    /**
+     * Given a method reference find out to which method declaration it corresponds.
+     */
+    public SymbolReference<ResolvedMethodDeclaration> solve(MethodReferenceExpr methodReferenceExpr, boolean solveLambdas) {
+        // pass empty argument list to be populated
+        List<ResolvedType> argumentTypes = new LinkedList<>();
+        return JavaParserFactory.getContext(methodReferenceExpr, typeSolver).solveMethod(methodReferenceExpr.getIdentifier(), argumentTypes, false);
     }
 
     public SymbolReference<ResolvedAnnotationDeclaration> solve(AnnotationExpr annotationExpr) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -66,6 +66,8 @@ public class JavaParserFactory {
             return new ClassOrInterfaceDeclarationContext((ClassOrInterfaceDeclaration) node, typeSolver);
         } else if (node instanceof MethodCallExpr) {
             return new MethodCallExprContext((MethodCallExpr) node, typeSolver);
+        } else if (node instanceof MethodReferenceExpr) {
+            return new MethodReferenceExprContext((MethodReferenceExpr) node, typeSolver);
         } else if (node instanceof EnumDeclaration) {
             return new EnumDeclarationContext((EnumDeclaration) node, typeSolver);
         } else if (node instanceof FieldAccessExpr) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
@@ -300,6 +301,21 @@ public class TypeExtractor extends DefaultVisitorAdapter {
             throw new com.github.javaparser.resolution.UnsolvedSymbolException("Solving " + node, node.getName().getId());
         } else {
             return value.get().getType();
+        }
+    }
+
+    @Override
+    public ResolvedType visit(TypeExpr node, Boolean solveLambdas) {
+        Log.trace("getType on type expr %s", ()-> node);
+        if (!(node.getType() instanceof com.github.javaparser.ast.type.ClassOrInterfaceType)) {
+            throw new UnsupportedOperationException(node.getType().getClass().getCanonicalName());
+        }
+        ClassOrInterfaceType classOrInterfaceType = (ClassOrInterfaceType) node.getType();
+        SymbolReference<ResolvedTypeDeclaration> typeDeclarationSymbolReference = JavaParserFactory.getContext(classOrInterfaceType, typeSolver).solveType(classOrInterfaceType.getName().getId());
+        if (!typeDeclarationSymbolReference.isSolved()) {
+            throw new com.github.javaparser.resolution.UnsolvedSymbolException("Solving " + node, classOrInterfaceType.getName().getId());
+        } else {
+            return new ReferenceTypeImpl(typeDeclarationSymbolReference.getCorrespondingDeclaration().asReferenceType(), typeSolver);
         }
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -22,11 +22,13 @@
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
@@ -130,6 +132,35 @@ public class LambdaExprContext extends AbstractJavaParserContext<LambdaExpr> {
                             return Optional.of(value);
                         } else {
                             throw new UnsupportedOperationException();
+                        }
+                    } else if (requireParentNode(wrappedNode) instanceof ReturnStmt) {
+                        ReturnStmt returnStmt = (ReturnStmt) requireParentNode(wrappedNode);
+                        Optional<MethodDeclaration> optDeclaration = returnStmt.findAncestor(MethodDeclaration.class);
+                        if (optDeclaration.isPresent()) {
+                            ResolvedType t = JavaParserFacade.get(typeSolver).convertToUsage(optDeclaration.get().asMethodDeclaration().getType());
+                            Optional<MethodUsage> functionalMethod = FunctionalInterfaceLogic.getFunctionalMethod(t);
+
+                            if (functionalMethod.isPresent()) {
+                                ResolvedType lambdaType = functionalMethod.get().getParamType(index);
+
+                                // Replace parameter from declarator
+                                Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes = new HashMap<>();
+                                if (lambdaType.isReferenceType()) {
+                                    for (com.github.javaparser.utils.Pair<ResolvedTypeParameterDeclaration, ResolvedType> entry : lambdaType.asReferenceType().getTypeParametersMap()) {
+                                        if (entry.b.isTypeVariable() && entry.b.asTypeParameter().declaredOnType()) {
+                                            ResolvedType ot = t.asReferenceType().typeParametersMap().getValue(entry.a);
+                                            lambdaType = lambdaType.replaceTypeVariables(entry.a, ot, inferredTypes);
+                                        }
+                                    }
+                                } else if (lambdaType.isTypeVariable() && lambdaType.asTypeParameter().declaredOnType()) {
+                                    lambdaType = t.asReferenceType().typeParametersMap().getValue(lambdaType.asTypeParameter());
+                                }
+
+                                Value value = new Value(lambdaType, name);
+                                return Optional.of(value);
+                            } else {
+                                throw new UnsupportedOperationException();
+                            }
                         }
                     } else {
                         throw new UnsupportedOperationException();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.types.*;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.logic.FunctionalInterfaceLogic;
+import com.github.javaparser.symbolsolver.logic.InferenceContext;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
+import com.github.javaparser.symbolsolver.reflectionmodel.MyObjectProvider;
+import com.github.javaparser.symbolsolver.resolution.MethodResolutionLogic;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.github.javaparser.symbolsolver.javaparser.Navigator.requireParentNode;
+
+public class MethodReferenceExprContext extends AbstractJavaParserContext<MethodReferenceExpr> {
+
+    ///
+    /// Constructors
+    ///
+
+    public MethodReferenceExprContext(MethodReferenceExpr wrappedNode, TypeSolver typeSolver) {
+        super(wrappedNode, typeSolver);
+    }
+
+    ///
+    /// Public methods
+    ///
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+        if ("new".equals(name)) {
+            throw new UnsupportedOperationException("Constructor calls not yet resolvable");
+        }
+
+        argumentsTypes.addAll(inferArgumentTypes());
+
+        Collection<ResolvedReferenceTypeDeclaration> rrtds = findTypeDeclarations(Optional.of(wrappedNode.getScope()));
+
+        if (rrtds.isEmpty()) {
+            // if the bounds of a type parameter are empty, then the bound is implicitly "extends Object"
+            // we don't make this _ex_plicit in the data representation because that would affect codegen
+            // and make everything generate like <T extends Object> instead of <T>
+            // https://github.com/javaparser/javaparser/issues/2044
+            rrtds = Collections.singleton(typeSolver.solveType(Object.class.getCanonicalName()));
+        }
+
+        for (ResolvedReferenceTypeDeclaration rrtd : rrtds) {
+            SymbolReference<ResolvedMethodDeclaration> firstResAttempt = MethodResolutionLogic.solveMethodInType(rrtd, name, argumentsTypes, false);
+            if (firstResAttempt.isSolved()) {
+                return firstResAttempt;
+            } else {
+                // If has not already been solved above then will be solved here if single argument type same as
+                // (or subclass of) rrtd, as call is actually performed on the argument itself with zero params
+                SymbolReference<ResolvedMethodDeclaration> secondResAttempt = MethodResolutionLogic.solveMethodInType(rrtd, name, Collections.emptyList(), false);
+                if (secondResAttempt.isSolved()) {
+                    return secondResAttempt;
+                }
+            }
+        }
+
+        return SymbolReference.unsolved(ResolvedMethodDeclaration.class);
+    }
+
+    ///
+    /// Private methods
+    ///
+
+    private List<ResolvedType> inferArgumentTypes() {
+        if (requireParentNode(wrappedNode) instanceof MethodCallExpr) {
+            MethodCallExpr methodCallExpr = (MethodCallExpr) requireParentNode(wrappedNode);
+            MethodUsage methodUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(methodCallExpr);
+            int pos = pos(methodCallExpr, wrappedNode);
+            ResolvedType lambdaType = methodUsage.getParamTypes().get(pos);
+
+            // Get the functional method in order for us to resolve it's type arguments properly
+            Optional<MethodUsage> functionalMethodOpt = FunctionalInterfaceLogic.getFunctionalMethod(lambdaType);
+            if (functionalMethodOpt.isPresent()) {
+                MethodUsage functionalMethod = functionalMethodOpt.get();
+
+                List<ResolvedType> resolvedTypes = new ArrayList<>();
+
+                for (ResolvedType type : functionalMethod.getParamTypes()) {
+                    InferenceContext inferenceContext = new InferenceContext(MyObjectProvider.INSTANCE);
+
+                    // Resolve each type variable of the lambda, and use this later to infer the type of each
+                    // implicit parameter
+                    inferenceContext.addPair(new ReferenceTypeImpl(functionalMethod.declaringType(), typeSolver), lambdaType);
+
+                    // Now resolve the argument type using the inference context
+                    ResolvedType argType = inferenceContext.resolve(inferenceContext.addSingle(type));
+
+                    ResolvedLambdaConstraintType conType;
+                    if (argType.isWildcard()){
+                        conType = ResolvedLambdaConstraintType.bound(argType.asWildcard().getBoundedType());
+                    } else {
+                        conType = ResolvedLambdaConstraintType.bound(argType);
+                    }
+
+                    resolvedTypes.add(conType);
+                }
+
+                return resolvedTypes;
+            } else {
+                throw new UnsupportedOperationException();
+            }
+        } else if (requireParentNode(wrappedNode) instanceof VariableDeclarator) {
+            VariableDeclarator variableDeclarator = (VariableDeclarator) requireParentNode(wrappedNode);
+            ResolvedType t = JavaParserFacade.get(typeSolver).convertToUsageVariableType(variableDeclarator);
+            Optional<MethodUsage> functionalMethod = FunctionalInterfaceLogic.getFunctionalMethod(t);
+            if (functionalMethod.isPresent()) {
+                List<ResolvedType> resolvedTypes = new ArrayList<>();
+                for (ResolvedType lambdaType : functionalMethod.get().getParamTypes()) {
+                    // Replace parameter from declarator
+                    Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes = new HashMap<>();
+                    if (lambdaType.isReferenceType()) {
+                        for (com.github.javaparser.utils.Pair<ResolvedTypeParameterDeclaration, ResolvedType> entry : lambdaType.asReferenceType().getTypeParametersMap()) {
+                            if (entry.b.isTypeVariable() && entry.b.asTypeParameter().declaredOnType()) {
+                                ResolvedType ot = t.asReferenceType().typeParametersMap().getValue(entry.a);
+                                lambdaType = lambdaType.replaceTypeVariables(entry.a, ot, inferredTypes);
+                            }
+                        }
+                    } else if (lambdaType.isTypeVariable() && lambdaType.asTypeParameter().declaredOnType()) {
+                        lambdaType = t.asReferenceType().typeParametersMap().getValue(lambdaType.asTypeParameter());
+                    }
+                    resolvedTypes.add(lambdaType);
+                }
+
+                return resolvedTypes;
+            } else {
+                throw new UnsupportedOperationException();
+            }
+        } else if (requireParentNode(wrappedNode) instanceof ReturnStmt) {
+            ReturnStmt returnStmt = (ReturnStmt) requireParentNode(wrappedNode);
+            Optional<MethodDeclaration> optDeclaration = returnStmt.findAncestor(MethodDeclaration.class);
+            if (optDeclaration.isPresent()) {
+                ResolvedType t = JavaParserFacade.get(typeSolver).convertToUsage(optDeclaration.get().asMethodDeclaration().getType());
+                Optional<MethodUsage> functionalMethod = FunctionalInterfaceLogic.getFunctionalMethod(t);
+                if (functionalMethod.isPresent()) {
+                    List<ResolvedType> resolvedTypes = new ArrayList<>();
+                    for (ResolvedType lambdaType : functionalMethod.get().getParamTypes()) {
+                        // Replace parameter from declarator
+                        Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes = new HashMap<>();
+                        if (lambdaType.isReferenceType()) {
+                            for (com.github.javaparser.utils.Pair<ResolvedTypeParameterDeclaration, ResolvedType> entry : lambdaType.asReferenceType().getTypeParametersMap()) {
+                                if (entry.b.isTypeVariable() && entry.b.asTypeParameter().declaredOnType()) {
+                                    ResolvedType ot = t.asReferenceType().typeParametersMap().getValue(entry.a);
+                                    lambdaType = lambdaType.replaceTypeVariables(entry.a, ot, inferredTypes);
+                                }
+                            }
+                        } else if (lambdaType.isTypeVariable() && lambdaType.asTypeParameter().declaredOnType()) {
+                            lambdaType = t.asReferenceType().typeParametersMap().getValue(lambdaType.asTypeParameter());
+                        }
+                        resolvedTypes.add(lambdaType);
+                    }
+
+                    return resolvedTypes;
+                } else {
+                    throw new UnsupportedOperationException();
+                }
+            }
+            throw new UnsupportedOperationException();
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private int pos(MethodCallExpr callExpr, Expression param) {
+        int i = 0;
+        for (Expression p : callExpr.getArguments()) {
+            if (p == param) {
+                return i;
+            }
+            i++;
+        }
+        throw new IllegalArgumentException();
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/JavaSymbolSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/JavaSymbolSolverTest.java
@@ -50,7 +50,7 @@ class JavaSymbolSolverTest extends AbstractResolutionTest {
     @Test
     void resolveMethodReferenceExpr() {
         JavaParser parser = createParserWithResolver(new ReflectionTypeSolver());
-        MethodReferenceExpr methodRef = parser.parse("class X{void x(){Function<Object, Integer>r=Object::hashCode;}}")
+        MethodReferenceExpr methodRef = parser.parse("import java.util.function.Function; class X{void x(){Function<Object, Integer>r=Object::hashCode;}}")
                 .getResult().get()
                 .findFirst(MethodReferenceExpr.class).get();
         ResolvedMethodDeclaration resolvedMethodRef = methodRef.resolve();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.resolution;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MethodReferenceResolutionTest extends AbstractResolutionTest {
+
+    @Test
+    void classMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "classMethod");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("java.lang.Object.hashCode()", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void superclassMethodNotOverridden() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "superclassMethodNotOverridden");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("java.lang.Object.hashCode()", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void superclassMethodOverridden() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "superclassMethodOverridden");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("java.util.AbstractList.hashCode()", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void superclassMethodWithSubclassType() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "superclassMethodWithSubclassType");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("java.lang.Object.hashCode()", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Disabled
+    @Test
+    void fieldAccessMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "fieldAccessMethod");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("java.lang.PrintStream.println()", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void thisClassMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "thisClassMethod");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("MethodReferences.print(java.lang.String)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void superclassMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "superclassMethod");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.print(java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Disabled
+    @Test
+    void instanceMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "instanceMethod");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("java.util.AbstractList.add()", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void staticMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "staticMethod");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.print(java.lang.Boolean)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void biPredicate() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "biPredicate");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.isEqual(java.lang.Integer, java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void biFunction() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "biFunction");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.isEqualAsStrings(java.lang.Integer, java.lang.String)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void customTriFunction() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "customTriFunction");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.getOneNumberAsString(java.lang.Integer, java.lang.Integer, java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void consumerDeclaredInMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "consumerDeclaredInMethod");
+        MethodReferenceExpr methodReferenceExpr = method.findFirst(MethodReferenceExpr.class).get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("MethodReferences.print(java.lang.String)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void functionDeclaredInMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "functionDeclaredInMethod");
+        MethodReferenceExpr methodReferenceExpr = method.findFirst(MethodReferenceExpr.class).get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.returnSameValue(java.lang.String)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void biFunctionDeclaredInMethod() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "biFunctionDeclaredInMethod");
+        MethodReferenceExpr methodReferenceExpr = method.findFirst(MethodReferenceExpr.class).get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.isEqual(java.lang.Integer, java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void consumerUsedInStream() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "consumerUsedInStream");
+        MethodReferenceExpr methodReferenceExpr = method.findFirst(MethodReferenceExpr.class).get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.print(java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void functionUsedInStream() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "functionUsedInStream");
+        MethodReferenceExpr methodReferenceExpr = method.findFirst(MethodReferenceExpr.class).get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.returnSameValue(java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void biFunctionUsedInStream() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "biFunctionUsedInStream");
+        MethodReferenceExpr methodReferenceExpr = method.findFirst(MethodReferenceExpr.class).get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.add(java.lang.Integer, java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void biFunctionInMethodCall() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "biFunctionInMethodCall");
+        MethodReferenceExpr methodReferenceExpr = method.findFirst(MethodReferenceExpr.class).get();
+
+        // resolve method reference expression
+        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+
+        // check that the expected method declaration equals the resolved method declaration
+        assertEquals("SuperClass.isEqualAsStrings(java.lang.Integer, java.lang.String)", resolvedMethodDeclaration.getQualifiedSignature());
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
@@ -91,7 +91,7 @@ class MethodReferenceResolutionTest extends AbstractResolutionTest {
         ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
 
         // check that the expected method declaration equals the resolved method declaration
-        assertEquals("java.util.AbstractList.hashCode()", resolvedMethodDeclaration.getQualifiedSignature());
+        assertEquals("java.lang.String.hashCode()", resolvedMethodDeclaration.getQualifiedSignature());
     }
 
     @Test
@@ -208,25 +208,6 @@ class MethodReferenceResolutionTest extends AbstractResolutionTest {
 
         // check that the expected method declaration equals the resolved method declaration
         assertEquals("SuperClass.print(java.lang.Boolean)", resolvedMethodDeclaration.getQualifiedSignature());
-    }
-
-    @Test
-    void biPredicate() {
-        // configure symbol solver before parsing
-        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
-
-        // parse compilation unit and get method reference expression
-        CompilationUnit cu = parseSample("MethodReferences");
-        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodReferences");
-        MethodDeclaration method = Navigator.demandMethod(clazz, "biPredicate");
-        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
-        MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) returnStmt.getExpression().get();
-
-        // resolve method reference expression
-        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
-
-        // check that the expected method declaration equals the resolved method declaration
-        assertEquals("SuperClass.isEqual(java.lang.Integer, java.lang.Integer)", resolvedMethodDeclaration.getQualifiedSignature());
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/resources/MethodReferences.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/MethodReferences.java.txt
@@ -1,10 +1,21 @@
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.BiPredicate;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
+
+interface Function<T, R> {
+    R apply(T t);
+}
+
+interface Consumer<T> {
+    void accept(T t);
+}
+
+interface Supplier<T> {
+    T get();
+}
+
+interface BiFunction<T, U, R> {
+    R apply(T t, U u);
+}
 
 interface TriFunction<T, U, V, R> {
     R apply(T t, U u, V v);
@@ -78,11 +89,11 @@ public class MethodReferences extends SuperClass {
         return SuperClass::hashCode;
     }
 
-    Function<ArrayList<?>, Integer> superclassMethodOverridden() {
-        return ArrayList::hashCode;
+    Function<String, Integer> superclassMethodOverridden() {
+        return String::hashCode;
     }
 
-    Function<Integer, Integer> superclassMethodWithSubclassType() {
+    Function<Object, Integer> superclassMethodWithSubclassType() {
         return Object::hashCode;
     }
 
@@ -112,10 +123,6 @@ public class MethodReferences extends SuperClass {
 
     Consumer<Boolean> staticMethod() {
         return SuperClass::print;
-    }
-
-    BiPredicate<Integer, Integer> biPredicate() {
-        return super::isEqual;
     }
 
     BiFunction<Integer, String, Boolean> biFunction() {

--- a/javaparser-symbol-solver-testing/src/test/resources/MethodReferences.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/MethodReferences.java.txt
@@ -1,0 +1,156 @@
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+interface TriFunction<T, U, V, R> {
+    R apply(T t, U u, V v);
+}
+
+public class SuperClass {
+
+    public SuperClass() {
+
+    }
+
+    public SuperClass(String s) {
+
+    }
+
+    void print(Integer val) {
+        System.out.println(val);
+    }
+
+    static void print(Boolean val) {
+        System.out.println(val);
+    }
+
+    boolean isEqual(Integer i, Integer j) {
+        return i.equals(j);
+    }
+
+    boolean isEqualAsStrings(Integer i, String j) {
+        return i.toString().equals(j);
+    }
+
+    int add(Integer i, Integer j) {
+        return i + j;
+    }
+
+    String getOneNumberAsString(Integer i, Integer j, Integer k) {
+        return i.toString();
+    }
+
+    int returnSameValue(Integer i) {
+        return i;
+    }
+
+    String returnSameValue(String s) {
+        return s;
+    }
+}
+
+public class MethodReferences extends SuperClass {
+
+    List<Integer> list = new ArrayList<>();
+
+    void print(String s) {
+        System.out.println(s);
+    }
+
+    boolean isAnyEqualToString5(List<Integer> list, BiFunction<Integer, String, Boolean> biFunction) {
+        for (Integer integer : list) {
+            if (biFunction.apply(integer, "5")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Function<Object, Integer> classMethod() {
+        return Object::hashCode;
+    }
+
+    Function<SuperClass, Integer> superclassMethodNotOverridden() {
+        return SuperClass::hashCode;
+    }
+
+    Function<ArrayList<?>, Integer> superclassMethodOverridden() {
+        return ArrayList::hashCode;
+    }
+
+    Function<Integer, Integer> superclassMethodWithSubclassType() {
+        return Object::hashCode;
+    }
+
+    Consumer<String> fieldAccessMethod() {
+        return System.out::println;
+    }
+
+    Consumer<String> thisClassMethod() {
+        return this::print;
+    }
+
+    Consumer<Integer> superclassMethod() {
+        return super::print;
+    }
+
+    Consumer<Integer> instanceMethod() {
+        return list::add;
+    }
+
+    Supplier<SuperClass> zeroArgumentConstructor() {
+        return SuperClass::new;
+    }
+
+    Function<String, SuperClass> singleArgumentConstructor() {
+        return SuperClass::new;
+    }
+
+    Consumer<Boolean> staticMethod() {
+        return SuperClass::print;
+    }
+
+    BiPredicate<Integer, Integer> biPredicate() {
+        return super::isEqual;
+    }
+
+    BiFunction<Integer, String, Boolean> biFunction() {
+        return super::isEqualAsStrings;
+    }
+
+    TriFunction<Integer, Integer, Integer, String> customTriFunction() {
+        return super::getOneNumberAsString;
+    }
+
+    void consumerDeclaredInMethod() {
+        Consumer<String> stringConsumer = this::print;
+    }
+
+    void functionDeclaredInMethod() {
+        Function<String, String> stringFunction = super::returnSameValue;
+    }
+
+    void biFunctionDeclaredInMethod() {
+        BiFunction<Integer, Integer, Boolean> biFunction = super::isEqual;
+    }
+
+    void consumerUsedInStream() {
+        list.stream().forEach(super::print);
+    }
+
+    void functionUsedInStream() {
+        list.stream().map(super::returnSameValue);
+    }
+
+    void biFunctionUsedInStream() {
+        list.stream().reduce(0, super::add);
+    }
+
+    void biFunctionInMethodCall() {
+        isAnyEqualToString5(list, super::isEqualAsStrings);
+    }
+}


### PR DESCRIPTION
Improved how `MethodReferenceExpr`'s are resolved to `MethodUsage`'s to more closely align with how it is done for regular `MethodCallExpr`'s. Also added plenty of test cases to verify new behavior.

Please note: I've left two test cases disabled as they currently fail due to #2455. I believe the solution lies in modifying the grammar so that field accesses and name expressions are parsed as such in the scope of `MethodReferenceExpr`'s, rather than copying symbol solving logic from these to the method solving a `TypeExpr`.