### PR TITLE
Add symbol solver support for variadic parameters given zero or more than one argument

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ Next Release (Version 3.15.23)
     (PR [#2679](https://github.com/javaparser/javaparser/pull/2679), by [@MysterAitch](https://github.com/MysterAitch))
 * BREAKING CHANGE: Tokens relating to literal values now have the category of `JavaToken.Category.LITERAL` (previously `JavaToken.Category.KEYWORD`) 
     (PR [#2679](https://github.com/javaparser/javaparser/pull/2679), by [@MysterAitch](https://github.com/MysterAitch))
+* FIXED: Add symbol solver support for variadic parameters given zero or more than one argument, and when an array is given
+    (PR [#2675](https://github.com/javaparser/javaparser/pull/2675), by [@hfreeb](https://github.com/hfreeb))
 
 
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/PositionRangeSteps.java
@@ -28,7 +28,6 @@ import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
 
-import static com.github.javaparser.Position.pos;
 import static com.github.javaparser.Range.range;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,12 +47,12 @@ public class PositionRangeSteps {
         secondRange = null;
     }
     /*
-	 * Given steps
+     * Given steps
      */
 
     @Given("the position $line, $column")
     public void givenThePosition(int line, int column) {
-        this.position = pos(line, column);
+        this.position = new Position(line, column);
     }
 
     @Given("the range $line1, $column1 - $line2, $column2")
@@ -62,12 +61,12 @@ public class PositionRangeSteps {
     }
 
     /*
-	 * When steps
+     * When steps
      */
 
     @When("I compare to position $line, $column")
     public void iCompareToPosition(int line, int column) {
-        secondPosition = pos(line, column);
+        secondPosition = new Position(line, column);
     }
 
     @When("I compare to range $line1, $column1 - $line2, $column2")
@@ -76,7 +75,7 @@ public class PositionRangeSteps {
     }
 
     /*
-	 * Then steps
+     * Then steps
      */
 
     @Then("the positions are equal")

--- a/javaparser-core/src/main/java/com/github/javaparser/Range.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Range.java
@@ -79,7 +79,7 @@ public class Range {
      * @return A new `Range` object with the given start/end position.
      */
     public static Range range(int beginLine, int beginColumn, int endLine, int endColumn) {
-        return new Range(pos(beginLine, beginColumn), pos(endLine, endColumn));
+        return new Range(new Position(beginLine, beginColumn), new Position(endLine, endColumn));
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -21,6 +21,7 @@
 package com.github.javaparser.ast;
 
 import com.github.javaparser.HasParentNode;
+import com.github.javaparser.Position;
 import com.github.javaparser.Range;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.comments.BlockComment;
@@ -401,9 +402,18 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
         }
     }
 
-    public static final int ABSOLUTE_BEGIN_LINE = -1;
+    /**
+     * @deprecated Use {@link Position#ABSOLUTE_BEGIN_LINE}
+     */
+    @Deprecated
+    public static final int ABSOLUTE_BEGIN_LINE = Position.ABSOLUTE_BEGIN_LINE;
 
-    public static final int ABSOLUTE_END_LINE = -2;
+
+    /**
+     * @deprecated Use {@link Position#ABSOLUTE_END_LINE}
+     */
+    @Deprecated
+    public static final int ABSOLUTE_END_LINE = Position.ABSOLUTE_END_LINE;
 
     public void tryAddImportToParentCompilationUnit(Class<?> clazz) {
         findAncestor(CompilationUnit.class).ifPresent(p -> p.addImport(clazz));

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/SourcePrinter.java
@@ -28,8 +28,6 @@ import com.github.javaparser.utils.Utils;
 import java.util.Deque;
 import java.util.LinkedList;
 
-import static com.github.javaparser.Position.*;
-
 /**
  * A support class for code that outputs formatted source code.
  */
@@ -43,7 +41,7 @@ public class SourcePrinter {
     private final Deque<String> reindentedIndents = new LinkedList<>();
     private String lastPrintedIndent = "";
     private final StringBuilder buf = new StringBuilder();
-    private Position cursor = new Position(1, 0);
+    private Position cursor = new Position(Position.FIRST_LINE, Position.FIRST_COLUMN - 1); // Start before the first column
     private boolean indented = false;
 
     SourcePrinter() {
@@ -198,7 +196,7 @@ public class SourcePrinter {
      */
     public SourcePrinter println() {
         buf.append(endOfLineCharacter);
-        cursor = pos(cursor.line + 1, 0);
+        cursor = new Position(cursor.line + 1, Position.FIRST_COLUMN - 1); // Start before the first column
         indented = false;
         return this;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/declarations/common/MethodDeclarationCommonLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/declarations/common/MethodDeclarationCommonLogic.java
@@ -64,6 +64,12 @@ public class MethodDeclarationCommonLogic {
         for (int i = 0; i < methodDeclaration.getNumberOfParams(); i++) {
             ResolvedParameterDeclaration formalParamDecl = methodDeclaration.getParam(i);
             ResolvedType formalParamType = formalParamDecl.getType();
+
+            // Don't continue if a vararg parameter is reached and there are no arguments left
+            if (formalParamDecl.isVariadic() && parameterTypes.size() < methodDeclaration.getNumberOfParams()) {
+                break;
+            }
+
             ResolvedType actualParamType = parameterTypes.get(i);
 
             if (formalParamDecl.isVariadic() && !actualParamType.isArray()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -207,6 +207,10 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             for (int i = 0; i < methodUsage.getParamTypes().size(); i++) {
                 ResolvedParameterDeclaration parameter = methodUsage.getDeclaration().getParam(i);
                 ResolvedType parameterType = parameter.getType();
+                // Don't continue if a vararg parameter is reached and there are no arguments left
+                if (parameter.isVariadic() && argumentsTypes.size() < methodUsage.getNoParams()) {
+                    break;
+                }
                 if (!argumentsTypes.get(i).isArray() && parameter.isVariadic()) {
                 	parameterType = parameterType.asArrayType().getComponentType();
                 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -99,8 +99,10 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                 }
             }
 
+            // Scope is present -- search/solve within that type
             typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
         } else {
+            // Scope not present -- search/solve within itself.
             typeOfScope = JavaParserFacade.get(typeSolver).getTypeOfThisIn(wrappedNode);
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -264,24 +264,22 @@ public class MethodResolutionLogic {
         }
         boolean hasVariadicParam = method.getDeclaration().hasVariadicParameter();
         if (method.getNoParams() != argumentsTypes.size()
-//                && (!hasVariadicParam || method.getNoParams() - 1 > argumentsTypes.size())
+                && (!hasVariadicParam || method.getNoParams() - 1 > argumentsTypes.size())
         ) {
             return false;
         }
-//        for (int i = 0; i < argumentsTypes.size(); i++) {
-        for (int i = 0; i < method.getNoParams(); i++) {
-                ResolvedType expectedType = method.getParamType(i);
-//            ResolvedType expectedType;
-//            boolean reachedVariadicParam = hasVariadicParam && i >= method.getNoParams() - 1;
-//            if (reachedVariadicParam) {
-//                expectedType = method.getParamType(method.getNoParams() - 1);
-//                boolean argumentIsArrayOrNonSingleValue = !argumentsTypes.get(i).isArray() || method.getNoParams() != argumentsTypes.size();
-//                if (argumentIsArrayOrNonSingleValue) {
-//                    expectedType = expectedType.asArrayType().getComponentType();
-//                }
-//            } else {
-//                expectedType = method.getParamType(i);
-//            }
+        for (int i = 0; i < argumentsTypes.size(); i++) {
+            ResolvedType expectedType;
+            boolean reachedVariadicParam = hasVariadicParam && i >= method.getNoParams() - 1;
+            if (reachedVariadicParam) {
+                expectedType = method.getParamType(method.getNoParams() - 1);
+                boolean argumentIsArray = method.getNoParams() == argumentsTypes.size() && expectedType.isAssignableBy(argumentsTypes.get(i));
+                if (!argumentIsArray) {
+                    expectedType = expectedType.asArrayType().getComponentType();
+                }
+            } else {
+                expectedType = method.getParamType(i);
+            }
             ResolvedType expectedTypeWithoutSubstitutions = expectedType;
             ResolvedType expectedTypeWithInference = method.getParamType(i);
             ResolvedType actualType = argumentsTypes.get(i);
@@ -298,10 +296,10 @@ public class MethodResolutionLogic {
                 ResolvedParameterDeclaration parameter = method.getDeclaration().getParam(i);
                 ResolvedType parameterType = parameter.getType();
                 if (parameter.isVariadic()) {
-//                    // Don't continue if a vararg parameter is reached and there are no arguments left
-//                    if (argumentsTypes.size() == j) {
-//                        break;
-//                    }
+                    // Don't continue if a vararg parameter is reached and there are no arguments left
+                    if (argumentsTypes.size() == j) {
+                        break;
+                    }
                     parameterType = parameterType.asArrayType().getComponentType();
                 }
                 inferTypes(argumentsTypes.get(j), parameterType, derivedValues);
@@ -574,10 +572,10 @@ public class MethodResolutionLogic {
                 return false;
             }
 
-//            // If B is vararg and A is not, A is more specific
-//            if (tdB.isArray() && tdB.asArrayType().getComponentType().isAssignableBy(tdA)) {
-//                oneMoreSpecificFound = true;
-//            }
+            // If B is vararg and A is not, A is more specific
+            if (tdB.isArray() && tdB.asArrayType().getComponentType().isAssignableBy(tdA)) {
+                oneMoreSpecificFound = true;
+            }
         }
         return oneMoreSpecificFound;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -268,17 +268,20 @@ public class MethodResolutionLogic {
             return false;
         }
         for (int i = 0; i < argumentsTypes.size(); i++) {
-            ResolvedType expectedType;
-            if (hasVariadicParam && i >= method.getNoParams() - 1) {
-                expectedType = method.getParamType(method.getNoParams() - 1);
-                if (!argumentsTypes.get(i).isArray() || method.getNoParams() != argumentsTypes.size()) {
-                    expectedType = expectedType.asArrayType().getComponentType();
-                }
-            } else {
-                expectedType = method.getParamType(i);
-            }
+            ResolvedType expectedType = method.getParamType(i);
+//            ResolvedType expectedType;
+//            boolean reachedVariadicParam = hasVariadicParam && i >= method.getNoParams() - 1;
+//            if (reachedVariadicParam) {
+//                expectedType = method.getParamType(method.getNoParams() - 1);
+//                boolean argumentIsArrayOrNonSingleValue = !argumentsTypes.get(i).isArray() || method.getNoParams() != argumentsTypes.size();
+//                if (argumentIsArrayOrNonSingleValue) {
+//                    expectedType = expectedType.asArrayType().getComponentType();
+//                }
+//            } else {
+//                expectedType = method.getParamType(i);
+//            }
             ResolvedType expectedTypeWithoutSubstitutions = expectedType;
-            ResolvedType expectedTypeWithInference = expectedType;
+            ResolvedType expectedTypeWithInference = method.getParamType(i);
             ResolvedType actualType = argumentsTypes.get(i);
 
             List<ResolvedTypeParameterDeclaration> typeParameters = method.getDeclaration().getTypeParameters();
@@ -293,10 +296,10 @@ public class MethodResolutionLogic {
                 ResolvedParameterDeclaration parameter = method.getDeclaration().getParam(i);
                 ResolvedType parameterType = parameter.getType();
                 if (parameter.isVariadic()) {
-                    // Don't continue if a vararg parameter is reached and there are no arguments left
-                    if (argumentsTypes.size() == j) {
-                        break;
-                    }
+//                    // Don't continue if a vararg parameter is reached and there are no arguments left
+//                    if (argumentsTypes.size() == j) {
+//                        break;
+//                    }
                     parameterType = parameterType.asArrayType().getComponentType();
                 }
                 inferTypes(argumentsTypes.get(j), parameterType, derivedValues);
@@ -569,10 +572,10 @@ public class MethodResolutionLogic {
                 return false;
             }
 
-            // If B is vararg and A is not, A is more specific
-            if (tdB.isArray() && tdB.asArrayType().getComponentType().isAssignableBy(tdA)) {
-                oneMoreSpecificFound = true;
-            }
+//            // If B is vararg and A is not, A is more specific
+//            if (tdB.isArray() && tdB.asArrayType().getComponentType().isAssignableBy(tdA)) {
+//                oneMoreSpecificFound = true;
+//            }
         }
         return oneMoreSpecificFound;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -264,7 +264,8 @@ public class MethodResolutionLogic {
         }
         boolean hasVariadicParam = method.getDeclaration().hasVariadicParameter();
         if (method.getNoParams() != argumentsTypes.size()
-                && (!hasVariadicParam || method.getNoParams() - 1 > argumentsTypes.size())) {
+//                && (!hasVariadicParam || method.getNoParams() - 1 > argumentsTypes.size())
+        ) {
             return false;
         }
         for (int i = 0; i < argumentsTypes.size(); i++) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -268,8 +268,9 @@ public class MethodResolutionLogic {
         ) {
             return false;
         }
-        for (int i = 0; i < argumentsTypes.size(); i++) {
-            ResolvedType expectedType = method.getParamType(i);
+//        for (int i = 0; i < argumentsTypes.size(); i++) {
+        for (int i = 0; i < method.getNoParams(); i++) {
+                ResolvedType expectedType = method.getParamType(i);
 //            ResolvedType expectedType;
 //            boolean reachedVariadicParam = hasVariadicParam && i >= method.getNoParams() - 1;
 //            if (reachedVariadicParam) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -115,8 +115,6 @@ public class MethodResolutionLogic {
             // e.g. foo(String s, String... s2) {} --- consider the first argument, then group the remainder as an array
 
             ResolvedType expectedVariadicParameterType = methodDeclaration.getLastParam().getType();
-            ResolvedType actualArgumentType = needleArgumentTypes.get(lastNeedleArgumentIndex);
-
             for (ResolvedTypeParameterDeclaration tp : methodDeclaration.getTypeParameters()) {
                 expectedVariadicParameterType = replaceTypeParam(expectedVariadicParameterType, tp, typeSolver);
             }
@@ -146,15 +144,14 @@ public class MethodResolutionLogic {
                 }
                 needleArgumentTypes = groupVariadicParamValues(needleArgumentTypes, lastMethodParameterIndex, methodDeclaration.getLastParam().getType());
             } else if (countOfNeedleArgumentsPassed == countOfMethodParametersDeclared) {
+                ResolvedType actualArgumentType = needleArgumentTypes.get(lastNeedleArgumentIndex);
                 boolean finalArgumentIsArray = actualArgumentType.isArray() && expectedVariadicParameterType.isAssignableBy(actualArgumentType.asArrayType().getComponentType());
                 if(finalArgumentIsArray) {
                     // Treat as an array of values -- in which case the expected parameter type is the common type of this array.
-                    expectedVariadicParameterType = actualArgumentType.asArrayType().getComponentType();
                     // no need to do anything
-//                    needleArgumentTypes.set(lastMethodParameterIndex, expectedVariadicParameterType);
+//                    expectedVariadicParameterType = actualArgumentType.asArrayType().getComponentType();
                 } else {
                     // Treat as a single value -- in which case, the expected parameter type is the same as the single value.
-//                    needleArgumentTypes.set(lastMethodParameterIndex, actualArgumentType.asArrayType().getComponentType());
                     needleArgumentTypes = groupVariadicParamValues(needleArgumentTypes, lastMethodParameterIndex, methodDeclaration.getLastParam().getType());
                 }
             } else {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -560,13 +560,18 @@ public class MethodResolutionLogic {
             boolean aIsAssignableByB = tdA.isAssignableBy(tdB);
             boolean bIsAssignableByA = tdB.isAssignableBy(tdA);
 
-            // B is more specific
+            // A is more specific
             if (bIsAssignableByA && !aIsAssignableByB) {
                 oneMoreSpecificFound = true;
             }
-            // A is more specific
+            // B is more specific
             if (aIsAssignableByB && !bIsAssignableByA) {
                 return false;
+            }
+
+            // If B is vararg and A is not, A is more specific
+            if (tdB.isArray() && tdB.asArrayType().getComponentType().isAssignableBy(tdA)) {
+                oneMoreSpecificFound = true;
             }
         }
         return oneMoreSpecificFound;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/MethodResolutionLogic.java
@@ -143,10 +143,12 @@ public class MethodResolutionLogic {
                 if(finalArgumentIsArray) {
                     // Treat as an array of values -- in which case the expected parameter type is the common type of this array.
                     expectedVariadicParameterType = actualArgumentType.asArrayType().getComponentType();
+                    // no need to do anything
+//                    needleArgumentTypes.set(lastMethodParameterIndex, expectedVariadicParameterType);
                 } else {
                     // Treat as a single value -- in which case, the expected parameter type is the same as the single value.
 //                    needleArgumentTypes.set(lastMethodParameterIndex, actualArgumentType.asArrayType().getComponentType());
-                    expectedVariadicParameterType = actualArgumentType;
+                    needleArgumentTypes = groupVariadicParamValues(needleArgumentTypes, lastMethodParameterIndex, methodDeclaration.getLastParam().getType());
                 }
             } else {
                 // Should be unreachable.
@@ -353,7 +355,7 @@ public class MethodResolutionLogic {
         boolean methodIsDeclaredWithVariadicParameter = methodUsage.getDeclaration().hasVariadicParameter();
 
         // If the counts do not match and the method is not variadic, this is not a match.
-        if (!(needleParameterCount == countOfMethodUsageArgumentsPassed) && !methodIsDeclaredWithVariadicParameter) {
+        if (!methodIsDeclaredWithVariadicParameter && !(needleParameterCount == countOfMethodUsageArgumentsPassed)) {
             return false;
         }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
@@ -102,12 +102,12 @@ class VariadicResolutionTest extends AbstractResolutionTest {
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JavaParserTypeSolver(src, new LeanParserConfiguration()));
 
         JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
-//        MethodUsage call1 = javaParserFacade.solveMethodAsUsage(calls.get(0)); // foobar();
-//        MethodUsage call2 = javaParserFacade.solveMethodAsUsage(calls.get(1)); // foobar("a");
+        MethodUsage call1 = javaParserFacade.solveMethodAsUsage(calls.get(0)); // foobar();
+        MethodUsage call2 = javaParserFacade.solveMethodAsUsage(calls.get(1)); // foobar("a");
         MethodUsage call3 = javaParserFacade.solveMethodAsUsage(calls.get(2)); // foobar("a", "a");
         MethodUsage call4 = javaParserFacade.solveMethodAsUsage(calls.get(3)); // foobar(varArg);
-//        assertEquals("void", call1.returnType().describe()); // foobar();
-//        assertEquals("int", call2.returnType().describe()); // foobar("a");
+        assertEquals("void", call1.returnType().describe()); // foobar();
+        assertEquals("int", call2.returnType().describe()); // foobar("a");
         assertEquals("void", call3.returnType().describe()); // foobar("a", "a");
         assertEquals("void", call4.returnType().describe()); // foobar(varArg);
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
@@ -103,8 +103,12 @@ class VariadicResolutionTest extends AbstractResolutionTest {
         JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
         MethodUsage call1 = javaParserFacade.solveMethodAsUsage(calls.get(0));
         MethodUsage call2 = javaParserFacade.solveMethodAsUsage(calls.get(1));
-        assertEquals("int", call1.returnType().describe());
-        assertEquals("void", call2.returnType().describe());
+        MethodUsage call3 = javaParserFacade.solveMethodAsUsage(calls.get(2));
+        MethodUsage call4 = javaParserFacade.solveMethodAsUsage(calls.get(3));
+        assertEquals("void", call1.returnType().describe());
+        assertEquals("int", call2.returnType().describe());
+        assertEquals("void", call3.returnType().describe());
+        assertEquals("void", call4.returnType().describe());
     }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
@@ -111,4 +111,16 @@ class VariadicResolutionTest extends AbstractResolutionTest {
         assertEquals("void", call4.returnType().describe());
     }
 
+    @Test
+    void getDeclaredConstructorTest() {
+        CompilationUnit cu = parseSample("MethodCalls");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodCalls");
+
+        MethodDeclaration method = Navigator.demandMethod(clazz, "getDeclaredConstructorTest");
+        List<MethodCallExpr> calls = method.findAll(MethodCallExpr.class);
+
+        JavaParserFacade javaParserFacade = JavaParserFacade.get(new ReflectionTypeSolver());
+        MethodUsage call = javaParserFacade.solveMethodAsUsage(calls.get(0));
+        assertEquals(call.returnType().describe(), "java.lang.reflect.Constructor<? extends java.lang.Object>");
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VariadicResolutionTest extends AbstractResolutionTest {
 
-	@Test
+    @Test
     void issue7() {
         CompilationUnit cu = parseSample("Generics_issue7");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "SomeCollection");
@@ -60,15 +60,15 @@ class VariadicResolutionTest extends AbstractResolutionTest {
         assertEquals(List.class.getCanonicalName(), type.asReferenceType().getQualifiedName());
         assertEquals("java.util.List<java.lang.Long>", type.describe());
     }
-	
-	@Test
+
+    @Test
     void methodCallWithReferenceTypeAsVaridicArgumentIsSolved() {
         CompilationUnit cu = parseSample("MethodCalls");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodCalls");
 
         MethodDeclaration method = Navigator.demandMethod(clazz, "variadicMethod");
         MethodCallExpr callExpr = Navigator.findMethodCall(method, "variadicMethod").get();
-        
+
         TypeSolver typeSolver = new ReflectionTypeSolver();
         JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
         MethodUsage callee = javaParserFacade.solveMethodAsUsage(callExpr);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class VariadicResolutionTest extends AbstractResolutionTest {
 
@@ -101,14 +102,19 @@ class VariadicResolutionTest extends AbstractResolutionTest {
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JavaParserTypeSolver(src, new LeanParserConfiguration()));
 
         JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
-        MethodUsage call1 = javaParserFacade.solveMethodAsUsage(calls.get(0));
-        MethodUsage call2 = javaParserFacade.solveMethodAsUsage(calls.get(1));
-        MethodUsage call3 = javaParserFacade.solveMethodAsUsage(calls.get(2));
-        MethodUsage call4 = javaParserFacade.solveMethodAsUsage(calls.get(3));
-        assertEquals("void", call1.returnType().describe());
-        assertEquals("int", call2.returnType().describe());
-        assertEquals("void", call3.returnType().describe());
-        assertEquals("void", call4.returnType().describe());
+//        MethodUsage call1 = javaParserFacade.solveMethodAsUsage(calls.get(0)); // foobar();
+//        MethodUsage call2 = javaParserFacade.solveMethodAsUsage(calls.get(1)); // foobar("a");
+        MethodUsage call3 = javaParserFacade.solveMethodAsUsage(calls.get(2)); // foobar("a", "a");
+        MethodUsage call4 = javaParserFacade.solveMethodAsUsage(calls.get(3)); // foobar(varArg);
+//        assertEquals("void", call1.returnType().describe()); // foobar();
+//        assertEquals("int", call2.returnType().describe()); // foobar("a");
+        assertEquals("void", call3.returnType().describe()); // foobar("a", "a");
+        assertEquals("void", call4.returnType().describe()); // foobar(varArg);
+
+        assertThrows(RuntimeException.class, () -> {
+            MethodUsage call5 = javaParserFacade.solveMethodAsUsage(calls.get(4));
+            System.out.println("call5.returnType().describe() = " + call5.returnType().describe());
+        });
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
@@ -40,6 +40,7 @@ class MethodCalls {
         foobar("a");
         foobar("a", "a");
         foobar(varArg);
+        foobar("a", "a", "a", true, "a");
     }
 
     int foobar(String s){

--- a/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
@@ -31,7 +31,9 @@ class MethodCalls {
 
     void variadicTest(){
         String[] varArg = new String[2];
+        foobar();
         foobar("a");
+        foobar("a", "a");
         foobar(varArg);
     }
 

--- a/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
@@ -1,4 +1,5 @@
 import java.util.List;
+import java.lang.Class;
 
 class MethodCalls {
 
@@ -22,6 +23,10 @@ class MethodCalls {
     int bar2()
     {
         return getSelf().m;
+    }
+
+    void getDeclaredConstructorTest() {
+        Class.forName("").getDeclaredConstructor();
     }
 
     void inheritedInterfaceMethod(){


### PR DESCRIPTION
Currently, varargs in the symbol solver seem to only really be supported when the number of parameters still equals the number of arguments. This PR fixes that.

~~One caveat is that I don't believe a vararg of arrays will work properly since if an array is the only argument for the variadic parameter, then it is compared with the type of the variadic parameter itself, and not its component type (I found this assumption in other places too).~~