### PR TITLE
Finding the functional method doesn't always succeed

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
@@ -186,7 +186,7 @@ public class MethodUsage implements ResolvedTypeParametrized {
      * followed by the signature of the method.
      */
     public String getQualifiedSignature() {
-        return getDeclaration().getQualifiedName() + "." + getSignature();
+        return getDeclaration().declaringType().getQualifiedName() + "." + getSignature();
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
@@ -181,9 +181,29 @@ public class MethodUsage implements ResolvedTypeParametrized {
         return typeParametersMap;
     }
 
+    /**
+     * The qualified signature of the method. It is composed by the qualified name of the declaring type
+     * followed by the signature of the method.
+     */
     public String getQualifiedSignature() {
-        // TODO use the type parameters
-        return this.getDeclaration().getQualifiedSignature();
+        return getDeclaration().getQualifiedName() + "." + getSignature();
+    }
+
+    /**
+     * The signature of the method.
+     */
+    public String getSignature() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getName());
+        sb.append("(");
+        for (int i = 0; i < getNoParams(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(getParamType(i).describe());
+        }
+        sb.append(")");
+        return sb.toString();
     }
 
     public List<ResolvedType> exceptionTypes() {

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
@@ -200,7 +200,12 @@ public class MethodUsage implements ResolvedTypeParametrized {
             if (i != 0) {
                 sb.append(", ");
             }
-            sb.append(getParamType(i).describe());
+            ResolvedType type = getParamType(i);
+            if (type.isArray() && getDeclaration().getParam(i).isVariadic()) {
+                sb.append(type.asArrayType().getComponentType().describe()).append("...");
+            } else {
+                sb.append(type.describe());
+            }
         }
         sb.append(")");
         return sb.toString();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
@@ -54,15 +54,16 @@ public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDe
 
         for (ResolvedReferenceType ancestor : getAllAncestors()) {
             List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap = ancestor.getTypeParametersMap();
-            for (MethodUsage ancestorMethodUsage : ancestor.getDeclaredMethods()) {
-                MethodUsage methodUsage = ancestorMethodUsage;
+            for (MethodUsage mu : ancestor.getDeclaredMethods()) {
+                // replace type parameters to be able to filter away overridden generified methods
+                MethodUsage methodUsage = mu;
                 for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> p : typeParametersMap) {
                     methodUsage = methodUsage.replaceTypeParameter(p.a, p.b);
                 }
                 String signature = getSignature(methodUsage);
                 if (!methodsSignatures.contains(signature)) {
                     methodsSignatures.add(signature);
-                    methods.add(ancestorMethodUsage);
+                    methods.add(mu);
                 }
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
@@ -49,7 +49,7 @@ public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDe
         for (ResolvedMethodDeclaration methodDeclaration : getDeclaredMethods()) {
             MethodUsage methodUsage = new MethodUsage(methodDeclaration);
             methods.add(methodUsage);
-            methodsSignatures.add(getSignature(methodUsage));
+            methodsSignatures.add(methodUsage.getSignature());
         }
 
         for (ResolvedReferenceType ancestor : getAllAncestors()) {
@@ -60,7 +60,7 @@ public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDe
                 for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> p : typeParametersMap) {
                     methodUsage = methodUsage.replaceTypeParameter(p.a, p.b);
                 }
-                String signature = getSignature(methodUsage);
+                String signature = methodUsage.getSignature();
                 if (!methodsSignatures.contains(signature)) {
                     methodsSignatures.add(signature);
                     methods.add(mu);
@@ -69,20 +69,6 @@ public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDe
         }
 
         return methods;
-    }
-
-    private String getSignature(MethodUsage mu) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(mu.getName());
-        sb.append("(");
-        for (int i = 0; i < mu.getNoParams(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(mu.getParamType(i).describe());
-        }
-        sb.append(")");
-        return sb.toString();
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2595Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2595Test.java
@@ -1,0 +1,158 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParseStart;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.github.javaparser.Providers.provider;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class Issue2595Test {
+
+
+    @Test
+    public void issue2595ImplicitTypeLambdaTest() {
+        String sourceCode = "" +
+                "import java.util.ArrayList;\n" +
+                "import java.util.List;\n" +
+                "import java.util.function.Function;\n" +
+                "\n" +
+                "public class Test {\n" +
+                "\n" +
+                "    ClassMetric<Integer> fdp = c -> {\n" +
+                "        List<String> classFieldNames = getAllClassFieldNames(c);\n" +
+                "        return classFieldNames.size();\n" +
+                "    };\n" +
+                "\n" +
+                "\n" +
+                "    private List<String> getAllClassFieldNames(final String c) {\n" +
+                "        return new ArrayList<>();\n" +
+                "    }\n" +
+                "\n" +
+                "\n" +
+                "    @FunctionalInterface\n" +
+                "    public interface ClassMetric<T> extends Function<String, T> {\n" +
+                "        @Override\n" +
+                "        T apply(String c);\n" +
+                "    }\n" +
+                "\n" +
+                "}\n";
+
+        parse(sourceCode);
+    }
+
+    @Test
+    public void issue2595ExplicitTypeLambdaTest() {
+        String sourceCode = "import java.util.ArrayList;\n" +
+                "import java.util.List;\n" +
+                "import java.util.function.Function;\n" +
+                "\n" +
+                "public class TestIssue2595 {\n" +
+                "    ClassMetric fdp = (String c) -> {\n" +
+                "        List<String> classFieldNames = getAllClassFieldNames(c);\n" +
+                "        return classFieldNames.size();\n" +
+                "    };\n" +
+                "    \n" +
+                "\n" +
+                "    private List<String> getAllClassFieldNames(final String c) {\n" +
+                "        return new ArrayList<>();\n" +
+                "    }\n" +
+                "\n" +
+                "    @FunctionalInterface\n" +
+                "    public interface ClassMetric extends Function<String, Integer> {\n" +
+                "        @Override\n" +
+                "        Integer apply(String c);\n" +
+                "    }\n" +
+                "}";
+
+        parse(sourceCode);
+    }
+
+    @Test
+    public void issue2595NoParameterLambdaTest() {
+        String sourceCode = "import java.util.ArrayList;\n" +
+                "import java.util.List;\n" +
+                "\n" +
+                "public class TestIssue2595 {\n" +
+                "    ClassMetric fdp = () -> {\n" +
+                "        List<String> classFieldNames = getAllClassFieldNames();\n" +
+                "        return classFieldNames.size();\n" +
+                "    };\n" +
+                "\n" +
+                "\n" +
+                "    private List<String> getAllClassFieldNames() {\n" +
+                "        return new ArrayList<>();\n" +
+                "    }\n" +
+                "\n" +
+                "    @FunctionalInterface\n" +
+                "    public interface ClassMetric {\n" +
+                "        Integer apply();\n" +
+                "    }\n" +
+                "}";
+
+        parse(sourceCode);
+    }
+
+    @Test
+    public void issue2595AnonymousInnerClassTest() {
+        String sourceCode = "import java.util.ArrayList;\n" +
+                "import java.util.List;\n" +
+                "import java.util.function.Function;\n" +
+                "\n" +
+                "public class TestIssue2595 {\n" +
+                "    ClassMetric fdp = new ClassMetric() {\n" +
+                "        @Override\n" +
+                "        public Integer apply(String c) {\n" +
+                "            List<String> classFieldNames = getAllClassFieldNames(c);\n" +
+                "            return classFieldNames.size();\n" +
+                "        }\n" +
+                "    };\n" +
+                "\n" +
+                "    private List<String> getAllClassFieldNames(final String c) {\n" +
+                "        return new ArrayList<>();\n" +
+                "    }\n" +
+                "\n" +
+                "    @FunctionalInterface\n" +
+                "    public interface ClassMetric extends Function<String, Integer> {\n" +
+                "        @Override\n" +
+                "        Integer apply(String c);\n" +
+                "    }\n" +
+                "}";
+
+        parse(sourceCode);
+    }
+
+    private void parse(String sourceCode) {
+        TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver());
+        ParserConfiguration configuration = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        JavaParser javaParser = new JavaParser(configuration);
+
+        ParseResult<CompilationUnit> result = javaParser.parse(ParseStart.COMPILATION_UNIT, provider(sourceCode));
+        assumeTrue(result.isSuccessful());
+        assumeTrue(result.getResult().isPresent());
+
+        CompilationUnit cu = result.getResult().get();
+//        System.out.println(cu);
+
+        List<MethodCallExpr> methodCalls = cu.findAll(MethodCallExpr.class);
+        assumeFalse(methodCalls.isEmpty());
+        for (int i = methodCalls.size() - 1; i >= 0; i--) {
+            MethodCallExpr methodCallExpr = methodCalls.get(i);
+            System.out.println();
+            System.out.println("methodCallExpr = " + methodCallExpr);
+            System.out.println("methodCallExpr.resolve() = " + methodCallExpr.resolve());
+            System.out.println("methodCallExpr.calculateResolvedType() = " + methodCallExpr.calculateResolvedType());
+        }
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclarationTest.java
@@ -50,8 +50,10 @@ class JavaParserAnonymousClassDeclarationTest extends AbstractResolutionTest {
     MethodUsage methodUsage =
         JavaParserFacade.get(combinedTypeSolver).solveMethodAsUsage(methodCall);
 
+    assertThat(methodUsage.getDeclaration().getQualifiedSignature(),
+            is("AnonymousClassDeclarations.ParDo.of(AnonymousClassDeclarations.DoFn<I, O>)"));
     assertThat(methodUsage.getQualifiedSignature(),
-               is("AnonymousClassDeclarations.ParDo.of(AnonymousClassDeclarations.DoFn<I, O>)"));
+               is("AnonymousClassDeclarations.ParDo.of(AnonymousClassDeclarations.DoFn<java.lang.Integer, java.lang.Long>)"));
   }
 
   @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/logic/FunctionInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/logic/FunctionInterfaceLogicTest.java
@@ -53,4 +53,22 @@ class FunctionInterfaceLogicTest {
         assertEquals(true, FunctionalInterfaceLogic.getFunctionalMethod(consumer).isPresent());
         assertEquals("accept", FunctionalInterfaceLogic.getFunctionalMethod(consumer).get().getName());
     }
+
+    @Test
+    void testGetFunctionalMethodWith2AbstractMethodsInHierarcy() {
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        ResolvedType function = new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Foo.class, typeSolver), typeSolver);
+        assertEquals(true, FunctionalInterfaceLogic.getFunctionalMethod(function).isPresent());
+        assertEquals("foo", FunctionalInterfaceLogic.getFunctionalMethod(function).get().getName());
+    }
+
+    public static interface Foo<S, T> extends Function<S, T> {
+
+        T foo(S str);
+
+        @Override
+        default T apply(S str) {
+            return foo(str);
+        }
+    }
 }


### PR DESCRIPTION
Finding the functional method doesn't always succeed when there is more than 1 abstract method in the class hierarchy.

Fixes #2595 
