### PR TITLE
edited configuration of testing modules to fail when zero tests are executed

### DIFF
--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -91,6 +91,14 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reportFormat>plain</reportFormat>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -90,6 +90,14 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reportFormat>plain</reportFormat>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -40,6 +40,8 @@
                             <parallel>methods</parallel>
                             <threadCount>4</threadCount>
                             <argLine>-Xms256m -Xmx2g -verbose:gc</argLine>
+                            <reportFormat>plain</reportFormat>
+                            <failIfNoTests>true</failIfNoTests>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -55,6 +57,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>-Xms256m -Xmx2g -verbose:gc</argLine>
+                            <reportFormat>plain</reportFormat>
+                            <failIfNoTests>true</failIfNoTests>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
edited configuration of testing modules to fail when zero tests are executed, and changed the report format to "plain" (as opposed to the default of "brief") which gives more detailed test output (e.g. timing)

Related to #3147 where I include a note that failing on zero executed tests would have noticed/caught the test running problems with junit-pioneer v1 and above.
