### PR TITLE
Implemented Node ID

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -156,7 +156,7 @@ class NodeTest {
         Node secondNode = new Parameter();
 
         assertEquals(firstNode, secondNode);
-        assertNotEquals(firstNode.getId(), secondNode.getId());
+        assertNotEquals(firstNode.getUniqueID(), secondNode.getUniqueID());
     }
 
     @Test
@@ -165,7 +165,7 @@ class NodeTest {
         Node secondNode = firstNode.clone();
 
         assertEquals(firstNode, secondNode);
-        assertNotEquals(firstNode.getId(), secondNode.getId());
+        assertNotEquals(firstNode.getUniqueID(), secondNode.getUniqueID());
     }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -21,10 +21,7 @@
 
 package com.github.javaparser.ast;
 
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
@@ -35,7 +32,6 @@ import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class NodeTest {
@@ -153,4 +149,23 @@ class NodeTest {
         // This will throw an exception if the parents are bad.
         unit.toString();
     }
+
+    @Test
+    void differentNodesShouldHaveDifferentIds() {
+        Node firstNode = new Parameter();
+        Node secondNode = new Parameter();
+
+        assertEquals(firstNode, secondNode);
+        assertNotEquals(firstNode.getId(), secondNode.getId());
+    }
+
+    @Test
+    void clonedNodesShouldHaveDifferentIds() {
+        Node firstNode = new Parameter();
+        Node secondNode = firstNode.clone();
+
+        assertEquals(firstNode, secondNode);
+        assertNotEquals(firstNode.getId(), secondNode.getId());
+    }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -1153,7 +1153,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      *
      * @return The unique id.
      */
-    public final String getId() {
+    public final String getUniqueID() {
         return uniqueID;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -20,31 +20,6 @@
  */
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.ast.Node.Parsedness.PARSED;
-import static com.github.javaparser.ast.Node.TreeTraversal.PREORDER;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Spliterator.DISTINCT;
-import static java.util.Spliterator.NONNULL;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.Set;
-import java.util.Spliterators;
-import java.util.Stack;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
 import com.github.javaparser.HasParentNode;
 import com.github.javaparser.Position;
 import com.github.javaparser.Range;
@@ -62,11 +37,7 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.EqualsVisitor;
 import com.github.javaparser.ast.visitor.HashCodeVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
-import com.github.javaparser.metamodel.InternalProperty;
-import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.metamodel.NodeMetaModel;
-import com.github.javaparser.metamodel.OptionalProperty;
-import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.metamodel.*;
 import com.github.javaparser.printer.DefaultPrettyPrinter;
 import com.github.javaparser.printer.Printer;
 import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
@@ -75,6 +46,20 @@ import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.C
 import com.github.javaparser.printer.configuration.PrinterConfiguration;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.utils.LineSeparator;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.github.javaparser.ast.Node.Parsedness.PARSED;
+import static com.github.javaparser.ast.Node.TreeTraversal.PREORDER;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Spliterator.DISTINCT;
+import static java.util.Spliterator.NONNULL;
 
 /**
  * Base class for all nodes of the abstract syntax tree.
@@ -168,7 +153,10 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     private static final int LEVELS_TO_EXPLORE = 3;
 
     protected static final PrinterConfiguration prettyPrinterNoCommentsConfiguration = new DefaultPrinterConfiguration().removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
-    
+
+    @InternalProperty
+    private final String uniqueID = UUID.randomUUID().toString();
+
     @InternalProperty
     private Range range;
 
@@ -1159,4 +1147,14 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
                 (isPhantom(node.getParentNode().get())
                         || inPhantomNode(node.getParentNode().get(), levels - 1));
     }
+
+    /**
+     * A unique identification for this node.
+     *
+     * @return The unique id.
+     */
+    public final String getId() {
+        return uniqueID;
+    }
+
 }


### PR DESCRIPTION
Sometimes may be harder to identify if two nodes are the same instance. Imagine the example below:
```java
class A {
  void method1(int param) {}
  void method2(int param) {}
}
```
Given the example above, we would like to check that the parameters are the same.
Using the equals or hash code method, they are considered to be equal (which is true because they have the same name, type and child nodes) but are not the same instance.

This PR adds a new constant property called unique id that is generated at the creation of the node and cannot be changed.

Related to (#3078).
