### PR TITLE
Update supported java versions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2667378.svg)](https://doi.org/10.5281/zenodo.2667378)
 
 
-This project contains a set of libraries implementing a Java 1.0 - Java 14 Parser with advanced analysis functionalities. This includes preview features to Java 13, with Java 14 preview features work-in-progress.
+This project contains a set of libraries implementing a Java 1.0 - Java 15 Parser with advanced analysis functionalities. This includes preview features to Java 13, with Java 14 preview features work-in-progress.
 
 Our main site is at [JavaParser.org](http://javaparser.org)
 


### PR DESCRIPTION
The github homepage for the project describes java version 15 to be the latest version JavaParser supports the README however states that version 14 is the latest supported version. This PR updates the docs.

Screenshot github project:
![image](https://user-images.githubusercontent.com/18325396/108493521-b6af2000-72a6-11eb-9bde-48ff743596c4.png)
