### PR TITLE
solve annotation element types in AnnotationDeclarationContext

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -48,6 +48,8 @@ public class JavaParserFactory {
     public static Context getContext(Node node, TypeSolver typeSolver) {
         if (node == null) {
             throw new NullPointerException("Node should not be null");
+        } else if (node instanceof AnnotationDeclaration) {
+            return new AnnotationDeclarationContext((AnnotationDeclaration) node, typeSolver);
         } else if (node instanceof BlockStmt) {
             return new BlockStmtContext((BlockStmt) node, typeSolver);
         } else if (node instanceof CompilationUnit) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnnotationDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnnotationDeclarationContext.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2020 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserAnnotationDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+
+import java.util.List;
+
+/**
+ * @author Takeshi D. Itoh
+ */
+public class AnnotationDeclarationContext extends AbstractJavaParserContext<AnnotationDeclaration> {
+
+    private JavaParserTypeDeclarationAdapter javaParserTypeDeclarationAdapter;
+
+    public AnnotationDeclarationContext(AnnotationDeclaration wrappedNode, TypeSolver typeSolver) {
+        super(wrappedNode, typeSolver);
+        this.javaParserTypeDeclarationAdapter = new JavaParserTypeDeclarationAdapter(wrappedNode, typeSolver,
+                getDeclaration(), this);
+    }
+
+    @Override
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name) {
+        if (typeSolver == null) throw new IllegalArgumentException();
+
+        if (this.getDeclaration().hasField(name)) {
+            return SymbolReference.solved(this.getDeclaration().getField(name));
+        }
+
+        // then to parent
+        return getParent().solveSymbol(name);
+    }
+
+    @Override
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
+        return javaParserTypeDeclarationAdapter.solveType(name);
+    }
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
+    }
+
+    ///
+    /// Private methods
+    ///
+
+    private ResolvedReferenceTypeDeclaration getDeclaration() {
+        return new JavaParserAnnotationDeclaration(this.wrappedNode, typeSolver);
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/AstResolutionUtils.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/AstResolutionUtils.java
@@ -82,6 +82,14 @@ class AstResolutionUtils {
             } else {
                 return b + "." + cn;
             }
+        } else if (container instanceof com.github.javaparser.ast.body.AnnotationDeclaration) {
+            String b = getClassName(base, container.getParentNode().orElse(null));
+            String cn = ((com.github.javaparser.ast.body.AnnotationDeclaration) container).getName().getId();
+            if (b.isEmpty()) {
+                return cn;
+            } else {
+                return b + "." + cn;
+            }
         } else if (container != null) {
             return getClassName(base, container.getParentNode().orElse(null));
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationMemberDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationMemberDeclaration.java
@@ -25,6 +25,9 @@ import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.core.resolution.Context;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 
 /**
@@ -51,11 +54,15 @@ public class JavaParserAnnotationMemberDeclaration implements ResolvedAnnotation
 
     @Override
     public ResolvedType getType() {
-        throw new UnsupportedOperationException();
+        return JavaParserFacade.get(typeSolver).convert(wrappedNode.getType(), getContext());
     }
 
     @Override
     public String getName() {
         return wrappedNode.getNameAsString();
+    }
+
+    private Context getContext() {
+        return JavaParserFactory.getContext(wrappedNode, typeSolver);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
@@ -298,6 +299,21 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
         List<ResolvedReferenceType> ancestors = referenceType.getAncestors();
         assertEquals(ancestors.size(), 1);
         assertEquals(ancestors.get(0).getQualifiedName(), "java.lang.annotation.Annotation");
+    }
+
+    @Test
+    void solvePrimitiveAnnotationMember() throws IOException {
+        CompilationUnit cu = parseSample("Annotations");
+        AnnotationDeclaration ad = Navigator.findType(cu, "MyAnnotationWithSingleValue").get().asAnnotationDeclaration();
+        assertEquals(ad.getMember(0).asAnnotationMemberDeclaration().resolve().getType().asPrimitive().describe(), "int");
+    }
+
+    @Test
+    void solveInnerClassAnnotationMember() throws IOException {
+        CompilationUnit cu = parseSample("Annotations");
+        AnnotationDeclaration ad = Navigator.findType(cu, "MyAnnotationWithInnerClass").get().asAnnotationDeclaration();
+        ResolvedAnnotationMemberDeclaration am = ad.getMember(0).asAnnotationMemberDeclaration().resolve();
+        assertEquals(am.getType().asReferenceType().getQualifiedName(), "foo.bar.MyAnnotationWithInnerClass.MyInnerClass");
     }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
@@ -20,6 +20,12 @@ public @interface MyAnnotationWithElements {
     String str();
 }
 
+public @interface MyAnnotationWithInnerClass {
+    MyInnerClass value();
+    class MyInnerClass {
+    }
+}
+
 @MyAnnotation
 class CA {
     @Override


### PR DESCRIPTION
Currently `JavaParserAnnotationMemberDeclaration.getType()` throws an `UnsupportedOperationException`, but it should return the corresponding type for the member.
Also, its type should be resolved in the enclosing `@interface`, which could have nested classes/interfaces/enums, thus I created `javaparsermodel.contexts.AnnotationDeclarationContext`.