### PR TITLE
Issue 2613 auto update the version in the readme

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -31,14 +31,14 @@ Just add the following to your maven configuration or tailor to your own depende
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-symbol-solver-core</artifactId>
-    <version>3.16.4-SNAPSHOT</version>
+    <version>${project.version}</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.16.4-SNAPSHOT'
+implementation 'com.github.javaparser:javaparser-symbol-solver-core:${project.version}'
 ```
 
 Since Version 3.5.10, the JavaParser project includes the JavaSymbolSolver. 
@@ -53,14 +53,14 @@ Using the dependency above will add both JavaParser and JavaSymbolSolver to your
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core</artifactId>
-    <version>3.16.4-SNAPSHOT</version>
+    <version>${project.version}</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core:3.16.4-SNAPSHOT'
+implementation 'com.github.javaparser:javaparser-core:${project.version}'
 ```
 
 Since version 3.6.17 the AST can be serialized to JSON.
@@ -72,14 +72,14 @@ There is a separate module for this:
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core-serialization</artifactId>
-    <version>3.16.4-SNAPSHOT</version>
+    <version>${project.version}</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core-serialization:3.16.4-SNAPSHOT'
+implementation 'com.github.javaparser:javaparser-core-serialization:${project.version}'
 ```
 
 ## How To Compile Sources

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <preparationGoals>-Preleasing clean verify</preparationGoals>
+                        <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
                         <artifactId>maven-scm-plugin</artifactId>
                         <configuration>
                             <includes>readme.md</includes>
-                            <message>[maven-release-plugin] commit updated readme</message>
+                            <message>[maven-release-plugin] update readme</message>
                             <!-- disabled here, as it will be pushed separately (either once the release has been prepared, or manually) -->
                             <pushChanges>false</pushChanges>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -193,31 +193,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-readme</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.basedir}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/doc</directory>
-                                    <includes>
-                                        <include>readme.md</include>
-                                    </includes>
-                                    <filtering>true</filtering>
-                                </resource>
-                            </resources>
-                            <encoding>UTF-8</encoding>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -247,6 +222,7 @@
                     <version>2.5.3</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <preparationGoals>-Preleasing clean verify</preparationGoals>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -411,6 +387,38 @@
             <activation>
                 <jdk>[1.8,)</jdk>
             </activation>
+        </profile>
+        <profile>
+            <id>releasing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-readme</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.basedir}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.basedir}/doc</directory>
+                                            <includes>
+                                                <include>readme.md</include>
+                                            </includes>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <encoding>UTF-8</encoding>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-scm-plugin</artifactId>
+                    <version>1.11.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
                                             <filtering>true</filtering>
                                         </resource>
                                     </resources>
-                                    <encoding>{project.build.sourceEncoding}</encoding>
+                                    <encoding>${project.build.sourceEncoding}</encoding>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-readme</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/doc</directory>
+                                    <includes>
+                                        <include>readme.md</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,8 @@
                     <version>2.5.3</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <preparationGoals>-Preleasing clean verify</preparationGoals>
+                        <!-- Update the readme only when compiling a new release. -->
+                        <preparationGoals>-Preleasing clean verify scm:add scm:checkin</preparationGoals>
                         <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
@@ -391,6 +392,7 @@
         </profile>
         <profile>
             <id>releasing</id>
+            <!-- Update the readme only when compiling a new release. -->
             <build>
                 <plugins>
                     <plugin>
@@ -417,6 +419,15 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-scm-plugin</artifactId>
+                        <configuration>
+                            <includes>readme.md</includes>
+                            <message>[maven-release-plugin] commit updated readme</message>
+                            <pushChanges>false</pushChanges><!-- because I use git -->
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,7 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <!-- Update the readme only when compiling a new release. -->
                         <preparationGoals>-Preleasing clean verify scm:add scm:checkin</preparationGoals>
+                        <!-- Disable pushing of changes (i.e. false, for local testing) -->
                         <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
@@ -415,7 +416,7 @@
                                             <filtering>true</filtering>
                                         </resource>
                                     </resources>
-                                    <encoding>UTF-8</encoding>
+                                    <encoding>{project.build.sourceEncoding}</encoding>
                                 </configuration>
                             </execution>
                         </executions>
@@ -426,7 +427,8 @@
                         <configuration>
                             <includes>readme.md</includes>
                             <message>[maven-release-plugin] commit updated readme</message>
-                            <pushChanges>false</pushChanges><!-- because I use git -->
+                            <!-- disabled here, as it will be pushed separately (either once the release has been prepared, or manually) -->
+                            <pushChanges>false</pushChanges>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/readme.md
+++ b/readme.md
@@ -31,14 +31,14 @@ Just add the following to your maven configuration or tailor to your own depende
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-symbol-solver-core</artifactId>
-    <version>3.16.2</version>
+    <version>3.16.3</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.16.2'
+implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.16.3'
 ```
 
 Since Version 3.5.10, the JavaParser project includes the JavaSymbolSolver. 
@@ -53,14 +53,14 @@ Using the dependency above will add both JavaParser and JavaSymbolSolver to your
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core</artifactId>
-    <version>3.16.2</version>
+    <version>3.16.3</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core:3.16.2'
+implementation 'com.github.javaparser:javaparser-core:3.16.3'
 ```
 
 Since version 3.6.17 the AST can be serialized to JSON.
@@ -72,14 +72,14 @@ There is a separate module for this:
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core-serialization</artifactId>
-    <version>3.16.2</version>
+    <version>3.16.3</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core-serialization:3.16.2'
+implementation 'com.github.javaparser:javaparser-core-serialization:3.16.3'
 ```
 
 ## How To Compile Sources

--- a/readme.md
+++ b/readme.md
@@ -31,14 +31,14 @@ Just add the following to your maven configuration or tailor to your own depende
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-symbol-solver-core</artifactId>
-    <version>3.16.4-SNAPSHOT</version>
+    <version>3.16.3</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.16.4-SNAPSHOT'
+implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.16.3'
 ```
 
 Since Version 3.5.10, the JavaParser project includes the JavaSymbolSolver. 
@@ -53,14 +53,14 @@ Using the dependency above will add both JavaParser and JavaSymbolSolver to your
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core</artifactId>
-    <version>3.16.4-SNAPSHOT</version>
+    <version>3.16.3</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core:3.16.4-SNAPSHOT'
+implementation 'com.github.javaparser:javaparser-core:3.16.3'
 ```
 
 Since version 3.6.17 the AST can be serialized to JSON.
@@ -72,14 +72,14 @@ There is a separate module for this:
 <dependency>
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-core-serialization</artifactId>
-    <version>3.16.4-SNAPSHOT</version>
+    <version>3.16.3</version>
 </dependency>
 ```
 
 **Gradle**:
 
 ```
-implementation 'com.github.javaparser:javaparser-core-serialization:3.16.4-SNAPSHOT'
+implementation 'com.github.javaparser:javaparser-core-serialization:3.16.3'
 ```
 
 ## How To Compile Sources


### PR DESCRIPTION
Fixes #2613

This PR:
- Has the readme.md file update with the current pom version during compile, ONLY when the `releasing` profile is enabled
- During the release:prepare phase, enable the `releasing` profile (thus update the pom version and the readme)
- Commit the updated readme.md file

This creates an additional commit during the `release:prepare`:
![image](https://user-images.githubusercontent.com/1537214/98836064-29536880-2439-11eb-89cd-3b6e4415d2a1.png)


(for now, it also has a manual update of the readme.md version -- in the future it should update automatically)