### PR TITLE
Issue 1511 - IndexOutOfBoundsException when attempting to resolve super()

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithExtends.java
@@ -28,9 +28,10 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 
 /**
- * A node that extends other types.
+ * A node that explicitly extends other types, using the <code>extends</code> keyword.
  */
 public interface NodeWithExtends<N extends Node> {
+
     NodeList<ClassOrInterfaceType> getExtendedTypes();
 
     void tryAddImportToParentCompilationUnit(Class<?> clazz);
@@ -56,6 +57,7 @@ public interface NodeWithExtends<N extends Node> {
     /**
      * @deprecated use addExtendedType
      */
+    @Deprecated
     default N addExtends(Class<?> clazz) {
         return addExtendedType(clazz);
     }
@@ -63,6 +65,7 @@ public interface NodeWithExtends<N extends Node> {
     /**
      * @deprecated use addExtendedType
      */
+    @Deprecated
     default N addExtends(String name) {
         return addExtendedType(name);
     }
@@ -70,7 +73,7 @@ public interface NodeWithExtends<N extends Node> {
     /**
      * Add an "extends" to this and automatically add the import
      *
-     * @param clazz the class to extand from
+     * @param clazz the class to extend from
      * @return this
      */
     default N addExtendedType(Class<?> clazz) {
@@ -89,4 +92,5 @@ public interface NodeWithExtends<N extends Node> {
         getExtendedTypes().add(parseClassOrInterfaceType(name));
         return (N) this;
     }
+
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -161,15 +161,16 @@ public class JavaParserFacade {
             if(classNode.getExtendedTypes().isNonEmpty()) {
                 // Get the first explicit extended type -- n.b. interfaces may extend multiple interfaces.
                 extendedType = classNode.getExtendedTypes(0);
-                ResolvedType classDecl = JavaParserFacade.get(typeSolver).convert(extendedType, classNode);
-                if (classDecl.isReferenceType()) {
-                    typeDecl = classDecl.asReferenceType().getTypeDeclaration();
-                }
             } else {
                 // If no explicit "extends", the extended type is implicitly `java.lang.Object`
 //                extendedType = new ClassOrInterfaceType("java.lang.Object");
 //                extendedType = new ClassOrInterfaceType(null, "Object");
                 extendedType = StaticJavaParser.parseClassOrInterfaceType("java.lang.Object"); // Feels clumsy, but works?
+            }
+
+            ResolvedType classDecl = JavaParserFacade.get(typeSolver).convert(extendedType, classNode);
+            if (classDecl.isReferenceType()) {
+                typeDecl = classDecl.asReferenceType().getTypeDeclaration();
             }
         } else {
             SymbolReference<ResolvedTypeDeclaration> sr = JavaParserFactory.getContext(classNode, typeSolver).solveType(classNode.getNameAsString());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel;
 
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.DataKey;
 import com.github.javaparser.ast.Node;
@@ -156,9 +157,19 @@ public class JavaParserFacade {
         ClassOrInterfaceDeclaration classNode = optAncestor.get();
         ResolvedTypeDeclaration typeDecl = null;
         if (!explicitConstructorInvocationStmt.isThis()) {
-            ResolvedType classDecl = JavaParserFacade.get(typeSolver).convert(classNode.getExtendedTypes(0), classNode);
-            if (classDecl.isReferenceType()) {
-                typeDecl = classDecl.asReferenceType().getTypeDeclaration();
+            final ClassOrInterfaceType extendedType;
+            if(classNode.getExtendedTypes().isNonEmpty()) {
+                // Get the first explicit extended type -- n.b. interfaces may extend multiple interfaces.
+                extendedType = classNode.getExtendedTypes(0);
+                ResolvedType classDecl = JavaParserFacade.get(typeSolver).convert(extendedType, classNode);
+                if (classDecl.isReferenceType()) {
+                    typeDecl = classDecl.asReferenceType().getTypeDeclaration();
+                }
+            } else {
+                // If no explicit "extends", the extended type is implicitly `java.lang.Object`
+//                extendedType = new ClassOrInterfaceType("java.lang.Object");
+//                extendedType = new ClassOrInterfaceType(null, "Object");
+                extendedType = StaticJavaParser.parseClassOrInterfaceType("java.lang.Object"); // Feels clumsy, but works?
             }
         } else {
             SymbolReference<ResolvedTypeDeclaration> sr = JavaParserFactory.getContext(classNode, typeSolver).solveType(classNode.getNameAsString());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -416,6 +416,8 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
             className = classOrInterfaceType.getScope().get().toString() + "." + className;
         }
         SymbolReference<ResolvedTypeDeclaration> ref = solveType(className);
+
+        // If unable to solve by the class name alone, attempt to qualify it.
         if (!ref.isSolved()) {
             Optional<ClassOrInterfaceType> localScope = classOrInterfaceType.getScope();
             if (localScope.isPresent()) {
@@ -423,12 +425,16 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
                 ref = solveType(localName);
             }
         }
+
+        // If still unable to resolve, throw an exception.
         if (!ref.isSolved()) {
             throw new UnsolvedSymbolException(classOrInterfaceType.getName().getId());
         }
+
         if (!classOrInterfaceType.getTypeArguments().isPresent()) {
             return new ReferenceTypeImpl(ref.getCorrespondingDeclaration().asReferenceType(), typeSolver);
         }
+
         List<ResolvedType> superClassTypeParameters = classOrInterfaceType.getTypeArguments().get()
                                                               .stream().map(ta -> new LazyType(v -> JavaParserFacade.get(typeSolver).convert(ta, ta)))
                                                               .collect(Collectors.toList());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1511Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1511Test.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2020 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+
+import static com.github.javaparser.symbolsolver.AbstractSymbolResolutionTest.adaptPath;
+
+public class Issue1511Test {
+
+    @Test
+    public void tempTest() throws FileNotFoundException {
+
+        Path dir = adaptPath("src/test/resources/issue1511");
+        Path file = adaptPath("src/test/resources/issue1511/A.java");
+
+        // configure symbol solver
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+        typeSolver.add(new ReflectionTypeSolver());
+        typeSolver.add(new JavaParserTypeSolver(dir.toFile()));
+        JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
+        StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
+
+        // get compilation unit & extract explicit constructor invocation statement
+        CompilationUnit cu = StaticJavaParser.parse(file.toFile());
+        ExplicitConstructorInvocationStmt ecis = cu.getPrimaryType().get()
+            .asClassOrInterfaceDeclaration().getMember(0)
+            .asConstructorDeclaration().getBody().getStatement(0)
+            .asExplicitConstructorInvocationStmt();
+
+        // attempt to resolve explicit constructor invocation statement
+        ResolvedConstructorDeclaration rcd = ecis.resolve(); //.resolveInvokedConstructor(); // <-- exception occurs
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1511Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1511Test.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
@@ -31,16 +30,20 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeS
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 
 import static com.github.javaparser.symbolsolver.AbstractSymbolResolutionTest.adaptPath;
 
+/**
+ * IndexOutOfBoundsException when attempting to resolve super() #1511
+ *
+ * @see <a href="https://github.com/javaparser/javaparser/issues/1511">https://github.com/javaparser/javaparser/issues/1511</a>
+ */
 public class Issue1511Test {
 
     @Test
-    public void tempTest() throws FileNotFoundException {
+    public void test() throws FileNotFoundException {
 
         Path dir = adaptPath("src/test/resources/issue1511");
         Path file = adaptPath("src/test/resources/issue1511/A.java");

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1511/A.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1511/A.java
@@ -1,0 +1,5 @@
+class A {
+    A() {
+        super();
+    }
+}


### PR DESCRIPTION
While this fixes #1511 , is there a better way?

It feels like there should be a better/less-"bitty" solution to have JSS recognise that an absence of an explicit parent should default to `java.lang.Object`. I can't see it at the moment though!

_(if there's no explicit `extends`, use `java.lang.Object` as the ancestor extended type)_