### PR TITLE
Deprecated and documented `JarTypeSolver#getJarTypeSolver(String)`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@ Next Release (3.15.19)
 ------------------
 [issues resolved](https://github.com/javaparser/javaparser/milestone/172?closed=1)
 
+* DEPRECATED: Deprecated and documented `JarTypeSolver#getJarTypeSolver(String)`, with a view to later removal.
+  ([#2598](https://github.com/javaparser/javaparser/pull/2598))
 
 Version 3.15.18
 ------------------

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
@@ -46,6 +46,7 @@ import java.util.jar.JarFile;
  */
 public class JarTypeSolver implements TypeSolver {
 
+    @Deprecated
     private static JarTypeSolver instance;
 
     private TypeSolver parent;
@@ -68,6 +69,13 @@ public class JarTypeSolver implements TypeSolver {
         addPathToJar(jarInputStream);
     }
 
+    /**
+     * Suitable for being called only once. If called multiple times, it will cause an IllegalStateException per #2547 .
+     *
+     * @deprecated Use of this static method / singleton pattern is strongly discouraged and will be removed (#2547).
+     * Instead, a new instance should be created for each jar (consistent with the other type solvers e.g. AarTypeSolver, JavaParserTypeSolver, ClassLoaderTypeSolver).
+     */
+    @Deprecated
     public static JarTypeSolver getJarTypeSolver(String pathToJar) throws IOException {
         if (instance == null) {
             instance = new JarTypeSolver(pathToJar);


### PR DESCRIPTION
See #2547 

My preference would be to remove the singleton stuff completely, rather than just deprecate it.

Given that #2547 shows anybody using a recent version will not be calling this method twice, the only people affected by its removal would be those who use it only once, and their workaround for this API change would be extremely simple (replace `JarTypeSolver.getJarTypeSolver(jar)` with `new JarTypeSolver(jar)`).
