### PR TITLE
Issue 2676 lexpres edit literals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 Next Release (Version 3.15.23)
 ------------------
 [issues resolved](https://github.com/javaparser/javaparser/milestone/174?closed=1)
+* FIXED: Edits to the value of a string value are now correctly handled for use with Lexical Preservation 
+    (PR [#2646](https://github.com/javaparser/javaparser/pull/2646), by [@lemoncurry](https://github.com/lemoncurry))
+* FIXED: Edits to the value of other literal values also now handled 
+    (PR [#2679](https://github.com/javaparser/javaparser/pull/2679), by [@MysterAitch](https://github.com/MysterAitch))
+* BREAKING CHANGE: Tokens relating to literal values now have the category of `JavaToken.Category.LITERAL` (previously `JavaToken.Category.KEYWORD`) 
+    (PR [#2679](https://github.com/javaparser/javaparser/pull/2679), by [@MysterAitch](https://github.com/MysterAitch))
+
+
 
 Version 3.15.22
 ------------------

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -47,19 +47,7 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.LineComment;
-import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.ast.expr.ArrayCreationExpr;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.BinaryExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.IntegerLiteralExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.SimpleName;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
-import com.github.javaparser.ast.expr.ThisExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -1341,17 +1329,32 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
 
         final String code = "\"asd\"";
+        final String expected = "\"REPLACEMENT\"";
+
         final Expression b = javaParser.parseExpression(code).getResult().orElseThrow(AssertionError::new);
-        LexicalPreservingPrinter.setup(b);
 
         assertTrue(b.isStringLiteralExpr());
         StringLiteralExpr sle = (StringLiteralExpr) b;
         sle.setValue("REPLACEMENT");
 
-        final String expected = "\"REPLACEMENT\"";
-
         final String actual = LexicalPreservingPrinter.print(b);
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReplaceStringLiteralWithinStatement() {
+        final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
+
+        String code = "String str = \"aaa\";";
+        String expected = "String str = \"REPLACEMENT\";";
+
+        Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
+        b.findAll(StringLiteralExpr.class).forEach(stringLiteralExpr -> {
+            stringLiteralExpr.setValue("REPLACEMENT");
+        });
+
+        assertEquals(expected, LexicalPreservingPrinter.print(b));
+        assertEquals(expected, b.toString());
     }
 
     @Test
@@ -1376,13 +1379,60 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
 
         final String code = "5";
+        final String expected = "10";
+
         final Expression b = javaParser.parseExpression(code).getResult().orElseThrow(AssertionError::new);
-        LexicalPreservingPrinter.setup(b);
 
         assertTrue(b.isIntegerLiteralExpr());
         ((IntegerLiteralExpr) b).setValue("10");
 
-        final String expected = "10";
+        final String actual = LexicalPreservingPrinter.print(b);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReplaceLongLiteral() {
+        final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
+
+        String code = "long x = 5L;";
+        String expected = "long x = 10L;";
+
+        final Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
+        b.findAll(LongLiteralExpr.class).forEach(longLiteralExpr -> {
+            longLiteralExpr.setValue("10L");
+        });
+
+        final String actual = LexicalPreservingPrinter.print(b);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReplaceBooleanLiteral() {
+        final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
+
+        String code = "boolean x = true;";
+        String expected = "boolean x = false;";
+
+        final Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
+        b.findAll(BooleanLiteralExpr.class).forEach(booleanLiteralExpr -> {
+            booleanLiteralExpr.setValue(false);
+        });
+
+        final String actual = LexicalPreservingPrinter.print(b);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReplaceDoubleLiteral() {
+        final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
+
+        String code = "double x = 5.0;";
+        String expected = "double x = 10.0;";
+
+        final Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
+        b.findAll(DoubleLiteralExpr.class).forEach(doubleLiteralExpr -> {
+            doubleLiteralExpr.setValue("10.0");
+        });
 
         final String actual = LexicalPreservingPrinter.print(b);
         assertEquals(expected, actual);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1453,4 +1453,20 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         final String actual = LexicalPreservingPrinter.print(b);
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void testReplaceCharLiteralUnicode() {
+        final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
+
+        String code = "char x = 'a';";
+        String expected = "char x = '\\u0000';";
+
+        final Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
+        b.findAll(CharLiteralExpr.class).forEach(charLiteralExpr -> {
+            charLiteralExpr.setValue("\\u0000");
+        });
+
+        final String actual = LexicalPreservingPrinter.print(b);
+        assertEquals(expected, actual);
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1426,12 +1426,28 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     public void testReplaceDoubleLiteral() {
         final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
 
-        String code = "double x = 5.0;";
-        String expected = "double x = 10.0;";
+        String code = "double x = 5.0D;";
+        String expected = "double x = 10.0D;";
 
         final Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
         b.findAll(DoubleLiteralExpr.class).forEach(doubleLiteralExpr -> {
-            doubleLiteralExpr.setValue("10.0");
+            doubleLiteralExpr.setValue("10.0D");
+        });
+
+        final String actual = LexicalPreservingPrinter.print(b);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReplaceCharLiteral() {
+        final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLexicalPreservationEnabled(true));
+
+        String code = "char x = 'a';";
+        String expected = "char x = 'b';";
+
+        final Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
+        b.findAll(CharLiteralExpr.class).forEach(charLiteralExpr -> {
+            charLiteralExpr.setValue("b");
         });
 
         final String actual = LexicalPreservingPrinter.print(b);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1483,8 +1483,8 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                 "     \"\"\";";
 
         final Statement b = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
-        b.findAll(CharLiteralExpr.class).forEach(charLiteralExpr -> {
-            charLiteralExpr.setValue("\n    REPLACEMENT\n    ");
+        b.findAll(TextBlockLiteralExpr.class).forEach(textblockLiteralExpr -> {
+            textblockLiteralExpr.setValue("\n     REPLACEMENT\n     ");
         });
 
         final String actual = LexicalPreservingPrinter.print(b);

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
@@ -106,7 +106,6 @@ public class TokenTypes {
             case ELSE:
             case ENUM:
             case EXTENDS:
-            case FALSE:
             case FINAL:
             case FINALLY:
             case FLOAT:
@@ -121,7 +120,6 @@ public class TokenTypes {
             case LONG:
             case NATIVE:
             case NEW:
-            case NULL:
             case PACKAGE:
             case PRIVATE:
             case PROTECTED:
@@ -137,7 +135,6 @@ public class TokenTypes {
             case THROW:
             case THROWS:
             case TRANSIENT:
-            case TRUE:
             case TRY:
             case VOID:
             case VOLATILE:
@@ -168,6 +165,9 @@ public class TokenTypes {
             case CHARACTER_LITERAL:
             case STRING_LITERAL:
             case TEXT_BLOCK_LITERAL:
+            case TRUE:
+            case FALSE:
+            case NULL:
                 return JavaToken.Category.LITERAL;
             case IDENTIFIER:
                 return JavaToken.Category.IDENTIFIER;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
@@ -116,6 +116,11 @@ class ChildTextElement extends TextElement {
     }
 
     @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
+    @Override
     public boolean isChildOfClass(Class<? extends Node> nodeClass) {
         return nodeClass.isInstance(child);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -412,6 +412,9 @@ public class Difference {
             diffIndex++;
         } else if (originalElementIsToken && originalElement.isWhiteSpaceOrComment()) {
             originalIndex++;
+        } else if (originalElement.isLiteral()) {
+            nodeText.removeElement(originalIndex);
+            diffIndex++;
         } else if (removed.isPrimitiveType()) {
             if (originalElement.isPrimitive()) {
                 nodeText.removeElement(originalIndex);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -286,6 +286,7 @@ class LexicalDifferenceCalculator {
                         "\"" + ((StringLiteralExpr) node).getValue() + "\""));
             }
         } else if ((csm instanceof CsmString) && (node instanceof TextBlockLiteralExpr)) {
+            // FIXME: csm should be CsmTextBlock -- See also #2677
             if (change instanceof PropertyChange) {
                 elements.add(new CsmToken(GeneratedJavaParserConstants.TEXT_BLOCK_LITERAL,
                         "\"\"\"" + ((PropertyChange) change).getNewValue() + "\"\"\""));

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.CharLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
@@ -283,6 +284,14 @@ class LexicalDifferenceCalculator {
             } else {
                 elements.add(new CsmToken(GeneratedJavaParserConstants.STRING_LITERAL,
                         "\"" + ((StringLiteralExpr) node).getValue() + "\""));
+            }
+        } else if ((csm instanceof CsmString) && (node instanceof TextBlockLiteralExpr)) {
+            if (change instanceof PropertyChange) {
+                elements.add(new CsmToken(GeneratedJavaParserConstants.TEXT_BLOCK_LITERAL,
+                        "\"\"\"" + ((PropertyChange) change).getNewValue() + "\"\"\""));
+            } else {
+                elements.add(new CsmToken(GeneratedJavaParserConstants.TEXT_BLOCK_LITERAL,
+                        "\"\"\"" + ((TextBlockLiteralExpr) node).getValue() + "\"\"\""));
             }
         } else if ((csm instanceof CsmChar) && (node instanceof CharLiteralExpr)) {
             if (change instanceof PropertyChange) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -26,6 +26,7 @@ import com.github.javaparser.JavaToken.Kind;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.CharLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -282,6 +283,14 @@ class LexicalDifferenceCalculator {
             } else {
                 elements.add(new CsmToken(GeneratedJavaParserConstants.STRING_LITERAL,
                         "\"" + ((StringLiteralExpr) node).getValue() + "\""));
+            }
+        } else if ((csm instanceof CsmChar) && (node instanceof CharLiteralExpr)) {
+            if (change instanceof PropertyChange) {
+                elements.add(new CsmToken(GeneratedJavaParserConstants.CHAR,
+                        "'" + ((PropertyChange) change).getNewValue() + "'"));
+            } else {
+                elements.add(new CsmToken(GeneratedJavaParserConstants.CHAR,
+                        "'" + ((CharLiteralExpr) node).getValue() + "'"));
             }
         } else if (csm instanceof CsmMix) {
             CsmMix csmMix = (CsmMix)csm;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElement.java
@@ -46,6 +46,8 @@ public abstract class TextElement implements TextElementMatcher {
 
     abstract boolean isNode(Node node);
 
+    public abstract boolean isLiteral();
+
     public abstract boolean isWhiteSpace();
 
     public abstract boolean isSpaceOrTab();

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
@@ -125,6 +125,11 @@ class TokenTextElement extends TextElement {
     public boolean isIdentifier() {
         return getToken().getCategory().isIdentifier();
     }
+
+    @Override
+    public boolean isLiteral() {
+        return getToken().getCategory().isLiteral();
+    }
     
     @Override
     public boolean isPrimitive() {


### PR DESCRIPTION
Fixes #2676 -- handling of edits to literal values of char/boolean/textblock etc, as an extension of #2643


Fixes #2678 -- Note that this changes the category of several literal value tokens, so might have an effect on end-user code (hence label)