### PR TITLE
fix jacoco and enable codecov.io action

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -27,6 +27,9 @@ jobs:
         ### exclude pre-8 (min development version jdk8)
         ### exclude post-12 (changes to jdk causes reflection tests to fail due to added methods #1701 )
         jdk: [8,9,10,11,12,13,14,15]
+    env:
+      OS: ${{ matrix.os }}
+      JDK: ${{ matrix.jdk }}
 
     runs-on: ${{ matrix.os }}
 
@@ -65,3 +68,12 @@ jobs:
       - name: Test with Maven (incl. slow tests)
         run: mvn --errors clean test --activate-profiles AlsoSlowTests
 
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        timeout-minutes: 10
+        with:
+          files: javaparser-core-testing/target/site/jacoco/jacoco.xml,javaparser-core-testing-bdd/target/site/jacoco/jacoco.xml,javaparser-symbol-solver-core/target/site/jacoco-aggregate/jacoco.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: false # optional (default = false):
+          flags: AlsoSlowTests,${{ matrix.os }},jdk-${{ matrix.jdk }}
+          env_vars: AlsoSlowTests,OS,JDK

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -36,8 +36,8 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>package</phase>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
@@ -48,8 +48,8 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-resources</id>
-                        <phase>pre-integration-test</phase>
+                        <id>copy-javaparser-core-classes</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -59,6 +59,23 @@
                             <resources>
                                 <resource>
                                     <directory>../javaparser-core/target/classes</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-javaparser-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-core/target/generated-sources</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -36,8 +36,8 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>package</phase>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
@@ -48,8 +48,8 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-resources</id>
-                        <phase>pre-integration-test</phase>
+                        <id>copy-javaparser-core-classes</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -59,6 +59,23 @@
                             <resources>
                                 <resource>
                                     <directory>../javaparser-core/target/classes</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-javaparser-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-core/target/generated-sources</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -64,8 +64,8 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>package</phase>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
@@ -76,8 +76,8 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-resources</id>
-                        <phase>pre-integration-test</phase>
+                        <id>copy-javaparser-core-classes</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -87,6 +87,57 @@
                             <resources>
                                 <resource>
                                     <directory>../javaparser-core/target/classes</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-javaparser-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-core/target/generated-sources</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-javaparser-symbol-solver-core-classes</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-symbol-solver-core/target/classes</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-javaparser-symbol-solver-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-symbol-solver-core/target/generated-sources</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>


### PR DESCRIPTION
fix jacoco reporting (unable to produce the report without having the sources available directly within that submodule), and enable code coverage github action / pr comments