### PR TITLE
Add test case for issue #1518

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1518Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1518Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+
+class Issue1518Test extends AbstractResolutionTest {
+
+    @Test()
+    void test() throws IOException {
+        Path rootSourceDir = adaptPath("src/test/resources/issue1518");
+
+        String src =
+                "public class App {\n" + 
+                "    public static void main(String[] args) {\n" + 
+                "        Test1.Test2 test2 = new Test1.Test2();\n" + 
+                "        Test1.Test3 test3 = new Test1.Test3();\n" + 
+                "    }\n" + 
+                "}";
+        
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new JavaParserTypeSolver(rootSourceDir.toFile())));
+        StaticJavaParser.setConfiguration(config);
+
+        CompilationUnit cu = StaticJavaParser.parse(src);
+
+        List<ObjectCreationExpr> oce = cu.findAll(ObjectCreationExpr.class);
+
+        assertEquals("Test1.Test2", oce.get(0).calculateResolvedType().describe());
+        assertEquals("Test1.Test3", oce.get(1).calculateResolvedType().describe());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1518/Test1.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1518/Test1.java
@@ -1,0 +1,7 @@
+
+public class Test1 {
+    public static class Test2 {
+    }
+    public static class Test3 {
+    }
+}


### PR DESCRIPTION
Fixes #1518.

Static nested classes are accessed using the enclosing class name. 
For example, to create an object for the static nested class, use this syntax:

    OuterClass.StaticNestedClass nestedObject =
         new OuterClass.StaticNestedClass();

So it seems that the test case provided is not correct.
