### PR TITLE
[TESTCASE] also test under jdk 13 and jdk 14

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -14,7 +14,7 @@ jobs:
         ## Different JDK versions have different implementations etc. -- test on all combinations (ideally 8 to latest).
         ### exclude pre-8 (min development version jdk8)
         ### exclude post-12 (changes to jdk causes reflection tests to fail due to added methods #1701 )
-        jdk: [8,9,10,11,12] # [8,9,10,11,12,13,14,15-ea]
+        jdk: [8,9,10,11,12,13,14] # [8,9,10,11,12,13,14,15-ea]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
closes #1701

The builds fail when running under jdk 13 and jdk 14 -- seemingly this is due to assumptions and that no longer hold true, rather than a fault in JavaParser.