### PR TITLE
Implemented getMethodDeclaration for Annotation declaration

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclaration.java
@@ -63,8 +63,9 @@ public class JavaParserAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
-        // TODO #1838
-        throw new UnsupportedOperationException();
+        // According to https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.6
+        // annotations can't have methods.
+        return Collections.emptySet();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -105,8 +105,9 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
-        // TODO #1838
-        throw new UnsupportedOperationException();
+        // According to https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.6
+        // annotations can't have methods.
+        return Collections.emptySet();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -147,8 +147,9 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
-        // TODO #1838
-        throw new UnsupportedOperationException();
+        // According to https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.6
+        // annotations can't have methods.
+        return Collections.emptySet();
     }
 
     @Override


### PR DESCRIPTION
Fixes #1838.

According to [JLS](https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.6
) and malteskoruppa in #1838 the annotation declaration doesn't have methods. 

Since it's an intended behavior i suggest returning a empty set instead of throwing the UnsupportedException.
