### PR TITLE
Remove the PhantomNodeLogic that generates memory issues  when Lexica…

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/AbstractLexicalPreservingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/AbstractLexicalPreservingTest.java
@@ -42,8 +42,6 @@ public abstract class AbstractLexicalPreservingTest {
     
     @AfterAll
     public static void tearDown() {
-        // clear internal caches
-        PhantomNodeLogic.cleanUpCache();
     }
     
     @AfterEach

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -20,21 +20,22 @@
  */
 package com.github.javaparser.ast.type;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.visitor.CloneVisitor;
-import com.github.javaparser.metamodel.UnknownTypeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.TokenRange;
+import com.github.javaparser.metamodel.UnknownTypeMetaModel;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
-import java.util.function.Consumer;
-import java.util.Optional;
-import com.github.javaparser.ast.Generated;
 
 /**
  * An unknown parameter type object. It plays the role of a null object for
@@ -140,5 +141,13 @@ public class UnknownType extends Type {
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<UnknownType> toUnknownType() {
         return Optional.of(this);
+    }
+    
+    /*
+     * A "phantom" node, is a node that is not really an AST node (like the fake type of variable in FieldDeclaration)
+     */
+    @Override
+    public boolean isPhantom() {
+        return true;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -21,6 +21,27 @@
 
 package com.github.javaparser.printer.lexicalpreservation;
 
+import static com.github.javaparser.GeneratedJavaParserConstants.*;
+import static com.github.javaparser.TokenTypes.eolTokenKind;
+import static com.github.javaparser.utils.Utils.assertNotNull;
+import static com.github.javaparser.utils.Utils.decapitalize;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import com.github.javaparser.JavaToken;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.DataKey;
@@ -46,27 +67,6 @@ import com.github.javaparser.printer.concretesyntaxmodel.CsmToken;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmUnindent;
 import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.utils.Pair;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static com.github.javaparser.GeneratedJavaParserConstants.*;
-import static com.github.javaparser.TokenTypes.eolTokenKind;
-import static com.github.javaparser.utils.Utils.assertNotNull;
-import static com.github.javaparser.utils.Utils.decapitalize;
-import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
 
 /**
  * A Lexical Preserving Printer is used to capture all the lexical information while parsing, update them when
@@ -353,7 +353,7 @@ public class LexicalPreservingPrinter {
             new TreeVisitor() {
                 @Override
                 public void process(Node node) {
-                    if (!PhantomNodeLogic.isPhantomNode(node)) {
+                    if (!node.isPhantom()) {
                         LexicalPreservingPrinter.storeInitialTextForOneNode(node, tokensByNode.get(node));
                     }
                 }
@@ -362,7 +362,7 @@ public class LexicalPreservingPrinter {
     }
 
     private static Optional<Node> findNodeForToken(Node node, Range tokenRange) {
-        if (PhantomNodeLogic.isPhantomNode(node)) {
+        if (node.isPhantom()) {
             return Optional.empty();
         }
         if(!node.getRange().isPresent()) {
@@ -387,7 +387,7 @@ public class LexicalPreservingPrinter {
         }
         List<Pair<Range, TextElement>> elements = new LinkedList<>();
         for (Node child : node.getChildNodes()) {
-            if (!PhantomNodeLogic.isPhantomNode(child)) {
+            if (!child.isPhantom()) {
                 if (!child.getRange().isPresent()) {
                     throw new RuntimeException("Range not present on node " + child);
                 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/PhantomNodeLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/PhantomNodeLogic.java
@@ -33,7 +33,9 @@ import com.github.javaparser.ast.type.UnknownType;
 
 /**
  * We want to recognize and ignore "phantom" nodes, like the fake type of variable in FieldDeclaration
+ * @deprecated This class is no longer used phantom node are now an attribute of each node
  */
+@Deprecated
 public class PhantomNodeLogic {
 
     private static final int LEVELS_TO_EXPLORE = 3;


### PR DESCRIPTION
…lPreservingPrinter is used. Phantom node is now an attribut of each node. This is an optimization of the JP memory usage.

Fixes #2996 .
