### PR TITLE
Fix trivial poly expression lambda, method reference, and parenthesized expressions

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/ExpressionHelper.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/ExpressionHelper.java
@@ -21,8 +21,16 @@
 
 package com.github.javaparser.symbolsolver.resolution.typeinference;
 
+import java.util.List;
+
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.expr.ConditionalExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
@@ -30,8 +38,6 @@ import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-
-import java.util.List;
 
 /**
  * @author Federico Tomassetti
@@ -51,8 +57,10 @@ public class ExpressionHelper {
      * @return
      */
     public static boolean isPolyExpression(Expression expression) {
+        // On Parenthesized Expressions, if the contained expression is a poly expression (§15.2), the parenthesized expression is also a poly expression. Otherwise, it is a standalone expression.
+        // (https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.8.5)
         if (expression instanceof EnclosedExpr) {
-            throw new UnsupportedOperationException(expression.toString());
+            return isPolyExpression(((EnclosedExpr) expression).getInner());
         }
         if (expression instanceof ObjectCreationExpr) {
             // A class instance creation expression is a poly expression (§15.2) if it uses the diamond form for type
@@ -92,12 +100,14 @@ public class ExpressionHelper {
             // Otherwise, the method invocation expression is a standalone expression.
             //return true;
         }
+        //  Method reference expressions are always poly expressions (https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html 15.13. Method Reference Expressions)
         if (expression instanceof MethodReferenceExpr) {
-            throw new UnsupportedOperationException(expression.toString());
+            return true;
         }
         if (expression instanceof ConditionalExpr) {
             throw new UnsupportedOperationException(expression.toString());
         }
+        //  Lambda expressions are always poly expressions
         if (expression instanceof LambdaExpr) {
             return true;
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/ExpressionHelperTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/ExpressionHelperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.resolution.typeinference;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+
+class ExpressionHelperTest extends AbstractResolutionTest {
+    
+    @Test
+    void parenthesizedExpressionAsStandaloneExpression() {
+        Expression expression = StaticJavaParser.parseExpression("(-1)");
+        assertTrue(ExpressionHelper.isStandaloneExpression(expression));
+    }
+    
+    @Test
+    void methodReferenceExpressionAsPolyExpression() {
+        Expression expression = StaticJavaParser.parseExpression("String::length");
+        assertTrue(ExpressionHelper.isPolyExpression(expression));
+    }
+    
+    @Test
+    void lambdaExpressionAsPolyExpression() {
+        Expression expression = StaticJavaParser.parseExpression("(s) -> s.toString()");
+        assertTrue(ExpressionHelper.isPolyExpression(expression));
+    }
+
+}


### PR DESCRIPTION
Fix trivial poly expression lambda, method reference, and parenthesized expressions and add some test cases to ExpressionHelper class
