### PR TITLE
JavaParserEnumDeclaration can have access specifier

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -392,7 +392,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
 
     @Override
     public AccessSpecifier accessSpecifier() {
-        throw new UnsupportedOperationException();
+        return wrappedNode.getAccessSpecifier();
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
@@ -23,8 +23,10 @@ package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
@@ -36,6 +38,7 @@ import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserEnumDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -92,6 +95,29 @@ class EnumResolutionTest extends AbstractResolutionTest {
             assertEquals("SOME", resolvedEnumConstantDeclaration.getName());
             assertTrue(resolvedEnumConstantDeclaration.isEnumConstant());
             assertTrue(resolvedEnumConstantDeclaration.hasName());
+        } finally {
+            StaticJavaParser.setConfiguration(new ParserConfiguration());
+        }
+    }
+
+    @Test
+    void enumAccessSpecifier() {
+        try {
+            StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+            CompilationUnit cu = parseSample("EnumAccessSpecifier");
+            ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MyClass");
+
+            EnumDeclaration ed_public = Navigator.findType(clazz, "EnumPublic").get().toEnumDeclaration().get();
+            assertEquals(AccessSpecifier.PUBLIC, ((JavaParserEnumDeclaration) ed_public.resolve()).accessSpecifier());
+
+            EnumDeclaration ed_protected = Navigator.findType(clazz, "EnumProtected").get().toEnumDeclaration().get();
+            assertEquals(AccessSpecifier.PROTECTED, ((JavaParserEnumDeclaration) ed_protected.resolve()).accessSpecifier());
+
+            EnumDeclaration ed_private = Navigator.findType(clazz, "EnumPrivate").get().toEnumDeclaration().get();
+            assertEquals(AccessSpecifier.PRIVATE, ((JavaParserEnumDeclaration) ed_private.resolve()).accessSpecifier());
+
+            EnumDeclaration ed_default = Navigator.findType(clazz, "EnumDefault").get().toEnumDeclaration().get();
+            assertEquals(AccessSpecifier.PACKAGE_PRIVATE, ((JavaParserEnumDeclaration) ed_default.resolve()).accessSpecifier());
         } finally {
             StaticJavaParser.setConfiguration(new ParserConfiguration());
         }

--- a/javaparser-symbol-solver-testing/src/test/resources/EnumAccessSpecifier.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/EnumAccessSpecifier.java.txt
@@ -1,0 +1,13 @@
+class MyClass {
+    public enum EnumPublic {
+    }
+
+    protected enum EnumProtected {
+    }
+
+    private enum EnumPrivate {
+    }
+
+    enum EnumDefault {
+    }
+}


### PR DESCRIPTION
According to [JLS-8.9](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.9), an enum declaration can have access modifiers.
This PR fixes `JavaParserEnumDeclaration.accessSpecifier()` to return a `AccessSpecifier` constant, which currently throws `UnsupportedOperation`.

I'm not sure about the place where I put the test case is good or not. Please tell me if there is elsewhere appropriate.