### PR TITLE
Add the zenodo DOI badge in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,8 @@
 [![Coverage Status](https://coveralls.io/repos/javaparser/javaparser/badge.svg?branch=master&service=github)](https://coveralls.io/github/javaparser/javaparser?branch=master)
 [![Join the chat at https://gitter.im/javaparser/javaparser](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/javaparser/javaparser?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License LGPL-3/Apache-2.0](https://img.shields.io/badge/license-LGPL--3%2FApache--2.0-blue.svg)](LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2667378.svg)](https://doi.org/10.5281/zenodo.2667378)
+
 
 This project contains a set of libraries implementing a Java 1.0 - Java 13 Parser with advanced analysis functionalities.
 


### PR DESCRIPTION
Note that DOI [10.5281/zenodo.2667378](https://doi.org/10.5281/zenodo.2667378) will always resolve to the latest version.
