### PR TITLE
fix JavaParserClassDeclaration canBeAssignedTo() to not cause a recur…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ Next Release (3.15.19)
     ([#2553](https://github.com/javaparser/javaparser/pull/2553))
 * FIXED: Parents of `NodeList`s now correctly retain their parent when a child is replaced 
     ([#2594](https://github.com/javaparser/javaparser/pull/2594))
+* FIXED: Fix JavaParserClassDeclaration canBeAssignedTo() to not cause a recursion when a node is its own parent (e.g. `java.lang.Object`)
+    ([#2608](https://github.com/javaparser/javaparser/pull/2608))
+
 
 Version 3.15.18
 ------------------

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -241,7 +241,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
             return true;
         }
         ResolvedClassDeclaration superclass = (ResolvedClassDeclaration) getSuperClass().getTypeDeclaration();
-        if (superclass != null) {
+        if (superclass != null && superclass != this ) {
             if (superclass.canBeAssignedTo(other)) {
                 return true;
             }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -83,9 +83,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
 
         JavaParserClassDeclaration that = (JavaParserClassDeclaration) o;
 
-        if (!wrappedNode.equals(that.wrappedNode)) return false;
-
-        return true;
+        return wrappedNode.equals(that.wrappedNode);
     }
 
     @Override
@@ -96,8 +94,8 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
     @Override
     public String toString() {
         return "JavaParserClassDeclaration{" +
-               "wrappedNode=" + wrappedNode +
-               '}';
+                "wrappedNode=" + wrappedNode +
+                '}';
     }
 
     ///
@@ -241,7 +239,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
             return true;
         }
         ResolvedClassDeclaration superclass = (ResolvedClassDeclaration) getSuperClass().getTypeDeclaration();
-        if (superclass != null && superclass != this ) {
+        if (superclass != null && superclass != this) {
             if (superclass.canBeAssignedTo(other)) {
                 return true;
             }
@@ -432,8 +430,10 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
         }
 
         List<ResolvedType> superClassTypeParameters = classOrInterfaceType.getTypeArguments().get()
-                                                              .stream().map(ta -> new LazyType(v -> JavaParserFacade.get(typeSolver).convert(ta, ta)))
-                                                              .collect(Collectors.toList());
+                .stream()
+                .map(ta -> new LazyType(v -> JavaParserFacade.get(typeSolver).convert(ta, ta)))
+                .collect(Collectors.toList());
+
         return new ReferenceTypeImpl(ref.getCorrespondingDeclaration().asReferenceType(), superClassTypeParameters, typeSolver);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2602Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2602Test.java
@@ -6,23 +6,16 @@ import com.github.javaparser.ParseStart;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
-import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
-import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.MemoryTypeSolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static com.github.javaparser.Providers.provider;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue2602Test extends AbstractSymbolResolutionTest {
 
@@ -65,10 +58,10 @@ public class Issue2602Test extends AbstractSymbolResolutionTest {
 
         JavaParserFacade javaParserFacade = JavaParserFacade.get(this.typeSolver);
 
-        for(TypeDeclaration t : this.cu.getTypes() ) {
-            JavaParserClassDeclaration classDecl = new JavaParserClassDeclaration((ClassOrInterfaceDeclaration)t,this.typeSolver);
+        for (TypeDeclaration t : this.cu.getTypes()) {
+            JavaParserClassDeclaration classDecl = new JavaParserClassDeclaration((ClassOrInterfaceDeclaration) t, this.typeSolver);
 
-            this.typeSolver.addDeclaration((String)t.getFullyQualifiedName().get(),classDecl);
+            this.typeSolver.addDeclaration((String) t.getFullyQualifiedName().get(), classDecl);
         }
     }
 
@@ -79,7 +72,7 @@ public class Issue2602Test extends AbstractSymbolResolutionTest {
         ResolvedReferenceTypeDeclaration thisDeclaration = typeSolver.solveType("java.lang.A");
         ResolvedReferenceTypeDeclaration secondDeclaration = typeSolver.solveType("java.lang.B");
 
-        assertFalse(thisDeclaration.canBeAssignedTo(secondDeclaration),"Both types should not be assignable");
+        assertFalse(thisDeclaration.canBeAssignedTo(secondDeclaration), "Both types should not be assignable");
     }
 
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2602Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2602Test.java
@@ -1,0 +1,86 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParseStart;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.MemoryTypeSolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.github.javaparser.Providers.provider;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2602Test extends AbstractSymbolResolutionTest {
+
+    private JavaParser javaParser;
+    private CompilationUnit cu;
+    private MemoryTypeSolver typeSolver;
+    private ParserConfiguration configuration;
+
+
+    @BeforeEach
+    public void setUp() {
+        typeSolver = new MemoryTypeSolver();
+        configuration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+
+        javaParser = new JavaParser(configuration);
+
+        //language=JAVA
+        String src = "package java.lang;" +
+                " class Object {}\n" +
+                "\n" +
+                "class A extends Object {}\n" +
+                "\n" +
+                "class B extends Object {}\n";
+
+
+        ParseResult<CompilationUnit> parseResult = javaParser.parse(
+                ParseStart.COMPILATION_UNIT,
+                provider(src)
+        );
+
+
+        System.out.println("parseResult = " + parseResult);
+        parseResult.getProblems().forEach(problem -> System.out.println("problem.getVerboseMessage() = " + problem.getVerboseMessage()));
+
+        assertTrue(parseResult.isSuccessful());
+        assertEquals(0, parseResult.getProblems().size(), "Expected zero errors when attempting to parse the input code.");
+        assertTrue(parseResult.getResult().isPresent(), "Must have a parse result to run this test.");
+
+        this.cu = parseResult.getResult().get();
+
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(this.typeSolver);
+
+        for(TypeDeclaration t : this.cu.getTypes() ) {
+            JavaParserClassDeclaration classDecl = new JavaParserClassDeclaration((ClassOrInterfaceDeclaration)t,this.typeSolver);
+
+            this.typeSolver.addDeclaration((String)t.getFullyQualifiedName().get(),classDecl);
+        }
+    }
+
+
+    @Test
+    public void doTest_checkForRecursionWhen_java_lang_Object_IsA_JavaParserClassDeclaration() {
+
+        ResolvedReferenceTypeDeclaration thisDeclaration = typeSolver.solveType("java.lang.A");
+        ResolvedReferenceTypeDeclaration secondDeclaration = typeSolver.solveType("java.lang.B");
+
+        assertFalse(thisDeclaration.canBeAssignedTo(secondDeclaration),"Both types should not be assignable");
+    }
+
+
+}


### PR DESCRIPTION
…sion when java.lang.Object is resolved as a JavaParserClassDeclaration, including unit test.

issue https://github.com/javaparser/javaparser/issues/2602

Fixes #2602
