### PR TITLE
Fix resolving method calls where the method has a generic vararg and is called with a primitive type

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/declarations/common/MethodDeclarationCommonLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/declarations/common/MethodDeclarationCommonLogic.java
@@ -23,6 +23,7 @@ package com.github.javaparser.symbolsolver.declarations.common;
 
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.resolution.types.ResolvedTypeVariable;
@@ -60,9 +61,15 @@ public class MethodDeclarationCommonLogic {
         // and then we replace them in the return type
         // Map<TypeParameterDeclaration, Type> determinedTypeParameters = new HashMap<>();
         InferenceContext inferenceContext = new InferenceContext(MyObjectProvider.INSTANCE);
-        for (int i = 0; i < methodDeclaration.getNumberOfParams() - (methodDeclaration.hasVariadicParameter() ? 1 : 0); i++) {
-            ResolvedType formalParamType = methodDeclaration.getParam(i).getType();
+        for (int i = 0; i < methodDeclaration.getNumberOfParams(); i++) {
+            ResolvedParameterDeclaration formalParamDecl = methodDeclaration.getParam(i);
+            ResolvedType formalParamType = formalParamDecl.getType();
             ResolvedType actualParamType = parameterTypes.get(i);
+
+            if (formalParamDecl.isVariadic() && !actualParamType.isArray()) {
+                formalParamType = formalParamType.asArrayType().getComponentType();
+            }
+
             inferenceContext.addPair(formalParamType, actualParamType);
         }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/GenericsResolutionTest.java
@@ -242,6 +242,20 @@ class GenericsResolutionTest extends AbstractResolutionTest {
     }
 
     @Test
+    void resolveUsageOfMethodOfGenericClassWithBoxing() {
+        CompilationUnit cu = parseSample("Generics");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "GenericMethodBoxing");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "bar");
+        MethodCallExpr expression = Navigator.findMethodCall(method, "foo").get();
+
+        MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(expression);
+
+        assertEquals("foo", methodUsage.getName());
+        assertEquals("GenericMethodBoxing", methodUsage.declaringType().getName());
+        assertEquals("java.lang.Long", methodUsage.returnType().describe());
+    }
+
+    @Test
     void resolveElementOfList() {
         CompilationUnit cu = parseSample("ElementOfList");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ElementOfList");

--- a/javaparser-symbol-solver-testing/src/test/resources/Generics.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Generics.java.txt
@@ -49,3 +49,15 @@ public final class GenericMethodCalls {
     }
 
 }
+
+public final class GenericMethodBoxing {
+
+    public <T> T foo(T... t) {
+        return null;
+    }
+
+    public void bar() {
+        foo(5L);
+    }
+
+}


### PR DESCRIPTION
Fixes #2523.
