### PR TITLE
Issue 2592 -- Fix: Nodes in NodeList losing their parent on replacing a child, with lpp enabled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,11 @@ Next Release (3.15.19)
 [issues resolved](https://github.com/javaparser/javaparser/milestone/172?closed=1)
 
 * DEPRECATED: Deprecated and documented `JarTypeSolver#getJarTypeSolver(String)`, with a view to later removal.
-  ([#2598](https://github.com/javaparser/javaparser/pull/2598))
+    ([#2598](https://github.com/javaparser/javaparser/pull/2598))
 * FIXED: Fix issue #2552 : UnsupportedOperationException caused by resolving inner annotation
-    ([#2585](https://github.com/javaparser/javaparser/pull/2553))
+    ([#2553](https://github.com/javaparser/javaparser/pull/2553))
+* FIXED: Parents of `NodeList`s now correctly retain their parent when a child is replaced 
+    ([#2594](https://github.com/javaparser/javaparser/pull/2594))
 
 Version 3.15.18
 ------------------

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -117,6 +117,7 @@ public class LexicalPreservingPrinter {
     }
 
     private static class Observer extends PropagatingAstObserver {
+
         @Override
         public void concretePropertyChange(Node observedNode, ObservableProperty property, Object oldValue, Object newValue) {
             if (oldValue == newValue) {
@@ -275,7 +276,7 @@ public class LexicalPreservingPrinter {
          * at the position of {@code index}, the new comment and the node will have the same indent.
          *
          * @param nodeText The text of the node
-         * @param index The position where a new comment will be added to
+         * @param index    The position where a new comment will be added to
          */
         private void fixIndentOfMovedNode(NodeText nodeText, int index) {
             if (index <= 0) {
@@ -296,7 +297,7 @@ public class LexicalPreservingPrinter {
         }
 
         @Override
-        public void concreteListChange(NodeList<?> changedList, AstObserver.ListChangeType type, int index, Node nodeAddedOrRemoved) {
+        public void concreteListChange(NodeList<?> changedList, ListChangeType type, int index, Node nodeAddedOrRemoved) {
             NodeText nodeText = getOrCreateNodeText(changedList.getParentNodeForChildren());
             final List<DifferenceElement> differenceElements;
             if (type == AstObserver.ListChangeType.REMOVAL) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
@@ -27,7 +27,7 @@ import com.github.javaparser.printer.concretesyntaxmodel.CsmConditional;
 import com.github.javaparser.utils.Utils;
 
 /**
- * This represent a change happened to a specific Node.
+ * This represents a change that has happened to a specific Node.
  */
 public interface Change {
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
@@ -25,10 +25,13 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
 
+import java.util.Optional;
+
 /**
  * The Addition of an element to a list.
  */
 public class ListAdditionChange implements Change {
+
     private final ObservableProperty observableProperty;
     private final int index;
     private final Node nodeAdded;
@@ -42,16 +45,25 @@ public class ListAdditionChange implements Change {
     @Override
     public Object getValue(ObservableProperty property, Node node) {
         if (property == observableProperty) {
-            NodeList<Node> nodeList = new NodeList<>();
-	    nodeList.setParentNode(node);
             Object currentRawValue = new NoChange().getValue(property, node);
-            if (!(currentRawValue instanceof NodeList)){
+            if (currentRawValue instanceof Optional) {
+                Optional<?> optional = (Optional<?>) currentRawValue;
+                currentRawValue = optional.orElseGet(null);
+            }
+            if (!(currentRawValue instanceof NodeList)) {
                 throw new IllegalStateException("Expected NodeList, found " + currentRawValue.getClass().getCanonicalName());
             }
-            NodeList<?> currentNodeList = (NodeList<?>)(currentRawValue);
-            nodeList.addAll(currentNodeList);
-            nodeList.add(index, nodeAdded);
-            return nodeList;
+            NodeList<Node> currentNodeList = (NodeList<Node>) currentRawValue;
+
+            // Note: When adding to a node list children get assigned the list's parent, thus we must set the list's parent before adding children (#2592).
+            NodeList<Node> newNodeList = new NodeList<>();
+            newNodeList.setParentNode(currentNodeList.getParentNodeForChildren());
+            newNodeList.addAll(currentNodeList);
+
+            // Perform modification -- add to the list
+            newNodeList.add(index, nodeAdded);
+
+            return newNodeList;
         } else {
             return new NoChange().getValue(property, node);
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
@@ -31,6 +31,7 @@ import java.util.Optional;
  * The replacement of an element in a list.
  */
 public class ListReplacementChange implements Change {
+
     private final ObservableProperty observableProperty;
     private final int index;
     private final Node newValue;
@@ -44,23 +45,25 @@ public class ListReplacementChange implements Change {
     @Override
     public Object getValue(ObservableProperty property, Node node) {
         if (property == observableProperty) {
-            NodeList nodeList = new NodeList();
             Object currentRawValue = new NoChange().getValue(property, node);
             if (currentRawValue instanceof Optional) {
-                Optional optional = (Optional)currentRawValue;
+                Optional<?> optional = (Optional<?>) currentRawValue;
                 currentRawValue = optional.orElseGet(null);
             }
-            if (!(currentRawValue instanceof NodeList)){
+            if (!(currentRawValue instanceof NodeList)) {
                 throw new IllegalStateException("Expected NodeList, found " + currentRawValue.getClass().getCanonicalName());
             }
+            NodeList<Node> currentNodeList = (NodeList<Node>) currentRawValue;
 
             // Note: When adding to a node list children get assigned the list's parent, thus we must set the list's parent before adding children (#2592).
-            NodeList currentNodeList = (NodeList) currentRawValue;
-            nodeList.setParentNode(currentNodeList.getParentNodeForChildren());
-            nodeList.addAll(currentNodeList);
-            nodeList.set(index, newValue);
+            NodeList<Node> newNodeList = new NodeList<>();
+            newNodeList.setParentNode(currentNodeList.getParentNodeForChildren());
+            newNodeList.addAll(currentNodeList);
 
-            return nodeList;
+            // Perform modification -- replace an item in the list
+            newNodeList.set(index, newValue);
+
+            return newNodeList;
         } else {
             return new NoChange().getValue(property, node);
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
@@ -53,9 +53,13 @@ public class ListReplacementChange implements Change {
             if (!(currentRawValue instanceof NodeList)){
                 throw new IllegalStateException("Expected NodeList, found " + currentRawValue.getClass().getCanonicalName());
             }
-            NodeList currentNodeList = (NodeList)currentRawValue;
+
+            // Note: When adding to a node list children get assigned the list's parent, thus we must set the list's parent before adding children (#2592).
+            NodeList currentNodeList = (NodeList) currentRawValue;
+            nodeList.setParentNode(currentNodeList.getParentNodeForChildren());
             nodeList.addAll(currentNodeList);
             nodeList.set(index, newValue);
+
             return nodeList;
         } else {
             return new NoChange().getValue(property, node);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/PropertyChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/PropertyChange.java
@@ -28,9 +28,16 @@ import com.github.javaparser.ast.observer.ObservableProperty;
  * The change in value of a property.
  */
 public class PropertyChange implements Change {
+
     private final ObservableProperty property;
     private final Object oldValue;
     private final Object newValue;
+
+    public PropertyChange(ObservableProperty property, Object oldValue, Object newValue) {
+        this.property = property;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
 
     public ObservableProperty getProperty() {
         return property;
@@ -42,12 +49,6 @@ public class PropertyChange implements Change {
 
     public Object getNewValue() {
         return newValue;
-    }
-
-    public PropertyChange(ObservableProperty property, Object oldValue, Object newValue) {
-        this.property = property;
-        this.oldValue = oldValue;
-        this.newValue = newValue;
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2592Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2592Test.java
@@ -18,8 +18,11 @@ public class Issue2592Test {
     @Test
     public void testLPP() {
 
+//        // Either do this before parsing, or manually pass the node to `LexicalPreservingPrinter.setup(node);`
+//        StaticJavaParser.getConfiguration().setLexicalPreservationEnabled(true);
+
         String s = "public class A {" +
-                "  public void m(final int a, int b) {" +
+                "  public void m(final int a_original, int b) {" +
                 "  }" +
                 "} ";
         CompilationUnit cu = StaticJavaParser.parse(s);
@@ -31,25 +34,32 @@ public class Issue2592Test {
         LexicalPreservingPrinter.setup(cu);
 
         //all parameters have parent nodes here
+        System.out.println("");
+        md.get().getParameters().forEach(p -> System.out.println(p + " parent " + p.getParentNode().isPresent()));
         assertTrue(md.get().getParameters().stream().allMatch(p -> p.getParentNode().isPresent()));
 
-        md.get().addParameter("Added", "a");
+
+        //add a third parameter
+        md.get().addParameter("String", "c_brand_new");
 
         //seems like we can add a parameter fine (and all of the parents still assigned)
         assertTrue(md.get().getParameters().stream().allMatch(p -> p.getParentNode().isPresent()));
 
 
+        System.out.println("");
         md.get().getParameters().forEach(p -> System.out.println(p + " parent " + p.getParentNode().isPresent()));
         Parameter p1 = md.get().getParameter(0);
-        Parameter p2 = new Parameter(p1.getModifiers(), p1.getType(), new SimpleName("a1"));
+        Parameter p2 = new Parameter(p1.getModifiers(), p1.getType(), new SimpleName("a_renamed"));
 
         //here we replace a parameter
         boolean isReplaced = md.get().replace(p1, p2);
         assertTrue(isReplaced); //the replacement seemed to work
+        System.out.println("");
         System.out.println(cu.toString()); //this looks right
 
 
         //...however when we replaced the parent nodes (for the replaced node AND the added node (after the replaced node) now null
+        System.out.println("");
         md.get().getParameters().forEach(p -> System.out.println(p + " parent " + p.getParentNode().isPresent()));
         assertTrue(md.get().getParameters().stream().allMatch(p -> p.getParentNode().isPresent()));
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2592Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2592Test.java
@@ -1,0 +1,57 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class Issue2592Test {
+
+    @Test
+    public void testLPP() {
+
+        String s = "public class A {" +
+                "  public void m(final int a, int b) {" +
+                "  }" +
+                "} ";
+        CompilationUnit cu = StaticJavaParser.parse(s);
+        Optional<MethodDeclaration> md = cu.findFirst(MethodDeclaration.class);
+        //all parameters have parent nodes here
+        assertTrue(md.get().getParameters().stream().allMatch(p -> p.getParentNode().isPresent()));
+
+        //this seems to be doing nasty things to parent nodes (after a change happens)
+        LexicalPreservingPrinter.setup(cu);
+
+        //all parameters have parent nodes here
+        assertTrue(md.get().getParameters().stream().allMatch(p -> p.getParentNode().isPresent()));
+
+        md.get().addParameter("Added", "a");
+
+        //seems like we can add a parameter fine (and all of the parents still assigned)
+        assertTrue(md.get().getParameters().stream().allMatch(p -> p.getParentNode().isPresent()));
+
+
+        md.get().getParameters().forEach(p -> System.out.println(p + " parent " + p.getParentNode().isPresent()));
+        Parameter p1 = md.get().getParameter(0);
+        Parameter p2 = new Parameter(p1.getModifiers(), p1.getType(), new SimpleName("a1"));
+
+        //here we replace a parameter
+        boolean isReplaced = md.get().replace(p1, p2);
+        assertTrue(isReplaced); //the replacement seemed to work
+        System.out.println(cu.toString()); //this looks right
+
+
+        //...however when we replaced the parent nodes (for the replaced node AND the added node (after the replaced node) now null
+        md.get().getParameters().forEach(p -> System.out.println(p + " parent " + p.getParentNode().isPresent()));
+        assertTrue(md.get().getParameters().stream().allMatch(p -> p.getParentNode().isPresent()));
+    }
+
+}


### PR DESCRIPTION
Fixes #2592


> Turns out that it's due to the way that list replacements are handled.
> 
> It seems that a brand new nodelist is created on every change, but because this new nodelist hasn't been assigned a parent yet (i.e. the list's parent is null) any children that get copied across (added to this new instance of a nodelist) then get assigned the new list's parent (i.e. null). Hence the clobbering.
> 
> Copying the parent across from the old list before performing the list insertions seems to fix this!
