### PR TITLE
Fixing Issue 3028

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3028Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3028Test.java
@@ -1,0 +1,36 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue3028Test extends AbstractResolutionTest {
+
+    @Test
+    void varArgsIssue() {
+    	
+    	TypeSolver typeSolver = new CombinedTypeSolver(
+				new ReflectionTypeSolver());
+		JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
+		
+		StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
+		
+        CompilationUnit cu = parseSample("Issue3028");
+        
+        final MethodCallExpr mce = Navigator.findMethodCall(cu, "doSomething").get();
+        ResolvedMethodDeclaration rmd = mce.resolve();
+        assertEquals("AParserTest.doSomething(java.lang.String, java.util.function.Supplier<?>...)", rmd.getQualifiedSignature());
+        
+    }
+    
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/Issue3028.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Issue3028.java.txt
@@ -1,0 +1,16 @@
+import java.util.function.Supplier;
+
+public class AParserTest {
+
+	public void testMethod() {
+		doSomething("abc");
+	}
+	
+	private void doSomething(String string, Supplier<?>... supplier) {
+		
+	}
+
+	private void doSomething(String string, Object... object) {
+		
+	}
+}


### PR DESCRIPTION
Changed MethodResolutionLogic to deal with multiple candidates with
varargs when varargs have not been specified in the call.

Fixes #3028 .
