### PR TITLE
Removed "empty" label from break statement and added additional test for BreakStmt 

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/BreakStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/BreakStmtTest.java
@@ -21,13 +21,16 @@
 
 package com.github.javaparser.ast.stmt;
 
+import com.github.javaparser.ast.expr.SimpleName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static com.github.javaparser.utils.TestParser.parseStatement;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 class BreakStmtTest {
+
     @Test
     void simpleBreak() {
         BreakStmt statement = parseStatement("break;").asBreakStmt();
@@ -39,4 +42,86 @@ class BreakStmtTest {
         BreakStmt statement = parseStatement("break hond;").asBreakStmt();
         assertEquals("hond", statement.getLabel().get().asString());
     }
+
+    @Test
+    void constructor_simpleBreakWithoutLabel() {
+        BreakStmt statement = new BreakStmt();
+        assertFalse(statement.getLabel().isPresent());
+        assertEquals("break;", statement.toString());
+    }
+
+    @Test
+    void constructor_simpleBreakWithLabel() {
+        BreakStmt statement = new BreakStmt("customLabel");
+        assertTrue(statement.getLabel().isPresent());
+    }
+
+    @Test
+    void constructor_simpleBreakWithSimpleNameLabel() {
+        SimpleName label = new SimpleName("customLabel");
+        BreakStmt statement = new BreakStmt(label);
+        assertTrue(statement.getLabel().isPresent());
+        assertEquals(label, statement.getLabel().get());
+    }
+
+    @Test
+    void removeLabel_shouldRemoveTheLabel() {
+        BreakStmt statement = new BreakStmt("customLabel");
+        assertTrue(statement.getLabel().isPresent());
+
+        statement.removeLabel();
+        assertFalse(statement.getLabel().isPresent());
+    }
+
+    @Test
+    void isBreakStmt_shouldBeTrue() {
+        assertTrue(new BreakStmt().isBreakStmt());
+    }
+
+    @Test
+    void asBreakStmt_shouldBeSame() {
+        BreakStmt breakStatement = new BreakStmt();
+        assertSame(breakStatement, breakStatement.asBreakStmt());
+    }
+
+    @Test
+    void toBreakStmt_shouldBePresentAndBeTheSame() {
+        BreakStmt breakStatement = new BreakStmt();
+        Optional<BreakStmt> optBreak = breakStatement.toBreakStmt();
+        assertTrue(optBreak.isPresent());
+        assertSame(breakStatement, optBreak.get());
+    }
+
+    @Test
+    void clone_shouldNotBeTheSameButShouldBeEquals() {
+        BreakStmt breakStatement = new BreakStmt();
+        BreakStmt clonedStatement = breakStatement.clone();
+        assertNotSame(breakStatement, clonedStatement);
+        assertEquals(breakStatement, clonedStatement);
+    }
+
+    @Test
+    void remove_whenLabelIsPassedAsArgumentItShouldBeRemoved() {
+        BreakStmt breakStatement = new BreakStmt("Label");
+        assertTrue(breakStatement.getLabel().isPresent());
+
+        SimpleName label = breakStatement.getLabel().get();
+        assertTrue(breakStatement.remove(label));
+        assertFalse(breakStatement.getLabel().isPresent());
+    }
+
+    @Test
+    void replace_testReplaceLabelWithNewOne() {
+        SimpleName originalLabel = new SimpleName("original");
+        SimpleName replacementLabel = new SimpleName("replacement");
+
+        BreakStmt breakStatement = new BreakStmt(originalLabel);
+        assertTrue(breakStatement.getLabel().isPresent());
+        assertSame(originalLabel, breakStatement.getLabel().get());
+
+        breakStatement.replace(originalLabel, replacementLabel);
+        assertTrue(breakStatement.getLabel().isPresent());
+        assertSame(replacementLabel, breakStatement.getLabel().get());
+    }
+
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
@@ -183,7 +183,7 @@ class HashCodeVisitorTest {
 	void testVisitBreakStmt() {
 		BreakStmt node = spy(new BreakStmt());
 		HashCodeVisitor.hashCode(node);
-		verify(node, times(2)).getLabel();
+		verify(node, times(1)).getLabel();
 		verify(node, times(1)).getComment();
 	}
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
@@ -218,7 +218,7 @@ class NoCommentHashCodeVisitorTest {
 		BreakStmt node = spy(new BreakStmt());
 		NoCommentHashCodeVisitor.hashCode(node);
 
-		verify(node, times(2)).getLabel();
+		verify(node, times(1)).getLabel();
 		verify(node, never()).getComment();
 	}
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/BreakStmt.java
@@ -20,20 +20,21 @@
  */
 package com.github.javaparser.ast.stmt;
 
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
-import java.util.Optional;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.BreakStmtMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.TokenRange;
 import com.github.javaparser.metamodel.OptionalProperty;
+
+import java.util.Optional;
 import java.util.function.Consumer;
-import com.github.javaparser.ast.Generated;
 
 /**
  * <h1>The break statement</h1>
@@ -61,7 +62,7 @@ public class BreakStmt extends Statement {
     private SimpleName label;
 
     public BreakStmt() {
-        this(null, new SimpleName());
+        this(null, null);
     }
 
     public BreakStmt(final String label) {


### PR DESCRIPTION
There was a issue with `BreakStmt` that was report in #2717.

When we create a new break we expect it to don't have any label (Expected: "break;"). But by default this didn't happen, the label has the value "empty". (Implemented: "break empty;")

This PR fixes this issue by setting the label as null instead of creating a new `SimpleName` on the empty constructor.