### PR TITLE
Add test case fro issue #1480 MethodCallExpr#resolveInvokedMethod() d…

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1480Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1480Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+
+class Issue1480Test extends AbstractResolutionTest {
+
+    @Test()
+    void test() throws IOException {
+        Path rootSourceDir = adaptPath("src/test/resources/issue1480");
+        Path pathToSourceFile = adaptPath(rootSourceDir.toString() + "/B.java");
+
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new JavaParserTypeSolver(rootSourceDir.toFile())));
+        StaticJavaParser.setConfiguration(config);
+
+        CompilationUnit cu = StaticJavaParser.parse(pathToSourceFile);
+
+        MethodCallExpr mce = cu.findFirst(MethodCallExpr.class).get();
+
+        assertThrows(UnsolvedSymbolException.class, () -> {
+            mce.resolve().getQualifiedName();
+        });
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1480/A.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1480/A.java
@@ -1,0 +1,5 @@
+
+public class A {
+  public void foo() {}
+  private void bar() {}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1480/B.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1480/B.java
@@ -1,0 +1,11 @@
+
+public class B extends A {
+
+//  public void test1() {
+//    foo(); // should be inherited from A, so there should exist an (implicit) method org.testapp.B.foo()
+//  }
+
+  public void test2() {
+    bar(); // should not be resolvable, since bar() is private in A and not inherited by B
+  }
+}


### PR DESCRIPTION
…oes not work correctly for inherited methods

Fixes #1480.

There appears to be no consensus on the first part of this issue. You are free to create a new issue only on this topic.
