### PR TITLE
Issue 1479 JavaParserFacade.solve(FieldAccessExpr fieldAccessExpr) doesn't return SymbolReference<ResolvedFieldDeclaration>

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedFieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedFieldDeclaration.java
@@ -21,12 +21,14 @@
 
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.body.FieldDeclaration;
+
 /**
  * Declaration of a field.
  *
  * @author Federico Tomassetti
  */
-public interface ResolvedFieldDeclaration extends ResolvedValueDeclaration, HasAccessSpecifier {
+public interface ResolvedFieldDeclaration extends ResolvedValueDeclaration, HasAccessSpecifier, AssociableToAST<FieldDeclaration> {
 
     /**
      * Is the field static?

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -150,9 +150,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
                                 
                                 @Override
                                 public Optional<FieldDeclaration> toAst() {
-                                    FieldDeclaration fd = JavaParserFieldDeclaration.class.isAssignableFrom(f.getClass()) ?
-                                            ((JavaParserFieldDeclaration)f).getWrappedNode() : null;
-                                    return Optional.ofNullable(fd);
+                                    return f.toAst();
                                 }
                             });
                         }));

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
@@ -21,8 +21,13 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import static com.github.javaparser.symbolsolver.javaparser.Navigator.demandParentNode;
+
+import java.util.Optional;
+
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
@@ -30,10 +35,6 @@ import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-
-import java.util.Optional;
-
-import static com.github.javaparser.symbolsolver.javaparser.Navigator.demandParentNode;
 
 /**
  * @author Federico Tomassetti
@@ -106,5 +107,10 @@ public class JavaParserFieldDeclaration implements ResolvedFieldDeclaration {
             return JavaParserFacade.get(typeSolver).getTypeDeclaration(typeDeclaration.get());
         }
         throw new IllegalStateException();
+    }
+    
+    @Override
+    public Optional<FieldDeclaration> toAst() {
+        return Optional.ofNullable(wrappedNode);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -21,10 +21,19 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
@@ -48,14 +57,6 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.LazyType;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -235,6 +236,11 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
                                 @Override
                                 public ResolvedTypeDeclaration declaringType() {
                                     return f.declaringType();
+                                }
+                                
+                                @Override
+                                public Optional<FieldDeclaration> toAst() {
+                                    return f.toAst();
                                 }
                             });
                         })

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1479Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1479Test.java
@@ -1,0 +1,47 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration.JavaParserFieldDeclarationAdapter;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue1479Test extends AbstractSymbolResolutionTest {
+
+    @Test
+    public void test() throws IOException {
+        
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JavaParserTypeSolver(adaptPath("src/test/resources/issue1479")));
+        JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
+        StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
+        
+        String src = 
+                "public class Foo {\n" +
+                "  public void m() {\n" +
+                "    doSomething(B.AFIELD);\n" +
+                "  }\n" +
+                "  public void doSomething(String a) {\n" +
+                "  }\n" +
+                "}\n";
+
+        CompilationUnit cu = StaticJavaParser.parse(src);
+        FieldAccessExpr fae = cu.findFirst(FieldAccessExpr.class).get();
+        assertTrue(fae.calculateResolvedType().describe().equals("java.lang.String"));
+        ResolvedFieldDeclaration value = fae.resolve().asField();
+        assertTrue(value.getName().equals("AFIELD"));
+        FieldDeclaration field = ((JavaParserFieldDeclarationAdapter)value).getWrappedNode();
+        assertEquals("a", field.getVariable(0).getInitializer().get().asStringLiteralExpr().getValue());
+    }
+    
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1479Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1479Test.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,6 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration.JavaParserFieldDeclarationAdapter;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -40,8 +40,8 @@ public class Issue1479Test extends AbstractSymbolResolutionTest {
         assertTrue(fae.calculateResolvedType().describe().equals("java.lang.String"));
         ResolvedFieldDeclaration value = fae.resolve().asField();
         assertTrue(value.getName().equals("AFIELD"));
-        FieldDeclaration field = ((JavaParserFieldDeclarationAdapter)value).getWrappedNode();
-        assertEquals("a", field.getVariable(0).getInitializer().get().asStringLiteralExpr().getValue());
+        Optional<FieldDeclaration> fd = value.toAst();
+        assertEquals("a", fd.get().getVariable(0).getInitializer().get().asStringLiteralExpr().getValue());
     }
     
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1479/A.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1479/A.java
@@ -1,0 +1,3 @@
+public class A {
+  public static final String AFIELD = "a";
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1479/B.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1479/B.java
@@ -1,0 +1,3 @@
+public class B extends A {
+  public static final String BFIELD = "b";
+}


### PR DESCRIPTION
Fixes #1479.
