### PR TITLE
Added asNumber function to literal and long literal expressions

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
@@ -23,6 +23,8 @@ package com.github.javaparser.ast.expr;
 import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,6 +90,17 @@ class LiteralStringValueExprTest {
         assertThat(negHex.asInt()).isEqualTo(0xffff_ffff);
         assertThat(posBin.asInt()).isEqualTo(0b0111_1111_1111_1111_1111_1111_1111_1111);
         assertThat(negBin.asInt()).isEqualTo(0b1000_0000_0000_0000_0000_0000_0000_0000);
+    }
+
+    @Test
+    void negativeLiteralValues() {
+        UnaryExpr unaryIntExpr = parseExpression("-2147483648"); // Integer.MIN_VALUE
+        IntegerLiteralExpr literalIntExpr = (IntegerLiteralExpr) unaryIntExpr.getExpression();
+        UnaryExpr unaryLongExpr = parseExpression("-9223372036854775808L"); // Long.MIN_VALUE
+        LongLiteralExpr literalLongExpr = (LongLiteralExpr) unaryLongExpr.getExpression();
+
+        assertThat(literalIntExpr.asNumber()).isEqualTo(2147483648L);
+        assertThat(literalLongExpr.asNumber()).isEqualTo(new BigInteger("9223372036854775808"));
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
@@ -27,6 +27,7 @@ import java.math.BigInteger;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("OctalInteger")
 class LiteralStringValueExprTest {
@@ -94,13 +95,19 @@ class LiteralStringValueExprTest {
 
     @Test
     void negativeLiteralValues() {
-        UnaryExpr unaryIntExpr = parseExpression("-2147483648"); // Integer.MIN_VALUE
+        UnaryExpr unaryIntExpr = parseExpression("-2147483648"); // valid, Integer.MIN_VALUE
         IntegerLiteralExpr literalIntExpr = (IntegerLiteralExpr) unaryIntExpr.getExpression();
-        UnaryExpr unaryLongExpr = parseExpression("-9223372036854775808L"); // Long.MIN_VALUE
+        IntegerLiteralExpr notValidIntExpr = parseExpression("2147483648"); // not valid
+
+        UnaryExpr unaryLongExpr = parseExpression("-9223372036854775808L"); // valid, Long.MIN_VALUE
         LongLiteralExpr literalLongExpr = (LongLiteralExpr) unaryLongExpr.getExpression();
+        LongLiteralExpr notValidLongExpr = parseExpression("9223372036854775808L"); // not valid
 
         assertThat(literalIntExpr.asNumber()).isEqualTo(2147483648L);
         assertThat(literalLongExpr.asNumber()).isEqualTo(new BigInteger("9223372036854775808"));
+
+        assertThatThrownBy(notValidIntExpr::asNumber).isInstanceOf(NumberFormatException.class);
+        assertThatThrownBy(notValidLongExpr::asNumber).isInstanceOf(NumberFormatException.class);
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.IntegerLiteralExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.TokenRange;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.Optional;
 import com.github.javaparser.ast.Generated;
@@ -101,6 +102,22 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
             return Integer.parseUnsignedInt(result.substring(1), 8);
         }
         return Integer.parseInt(result);
+    }
+
+    /**
+     * @return the literal value as an integer while respecting different number representations
+     */
+    public Number asNumber() {
+        /* we need to handle the special case for the literal 2147483648, which is used to
+         * represent Integer.MIN_VALUE (-2147483648) as a combination of a UnaryExpr and an
+         * IntegerLiteralExpr. However 2147483648 cannot be represented in an integer, so we
+         * need to return a long
+         */
+        if (Objects.equals(value, "2147483648")) {
+            return 2147483648L;
+        } else {
+            return asInt();
+        }
     }
 
     public IntegerLiteralExpr setInt(int value) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -52,6 +52,9 @@ import static com.github.javaparser.utils.Utils.hasUnaryMinusAsParent;
  */
 public class IntegerLiteralExpr extends LiteralStringValueExpr {
 
+    public static final String MAX_31_BIT_UNSIGNED_VALUE_AS_STRING = "2147483648";
+    public static final long MAX_31_BIT_UNSIGNED_VALUE_AS_LONG = 2147483648L;
+
     public IntegerLiteralExpr() {
         this(null, "0");
     }
@@ -96,7 +99,9 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
 
     /**
      * @return the literal value as an integer while respecting different number representations
-     * @deprecated Will be made private or merged with {@link IntegerLiteralExpr#asNumber()} in future releases
+     * @deprecated This function has issues with corner cases, such as 2147483648, so please use {@link
+     * IntegerLiteralExpr#asNumber()}. It will be made private or merged with {@link IntegerLiteralExpr#asNumber()} in
+     * future releases
      */
     public int asInt() {
         String result = value.replaceAll("_", "");
@@ -113,9 +118,10 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
     }
 
     /**
-     * This function returns a representation of the literal values as a number. This will return an integer, except for
-     * the case when the literal has the value 2147483648 (which is only allowed in the expression
-     * <code>-2147483648</code>) and returns a long.
+     * This function returns a representation of the literal value as a number. This will return an integer, except for
+     * the case when the literal has the value <code>2147483648</code>. This special literal is only allowed in the
+     * expression <code>-2147483648</code> which represents <code>Integer.MIN_VALUE</code>). However 2147483648 (2^31)
+     * is out of range of int, which is -(2^31) to (2^31)-1 and thus a long must be returned.
      * <p>
      * Note, that this function will NOT return a negative number if the literal was specified in decimal, since
      * according to the language specification an expression such as <code>-1</code> is represented by a unary
@@ -132,8 +138,8 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
          * IntegerLiteralExpr. However 2147483648 cannot be represented in an integer, so we
          * need to return a long
          */
-        if (Objects.equals(value, "2147483648") && hasUnaryMinusAsParent(this)) {
-            return 2147483648L;
+        if (Objects.equals(value, MAX_31_BIT_UNSIGNED_VALUE_AS_STRING) && hasUnaryMinusAsParent(this)) {
+            return MAX_31_BIT_UNSIGNED_VALUE_AS_LONG;
         } else {
             return asInt();
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -38,11 +38,10 @@ import static com.github.javaparser.utils.Utils.hasUnaryMinusAsParent;
  * All ways to specify an int literal.
  *
  * <ul>
- * <li><code>8934</code>
- * <li><code>0x01</code>
- * <li><code>022</code>
- * <li><code>0B10101010</code>
- * <li><code>99999999L</code>
+ * <li><code>8934</code></li>
+ * <li><code>0x01</code></li>
+ * <li><code>022</code></li>
+ * <li><code>0B10101010</code></li>
  * </ul>
  *
  * @author Julio Vilmar Gesser
@@ -72,8 +71,8 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
     }
 
     /**
-     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
-     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     * @deprecated This function is deprecated in favor of {@link #IntegerLiteralExpr(String)}. Please refer to the
+     * {@link #asNumber()} function for valid formats and how to construct literals holding negative values.
      */
     @Deprecated
     public IntegerLiteralExpr(final int value) {
@@ -150,8 +149,8 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
     }
 
     /**
-     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
-     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     * @deprecated This function is deprecated in favor of {@link #setValue(String)}. Please refer to the {@link
+     * #asNumber()} function for valid formats and how to construct literals holding negative values.
      */
     @Deprecated
     public IntegerLiteralExpr setInt(int value) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -20,32 +20,29 @@
  */
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Generated;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.IntegerLiteralExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.TokenRange;
-
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.Optional;
-
-import com.github.javaparser.ast.Generated;
-import com.github.javaparser.utils.Utils;
-
+import java.util.function.Consumer;
 import static com.github.javaparser.utils.Utils.hasUnaryMinusAsParent;
 
 /**
  * All ways to specify an int literal.
+ *
  * <ul>
- * <li><code>8934</code></li>
- * <li><code>0x01</code></li>
- * <li><code>022</code></li>
- * <li><code>0B10101010</code></li>
- * <li><code>99999999L</code></li>
+ * <li><code>8934</code>
+ * <li><code>0x01</code>
+ * <li><code>022</code>
+ * <li><code>0B10101010</code>
+ * <li><code>99999999L</code>
  * </ul>
  *
  * @author Julio Vilmar Gesser
@@ -53,6 +50,7 @@ import static com.github.javaparser.utils.Utils.hasUnaryMinusAsParent;
 public class IntegerLiteralExpr extends LiteralStringValueExpr {
 
     public static final String MAX_31_BIT_UNSIGNED_VALUE_AS_STRING = "2147483648";
+
     public static final long MAX_31_BIT_UNSIGNED_VALUE_AS_LONG = 2147483648L;
 
     public IntegerLiteralExpr() {
@@ -73,6 +71,11 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
         customInitialization();
     }
 
+    /**
+     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
+     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     */
+    @Deprecated
     public IntegerLiteralExpr(final int value) {
         this(null, String.valueOf(value));
     }
@@ -103,6 +106,7 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
      * IntegerLiteralExpr#asNumber()}. It will be made private or merged with {@link IntegerLiteralExpr#asNumber()} in
      * future releases
      */
+    @Deprecated
     public int asInt() {
         String result = value.replaceAll("_", "");
         if (result.startsWith("0x") || result.startsWith("0X")) {
@@ -122,12 +126,12 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
      * the case when the literal has the value <code>2147483648</code>. This special literal is only allowed in the
      * expression <code>-2147483648</code> which represents <code>Integer.MIN_VALUE</code>). However 2147483648 (2^31)
      * is out of range of int, which is -(2^31) to (2^31)-1 and thus a long must be returned.
-     * <p>
-     * Note, that this function will NOT return a negative number if the literal was specified in decimal, since
-     * according to the language specification an expression such as <code>-1</code> is represented by a unary
-     * expression with a minus operator and the literal <code>1</code>. It is however possible to represent negative
-     * numbers in a literal directly, i.e. by using the binary or hexadecimal representation. For example
-     * <code>0xffff_ffff</code> represents the value <code>-1</code>.
+     *
+     * <p>Note, that this function will NOT return a negative number if the literal was specified in decimal, since
+     * according to the language specification (chapter 3.10.1) an expression such as <code>-1</code> is represented by
+     * a unary expression with a minus operator and the literal <code>1</code>. It is however possible to represent
+     * negative numbers in a literal directly, i.e. by using the binary or hexadecimal representation. For example
+     * <code>0xffff_ffff</code> represents the value <code> -1</code>.
      *
      * @return the literal value as a number while respecting different number representations
      */
@@ -145,6 +149,11 @@ public class IntegerLiteralExpr extends LiteralStringValueExpr {
         }
     }
 
+    /**
+     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
+     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     */
+    @Deprecated
     public IntegerLiteralExpr setInt(int value) {
         this.value = String.valueOf(value);
         return this;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -39,11 +39,11 @@ import static com.github.javaparser.utils.Utils.hasUnaryMinusAsParent;
  * All ways to specify a long literal.
  *
  * <ul>
- * <li><code>8934l</code>
- * <li><code>0x01L</code>
- * <li><code>022l</code>
- * <li><code>0B10101010L</code>
- * <li><code>99999999L</code>
+ * <li><code>8934l</code></li>
+ * <li><code>0x01L</code></li>
+ * <li><code>022l</code></li>
+ * <li><code>0B10101010L</code></li>
+ * <li><code>99999999L</code></li>
  * </ul>
  *
  * @author Julio Vilmar Gesser
@@ -73,8 +73,8 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
     }
 
     /**
-     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
-     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     * @deprecated This function is deprecated in favor of {@link #LongLiteralExpr(String)}. Please refer to the {@link
+     * #asNumber()} function for valid formats and how to construct literals holding negative values.
      */
     @Deprecated
     public LongLiteralExpr(final long value) {
@@ -155,8 +155,8 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
     }
 
     /**
-     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
-     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     * @deprecated This function is deprecated in favor of {@link #setValue(String)}. Please refer to the {@link
+     * #asNumber()} function for valid formats and how to construct literals holding negative values.
      */
     @Deprecated
     public LongLiteralExpr setLong(long value) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -28,6 +28,8 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LongLiteralExprMetaModel;
 import com.github.javaparser.TokenRange;
+import java.math.BigInteger;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.Optional;
 import com.github.javaparser.ast.Generated;
@@ -105,6 +107,22 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
             return Long.parseUnsignedLong(result.substring(1), 8);
         }
         return Long.parseLong(result);
+    }
+
+    /**
+     * @return the literal value as an long while respecting different number representations
+     */
+    public Number asNumber() {
+        /* we need to handle the special case for the literal 9223372036854775808L, which is used to
+         * represent Integer.MIN_VALUE (-9223372036854775808L) as a combination of a UnaryExpr and a
+         * LongLiteralExpr. However 9223372036854775808L cannot be represented in a long, so we need
+         * to return a BigInteger
+         */
+        if (Objects.equals(value, "9223372036854775808L")) {
+            return new BigInteger("9223372036854775808");
+        } else {
+            return asLong();
+        }
     }
 
     public LongLiteralExpr setLong(long value) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -20,37 +20,39 @@
  */
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Generated;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LongLiteralExprMetaModel;
-import com.github.javaparser.TokenRange;
-
 import java.math.BigInteger;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.Optional;
-
-import com.github.javaparser.ast.Generated;
-
+import java.util.function.Consumer;
 import static com.github.javaparser.utils.Utils.hasUnaryMinusAsParent;
 
 /**
  * All ways to specify a long literal.
+ *
  * <ul>
- * <li><code>8934l</code></li>
- * <li><code>0x01L</code></li>
- * <li><code>022l</code></li>
- * <li><code>0B10101010L</code></li>
- * <li><code>99999999L</code></li>
+ * <li><code>8934l</code>
+ * <li><code>0x01L</code>
+ * <li><code>022l</code>
+ * <li><code>0B10101010L</code>
+ * <li><code>99999999L</code>
  * </ul>
  *
  * @author Julio Vilmar Gesser
  */
 public class LongLiteralExpr extends LiteralStringValueExpr {
+
+    public static final String MAX_63_BIT_UNSIGNED_VALUE_AS_STRING = "9223372036854775808L";
+
+    public static final BigInteger MAX_63_BIT_UNSIGNED_VALUE_AS_BIG_INTEGER = new BigInteger("9223372036854775808");
 
     public LongLiteralExpr() {
         this(null, "0");
@@ -70,6 +72,11 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
         customInitialization();
     }
 
+    /**
+     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
+     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     */
+    @Deprecated
     public LongLiteralExpr(final long value) {
         this(null, String.valueOf(value));
     }
@@ -100,6 +107,7 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
      * LongLiteralExpr#asNumber()}. It will be made private or merged with {@link LongLiteralExpr#asNumber()} in future
      * releases
      */
+    @Deprecated
     public long asLong() {
         String result = value.replaceAll("_", "");
         char lastChar = result.charAt(result.length() - 1);
@@ -124,12 +132,12 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
      * the expression <code>-9223372036854775808L</code> which represents <code>Long.MIN_VALUE</code>). However
      * 9223372036854775808 (2^63) is out of range of long, which is -(2^63) to (2^63)-1 and thus a BigInteger must be
      * returned.
-     * <p>
-     * Note, that this function will NOT return a negative number if the literal was specified in decimal, since *
-     * according to the language specification an expression such as <code>-1L</code> is represented by a unary *
-     * expression with a minus operator and the literal <code>1L</code>. It is however possible to represent negative *
-     * numbers in a literal directly, i.e. by using the binary or hexadecimal representation. For example *
-     * <code>0xffff_ffff_ffff_ffffL</code> represents the value <code>-1L</code>.
+     *
+     * <p>Note, that this function will NOT return a negative number if the literal was specified in decimal, since
+     * according to the language specification (chapter 3.10.1) an expression such as <code>-1L</code> is represented by
+     * a unary * expression with a minus operator and the literal <code>1L</code>. It is however possible to represent
+     * negative * numbers in a literal directly,  i.e. by using the binary or hexadecimal representation. For example
+     * <code> 0xffff_ffff_ffff_ffffL</code> represents the value <code>-1L</code>.
      *
      * @return the literal value as a number while respecting different number representations
      */
@@ -139,13 +147,18 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
          * LongLiteralExpr. However 9223372036854775808L cannot be represented in a long, so we need
          * to return a BigInteger
          */
-        if (Objects.equals(value, "9223372036854775808L") && hasUnaryMinusAsParent(this)) {
-            return new BigInteger("9223372036854775808");
+        if (Objects.equals(value, MAX_63_BIT_UNSIGNED_VALUE_AS_STRING) && hasUnaryMinusAsParent(this)) {
+            return MAX_63_BIT_UNSIGNED_VALUE_AS_BIG_INTEGER;
         } else {
             return asLong();
         }
     }
 
+    /**
+     * @deprecated This function is deprecated in favor of constructing the literal by a string value. Please refer to
+     * the {@link #asNumber()} function especially on how to construct literals holding negative values.
+     */
+    @Deprecated
     public LongLiteralExpr setLong(long value) {
         this.value = String.valueOf(value);
         return this;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -96,7 +96,9 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
 
     /**
      * @return the literal value as an long while respecting different number representations
-     * @deprecated Will be made private or merged with {@link LongLiteralExpr#asNumber()} in future releases
+     * @deprecated This function has issues with corner cases, such as 9223372036854775808L, so please use {@link
+     * LongLiteralExpr#asNumber()}. It will be made private or merged with {@link LongLiteralExpr#asNumber()} in future
+     * releases
      */
     public long asLong() {
         String result = value.replaceAll("_", "");
@@ -117,9 +119,11 @@ public class LongLiteralExpr extends LiteralStringValueExpr {
     }
 
     /**
-     * This function returns a representation of the literal values as a number. This will return a long, except for the
-     * case when the literal has the value 9223372036854775808L (which is only allowed in the expression
-     * <code>-9223372036854775808L</code>) and returns a BigInteger.
+     * This function returns a representation of the literal value as a number. This will return a long, except for the
+     * case when the literal has the value <code>9223372036854775808L</code>. This special literal is only allowed in
+     * the expression <code>-9223372036854775808L</code> which represents <code>Long.MIN_VALUE</code>). However
+     * 9223372036854775808 (2^63) is out of range of long, which is -(2^63) to (2^63)-1 and thus a BigInteger must be
+     * returned.
      * <p>
      * Note, that this function will NOT return a negative number if the literal was specified in decimal, since *
      * according to the language specification an expression such as <code>-1L</code> is represented by a unary *

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -21,6 +21,9 @@
 
 package com.github.javaparser.utils;
 
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.UnaryExpr;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
@@ -291,6 +294,17 @@ public class Utils {
             line = line.substring(0, line.length() - 1);
         }
         return line;
+    }
+
+    /**
+     * Checks, if the parent is a unary expression with a minus operator. Used to check for negative literals.
+     */
+    public static boolean hasUnaryMinusAsParent(Node n) {
+        return n.getParentNode()
+                .filter(parent -> parent instanceof UnaryExpr)
+                .map(parent -> (UnaryExpr) parent)
+                .map(unaryExpr -> unaryExpr.getOperator() == UnaryExpr.Operator.MINUS)
+                .orElse(false);
     }
 
 }


### PR DESCRIPTION
- [x] Fixes #2483
- [x] Documentation as to when to use `toNumber` and deprecate `toInt`
- [x] Ensure that the number is only returned in combination with a unary minus expression