### PR TITLE
Issue 2283: fix boxing primitive type generics in some method calls

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -81,24 +81,6 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
         ResolvedType typeOfScope;
         if (wrappedNode.getScope().isPresent()) {
             Expression scope = wrappedNode.getScope().get();
-            // Consider static method calls
-            if (scope instanceof NameExpr) {
-                String className = ((NameExpr) scope).getName().getId();
-                SymbolReference<ResolvedTypeDeclaration> ref = solveType(className);
-                if (ref.isSolved()) {
-                    SymbolReference<ResolvedMethodDeclaration> m = MethodResolutionLogic.solveMethodInType(ref.getCorrespondingDeclaration(), name, argumentsTypes);
-                    if (m.isSolved()) {
-                        MethodUsage methodUsage = new MethodUsage(m.getCorrespondingDeclaration());
-                        methodUsage = resolveMethodTypeParametersFromExplicitList(typeSolver, methodUsage);
-                        methodUsage = resolveMethodTypeParameters(methodUsage, argumentsTypes);
-                        return Optional.of(methodUsage);
-                    } else {
-                        throw new UnsolvedSymbolException(ref.getCorrespondingDeclaration().toString(),
-                                "Method '" + name + "' with parameterTypes " + argumentsTypes);
-                    }
-                }
-            }
-
             // Scope is present -- search/solve within that type
             typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
         } else {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -106,6 +106,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                     }
                 }
             }
+
             // Scope is present -- search/solve within that type
             typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
         } else {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2283Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2283Test.java
@@ -20,6 +20,9 @@
  */
 package com.github.javaparser.symbolsolver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParseStart;
@@ -27,20 +30,12 @@ import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Providers;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 
-import org.junit.jupiter.api.Test;
-
-import static com.github.javaparser.StaticJavaParser.parseStatement;
-import static com.github.javaparser.utils.Utils.EOL;
-import static com.github.javaparser.utils.Utils.normalizeEolInTextBlock;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Issue2283Test {
     private JavaParser javaParser;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2283Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2283Test.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParseStart;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.Providers;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+
+import org.junit.jupiter.api.Test;
+
+import static com.github.javaparser.StaticJavaParser.parseStatement;
+import static com.github.javaparser.utils.Utils.EOL;
+import static com.github.javaparser.utils.Utils.normalizeEolInTextBlock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class Issue2283Test {
+    private JavaParser javaParser;
+
+    @BeforeEach
+    void setUp() {
+        TypeSolver typeSolver = new CombinedTypeSolver();
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        javaParser = new JavaParser(config);
+    }
+
+    @Test
+    void resolveGenericMethodCallWithPrimitiveTypeArgument() {
+        String code =
+                "class A {" +
+                "  static <T> T foo(T a) {" +
+                "    return a;" +
+                "  }" +
+                "  public static void main(String[] args) {" +
+                "    A.foo(10);" +
+                "  }" +
+                "}";
+
+        ParseResult<CompilationUnit> parseResult = javaParser.parse(ParseStart.COMPILATION_UNIT, Providers.provider(code));
+        assertTrue(parseResult.isSuccessful());
+        assertTrue(parseResult.getResult().isPresent());
+
+        CompilationUnit cu = parseResult.getResult().get();
+        MethodCallExpr methodCall = cu.findFirst(MethodCallExpr.class, m -> m.getNameAsString().equals("foo")).get();
+        ResolvedType returnType = methodCall.calculateResolvedType();
+
+        assertEquals("java.lang.Integer", returnType.describe());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2283Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2283Test.java
@@ -30,9 +30,10 @@ import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Providers;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ public class Issue2283Test {
 
     @BeforeEach
     void setUp() {
-        TypeSolver typeSolver = new CombinedTypeSolver();
+        TypeSolver typeSolver = new ReflectionTypeSolver();
         ParserConfiguration config = new ParserConfiguration();
         config.setSymbolResolver(new JavaSymbolSolver(typeSolver));
         javaParser = new JavaParser(config);


### PR DESCRIPTION
Fixes #2283.

Treat 'foo()' the same as 'A.foo()' wrt resolving types of static method calls.

---

Simply qualified method calls were being being treated specially and incorrectly. This caused some type parameters to be incorrectly inferred when boxing primitive types, leading to the behavior observed in #2283.

Notably, this special path didn't catch all static method calls, but only when the method name was qualified with a simple name. So `A.foo()` would trigger this path, but `some.pkg.A.foo()` and `foo()` would not trigger this path.

This PR simply deletes this path.

Included test fails before this fix is applied, and passes after.
Note, replacing `A.foo(10)` with just `foo(10)` allows the test to pass even without this fix