### PR TITLE
Actions optimisation / streamline

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -15,21 +15,75 @@ on:
     paths-ignore:
     - '**.md'
 
+
+
+## Different OSs have different default line-endings -- test on all combinations.
+## Different JDK versions have different implementations etc. -- test on all combinations (ideally 8 to latest).
+### -> exclude pre-8 (min development version jdk8)
+
 jobs:
-  maven_test:
+
+
+  # Do a quick test using min/max JDK
+  test_min_max_jdk:
     strategy:
       ## Optionally cancel all other combinations if one fails
       fail-fast: false
       matrix:
-        ## Different OSs have different default line-endings -- test on all combinations.
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        ## Different JDK versions have different implementations etc. -- test on all combinations (ideally 8 to latest).
-        ### exclude pre-8 (min development version jdk8)
-        ### exclude post-12 (changes to jdk causes reflection tests to fail due to added methods #1701 )
-        jdk: [8,9,10,11,12,13,14,15]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        jdk: [ 8,15 ]
 
     runs-on: ${{ matrix.os }}
 
+    # Steps should be identical for all runs
+    steps:
+      ## Checkout the current version of the code from the repo.
+      - name: Checkout latest code
+        uses: actions/checkout@v2
+
+      ## Setup the specified version of Java (includes maven/gradle).
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+
+      ## Given that the build matrix only specifies the major version (configurable), output the precise version used.
+      - name: Echo exact java version being used
+        run: java -version
+
+      ## Use a cache to reduce the build/test times (avoids having to download dependencies on EVERY run).
+      ### https://help.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      ## Actually perform the tests. Unsuccessful tests will indicate a failed build.
+      ### -e : show traces where any errors occur
+      ### -B test : run the maven lifecycle stage `test`
+      ### -P AlsoSlowTests : by default, only quick tests are run - the profile `AlsoSlowTests` runs the full test suite
+      - name: Test with Maven (incl. slow tests)
+        run: mvn -e -B test -P AlsoSlowTests
+
+
+
+  # Do a test of the intermediary JDK versions
+  test_intermediary_versions:
+    # ONLY START THIS TEST IF THE ONE BEFORE FINISHED FINE
+    needs: test_min_max_jdk
+
+    strategy:
+      ## Optionally cancel all other combinations if one fails
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        jdk: [ 9,10,11,12,13,14 ]
+
+    runs-on: ${{ matrix.os }}
+
+    # Steps should be identical for all runs
     steps:
       ## Checkout the current version of the code from the repo.
       - name: Checkout latest code

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -24,13 +24,13 @@ on:
 jobs:
 
 
-  # Do a quick test using min/max JDK ((on ubuntu))
-  test_min_max_jdk_ubuntu:
+  # Do a quick test using min/max JDK versions ((on ubuntu, mac, and windows))
+  test_min_max_jdk:
     strategy:
       ## Optionally cancel all other combinations if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         jdk: [ 8,15 ]
 
     runs-on: ${{ matrix.os }}
@@ -70,58 +70,10 @@ jobs:
 
 
 
-  # Do a quick test using min/max JDK ((on mac and windows))
-  test_min_max_jdk__mac_and_windows:
-    # ONLY START THIS TEST IF THE ONE BEFORE FINISHED FINE
-    needs: test_min_max_jdk_ubuntu
-
-    strategy:
-      ## Optionally cancel all other combinations if one fails
-      fail-fast: false
-      matrix:
-        os: [ macos-latest, windows-latest ]
-        jdk: [ 8,15 ]
-
-    runs-on: ${{ matrix.os }}
-
-    # Steps should be identical for all runs
-    steps:
-      ## Checkout the current version of the code from the repo.
-      - name: Checkout latest code
-        uses: actions/checkout@v2
-
-      ## Setup the specified version of Java (includes maven/gradle).
-      - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.jdk }}
-
-      ## Given that the build matrix only specifies the major version (configurable), output the precise version used.
-      - name: Echo exact java version being used
-        run: java -version
-
-      ## Use a cache to reduce the build/test times (avoids having to download dependencies on EVERY run).
-      ### https://help.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-maven#caching-dependencies
-      - name: Cache Maven packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      ## Actually perform the tests. Unsuccessful tests will indicate a failed build.
-      ### -e : show traces where any errors occur
-      ### -B test : run the maven lifecycle stage `test`
-      ### -P AlsoSlowTests : by default, only quick tests are run - the profile `AlsoSlowTests` runs the full test suite
-      - name: Test with Maven (incl. slow tests)
-        run: mvn -e -B test -P AlsoSlowTests
-
-
-
-  # Do a test of the intermediary JDK versions
+  # Do a thorough test of the other intermediary JDK versions
   test_intermediary_versions:
     # ONLY START THIS TEST IF THE ONE BEFORE FINISHED FINE
