### PR TITLE
Fix issue 2781 resolve Stack overflow occurs when the name of the interface implemented by the class is the same as the name of the internal class

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -351,7 +351,12 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
         for (ClassOrInterfaceType implemented : wrappedNode.getImplementedTypes()) {
             try {
                 // If an implemented interface is found, add it as an ancestor
-                ancestors.add(toReferenceType(implemented));
+                ResolvedReferenceType rrt = toReferenceType(implemented);
+                ResolvedTypeDeclaration rtd = rrt.getTypeDeclaration().get().asType();
+                // do not consider an inner or nested class as an ancestor
+                if (!rtd.getQualifiedName().contains(wrappedNode.getFullyQualifiedName().get())) {
+                    ancestors.add(rrt);
+                }
             } catch (UnsolvedSymbolException e) {
                 // in case we could not resolve some implemented interface, we may still be able to resolve the
                 // extended class or (some of) the other implemented interfaces and so we continue gracefully

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2781Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2781Test.java
@@ -1,0 +1,52 @@
+package com.github.javaparser.symbolsolver;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue2781Test extends AbstractResolutionTest {
+    
+    @Test()
+    void test() throws FileNotFoundException {
+        
+        String code =
+                "public class A implements AnInterface {\n" + 
+                "        private AnInterface field;\n" + 
+                "\n" + 
+                "        protected AnInterface getContainer() {\n" + 
+                "            return this.field;\n" + 
+                "        }\n" + 
+                "        protected static class AnInterface {\n" + 
+                "        }\n" + 
+                "}";
+        
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver());
+        combinedTypeSolver.add(new JavaParserTypeSolver(adaptPath("src/test/resources")));
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver));
+        
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        List<ConstructorDeclaration> constructorDeclarations = cu.findAll(ConstructorDeclaration.class);
+        constructorDeclarations.forEach(constructorDeclaration -> {
+            constructorDeclaration.findAll(MethodCallExpr.class).forEach(methodCallExpr -> {
+                //Exception in thread "main" java.lang.StackOverflowError
+                ResolvedMethodDeclaration rmd = methodCallExpr.resolve();
+                System.out.println(rmd.getQualifiedName());
+            });
+        });
+
+        
+    }
+    
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/AnInterface.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/AnInterface.java.txt
@@ -1,0 +1,2 @@
+public interface AnInterface {
+}


### PR DESCRIPTION
Fixes #2781 .
