### PR TITLE
#2501 - Updated maven version in appveyor script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,15 +7,15 @@ install:
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
+          'http://www.us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET PATH=C:\maven\apache-maven-3.6.3\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET MAVEN_OPTS=-Xmx1g
   - cmd: SET JAVA_OPTS=-Xmx1g
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.6.3
   - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk10
 build_script:
   - echo ignore this


### PR DESCRIPTION
Closes #2501

I noticed that in #100 the minimum build version is JDK8 and in appveyor.yml it specifies JDK10 as the version it actually runs during the test.

Given this, (presumably!) it should be fine to bump the maven version that gets run to the latest available (this is v3.6.3 released 2019-11-25 according to the [maven site](https://maven.apache.org/docs/history.html))

Let's see what happens when it triggers! :) 