-    needs: test_min_max_jdk__mac_and_windows
+    needs: test_min_max_jdk
 
     strategy:
       ## Optionally cancel all other combinations if one fails

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -35,6 +35,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    name: test jdk${{ matrix.jdk }} on ${{ matrix.os }}
 
     # Steps should be identical for all runs
     steps:
@@ -85,6 +86,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    name: test jdk${{ matrix.jdk }} on ${{ matrix.os }}
 
     # Steps should be identical for all runs
     steps:

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -34,6 +34,7 @@ jobs:
         jdk: [ 8,15 ]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     # Steps should be identical for all runs
     steps:
@@ -83,6 +84,7 @@ jobs:
         jdk: [ 9,10,11,12,13,14 ]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     # Steps should be identical for all runs
     steps:

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -24,13 +24,62 @@ on:
 jobs:
 
 
-  # Do a quick test using min/max JDK
-  test_min_max_jdk:
+  # Do a quick test using min/max JDK ((on ubuntu))
+  test_min_max_jdk_ubuntu:
     strategy:
       ## Optionally cancel all other combinations if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest ]
+        jdk: [ 8,15 ]
+
+    runs-on: ${{ matrix.os }}
+
+    # Steps should be identical for all runs
+    steps:
+      ## Checkout the current version of the code from the repo.
+      - name: Checkout latest code
+        uses: actions/checkout@v2
+
+      ## Setup the specified version of Java (includes maven/gradle).
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+
+      ## Given that the build matrix only specifies the major version (configurable), output the precise version used.
+      - name: Echo exact java version being used
+        run: java -version
+
+      ## Use a cache to reduce the build/test times (avoids having to download dependencies on EVERY run).
+      ### https://help.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      ## Actually perform the tests. Unsuccessful tests will indicate a failed build.
+      ### -e : show traces where any errors occur
+      ### -B test : run the maven lifecycle stage `test`
+      ### -P AlsoSlowTests : by default, only quick tests are run - the profile `AlsoSlowTests` runs the full test suite
+      - name: Test with Maven (incl. slow tests)
+        run: mvn -e -B test -P AlsoSlowTests
+
+
+
+
+  # Do a quick test using min/max JDK ((on mac and windows))
+  test_min_max_jdk__mac_and_windows:
+    # ONLY START THIS TEST IF THE ONE BEFORE FINISHED FINE
+    needs: test_min_max_jdk_ubuntu
+
+    strategy:
+      ## Optionally cancel all other combinations if one fails
+      fail-fast: false
+      matrix:
+        os: [ macos-latest, windows-latest ]
         jdk: [ 8,15 ]
 
     runs-on: ${{ matrix.os }}
@@ -72,7 +121,7 @@ jobs:
   # Do a test of the intermediary JDK versions
   test_intermediary_versions:
     # ONLY START THIS TEST IF THE ONE BEFORE FINISHED FINE
-    needs: test_min_max_jdk
+    needs: test_min_max_jdk__mac_and_windows
 
     strategy:
       ## Optionally cancel all other combinations if one fails


### PR DESCRIPTION
limit the initial burst of github actions combinations to jdk 8 and 15, only testing the intermediary versions if these two pass