### PR TITLE
minor bugfix -- now checking presence of both `getBegin()` _and_ `getEnd()`

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -213,7 +213,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
 
     public Node setTokenRange(TokenRange tokenRange) {
         this.tokenRange = tokenRange;
-        if (tokenRange == null || !(tokenRange.getBegin().getRange().isPresent() && tokenRange.getBegin().getRange().isPresent())) {
+        if (tokenRange == null || !(tokenRange.getBegin().getRange().isPresent() && tokenRange.getEnd().getRange().isPresent())) {
             range = null;
         } else {
             range = new Range(tokenRange.getBegin().getRange().get().begin, tokenRange.getEnd().getRange().get().end);


### PR DESCRIPTION
minor bugfix -- now checking presence of both `getBegin()` _and_ `getEnd()` (as opposed to checking the presence of `getBegin()` twice).

Sidenote: would it be better to throw an exception rather than fail silently?
