### PR TITLE
Minor refactoring in ResolvedReferenceType and add corresponding tests

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -445,27 +445,12 @@ public abstract class ResolvedReferenceType implements ResolvedType,
 
     protected abstract ResolvedReferenceType create(ResolvedReferenceTypeDeclaration typeDeclaration);
 
+    /*
+     * Verify if the resolved type is a boxing type of a primitive  
+     */
     protected boolean isCorrespondingBoxingType(String typeName) {
-        switch (typeName) {
-            case "boolean":
-                return getQualifiedName().equals(Boolean.class.getCanonicalName());
-            case "char":
-                return getQualifiedName().equals(Character.class.getCanonicalName());
-            case "byte":
-                return getQualifiedName().equals(Byte.class.getCanonicalName());
-            case "short":
-                return getQualifiedName().equals(Short.class.getCanonicalName());
-            case "int":
-                return getQualifiedName().equals(Integer.class.getCanonicalName());
-            case "long":
-                return getQualifiedName().equals(Long.class.getCanonicalName());
-            case "float":
-                return getQualifiedName().equals(Float.class.getCanonicalName());
-            case "double":
-                return getQualifiedName().equals(Double.class.getCanonicalName());
-            default:
-                throw new UnsupportedOperationException(typeName);
-        }
+        ResolvedPrimitiveType resolvedPrimitiveType = (ResolvedPrimitiveType) ResolvedPrimitiveType.byName(typeName);
+        return getQualifiedName().equals(resolvedPrimitiveType.getBoxTypeQName());
     }
 
     protected boolean compareConsideringTypeParameters(ResolvedReferenceType other) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -65,6 +65,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedClassDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedInterfaceDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
@@ -253,6 +254,12 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
         ResolvedReferenceType numberType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Number.class, typeSolver), typeSolver);
         ResolvedReferenceType intType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Integer.class, typeSolver), typeSolver);
         ResolvedReferenceType doubleType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Double.class, typeSolver), typeSolver);
+        ResolvedReferenceType byteType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Byte.class, typeSolver), typeSolver);
+        ResolvedReferenceType shortType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Short.class, typeSolver), typeSolver);
+        ResolvedReferenceType charType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Character.class, typeSolver), typeSolver);
+        ResolvedReferenceType longType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Long.class, typeSolver), typeSolver);
+        ResolvedReferenceType booleanType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Boolean.class, typeSolver), typeSolver);
+        ResolvedReferenceType floatType = new ReferenceTypeImpl(new ReflectionClassDeclaration(Float.class, typeSolver), typeSolver);
 
         assertEquals(true, numberType.isAssignableBy(ResolvedPrimitiveType.INT));
         assertEquals(true, numberType.isAssignableBy(ResolvedPrimitiveType.DOUBLE));
@@ -262,6 +269,67 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
         assertEquals(false, numberType.isAssignableBy(ResolvedPrimitiveType.BOOLEAN));
         assertEquals(true, intType.isAssignableBy(ResolvedPrimitiveType.INT));
         assertEquals(true, doubleType.isAssignableBy(ResolvedPrimitiveType.DOUBLE));
+        assertEquals(true, byteType.isAssignableBy(ResolvedPrimitiveType.BYTE));
+        assertEquals(true, shortType.isAssignableBy(ResolvedPrimitiveType.SHORT));
+        assertEquals(true, charType.isAssignableBy(ResolvedPrimitiveType.CHAR));
+        assertEquals(true, longType.isAssignableBy(ResolvedPrimitiveType.LONG));
+        assertEquals(true, booleanType.isAssignableBy(ResolvedPrimitiveType.BOOLEAN));
+        assertEquals(true, floatType.isAssignableBy(ResolvedPrimitiveType.FLOAT));
+    }
+
+    @Test
+    void testIsCorresponding() {
+
+        // ResolvedReferenceTypeTester is defined to allow to test protected method isCorrespondingBoxingType(..)
+        class ResolvedReferenceTypeTester extends ReferenceTypeImpl {
+
+            public ResolvedReferenceTypeTester(ResolvedReferenceTypeDeclaration typeDeclaration,
+                                               TypeSolver typeSolver) {
+                super(typeDeclaration, typeSolver);
+            }
+
+            public boolean isCorrespondingBoxingType(String name) {
+                return super.isCorrespondingBoxingType(name);
+            }
+
+        }
+
+        ResolvedReferenceTypeTester numberType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Number.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester intType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Integer.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester doubleType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Double.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester byteType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Byte.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester shortType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Short.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester charType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Character.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester longType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Long.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester booleanType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Boolean.class, typeSolver), typeSolver);
+        ResolvedReferenceTypeTester floatType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(Float.class, typeSolver), typeSolver);
+
+        ResolvedReferenceTypeTester otherType = new ResolvedReferenceTypeTester(
+                new ReflectionClassDeclaration(String.class, typeSolver), typeSolver);
+
+        assertEquals(true, intType.isCorrespondingBoxingType(ResolvedPrimitiveType.INT.describe()));
+        assertEquals(true, doubleType.isCorrespondingBoxingType(ResolvedPrimitiveType.DOUBLE.describe()));
+        assertEquals(true, byteType.isCorrespondingBoxingType(ResolvedPrimitiveType.BYTE.describe()));
+        assertEquals(true, shortType.isCorrespondingBoxingType(ResolvedPrimitiveType.SHORT.describe()));
+        assertEquals(true, charType.isCorrespondingBoxingType(ResolvedPrimitiveType.CHAR.describe()));
+        assertEquals(true, longType.isCorrespondingBoxingType(ResolvedPrimitiveType.LONG.describe()));
+        assertEquals(true, booleanType.isCorrespondingBoxingType(ResolvedPrimitiveType.BOOLEAN.describe()));
+        assertEquals(true, floatType.isCorrespondingBoxingType(ResolvedPrimitiveType.FLOAT.describe()));
+
+        assertEquals(false, numberType.isCorrespondingBoxingType(ResolvedPrimitiveType.INT.describe()));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            intType.isCorrespondingBoxingType("String");
+        });
     }
 
     @Test


### PR DESCRIPTION
Verify if the resolved type is a boxing type of a primitive
