### PR TITLE
Fixed generator visitor order to match the expected behavior

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
@@ -28,9 +28,13 @@ import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
+import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.Log;
 import com.github.javaparser.utils.SourceRoot;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
@@ -97,6 +101,19 @@ public abstract class VisitorGenerator extends Generator {
             }
             generateVisitMethodBody(node, newVisitMethod, compilationUnit);
         }
+    }
+
+    /**
+     * Get the list of properties in the order they should be visited.
+     *
+     * @param baseNodeMetaModel The metamodel to get the properties.
+     *
+     * @return The list of properties.
+     */
+    public List<PropertyMetaModel> getAllPropertyMetaModels(BaseNodeMetaModel baseNodeMetaModel) {
+        List<PropertyMetaModel> propertiesList = new ArrayList<>(baseNodeMetaModel.getAllPropertyMetaModels());
+        Collections.reverse(propertiesList);
+        return propertiesList;
     }
 
     protected abstract void generateVisitMethodBody(BaseNodeMetaModel node, MethodDeclaration visitMethod, CompilationUnit compilationUnit);

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
@@ -25,11 +25,11 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.generator.VisitorGenerator;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.CompilationUnitMetaModel;
+import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.utils.SourceRoot;
-import com.github.javaparser.metamodel.BaseNodeMetaModel;
-import com.github.javaparser.metamodel.PropertyMetaModel;
 
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
@@ -48,7 +48,7 @@ public class CloneVisitorGenerator extends VisitorGenerator {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
-        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
+        for (PropertyMetaModel field : getAllPropertyMetaModels(node)) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isOptional() && field.isNodeList()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/EqualsVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/EqualsVisitorGenerator.java
@@ -25,9 +25,9 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.generator.VisitorGenerator;
-import com.github.javaparser.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.utils.SourceRoot;
 
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
@@ -48,7 +48,7 @@ public class EqualsVisitorGenerator extends VisitorGenerator {
 
         body.addStatement(f("final %s n2 = (%s) arg;", node.getTypeName(), node.getTypeName()));
 
-        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
+        for (PropertyMetaModel field : getAllPropertyMetaModels(node)) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isNodeList()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericListVisitorAdapterGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericListVisitorAdapterGenerator.java
@@ -54,7 +54,7 @@ public class GenericListVisitorAdapterGenerator extends VisitorGenerator {
 
         final String resultCheck = "if (tmp != null) result.addAll(tmp);";
 
-        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
+        for (PropertyMetaModel field : getAllPropertyMetaModels(node)) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isOptional()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericVisitorAdapterGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/GenericVisitorAdapterGenerator.java
@@ -25,9 +25,9 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.generator.VisitorGenerator;
-import com.github.javaparser.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.utils.SourceRoot;
 
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
@@ -50,7 +50,7 @@ public class GenericVisitorAdapterGenerator extends VisitorGenerator {
 
         final String resultCheck = "if (result != null) return result;";
 
-        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
+        for (PropertyMetaModel field : getAllPropertyMetaModels(node)) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isOptional()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/HashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/HashCodeVisitorGenerator.java
@@ -25,10 +25,10 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.generator.VisitorGenerator;
-import com.github.javaparser.utils.SeparatedItemStringBuilder;
-import com.github.javaparser.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.utils.SeparatedItemStringBuilder;
+import com.github.javaparser.utils.SourceRoot;
 
 import java.util.List;
 
@@ -50,7 +50,7 @@ public class HashCodeVisitorGenerator extends VisitorGenerator {
         body.getStatements().clear();
 
         final SeparatedItemStringBuilder builder = new SeparatedItemStringBuilder("return ", "* 31 +", ";");
-        final List<PropertyMetaModel> propertyMetaModels= node.getAllPropertyMetaModels();
+        final List<PropertyMetaModel> propertyMetaModels = getAllPropertyMetaModels(node);
         if (propertyMetaModels.isEmpty()) {
             builder.append("0");
         } else {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/ModifierVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/ModifierVisitorGenerator.java
@@ -31,6 +31,8 @@ import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.utils.SourceRoot;
 
+import java.util.List;
+
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
 public class ModifierVisitorGenerator extends VisitorGenerator {
@@ -45,7 +47,8 @@ public class ModifierVisitorGenerator extends VisitorGenerator {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
-        for (PropertyMetaModel property : node.getAllPropertyMetaModels()) {
+        List<PropertyMetaModel> allProperties = getAllPropertyMetaModels(node);
+        for (PropertyMetaModel property : allProperties) {
             if (property.isNode()) {
                 if (property.isNodeList()) {
                     body.addStatement(f("NodeList<%s> %s = modifyList(n.%s(), arg);",
@@ -73,7 +76,7 @@ public class ModifierVisitorGenerator extends VisitorGenerator {
             body.addStatement("if (right == null) return left;");
         }else {
             final SeparatedItemStringBuilder collapseCheck = new SeparatedItemStringBuilder("if(", "||", ") return null;");
-            for (PropertyMetaModel property : node.getAllPropertyMetaModels()) {
+            for (PropertyMetaModel property : allProperties) {
                 if (property.isRequired() && property.isNode()) {
                     if (property.isNodeList()) {
                         if(property.isNonEmpty()){
@@ -89,7 +92,7 @@ public class ModifierVisitorGenerator extends VisitorGenerator {
             }
         }
 
-        for (PropertyMetaModel property : node.getAllPropertyMetaModels()) {
+        for (PropertyMetaModel property : allProperties) {
             if (property.isNode()) {
                 body.addStatement(f("n.%s(%s);", property.getSetterMethodName(), property.getName()));
             }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentEqualsVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentEqualsVisitorGenerator.java
@@ -21,8 +21,6 @@
 
 package com.github.javaparser.generator.core.visitor;
 
-import static com.github.javaparser.utils.CodeGenerationUtils.f;
-
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -31,6 +29,8 @@ import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SourceRoot;
+
+import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
 public class NoCommentEqualsVisitorGenerator extends VisitorGenerator {
 
@@ -52,7 +52,7 @@ public class NoCommentEqualsVisitorGenerator extends VisitorGenerator {
 
             body.addStatement(f("final %s n2 = (%s) arg;", node.getTypeName(), node.getTypeName()));
 
-            for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
+            for (PropertyMetaModel field : getAllPropertyMetaModels(node)) {
                 final String getter = field.getGetterMethodName() + "()";
                 if (field.equals(JavaParserMetaModel.nodeMetaModel.commentPropertyMetaModel))
                     continue;

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
@@ -21,8 +21,6 @@
 
 package com.github.javaparser.generator.core.visitor;
 
-import java.util.List;
-
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -32,6 +30,8 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 import com.github.javaparser.utils.SeparatedItemStringBuilder;
 import com.github.javaparser.utils.SourceRoot;
+
+import java.util.List;
 
 import static com.github.javaparser.StaticJavaParser.parseStatement;
 
@@ -50,7 +50,7 @@ public class NoCommentHashCodeVisitorGenerator extends VisitorGenerator {
         body.getStatements().clear();
 
         final SeparatedItemStringBuilder builder = new SeparatedItemStringBuilder("return ", "* 31 +", ";");
-        final List<PropertyMetaModel> propertyMetaModels = node.getAllPropertyMetaModels();
+        final List<PropertyMetaModel> propertyMetaModels = getAllPropertyMetaModels(node);
         if (node.equals(JavaParserMetaModel.lineCommentMetaModel)
                 || node.equals(JavaParserMetaModel.blockCommentMetaModel)
                 || node.equals(JavaParserMetaModel.javadocCommentMetaModel) || propertyMetaModels.isEmpty()) {

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/VoidVisitorAdapterGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/VoidVisitorAdapterGenerator.java
@@ -25,9 +25,9 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.generator.VisitorGenerator;
-import com.github.javaparser.utils.SourceRoot;
 import com.github.javaparser.metamodel.BaseNodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.utils.SourceRoot;
 
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
@@ -46,7 +46,7 @@ public class VoidVisitorAdapterGenerator extends VisitorGenerator {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
-        for (PropertyMetaModel field : node.getAllPropertyMetaModels()) {
+        for (PropertyMetaModel field : getAllPropertyMetaModels(node)) {
             final String getter = field.getGetterMethodName() + "()";
             if (field.getNodeReference().isPresent()) {
                 if (field.isOptional() && field.isNodeList()) {

--- a/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/visitor_scenarios.story
+++ b/javaparser-core-testing-bdd/src/test/resources/com/github/javaparser/visitor_scenarios.story
@@ -46,7 +46,7 @@ public class ToUpperClass {
     }
 }
 When the CompilationUnit is visited by the variable name collector visitor
-Then the collected variable name is "exception;zero;"
+Then the collected variable name is "zero;exception;"
 
 
 Scenario: A class with a try statement is visited using by a GenericVisitorAdapter

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -22,11 +22,15 @@ package com.github.javaparser.ast.visitor;
 
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
-import com.github.javaparser.ast.comments.*;
+import com.github.javaparser.ast.comments.BlockComment;
+import com.github.javaparser.ast.comments.Comment;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
+
 import java.util.Optional;
 
 /**
@@ -37,11 +41,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(final CompilationUnit n, final Object arg) {
-        NodeList<ImportDeclaration> imports = cloneList(n.getImports(), arg);
-        ModuleDeclaration module = cloneNode(n.getModule(), arg);
-        PackageDeclaration packageDeclaration = cloneNode(n.getPackageDeclaration(), arg);
-        NodeList<TypeDeclaration<?>> types = cloneList(n.getTypes(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<TypeDeclaration<?>> types = cloneList(n.getTypes(), arg);
+        PackageDeclaration packageDeclaration = cloneNode(n.getPackageDeclaration(), arg);
+        ModuleDeclaration module = cloneNode(n.getModule(), arg);
+        NodeList<ImportDeclaration> imports = cloneList(n.getImports(), arg);
         CompilationUnit r = new CompilationUnit(n.getTokenRange().orElse(null), packageDeclaration, imports, types, module);
         n.getStorage().ifPresent(s -> r.setStorage(s.getPath(), s.getEncoding()));
         r.setComment(comment);
@@ -53,9 +57,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     @Generated("com.github.javaparser.generator.core.visitor.CloneVisitorGenerator")
     public Visitable visit(final PackageDeclaration n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         PackageDeclaration r = new PackageDeclaration(n.getTokenRange().orElse(null), annotations, name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -65,10 +69,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final TypeParameter n, final Object arg) {
-        SimpleName name = cloneNode(n.getName(), arg);
-        NodeList<ClassOrInterfaceType> typeBound = cloneList(n.getTypeBound(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        NodeList<ClassOrInterfaceType> typeBound = cloneList(n.getTypeBound(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
         TypeParameter r = new TypeParameter(n.getTokenRange().orElse(null), name, typeBound, annotations);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -98,14 +102,14 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ClassOrInterfaceDeclaration n, final Object arg) {
-        NodeList<ClassOrInterfaceType> extendedTypes = cloneList(n.getExtendedTypes(), arg);
-        NodeList<ClassOrInterfaceType> implementedTypes = cloneList(n.getImplementedTypes(), arg);
-        NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
-        NodeList<BodyDeclaration<?>> members = cloneList(n.getMembers(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        NodeList<BodyDeclaration<?>> members = cloneList(n.getMembers(), arg);
+        NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
+        NodeList<ClassOrInterfaceType> implementedTypes = cloneList(n.getImplementedTypes(), arg);
+        NodeList<ClassOrInterfaceType> extendedTypes = cloneList(n.getExtendedTypes(), arg);
         ClassOrInterfaceDeclaration r = new ClassOrInterfaceDeclaration(n.getTokenRange().orElse(null), modifiers, annotations, n.isInterface(), name, typeParameters, extendedTypes, implementedTypes, members);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -115,13 +119,13 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final EnumDeclaration n, final Object arg) {
-        NodeList<EnumConstantDeclaration> entries = cloneList(n.getEntries(), arg);
-        NodeList<ClassOrInterfaceType> implementedTypes = cloneList(n.getImplementedTypes(), arg);
-        NodeList<BodyDeclaration<?>> members = cloneList(n.getMembers(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        NodeList<BodyDeclaration<?>> members = cloneList(n.getMembers(), arg);
+        NodeList<ClassOrInterfaceType> implementedTypes = cloneList(n.getImplementedTypes(), arg);
+        NodeList<EnumConstantDeclaration> entries = cloneList(n.getEntries(), arg);
         EnumDeclaration r = new EnumDeclaration(n.getTokenRange().orElse(null), modifiers, annotations, name, implementedTypes, entries, members);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -131,11 +135,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final EnumConstantDeclaration n, final Object arg) {
-        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
-        NodeList<BodyDeclaration<?>> classBody = cloneList(n.getClassBody(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<BodyDeclaration<?>> classBody = cloneList(n.getClassBody(), arg);
+        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
         EnumConstantDeclaration r = new EnumConstantDeclaration(n.getTokenRange().orElse(null), annotations, name, arguments, classBody);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -145,11 +149,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final AnnotationDeclaration n, final Object arg) {
-        NodeList<BodyDeclaration<?>> members = cloneList(n.getMembers(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        NodeList<BodyDeclaration<?>> members = cloneList(n.getMembers(), arg);
         AnnotationDeclaration r = new AnnotationDeclaration(n.getTokenRange().orElse(null), modifiers, annotations, name, members);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -159,12 +163,12 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final AnnotationMemberDeclaration n, final Object arg) {
-        Expression defaultValue = cloneNode(n.getDefaultValue(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        Type type = cloneNode(n.getType(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        Type type = cloneNode(n.getType(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        Expression defaultValue = cloneNode(n.getDefaultValue(), arg);
         AnnotationMemberDeclaration r = new AnnotationMemberDeclaration(n.getTokenRange().orElse(null), modifiers, annotations, type, name, defaultValue);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -174,10 +178,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final FieldDeclaration n, final Object arg) {
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        NodeList<VariableDeclarator> variables = cloneList(n.getVariables(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        NodeList<VariableDeclarator> variables = cloneList(n.getVariables(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
         FieldDeclaration r = new FieldDeclaration(n.getTokenRange().orElse(null), modifiers, annotations, variables);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -187,10 +191,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final VariableDeclarator n, final Object arg) {
-        Expression initializer = cloneNode(n.getInitializer(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Type type = cloneNode(n.getType(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        Expression initializer = cloneNode(n.getInitializer(), arg);
         VariableDeclarator r = new VariableDeclarator(n.getTokenRange().orElse(null), type, name, initializer);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -200,15 +204,15 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ConstructorDeclaration n, final Object arg) {
-        BlockStmt body = cloneNode(n.getBody(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        NodeList<Parameter> parameters = cloneList(n.getParameters(), arg);
-        ReceiverParameter receiverParameter = cloneNode(n.getReceiverParameter(), arg);
-        NodeList<ReferenceType> thrownExceptions = cloneList(n.getThrownExceptions(), arg);
-        NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
+        NodeList<ReferenceType> thrownExceptions = cloneList(n.getThrownExceptions(), arg);
+        ReceiverParameter receiverParameter = cloneNode(n.getReceiverParameter(), arg);
+        NodeList<Parameter> parameters = cloneList(n.getParameters(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        BlockStmt body = cloneNode(n.getBody(), arg);
         ConstructorDeclaration r = new ConstructorDeclaration(n.getTokenRange().orElse(null), modifiers, annotations, typeParameters, name, parameters, thrownExceptions, body, receiverParameter);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -218,16 +222,16 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final MethodDeclaration n, final Object arg) {
-        BlockStmt body = cloneNode(n.getBody(), arg);
-        Type type = cloneNode(n.getType(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        NodeList<Parameter> parameters = cloneList(n.getParameters(), arg);
-        ReceiverParameter receiverParameter = cloneNode(n.getReceiverParameter(), arg);
-        NodeList<ReferenceType> thrownExceptions = cloneList(n.getThrownExceptions(), arg);
-        NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        NodeList<TypeParameter> typeParameters = cloneList(n.getTypeParameters(), arg);
+        NodeList<ReferenceType> thrownExceptions = cloneList(n.getThrownExceptions(), arg);
+        ReceiverParameter receiverParameter = cloneNode(n.getReceiverParameter(), arg);
+        NodeList<Parameter> parameters = cloneList(n.getParameters(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        Type type = cloneNode(n.getType(), arg);
+        BlockStmt body = cloneNode(n.getBody(), arg);
         MethodDeclaration r = new MethodDeclaration(n.getTokenRange().orElse(null), modifiers, annotations, typeParameters, type, name, parameters, thrownExceptions, body, receiverParameter);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -237,12 +241,12 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final Parameter n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        Type type = cloneNode(n.getType(), arg);
-        NodeList<AnnotationExpr> varArgsAnnotations = cloneList(n.getVarArgsAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> varArgsAnnotations = cloneList(n.getVarArgsAnnotations(), arg);
+        Type type = cloneNode(n.getType(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Parameter r = new Parameter(n.getTokenRange().orElse(null), modifiers, annotations, type, n.isVarArgs(), varArgsAnnotations, name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -252,9 +256,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final InitializerDeclaration n, final Object arg) {
-        BlockStmt body = cloneNode(n.getBody(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        BlockStmt body = cloneNode(n.getBody(), arg);
         InitializerDeclaration r = new InitializerDeclaration(n.getTokenRange().orElse(null), n.isStatic(), body);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -274,11 +278,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ClassOrInterfaceType n, final Object arg) {
-        SimpleName name = cloneNode(n.getName(), arg);
-        ClassOrInterfaceType scope = cloneNode(n.getScope(), arg);
-        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
+        ClassOrInterfaceType scope = cloneNode(n.getScope(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
         ClassOrInterfaceType r = new ClassOrInterfaceType(n.getTokenRange().orElse(null), scope, name, typeArguments, annotations);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -288,8 +292,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final PrimitiveType n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         PrimitiveType r = new PrimitiveType(n.getTokenRange().orElse(null), n.getType(), annotations);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -299,9 +303,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ArrayType n, final Object arg) {
-        Type componentType = cloneNode(n.getComponentType(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        Type componentType = cloneNode(n.getComponentType(), arg);
         ArrayType r = new ArrayType(n.getTokenRange().orElse(null), componentType, n.getOrigin(), annotations);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -311,9 +315,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ArrayCreationLevel n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
-        Expression dimension = cloneNode(n.getDimension(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression dimension = cloneNode(n.getDimension(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         ArrayCreationLevel r = new ArrayCreationLevel(n.getTokenRange().orElse(null), dimension, annotations);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -323,9 +327,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final IntersectionType n, final Object arg) {
-        NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
         IntersectionType r = new IntersectionType(n.getTokenRange().orElse(null), elements);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -335,9 +339,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final UnionType n, final Object arg) {
-        NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
         UnionType r = new UnionType(n.getTokenRange().orElse(null), elements);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -347,8 +351,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final VoidType n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         VoidType r = new VoidType(n.getTokenRange().orElse(null));
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -358,10 +362,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final WildcardType n, final Object arg) {
-        ReferenceType extendedType = cloneNode(n.getExtendedType(), arg);
-        ReferenceType superType = cloneNode(n.getSuperType(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
+        ReferenceType superType = cloneNode(n.getSuperType(), arg);
+        ReferenceType extendedType = cloneNode(n.getExtendedType(), arg);
         WildcardType r = new WildcardType(n.getTokenRange().orElse(null), extendedType, superType, annotations);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -371,8 +375,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final UnknownType n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         UnknownType r = new UnknownType(n.getTokenRange().orElse(null));
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -382,9 +386,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ArrayAccessExpr n, final Object arg) {
-        Expression index = cloneNode(n.getIndex(), arg);
-        Expression name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression name = cloneNode(n.getName(), arg);
+        Expression index = cloneNode(n.getIndex(), arg);
         ArrayAccessExpr r = new ArrayAccessExpr(n.getTokenRange().orElse(null), name, index);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -394,10 +398,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ArrayCreationExpr n, final Object arg) {
-        Type elementType = cloneNode(n.getElementType(), arg);
-        ArrayInitializerExpr initializer = cloneNode(n.getInitializer(), arg);
-        NodeList<ArrayCreationLevel> levels = cloneList(n.getLevels(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<ArrayCreationLevel> levels = cloneList(n.getLevels(), arg);
+        ArrayInitializerExpr initializer = cloneNode(n.getInitializer(), arg);
+        Type elementType = cloneNode(n.getElementType(), arg);
         ArrayCreationExpr r = new ArrayCreationExpr(n.getTokenRange().orElse(null), elementType, levels, initializer);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -407,8 +411,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ArrayInitializerExpr n, final Object arg) {
-        NodeList<Expression> values = cloneList(n.getValues(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Expression> values = cloneList(n.getValues(), arg);
         ArrayInitializerExpr r = new ArrayInitializerExpr(n.getTokenRange().orElse(null), values);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -418,9 +422,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final AssignExpr n, final Object arg) {
-        Expression target = cloneNode(n.getTarget(), arg);
-        Expression value = cloneNode(n.getValue(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression value = cloneNode(n.getValue(), arg);
+        Expression target = cloneNode(n.getTarget(), arg);
         AssignExpr r = new AssignExpr(n.getTokenRange().orElse(null), target, value, n.getOperator());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -430,9 +434,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final BinaryExpr n, final Object arg) {
-        Expression left = cloneNode(n.getLeft(), arg);
-        Expression right = cloneNode(n.getRight(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression right = cloneNode(n.getRight(), arg);
+        Expression left = cloneNode(n.getLeft(), arg);
         BinaryExpr r = new BinaryExpr(n.getTokenRange().orElse(null), left, right, n.getOperator());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -442,9 +446,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final CastExpr n, final Object arg) {
-        Expression expression = cloneNode(n.getExpression(), arg);
-        Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Type type = cloneNode(n.getType(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
         CastExpr r = new CastExpr(n.getTokenRange().orElse(null), type, expression);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -454,8 +458,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ClassExpr n, final Object arg) {
-        Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Type type = cloneNode(n.getType(), arg);
         ClassExpr r = new ClassExpr(n.getTokenRange().orElse(null), type);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -465,10 +469,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ConditionalExpr n, final Object arg) {
-        Expression condition = cloneNode(n.getCondition(), arg);
-        Expression elseExpr = cloneNode(n.getElseExpr(), arg);
-        Expression thenExpr = cloneNode(n.getThenExpr(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression thenExpr = cloneNode(n.getThenExpr(), arg);
+        Expression elseExpr = cloneNode(n.getElseExpr(), arg);
+        Expression condition = cloneNode(n.getCondition(), arg);
         ConditionalExpr r = new ConditionalExpr(n.getTokenRange().orElse(null), condition, thenExpr, elseExpr);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -478,8 +482,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final EnclosedExpr n, final Object arg) {
-        Expression inner = cloneNode(n.getInner(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression inner = cloneNode(n.getInner(), arg);
         EnclosedExpr r = new EnclosedExpr(n.getTokenRange().orElse(null), inner);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -489,10 +493,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final FieldAccessExpr n, final Object arg) {
-        SimpleName name = cloneNode(n.getName(), arg);
-        Expression scope = cloneNode(n.getScope(), arg);
-        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
+        Expression scope = cloneNode(n.getScope(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
         FieldAccessExpr r = new FieldAccessExpr(n.getTokenRange().orElse(null), scope, typeArguments, name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -502,10 +506,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final InstanceOfExpr n, final Object arg) {
-        Expression expression = cloneNode(n.getExpression(), arg);
-        PatternExpr pattern = cloneNode(n.getPattern(), arg);
-        ReferenceType type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        ReferenceType type = cloneNode(n.getType(), arg);
+        PatternExpr pattern = cloneNode(n.getPattern(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
         InstanceOfExpr r = new InstanceOfExpr(n.getTokenRange().orElse(null), expression, type, pattern);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -585,11 +589,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final MethodCallExpr n, final Object arg) {
-        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
-        SimpleName name = cloneNode(n.getName(), arg);
-        Expression scope = cloneNode(n.getScope(), arg);
-        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
+        Expression scope = cloneNode(n.getScope(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
+        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
         MethodCallExpr r = new MethodCallExpr(n.getTokenRange().orElse(null), scope, typeArguments, name, arguments);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -599,8 +603,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final NameExpr n, final Object arg) {
-        SimpleName name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
         NameExpr r = new NameExpr(n.getTokenRange().orElse(null), name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -610,12 +614,12 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ObjectCreationExpr n, final Object arg) {
-        NodeList<BodyDeclaration<?>> anonymousClassBody = cloneList(n.getAnonymousClassBody().orElse(null), arg);
-        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
-        Expression scope = cloneNode(n.getScope(), arg);
-        ClassOrInterfaceType type = cloneNode(n.getType(), arg);
-        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
+        ClassOrInterfaceType type = cloneNode(n.getType(), arg);
+        Expression scope = cloneNode(n.getScope(), arg);
+        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
+        NodeList<BodyDeclaration<?>> anonymousClassBody = cloneList(n.getAnonymousClassBody().orElse(null), arg);
         ObjectCreationExpr r = new ObjectCreationExpr(n.getTokenRange().orElse(null), scope, type, typeArguments, arguments, anonymousClassBody);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -625,8 +629,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final Name n, final Object arg) {
-        Name qualifier = cloneNode(n.getQualifier(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name qualifier = cloneNode(n.getQualifier(), arg);
         Name r = new Name(n.getTokenRange().orElse(null), qualifier, n.getIdentifier());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -646,8 +650,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ThisExpr n, final Object arg) {
-        Name typeName = cloneNode(n.getTypeName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name typeName = cloneNode(n.getTypeName(), arg);
         ThisExpr r = new ThisExpr(n.getTokenRange().orElse(null), typeName);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -657,8 +661,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final SuperExpr n, final Object arg) {
-        Name typeName = cloneNode(n.getTypeName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name typeName = cloneNode(n.getTypeName(), arg);
         SuperExpr r = new SuperExpr(n.getTokenRange().orElse(null), typeName);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -668,8 +672,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final UnaryExpr n, final Object arg) {
-        Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
         UnaryExpr r = new UnaryExpr(n.getTokenRange().orElse(null), expression, n.getOperator());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -679,10 +683,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final VariableDeclarationExpr n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        NodeList<VariableDeclarator> variables = cloneList(n.getVariables(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<VariableDeclarator> variables = cloneList(n.getVariables(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         VariableDeclarationExpr r = new VariableDeclarationExpr(n.getTokenRange().orElse(null), modifiers, annotations, variables);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -692,8 +696,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final MarkerAnnotationExpr n, final Object arg) {
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
         MarkerAnnotationExpr r = new MarkerAnnotationExpr(n.getTokenRange().orElse(null), name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -703,9 +707,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final SingleMemberAnnotationExpr n, final Object arg) {
-        Expression memberValue = cloneNode(n.getMemberValue(), arg);
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        Expression memberValue = cloneNode(n.getMemberValue(), arg);
         SingleMemberAnnotationExpr r = new SingleMemberAnnotationExpr(n.getTokenRange().orElse(null), name, memberValue);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -715,9 +719,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final NormalAnnotationExpr n, final Object arg) {
-        NodeList<MemberValuePair> pairs = cloneList(n.getPairs(), arg);
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        NodeList<MemberValuePair> pairs = cloneList(n.getPairs(), arg);
         NormalAnnotationExpr r = new NormalAnnotationExpr(n.getTokenRange().orElse(null), name, pairs);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -727,9 +731,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final MemberValuePair n, final Object arg) {
-        SimpleName name = cloneNode(n.getName(), arg);
-        Expression value = cloneNode(n.getValue(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression value = cloneNode(n.getValue(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
         MemberValuePair r = new MemberValuePair(n.getTokenRange().orElse(null), name, value);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -739,10 +743,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ExplicitConstructorInvocationStmt n, final Object arg) {
-        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
-        Expression expression = cloneNode(n.getExpression(), arg);
-        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
+        NodeList<Expression> arguments = cloneList(n.getArguments(), arg);
         ExplicitConstructorInvocationStmt r = new ExplicitConstructorInvocationStmt(n.getTokenRange().orElse(null), typeArguments, n.isThis(), expression, arguments);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -752,8 +756,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final LocalClassDeclarationStmt n, final Object arg) {
-        ClassOrInterfaceDeclaration classDeclaration = cloneNode(n.getClassDeclaration(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        ClassOrInterfaceDeclaration classDeclaration = cloneNode(n.getClassDeclaration(), arg);
         LocalClassDeclarationStmt r = new LocalClassDeclarationStmt(n.getTokenRange().orElse(null), classDeclaration);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -763,9 +767,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final AssertStmt n, final Object arg) {
-        Expression check = cloneNode(n.getCheck(), arg);
-        Expression message = cloneNode(n.getMessage(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression message = cloneNode(n.getMessage(), arg);
+        Expression check = cloneNode(n.getCheck(), arg);
         AssertStmt r = new AssertStmt(n.getTokenRange().orElse(null), check, message);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -775,8 +779,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final BlockStmt n, final Object arg) {
-        NodeList<Statement> statements = cloneList(n.getStatements(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Statement> statements = cloneList(n.getStatements(), arg);
         BlockStmt r = new BlockStmt(n.getTokenRange().orElse(null), statements);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -786,9 +790,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final LabeledStmt n, final Object arg) {
-        SimpleName label = cloneNode(n.getLabel(), arg);
-        Statement statement = cloneNode(n.getStatement(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Statement statement = cloneNode(n.getStatement(), arg);
+        SimpleName label = cloneNode(n.getLabel(), arg);
         LabeledStmt r = new LabeledStmt(n.getTokenRange().orElse(null), label, statement);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -808,8 +812,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ExpressionStmt n, final Object arg) {
-        Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
         ExpressionStmt r = new ExpressionStmt(n.getTokenRange().orElse(null), expression);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -819,9 +823,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final SwitchStmt n, final Object arg) {
-        NodeList<SwitchEntry> entries = cloneList(n.getEntries(), arg);
-        Expression selector = cloneNode(n.getSelector(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression selector = cloneNode(n.getSelector(), arg);
+        NodeList<SwitchEntry> entries = cloneList(n.getEntries(), arg);
         SwitchStmt r = new SwitchStmt(n.getTokenRange().orElse(null), selector, entries);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -831,9 +835,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final SwitchEntry n, final Object arg) {
-        NodeList<Expression> labels = cloneList(n.getLabels(), arg);
-        NodeList<Statement> statements = cloneList(n.getStatements(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Statement> statements = cloneList(n.getStatements(), arg);
+        NodeList<Expression> labels = cloneList(n.getLabels(), arg);
         SwitchEntry r = new SwitchEntry(n.getTokenRange().orElse(null), labels, n.getType(), statements);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -843,8 +847,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final BreakStmt n, final Object arg) {
-        SimpleName label = cloneNode(n.getLabel(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        SimpleName label = cloneNode(n.getLabel(), arg);
         BreakStmt r = new BreakStmt(n.getTokenRange().orElse(null), label);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -854,8 +858,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ReturnStmt n, final Object arg) {
-        Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
         ReturnStmt r = new ReturnStmt(n.getTokenRange().orElse(null), expression);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -865,10 +869,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final IfStmt n, final Object arg) {
-        Expression condition = cloneNode(n.getCondition(), arg);
-        Statement elseStmt = cloneNode(n.getElseStmt(), arg);
-        Statement thenStmt = cloneNode(n.getThenStmt(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Statement thenStmt = cloneNode(n.getThenStmt(), arg);
+        Statement elseStmt = cloneNode(n.getElseStmt(), arg);
+        Expression condition = cloneNode(n.getCondition(), arg);
         IfStmt r = new IfStmt(n.getTokenRange().orElse(null), condition, thenStmt, elseStmt);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -878,9 +882,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final WhileStmt n, final Object arg) {
-        Statement body = cloneNode(n.getBody(), arg);
-        Expression condition = cloneNode(n.getCondition(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression condition = cloneNode(n.getCondition(), arg);
+        Statement body = cloneNode(n.getBody(), arg);
         WhileStmt r = new WhileStmt(n.getTokenRange().orElse(null), condition, body);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -890,8 +894,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ContinueStmt n, final Object arg) {
-        SimpleName label = cloneNode(n.getLabel(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        SimpleName label = cloneNode(n.getLabel(), arg);
         ContinueStmt r = new ContinueStmt(n.getTokenRange().orElse(null), label);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -901,9 +905,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final DoStmt n, final Object arg) {
-        Statement body = cloneNode(n.getBody(), arg);
-        Expression condition = cloneNode(n.getCondition(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression condition = cloneNode(n.getCondition(), arg);
+        Statement body = cloneNode(n.getBody(), arg);
         DoStmt r = new DoStmt(n.getTokenRange().orElse(null), body, condition);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -913,10 +917,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ForEachStmt n, final Object arg) {
-        Statement body = cloneNode(n.getBody(), arg);
-        Expression iterable = cloneNode(n.getIterable(), arg);
-        VariableDeclarationExpr variable = cloneNode(n.getVariable(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        VariableDeclarationExpr variable = cloneNode(n.getVariable(), arg);
+        Expression iterable = cloneNode(n.getIterable(), arg);
+        Statement body = cloneNode(n.getBody(), arg);
         ForEachStmt r = new ForEachStmt(n.getTokenRange().orElse(null), variable, iterable, body);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -926,11 +930,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ForStmt n, final Object arg) {
-        Statement body = cloneNode(n.getBody(), arg);
-        Expression compare = cloneNode(n.getCompare(), arg);
-        NodeList<Expression> initialization = cloneList(n.getInitialization(), arg);
-        NodeList<Expression> update = cloneList(n.getUpdate(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Expression> update = cloneList(n.getUpdate(), arg);
+        NodeList<Expression> initialization = cloneList(n.getInitialization(), arg);
+        Expression compare = cloneNode(n.getCompare(), arg);
+        Statement body = cloneNode(n.getBody(), arg);
         ForStmt r = new ForStmt(n.getTokenRange().orElse(null), initialization, compare, update, body);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -940,8 +944,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ThrowStmt n, final Object arg) {
-        Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
         ThrowStmt r = new ThrowStmt(n.getTokenRange().orElse(null), expression);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -951,9 +955,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final SynchronizedStmt n, final Object arg) {
-        BlockStmt body = cloneNode(n.getBody(), arg);
-        Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
+        BlockStmt body = cloneNode(n.getBody(), arg);
         SynchronizedStmt r = new SynchronizedStmt(n.getTokenRange().orElse(null), expression, body);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -963,11 +967,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final TryStmt n, final Object arg) {
-        NodeList<CatchClause> catchClauses = cloneList(n.getCatchClauses(), arg);
-        BlockStmt finallyBlock = cloneNode(n.getFinallyBlock(), arg);
-        NodeList<Expression> resources = cloneList(n.getResources(), arg);
-        BlockStmt tryBlock = cloneNode(n.getTryBlock(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        BlockStmt tryBlock = cloneNode(n.getTryBlock(), arg);
+        NodeList<Expression> resources = cloneList(n.getResources(), arg);
+        BlockStmt finallyBlock = cloneNode(n.getFinallyBlock(), arg);
+        NodeList<CatchClause> catchClauses = cloneList(n.getCatchClauses(), arg);
         TryStmt r = new TryStmt(n.getTokenRange().orElse(null), resources, tryBlock, catchClauses, finallyBlock);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -977,9 +981,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final CatchClause n, final Object arg) {
-        BlockStmt body = cloneNode(n.getBody(), arg);
-        Parameter parameter = cloneNode(n.getParameter(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Parameter parameter = cloneNode(n.getParameter(), arg);
+        BlockStmt body = cloneNode(n.getBody(), arg);
         CatchClause r = new CatchClause(n.getTokenRange().orElse(null), parameter, body);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -989,9 +993,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final LambdaExpr n, final Object arg) {
-        Statement body = cloneNode(n.getBody(), arg);
-        NodeList<Parameter> parameters = cloneList(n.getParameters(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Parameter> parameters = cloneList(n.getParameters(), arg);
+        Statement body = cloneNode(n.getBody(), arg);
         LambdaExpr r = new LambdaExpr(n.getTokenRange().orElse(null), parameters, body, n.isEnclosingParameters());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1001,9 +1005,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final MethodReferenceExpr n, final Object arg) {
-        Expression scope = cloneNode(n.getScope(), arg);
-        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Type> typeArguments = cloneList(n.getTypeArguments().orElse(null), arg);
+        Expression scope = cloneNode(n.getScope(), arg);
         MethodReferenceExpr r = new MethodReferenceExpr(n.getTokenRange().orElse(null), scope, typeArguments, n.getIdentifier());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1013,8 +1017,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final TypeExpr n, final Object arg) {
-        Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Type type = cloneNode(n.getType(), arg);
         TypeExpr r = new TypeExpr(n.getTokenRange().orElse(null), type);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1036,8 +1040,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Node visit(final ImportDeclaration n, final Object arg) {
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
         ImportDeclaration r = new ImportDeclaration(n.getTokenRange().orElse(null), name, n.isStatic(), n.isAsterisk());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1047,10 +1051,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ModuleDeclaration n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
-        NodeList<ModuleDirective> directives = cloneList(n.getDirectives(), arg);
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        NodeList<ModuleDirective> directives = cloneList(n.getDirectives(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         ModuleDeclaration r = new ModuleDeclaration(n.getTokenRange().orElse(null), annotations, name, n.isOpen(), directives);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1060,9 +1064,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ModuleRequiresDirective n, final Object arg) {
-        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
         ModuleRequiresDirective r = new ModuleRequiresDirective(n.getTokenRange().orElse(null), modifiers, name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1103,9 +1107,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ModuleExportsDirective n, final Object arg) {
-        NodeList<Name> moduleNames = cloneList(n.getModuleNames(), arg);
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        NodeList<Name> moduleNames = cloneList(n.getModuleNames(), arg);
         ModuleExportsDirective r = new ModuleExportsDirective(n.getTokenRange().orElse(null), name, moduleNames);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1115,9 +1119,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ModuleProvidesDirective n, final Object arg) {
-        Name name = cloneNode(n.getName(), arg);
-        NodeList<Name> with = cloneList(n.getWith(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<Name> with = cloneList(n.getWith(), arg);
+        Name name = cloneNode(n.getName(), arg);
         ModuleProvidesDirective r = new ModuleProvidesDirective(n.getTokenRange().orElse(null), name, with);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1127,8 +1131,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ModuleUsesDirective n, final Object arg) {
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
         ModuleUsesDirective r = new ModuleUsesDirective(n.getTokenRange().orElse(null), name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1138,9 +1142,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ModuleOpensDirective n, final Object arg) {
-        NodeList<Name> moduleNames = cloneList(n.getModuleNames(), arg);
-        Name name = cloneNode(n.getName(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        NodeList<Name> moduleNames = cloneList(n.getModuleNames(), arg);
         ModuleOpensDirective r = new ModuleOpensDirective(n.getTokenRange().orElse(null), name, moduleNames);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1160,10 +1164,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final ReceiverParameter n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
-        Name name = cloneNode(n.getName(), arg);
-        Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Type type = cloneNode(n.getType(), arg);
+        Name name = cloneNode(n.getName(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         ReceiverParameter r = new ReceiverParameter(n.getTokenRange().orElse(null), annotations, type, name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1173,8 +1177,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final VarType n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         VarType r = new VarType(n.getTokenRange().orElse(null));
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1194,9 +1198,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final SwitchExpr n, final Object arg) {
-        NodeList<SwitchEntry> entries = cloneList(n.getEntries(), arg);
-        Expression selector = cloneNode(n.getSelector(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression selector = cloneNode(n.getSelector(), arg);
+        NodeList<SwitchEntry> entries = cloneList(n.getEntries(), arg);
         SwitchExpr r = new SwitchExpr(n.getTokenRange().orElse(null), selector, entries);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1212,8 +1216,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final YieldStmt n, final Object arg) {
-        Expression expression = cloneNode(n.getExpression(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        Expression expression = cloneNode(n.getExpression(), arg);
         YieldStmt r = new YieldStmt(n.getTokenRange().orElse(null), expression);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
@@ -1233,9 +1237,9 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final PatternExpr n, final Object arg) {
-        SimpleName name = cloneNode(n.getName(), arg);
-        ReferenceType type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
+        ReferenceType type = cloneNode(n.getType(), arg);
+        SimpleName name = cloneNode(n.getName(), arg);
         PatternExpr r = new PatternExpr(n.getTokenRange().orElse(null), type, name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -132,15 +133,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final CompilationUnit n, final Visitable arg) {
         final CompilationUnit n2 = (CompilationUnit) arg;
-        if (!nodesEquals(n.getImports(), n2.getImports()))
-            return false;
-        if (!nodeEquals(n.getModule(), n2.getModule()))
-            return false;
-        if (!nodeEquals(n.getPackageDeclaration(), n2.getPackageDeclaration()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getTypes(), n2.getTypes()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getPackageDeclaration(), n2.getPackageDeclaration()))
+            return false;
+        if (!nodeEquals(n.getModule(), n2.getModule()))
+            return false;
+        if (!nodesEquals(n.getImports(), n2.getImports()))
             return false;
         return true;
     }
@@ -148,11 +149,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final PackageDeclaration n, final Visitable arg) {
         final PackageDeclaration n2 = (PackageDeclaration) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -160,13 +161,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final TypeParameter n, final Visitable arg) {
         final TypeParameter n2 = (TypeParameter) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodesEquals(n.getTypeBound(), n2.getTypeBound()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getTypeBound(), n2.getTypeBound()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -174,9 +175,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final LineComment n, final Visitable arg) {
         final LineComment n2 = (LineComment) arg;
-        if (!objEquals(n.getContent(), n2.getContent()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getContent(), n2.getContent()))
             return false;
         return true;
     }
@@ -184,9 +185,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final BlockComment n, final Visitable arg) {
         final BlockComment n2 = (BlockComment) arg;
-        if (!objEquals(n.getContent(), n2.getContent()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getContent(), n2.getContent()))
             return false;
         return true;
     }
@@ -194,23 +195,23 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ClassOrInterfaceDeclaration n, final Visitable arg) {
         final ClassOrInterfaceDeclaration n2 = (ClassOrInterfaceDeclaration) arg;
-        if (!nodesEquals(n.getExtendedTypes(), n2.getExtendedTypes()))
-            return false;
-        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
-            return false;
-        if (!objEquals(n.isInterface(), n2.isInterface()))
-            return false;
-        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
-            return false;
-        if (!nodesEquals(n.getMembers(), n2.getMembers()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodesEquals(n.getMembers(), n2.getMembers()))
+            return false;
+        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
+            return false;
+        if (!objEquals(n.isInterface(), n2.isInterface()))
+            return false;
+        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
+            return false;
+        if (!nodesEquals(n.getExtendedTypes(), n2.getExtendedTypes()))
             return false;
         return true;
     }
@@ -218,19 +219,19 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final EnumDeclaration n, final Visitable arg) {
         final EnumDeclaration n2 = (EnumDeclaration) arg;
-        if (!nodesEquals(n.getEntries(), n2.getEntries()))
-            return false;
-        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
-            return false;
-        if (!nodesEquals(n.getMembers(), n2.getMembers()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodesEquals(n.getMembers(), n2.getMembers()))
+            return false;
+        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
+            return false;
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
             return false;
         return true;
     }
@@ -238,15 +239,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final EnumConstantDeclaration n, final Visitable arg) {
         final EnumConstantDeclaration n2 = (EnumConstantDeclaration) arg;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodesEquals(n.getClassBody(), n2.getClassBody()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getClassBody(), n2.getClassBody()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
             return false;
         return true;
     }
@@ -254,15 +255,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final AnnotationDeclaration n, final Visitable arg) {
         final AnnotationDeclaration n2 = (AnnotationDeclaration) arg;
-        if (!nodesEquals(n.getMembers(), n2.getMembers()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodesEquals(n.getMembers(), n2.getMembers()))
             return false;
         return true;
     }
@@ -270,17 +271,17 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final AnnotationMemberDeclaration n, final Visitable arg) {
         final AnnotationMemberDeclaration n2 = (AnnotationMemberDeclaration) arg;
-        if (!nodeEquals(n.getDefaultValue(), n2.getDefaultValue()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getType(), n2.getType()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodeEquals(n.getDefaultValue(), n2.getDefaultValue()))
             return false;
         return true;
     }
@@ -288,13 +289,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final FieldDeclaration n, final Visitable arg) {
         final FieldDeclaration n2 = (FieldDeclaration) arg;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodesEquals(n.getVariables(), n2.getVariables()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getVariables(), n2.getVariables()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
             return false;
         return true;
     }
@@ -302,13 +303,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final VariableDeclarator n, final Visitable arg) {
         final VariableDeclarator n2 = (VariableDeclarator) arg;
-        if (!nodeEquals(n.getInitializer(), n2.getInitializer()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodeEquals(n.getInitializer(), n2.getInitializer()))
             return false;
         return true;
     }
@@ -316,23 +317,23 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ConstructorDeclaration n, final Visitable arg) {
         final ConstructorDeclaration n2 = (ConstructorDeclaration) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodesEquals(n.getParameters(), n2.getParameters()))
-            return false;
-        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
-            return false;
-        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
-            return false;
-        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
+            return false;
+        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
+            return false;
+        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
+            return false;
+        if (!nodesEquals(n.getParameters(), n2.getParameters()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -340,25 +341,25 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final MethodDeclaration n, final Visitable arg) {
         final MethodDeclaration n2 = (MethodDeclaration) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodesEquals(n.getParameters(), n2.getParameters()))
-            return false;
-        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
-            return false;
-        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
-            return false;
-        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
+            return false;
+        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
+            return false;
+        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
+            return false;
+        if (!nodesEquals(n.getParameters(), n2.getParameters()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodeEquals(n.getType(), n2.getType()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -366,19 +367,19 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final Parameter n, final Visitable arg) {
         final Parameter n2 = (Parameter) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
-        if (!objEquals(n.isVarArgs(), n2.isVarArgs()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getVarArgsAnnotations(), n2.getVarArgsAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getType(), n2.getType()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!objEquals(n.isVarArgs(), n2.isVarArgs()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -386,13 +387,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final InitializerDeclaration n, final Visitable arg) {
         final InitializerDeclaration n2 = (InitializerDeclaration) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!objEquals(n.isStatic(), n2.isStatic()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.isStatic(), n2.isStatic()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -400,9 +401,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final JavadocComment n, final Visitable arg) {
         final JavadocComment n2 = (JavadocComment) arg;
-        if (!objEquals(n.getContent(), n2.getContent()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getContent(), n2.getContent()))
             return false;
         return true;
     }
@@ -410,15 +411,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ClassOrInterfaceType n, final Visitable arg) {
         final ClassOrInterfaceType n2 = (ClassOrInterfaceType) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodeEquals(n.getScope(), n2.getScope()))
-            return false;
-        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
+            return false;
+        if (!nodeEquals(n.getScope(), n2.getScope()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -426,11 +427,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final PrimitiveType n, final Visitable arg) {
         final PrimitiveType n2 = (PrimitiveType) arg;
-        if (!objEquals(n.getType(), n2.getType()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.getType(), n2.getType()))
             return false;
         return true;
     }
@@ -438,13 +439,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ArrayType n, final Visitable arg) {
         final ArrayType n2 = (ArrayType) arg;
-        if (!nodeEquals(n.getComponentType(), n2.getComponentType()))
-            return false;
-        if (!objEquals(n.getOrigin(), n2.getOrigin()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.getOrigin(), n2.getOrigin()))
+            return false;
+        if (!nodeEquals(n.getComponentType(), n2.getComponentType()))
             return false;
         return true;
     }
@@ -452,11 +453,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ArrayCreationLevel n, final Visitable arg) {
         final ArrayCreationLevel n2 = (ArrayCreationLevel) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getDimension(), n2.getDimension()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -464,11 +465,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final IntersectionType n, final Visitable arg) {
         final IntersectionType n2 = (IntersectionType) arg;
-        if (!nodesEquals(n.getElements(), n2.getElements()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getElements(), n2.getElements()))
             return false;
         return true;
     }
@@ -476,11 +477,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final UnionType n, final Visitable arg) {
         final UnionType n2 = (UnionType) arg;
-        if (!nodesEquals(n.getElements(), n2.getElements()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getElements(), n2.getElements()))
             return false;
         return true;
     }
@@ -488,9 +489,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final VoidType n, final Visitable arg) {
         final VoidType n2 = (VoidType) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -498,13 +499,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final WildcardType n, final Visitable arg) {
         final WildcardType n2 = (WildcardType) arg;
-        if (!nodeEquals(n.getExtendedType(), n2.getExtendedType()))
-            return false;
-        if (!nodeEquals(n.getSuperType(), n2.getSuperType()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getSuperType(), n2.getSuperType()))
+            return false;
+        if (!nodeEquals(n.getExtendedType(), n2.getExtendedType()))
             return false;
         return true;
     }
@@ -512,9 +513,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final UnknownType n, final Visitable arg) {
         final UnknownType n2 = (UnknownType) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -522,11 +523,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ArrayAccessExpr n, final Visitable arg) {
         final ArrayAccessExpr n2 = (ArrayAccessExpr) arg;
-        if (!nodeEquals(n.getIndex(), n2.getIndex()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getIndex(), n2.getIndex()))
             return false;
         return true;
     }
@@ -534,13 +535,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ArrayCreationExpr n, final Visitable arg) {
         final ArrayCreationExpr n2 = (ArrayCreationExpr) arg;
-        if (!nodeEquals(n.getElementType(), n2.getElementType()))
-            return false;
-        if (!nodeEquals(n.getInitializer(), n2.getInitializer()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getLevels(), n2.getLevels()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getInitializer(), n2.getInitializer()))
+            return false;
+        if (!nodeEquals(n.getElementType(), n2.getElementType()))
             return false;
         return true;
     }
@@ -548,9 +549,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ArrayInitializerExpr n, final Visitable arg) {
         final ArrayInitializerExpr n2 = (ArrayInitializerExpr) arg;
-        if (!nodesEquals(n.getValues(), n2.getValues()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodesEquals(n.getValues(), n2.getValues()))
             return false;
         return true;
     }
@@ -558,13 +559,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final AssignExpr n, final Visitable arg) {
         final AssignExpr n2 = (AssignExpr) arg;
-        if (!objEquals(n.getOperator(), n2.getOperator()))
-            return false;
-        if (!nodeEquals(n.getTarget(), n2.getTarget()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getValue(), n2.getValue()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getTarget(), n2.getTarget()))
+            return false;
+        if (!objEquals(n.getOperator(), n2.getOperator()))
             return false;
         return true;
     }
@@ -572,13 +573,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final BinaryExpr n, final Visitable arg) {
         final BinaryExpr n2 = (BinaryExpr) arg;
-        if (!nodeEquals(n.getLeft(), n2.getLeft()))
-            return false;
-        if (!objEquals(n.getOperator(), n2.getOperator()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getRight(), n2.getRight()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.getOperator(), n2.getOperator()))
+            return false;
+        if (!nodeEquals(n.getLeft(), n2.getLeft()))
             return false;
         return true;
     }
@@ -586,11 +587,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final CastExpr n, final Visitable arg) {
         final CastExpr n2 = (CastExpr) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -598,9 +599,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ClassExpr n, final Visitable arg) {
         final ClassExpr n2 = (ClassExpr) arg;
-        if (!nodeEquals(n.getType(), n2.getType()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getType(), n2.getType()))
             return false;
         return true;
     }
@@ -608,13 +609,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ConditionalExpr n, final Visitable arg) {
         final ConditionalExpr n2 = (ConditionalExpr) arg;
-        if (!nodeEquals(n.getCondition(), n2.getCondition()))
-            return false;
-        if (!nodeEquals(n.getElseExpr(), n2.getElseExpr()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getThenExpr(), n2.getThenExpr()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getElseExpr(), n2.getElseExpr()))
+            return false;
+        if (!nodeEquals(n.getCondition(), n2.getCondition()))
             return false;
         return true;
     }
@@ -622,9 +623,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final EnclosedExpr n, final Visitable arg) {
         final EnclosedExpr n2 = (EnclosedExpr) arg;
-        if (!nodeEquals(n.getInner(), n2.getInner()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getInner(), n2.getInner()))
             return false;
         return true;
     }
@@ -632,13 +633,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final FieldAccessExpr n, final Visitable arg) {
         final FieldAccessExpr n2 = (FieldAccessExpr) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodeEquals(n.getScope(), n2.getScope()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getScope(), n2.getScope()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -646,13 +647,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final InstanceOfExpr n, final Visitable arg) {
         final InstanceOfExpr n2 = (InstanceOfExpr) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
-        if (!nodeEquals(n.getPattern(), n2.getPattern()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getPattern(), n2.getPattern()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -660,9 +661,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final StringLiteralExpr n, final Visitable arg) {
         final StringLiteralExpr n2 = (StringLiteralExpr) arg;
-        if (!objEquals(n.getValue(), n2.getValue()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getValue(), n2.getValue()))
             return false;
         return true;
     }
@@ -670,9 +671,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final IntegerLiteralExpr n, final Visitable arg) {
         final IntegerLiteralExpr n2 = (IntegerLiteralExpr) arg;
-        if (!objEquals(n.getValue(), n2.getValue()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getValue(), n2.getValue()))
             return false;
         return true;
     }
@@ -680,9 +681,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final LongLiteralExpr n, final Visitable arg) {
         final LongLiteralExpr n2 = (LongLiteralExpr) arg;
-        if (!objEquals(n.getValue(), n2.getValue()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getValue(), n2.getValue()))
             return false;
         return true;
     }
@@ -690,9 +691,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final CharLiteralExpr n, final Visitable arg) {
         final CharLiteralExpr n2 = (CharLiteralExpr) arg;
-        if (!objEquals(n.getValue(), n2.getValue()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getValue(), n2.getValue()))
             return false;
         return true;
     }
@@ -700,9 +701,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final DoubleLiteralExpr n, final Visitable arg) {
         final DoubleLiteralExpr n2 = (DoubleLiteralExpr) arg;
-        if (!objEquals(n.getValue(), n2.getValue()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getValue(), n2.getValue()))
             return false;
         return true;
     }
@@ -710,9 +711,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final BooleanLiteralExpr n, final Visitable arg) {
         final BooleanLiteralExpr n2 = (BooleanLiteralExpr) arg;
-        if (!objEquals(n.isValue(), n2.isValue()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.isValue(), n2.isValue()))
             return false;
         return true;
     }
@@ -728,15 +729,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final MethodCallExpr n, final Visitable arg) {
         final MethodCallExpr n2 = (MethodCallExpr) arg;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodeEquals(n.getScope(), n2.getScope()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getScope(), n2.getScope()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
             return false;
         return true;
     }
@@ -744,9 +745,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final NameExpr n, final Visitable arg) {
         final NameExpr n2 = (NameExpr) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -754,17 +755,17 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ObjectCreationExpr n, final Visitable arg) {
         final ObjectCreationExpr n2 = (ObjectCreationExpr) arg;
-        if (!nodesEquals(n.getAnonymousClassBody(), n2.getAnonymousClassBody()))
-            return false;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodeEquals(n.getScope(), n2.getScope()))
-            return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getType(), n2.getType()))
+            return false;
+        if (!nodeEquals(n.getScope(), n2.getScope()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
+            return false;
+        if (!nodesEquals(n.getAnonymousClassBody(), n2.getAnonymousClassBody()))
             return false;
         return true;
     }
@@ -772,11 +773,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final Name n, final Visitable arg) {
         final Name n2 = (Name) arg;
-        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getQualifier(), n2.getQualifier()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
             return false;
         return true;
     }
@@ -784,9 +785,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final SimpleName n, final Visitable arg) {
         final SimpleName n2 = (SimpleName) arg;
-        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
             return false;
         return true;
     }
@@ -794,9 +795,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ThisExpr n, final Visitable arg) {
         final ThisExpr n2 = (ThisExpr) arg;
-        if (!nodeEquals(n.getTypeName(), n2.getTypeName()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getTypeName(), n2.getTypeName()))
             return false;
         return true;
     }
@@ -804,9 +805,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final SuperExpr n, final Visitable arg) {
         final SuperExpr n2 = (SuperExpr) arg;
-        if (!nodeEquals(n.getTypeName(), n2.getTypeName()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getTypeName(), n2.getTypeName()))
             return false;
         return true;
     }
@@ -814,11 +815,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final UnaryExpr n, final Visitable arg) {
         final UnaryExpr n2 = (UnaryExpr) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!objEquals(n.getOperator(), n2.getOperator()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -826,13 +827,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final VariableDeclarationExpr n, final Visitable arg) {
         final VariableDeclarationExpr n2 = (VariableDeclarationExpr) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getVariables(), n2.getVariables()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -840,9 +841,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final MarkerAnnotationExpr n, final Visitable arg) {
         final MarkerAnnotationExpr n2 = (MarkerAnnotationExpr) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -850,11 +851,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final SingleMemberAnnotationExpr n, final Visitable arg) {
         final SingleMemberAnnotationExpr n2 = (SingleMemberAnnotationExpr) arg;
-        if (!nodeEquals(n.getMemberValue(), n2.getMemberValue()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getMemberValue(), n2.getMemberValue()))
             return false;
         return true;
     }
@@ -862,11 +863,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final NormalAnnotationExpr n, final Visitable arg) {
         final NormalAnnotationExpr n2 = (NormalAnnotationExpr) arg;
-        if (!nodesEquals(n.getPairs(), n2.getPairs()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getPairs(), n2.getPairs()))
             return false;
         return true;
     }
@@ -874,11 +875,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final MemberValuePair n, final Visitable arg) {
         final MemberValuePair n2 = (MemberValuePair) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getValue(), n2.getValue()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -886,15 +887,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ExplicitConstructorInvocationStmt n, final Visitable arg) {
         final ExplicitConstructorInvocationStmt n2 = (ExplicitConstructorInvocationStmt) arg;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
-        if (!objEquals(n.isThis(), n2.isThis()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.isThis(), n2.isThis()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
             return false;
         return true;
     }
@@ -902,9 +903,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final LocalClassDeclarationStmt n, final Visitable arg) {
         final LocalClassDeclarationStmt n2 = (LocalClassDeclarationStmt) arg;
-        if (!nodeEquals(n.getClassDeclaration(), n2.getClassDeclaration()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getClassDeclaration(), n2.getClassDeclaration()))
             return false;
         return true;
     }
@@ -912,11 +913,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final AssertStmt n, final Visitable arg) {
         final AssertStmt n2 = (AssertStmt) arg;
-        if (!nodeEquals(n.getCheck(), n2.getCheck()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getMessage(), n2.getMessage()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getCheck(), n2.getCheck()))
             return false;
         return true;
     }
@@ -924,9 +925,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final BlockStmt n, final Visitable arg) {
         final BlockStmt n2 = (BlockStmt) arg;
-        if (!nodesEquals(n.getStatements(), n2.getStatements()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodesEquals(n.getStatements(), n2.getStatements()))
             return false;
         return true;
     }
@@ -934,11 +935,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final LabeledStmt n, final Visitable arg) {
         final LabeledStmt n2 = (LabeledStmt) arg;
-        if (!nodeEquals(n.getLabel(), n2.getLabel()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getStatement(), n2.getStatement()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getLabel(), n2.getLabel()))
             return false;
         return true;
     }
@@ -954,9 +955,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ExpressionStmt n, final Visitable arg) {
         final ExpressionStmt n2 = (ExpressionStmt) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -964,11 +965,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final SwitchStmt n, final Visitable arg) {
         final SwitchStmt n2 = (SwitchStmt) arg;
-        if (!nodesEquals(n.getEntries(), n2.getEntries()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getSelector(), n2.getSelector()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
             return false;
         return true;
     }
@@ -976,13 +977,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final SwitchEntry n, final Visitable arg) {
         final SwitchEntry n2 = (SwitchEntry) arg;
-        if (!nodesEquals(n.getLabels(), n2.getLabels()))
-            return false;
-        if (!nodesEquals(n.getStatements(), n2.getStatements()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!objEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getStatements(), n2.getStatements()))
+            return false;
+        if (!nodesEquals(n.getLabels(), n2.getLabels()))
             return false;
         return true;
     }
@@ -990,9 +991,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final BreakStmt n, final Visitable arg) {
         final BreakStmt n2 = (BreakStmt) arg;
-        if (!nodeEquals(n.getLabel(), n2.getLabel()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getLabel(), n2.getLabel()))
             return false;
         return true;
     }
@@ -1000,9 +1001,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ReturnStmt n, final Visitable arg) {
         final ReturnStmt n2 = (ReturnStmt) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -1010,13 +1011,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final IfStmt n, final Visitable arg) {
         final IfStmt n2 = (IfStmt) arg;
-        if (!nodeEquals(n.getCondition(), n2.getCondition()))
-            return false;
-        if (!nodeEquals(n.getElseStmt(), n2.getElseStmt()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getThenStmt(), n2.getThenStmt()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getElseStmt(), n2.getElseStmt()))
+            return false;
+        if (!nodeEquals(n.getCondition(), n2.getCondition()))
             return false;
         return true;
     }
@@ -1024,11 +1025,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final WhileStmt n, final Visitable arg) {
         final WhileStmt n2 = (WhileStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getCondition(), n2.getCondition()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -1036,9 +1037,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ContinueStmt n, final Visitable arg) {
         final ContinueStmt n2 = (ContinueStmt) arg;
-        if (!nodeEquals(n.getLabel(), n2.getLabel()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getLabel(), n2.getLabel()))
             return false;
         return true;
     }
@@ -1046,11 +1047,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final DoStmt n, final Visitable arg) {
         final DoStmt n2 = (DoStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getCondition(), n2.getCondition()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -1058,13 +1059,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ForEachStmt n, final Visitable arg) {
         final ForEachStmt n2 = (ForEachStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!nodeEquals(n.getIterable(), n2.getIterable()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getVariable(), n2.getVariable()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getIterable(), n2.getIterable()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -1072,15 +1073,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ForStmt n, final Visitable arg) {
         final ForStmt n2 = (ForStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!nodeEquals(n.getCompare(), n2.getCompare()))
-            return false;
-        if (!nodesEquals(n.getInitialization(), n2.getInitialization()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getUpdate(), n2.getUpdate()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getInitialization(), n2.getInitialization()))
+            return false;
+        if (!nodeEquals(n.getCompare(), n2.getCompare()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -1088,9 +1089,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ThrowStmt n, final Visitable arg) {
         final ThrowStmt n2 = (ThrowStmt) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -1098,11 +1099,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final SynchronizedStmt n, final Visitable arg) {
         final SynchronizedStmt n2 = (SynchronizedStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -1110,15 +1111,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final TryStmt n, final Visitable arg) {
         final TryStmt n2 = (TryStmt) arg;
-        if (!nodesEquals(n.getCatchClauses(), n2.getCatchClauses()))
-            return false;
-        if (!nodeEquals(n.getFinallyBlock(), n2.getFinallyBlock()))
-            return false;
-        if (!nodesEquals(n.getResources(), n2.getResources()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getTryBlock(), n2.getTryBlock()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getResources(), n2.getResources()))
+            return false;
+        if (!nodeEquals(n.getFinallyBlock(), n2.getFinallyBlock()))
+            return false;
+        if (!nodesEquals(n.getCatchClauses(), n2.getCatchClauses()))
             return false;
         return true;
     }
@@ -1126,11 +1127,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final CatchClause n, final Visitable arg) {
         final CatchClause n2 = (CatchClause) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getParameter(), n2.getParameter()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -1138,13 +1139,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final LambdaExpr n, final Visitable arg) {
         final LambdaExpr n2 = (LambdaExpr) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!objEquals(n.isEnclosingParameters(), n2.isEnclosingParameters()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getParameters(), n2.getParameters()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.isEnclosingParameters(), n2.isEnclosingParameters()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -1152,13 +1153,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final MethodReferenceExpr n, final Visitable arg) {
         final MethodReferenceExpr n2 = (MethodReferenceExpr) arg;
-        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
-            return false;
-        if (!nodeEquals(n.getScope(), n2.getScope()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getScope(), n2.getScope()))
+            return false;
+        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
             return false;
         return true;
     }
@@ -1166,9 +1167,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final TypeExpr n, final Visitable arg) {
         final TypeExpr n2 = (TypeExpr) arg;
-        if (!nodeEquals(n.getType(), n2.getType()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getType(), n2.getType()))
             return false;
         return true;
     }
@@ -1176,13 +1177,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ImportDeclaration n, final Visitable arg) {
         final ImportDeclaration n2 = (ImportDeclaration) arg;
-        if (!objEquals(n.isAsterisk(), n2.isAsterisk()))
-            return false;
-        if (!objEquals(n.isStatic(), n2.isStatic()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.isStatic(), n2.isStatic()))
+            return false;
+        if (!objEquals(n.isAsterisk(), n2.isAsterisk()))
             return false;
         return true;
     }
@@ -1195,15 +1196,15 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ModuleDeclaration n, final Visitable arg) {
         final ModuleDeclaration n2 = (ModuleDeclaration) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
-        if (!nodesEquals(n.getDirectives(), n2.getDirectives()))
-            return false;
-        if (!objEquals(n.isOpen(), n2.isOpen()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!objEquals(n.isOpen(), n2.isOpen()))
+            return false;
+        if (!nodesEquals(n.getDirectives(), n2.getDirectives()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -1211,11 +1212,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ModuleRequiresDirective n, final Visitable arg) {
         final ModuleRequiresDirective n2 = (ModuleRequiresDirective) arg;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
             return false;
         return true;
     }
@@ -1223,11 +1224,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override()
     public Boolean visit(final ModuleExportsDirective n, final Visitable arg) {
         final ModuleExportsDirective n2 = (ModuleExportsDirective) arg;
-        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
             return false;
         return true;
     }
@@ -1235,11 +1236,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override()
     public Boolean visit(final ModuleProvidesDirective n, final Visitable arg) {
         final ModuleProvidesDirective n2 = (ModuleProvidesDirective) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodesEquals(n.getWith(), n2.getWith()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -1247,9 +1248,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override()
     public Boolean visit(final ModuleUsesDirective n, final Visitable arg) {
         final ModuleUsesDirective n2 = (ModuleUsesDirective) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -1257,11 +1258,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ModuleOpensDirective n, final Visitable arg) {
         final ModuleOpensDirective n2 = (ModuleOpensDirective) arg;
-        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
             return false;
         return true;
     }
@@ -1277,13 +1278,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final ReceiverParameter n, final Visitable arg) {
         final ReceiverParameter n2 = (ReceiverParameter) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -1291,9 +1292,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final VarType n, final Visitable arg) {
         final VarType n2 = (VarType) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -1301,9 +1302,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final Modifier n, final Visitable arg) {
         final Modifier n2 = (Modifier) arg;
-        if (!objEquals(n.getKeyword(), n2.getKeyword()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getKeyword(), n2.getKeyword()))
             return false;
         return true;
     }
@@ -1311,11 +1312,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final SwitchExpr n, final Visitable arg) {
         final SwitchExpr n2 = (SwitchExpr) arg;
-        if (!nodesEquals(n.getEntries(), n2.getEntries()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getSelector(), n2.getSelector()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
             return false;
         return true;
     }
@@ -1323,9 +1324,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final YieldStmt n, final Visitable arg) {
         final YieldStmt n2 = (YieldStmt) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -1333,9 +1334,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final TextBlockLiteralExpr n, final Visitable arg) {
         final TextBlockLiteralExpr n2 = (TextBlockLiteralExpr) arg;
-        if (!objEquals(n.getValue(), n2.getValue()))
-            return false;
         if (!nodeEquals(n.getComment(), n2.getComment()))
+            return false;
+        if (!objEquals(n.getValue(), n2.getValue()))
             return false;
         return true;
     }
@@ -1343,11 +1344,11 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final PatternExpr n, final Visitable arg) {
         final PatternExpr n2 = (PatternExpr) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodeEquals(n.getComment(), n2.getComment()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
@@ -47,13 +47,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final AnnotationDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getMembers().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getModifiers().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -63,12 +63,12 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getAnnotations().accept(this, arg);
+            tmp = n.getModifiers().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getMembers().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -78,18 +78,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final AnnotationMemberDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getDefaultValue().isPresent()) {
-            tmp = n.getDefaultValue().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getModifiers().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getName().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -99,12 +94,17 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getAnnotations().accept(this, arg);
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getModifiers().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getDefaultValue().isPresent()) {
+            tmp = n.getDefaultValue().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -114,8 +114,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ArrayAccessExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getIndex().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -124,8 +124,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getIndex().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -135,8 +135,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ArrayCreationExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getElementType().accept(this, arg);
+            tmp = n.getLevels().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -146,12 +151,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getLevels().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getElementType().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -161,8 +161,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ArrayCreationLevel n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -171,8 +171,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -182,13 +182,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ArrayInitializerExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getValues().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getValues().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -198,8 +198,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ArrayType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getComponentType().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -208,8 +208,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getComponentType().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -219,8 +219,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final AssertStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getCheck().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -229,8 +229,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getCheck().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -240,8 +240,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final AssignExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getTarget().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -250,8 +250,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getTarget().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -261,8 +261,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final BinaryExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getLeft().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -271,8 +271,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getLeft().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -293,13 +293,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final BlockStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getStatements().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getStatements().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -320,13 +320,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final BreakStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getLabel().isPresent()) {
-            tmp = n.getLabel().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getLabel().isPresent()) {
+            tmp = n.getLabel().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -336,8 +336,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final CastExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -346,8 +346,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getExpression().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -357,8 +357,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final CatchClause n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -367,8 +367,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -389,13 +389,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ClassExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getType().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getType().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -405,18 +405,23 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ClassOrInterfaceDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getExtendedTypes().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getImplementedTypes().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getTypeParameters().accept(this, arg);
+            tmp = n.getName().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getModifiers().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -426,22 +431,17 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getModifiers().accept(this, arg);
+            tmp = n.getTypeParameters().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getName().accept(this, arg);
+            tmp = n.getImplementedTypes().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getAnnotations().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getExtendedTypes().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -451,18 +451,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ClassOrInterfaceType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getScope().isPresent()) {
-            tmp = n.getScope().get().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getTypeArguments().isPresent()) {
-            tmp = n.getTypeArguments().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -471,8 +461,18 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getTypeArguments().isPresent()) {
+            tmp = n.getTypeArguments().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getScope().isPresent()) {
+            tmp = n.getScope().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -482,18 +482,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final CompilationUnit n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getImports().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getModule().isPresent()) {
-            tmp = n.getModule().get().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getPackageDeclaration().isPresent()) {
-            tmp = n.getPackageDeclaration().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -502,8 +492,18 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getPackageDeclaration().isPresent()) {
+            tmp = n.getPackageDeclaration().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getModule().isPresent()) {
+            tmp = n.getModule().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getImports().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -513,8 +513,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ConditionalExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getCondition().accept(this, arg);
+            tmp = n.getThenExpr().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -524,12 +529,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getThenExpr().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getCondition().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -539,33 +539,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ConstructorDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getModifiers().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getParameters().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getReceiverParameter().isPresent()) {
-            tmp = n.getReceiverParameter().get().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getThrownExceptions().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -575,12 +555,32 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getAnnotations().accept(this, arg);
+            tmp = n.getThrownExceptions().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getReceiverParameter().isPresent()) {
+            tmp = n.getReceiverParameter().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getParameters().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getName().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getModifiers().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -590,13 +590,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ContinueStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getLabel().isPresent()) {
-            tmp = n.getLabel().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getLabel().isPresent()) {
+            tmp = n.getLabel().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -606,8 +606,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final DoStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -616,8 +616,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -649,13 +649,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final EnclosedExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getInner().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getInner().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -665,8 +665,18 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final EnumConstantDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getArguments().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -676,17 +686,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getAnnotations().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getArguments().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -696,13 +696,23 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final EnumDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getEntries().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getImplementedTypes().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getName().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getModifiers().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -712,22 +722,12 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getModifiers().accept(this, arg);
+            tmp = n.getImplementedTypes().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getAnnotations().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getEntries().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -737,13 +737,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ExplicitConstructorInvocationStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getArguments().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getExpression().isPresent()) {
-            tmp = n.getExpression().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -752,8 +747,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getExpression().isPresent()) {
+            tmp = n.getExpression().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getArguments().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -763,13 +763,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ExpressionStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getExpression().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -779,13 +779,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final FieldAccessExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getScope().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -794,8 +789,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getScope().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -805,8 +805,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final FieldDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getModifiers().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -816,12 +821,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getAnnotations().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getModifiers().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -831,8 +831,18 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ForStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getBody().accept(this, arg);
+            tmp = n.getUpdate().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getInitialization().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -842,17 +852,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getInitialization().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getUpdate().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -862,8 +862,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ForEachStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getBody().accept(this, arg);
+            tmp = n.getVariable().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -873,12 +878,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getVariable().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -888,8 +888,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final IfStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getCondition().accept(this, arg);
+            tmp = n.getThenStmt().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -899,12 +904,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getThenStmt().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getCondition().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -914,13 +914,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ImportDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -930,8 +930,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final InitializerDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -940,8 +940,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -951,8 +951,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final InstanceOfExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getExpression().accept(this, arg);
+            tmp = n.getType().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -962,12 +967,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getType().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getExpression().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -988,8 +988,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final IntersectionType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getElements().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -998,8 +998,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getElements().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1020,8 +1020,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final LabeledStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getLabel().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1030,8 +1030,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getLabel().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1041,8 +1041,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final LambdaExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1051,8 +1051,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1073,13 +1073,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final LocalClassDeclarationStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getClassDeclaration().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getClassDeclaration().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1100,13 +1100,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final MarkerAnnotationExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1116,8 +1116,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final MemberValuePair n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1126,8 +1126,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1137,18 +1137,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final MethodCallExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getArguments().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getScope().isPresent()) {
-            tmp = n.getScope().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1157,8 +1147,18 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getScope().isPresent()) {
+            tmp = n.getScope().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getName().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getArguments().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1168,38 +1168,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final MethodDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getBody().isPresent()) {
-            tmp = n.getBody().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getType().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getModifiers().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getParameters().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getReceiverParameter().isPresent()) {
-            tmp = n.getReceiverParameter().get().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getThrownExceptions().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1209,12 +1184,37 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getAnnotations().accept(this, arg);
+            tmp = n.getThrownExceptions().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getReceiverParameter().isPresent()) {
+            tmp = n.getReceiverParameter().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getParameters().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getName().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getModifiers().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getType().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getBody().isPresent()) {
+            tmp = n.getBody().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1224,8 +1224,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final MethodReferenceExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getScope().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1234,8 +1234,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getScope().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1245,13 +1245,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final NameExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1261,13 +1261,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final Name n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getQualifier().isPresent()) {
-            tmp = n.getQualifier().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getQualifier().isPresent()) {
+            tmp = n.getQualifier().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1277,8 +1277,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final NormalAnnotationExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getPairs().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1287,8 +1287,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getPairs().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1309,13 +1309,18 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ObjectCreationExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getAnonymousClassBody().isPresent()) {
-            tmp = n.getAnonymousClassBody().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getTypeArguments().isPresent()) {
+            tmp = n.getTypeArguments().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getArguments().accept(this, arg);
+            tmp = n.getType().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1325,17 +1330,12 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getType().accept(this, arg);
+            tmp = n.getArguments().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getTypeArguments().isPresent()) {
-            tmp = n.getTypeArguments().get().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getAnonymousClassBody().isPresent()) {
+            tmp = n.getAnonymousClassBody().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1345,8 +1345,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final PackageDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1355,8 +1355,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1366,18 +1366,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final Parameter n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
         {
-            tmp = n.getModifiers().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getName().accept(this, arg);
+            tmp = n.getVarArgsAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1387,12 +1382,17 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getVarArgsAnnotations().accept(this, arg);
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getModifiers().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1402,13 +1402,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final PrimitiveType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1418,13 +1418,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ReturnStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getExpression().isPresent()) {
-            tmp = n.getExpression().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getExpression().isPresent()) {
+            tmp = n.getExpression().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1445,8 +1445,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final SingleMemberAnnotationExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getMemberValue().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1455,8 +1455,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getMemberValue().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1477,13 +1477,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final SuperExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getTypeName().isPresent()) {
-            tmp = n.getTypeName().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getTypeName().isPresent()) {
+            tmp = n.getTypeName().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1493,8 +1493,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final SwitchEntry n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getLabels().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1503,8 +1503,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getLabels().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1514,8 +1514,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final SwitchStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getEntries().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1524,8 +1524,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getEntries().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1535,8 +1535,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final SynchronizedStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1545,8 +1545,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1556,13 +1556,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ThisExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getTypeName().isPresent()) {
-            tmp = n.getTypeName().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getTypeName().isPresent()) {
+            tmp = n.getTypeName().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1572,13 +1572,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ThrowStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getExpression().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1588,8 +1588,18 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final TryStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getCatchClauses().accept(this, arg);
+            tmp = n.getTryBlock().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
+            tmp = n.getResources().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1599,17 +1609,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getResources().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getTryBlock().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getCatchClauses().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1619,13 +1619,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final TypeExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getType().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getType().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1635,8 +1635,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final TypeParameter n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getName().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1646,12 +1651,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getAnnotations().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1661,13 +1661,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final UnaryExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getExpression().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1677,8 +1677,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final UnionType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getElements().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1687,8 +1687,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getElements().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1698,13 +1698,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final UnknownType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1714,8 +1714,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final VariableDeclarationExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getAnnotations().accept(this, arg);
+            tmp = n.getVariables().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1725,12 +1730,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getVariables().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1740,13 +1740,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final VariableDeclarator n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getInitializer().isPresent()) {
-            tmp = n.getInitializer().get().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1755,8 +1750,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getInitializer().isPresent()) {
+            tmp = n.getInitializer().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1766,13 +1766,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final VoidType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1782,8 +1782,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final WhileStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1792,8 +1792,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getBody().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1803,13 +1803,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final WildcardType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        if (n.getExtendedType().isPresent()) {
-            tmp = n.getExtendedType().get().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getSuperType().isPresent()) {
-            tmp = n.getSuperType().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1818,8 +1813,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        if (n.getSuperType().isPresent()) {
+            tmp = n.getSuperType().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        if (n.getExtendedType().isPresent()) {
+            tmp = n.getExtendedType().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1835,8 +1835,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ModuleDeclaration n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getAnnotations().accept(this, arg);
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1846,12 +1851,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getName().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1862,8 +1862,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ModuleExportsDirective n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getModuleNames().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1872,8 +1872,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getModuleNames().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1884,8 +1884,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ModuleOpensDirective n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getModuleNames().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1894,8 +1894,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getModuleNames().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1906,8 +1906,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ModuleProvidesDirective n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1916,8 +1916,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1928,8 +1928,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ModuleRequiresDirective n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getModifiers().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1938,8 +1938,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getModifiers().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1950,13 +1950,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ModuleUsesDirective n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1979,8 +1979,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final ReceiverParameter n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
         {
-            tmp = n.getAnnotations().accept(this, arg);
+            tmp = n.getType().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -1990,12 +1995,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
                 result.addAll(tmp);
         }
         {
-            tmp = n.getType().accept(this, arg);
-            if (tmp != null)
-                result.addAll(tmp);
-        }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -2006,13 +2006,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final VarType n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getAnnotations().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -2035,8 +2035,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final SwitchExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getEntries().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -2045,8 +2045,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getEntries().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -2057,13 +2057,13 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final YieldStmt n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getExpression().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -2086,8 +2086,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     public List<R> visit(final PatternExpr n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
-        {
-            tmp = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }
@@ -2096,8 +2096,8 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             if (tmp != null)
                 result.addAll(tmp);
         }
-        if (n.getComment().isPresent()) {
-            tmp = n.getComment().get().accept(this, arg);
+        {
+            tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -42,13 +42,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final AnnotationDeclaration n, final A arg) {
         R result;
-        {
-            result = n.getMembers().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getModifiers().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -58,12 +58,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getAnnotations().accept(this, arg);
+            result = n.getModifiers().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getMembers().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -73,18 +73,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final AnnotationMemberDeclaration n, final A arg) {
         R result;
-        if (n.getDefaultValue().isPresent()) {
-            result = n.getDefaultValue().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getModifiers().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getName().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -94,12 +89,17 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getAnnotations().accept(this, arg);
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getModifiers().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getDefaultValue().isPresent()) {
+            result = n.getDefaultValue().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -109,8 +109,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ArrayAccessExpr n, final A arg) {
         R result;
-        {
-            result = n.getIndex().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -119,8 +119,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getIndex().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -130,8 +130,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ArrayCreationExpr n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getElementType().accept(this, arg);
+            result = n.getLevels().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -141,12 +146,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getLevels().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getElementType().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -156,13 +156,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ArrayInitializerExpr n, final A arg) {
         R result;
-        {
-            result = n.getValues().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getValues().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -172,8 +172,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final AssertStmt n, final A arg) {
         R result;
-        {
-            result = n.getCheck().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -182,8 +182,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getCheck().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -193,8 +193,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final AssignExpr n, final A arg) {
         R result;
-        {
-            result = n.getTarget().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -203,8 +203,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getTarget().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -214,8 +214,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final BinaryExpr n, final A arg) {
         R result;
-        {
-            result = n.getLeft().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -224,8 +224,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getLeft().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -235,13 +235,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final BlockStmt n, final A arg) {
         R result;
-        {
-            result = n.getStatements().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getStatements().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -262,13 +262,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final BreakStmt n, final A arg) {
         R result;
-        if (n.getLabel().isPresent()) {
-            result = n.getLabel().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getLabel().isPresent()) {
+            result = n.getLabel().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -278,8 +278,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final CastExpr n, final A arg) {
         R result;
-        {
-            result = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -288,8 +288,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getExpression().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -299,8 +299,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final CatchClause n, final A arg) {
         R result;
-        {
-            result = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -309,8 +309,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -331,13 +331,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ClassExpr n, final A arg) {
         R result;
-        {
-            result = n.getType().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getType().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -347,18 +347,23 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ClassOrInterfaceDeclaration n, final A arg) {
         R result;
-        {
-            result = n.getExtendedTypes().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getImplementedTypes().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getTypeParameters().accept(this, arg);
+            result = n.getName().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getModifiers().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -368,22 +373,17 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getModifiers().accept(this, arg);
+            result = n.getTypeParameters().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getName().accept(this, arg);
+            result = n.getImplementedTypes().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getAnnotations().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getExtendedTypes().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -393,18 +393,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ClassOrInterfaceType n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getScope().isPresent()) {
-            result = n.getScope().get().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getTypeArguments().isPresent()) {
-            result = n.getTypeArguments().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -413,8 +403,18 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getTypeArguments().isPresent()) {
+            result = n.getTypeArguments().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getScope().isPresent()) {
+            result = n.getScope().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -424,18 +424,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final CompilationUnit n, final A arg) {
         R result;
-        {
-            result = n.getImports().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getModule().isPresent()) {
-            result = n.getModule().get().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getPackageDeclaration().isPresent()) {
-            result = n.getPackageDeclaration().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -444,8 +434,18 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getPackageDeclaration().isPresent()) {
+            result = n.getPackageDeclaration().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getModule().isPresent()) {
+            result = n.getModule().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getImports().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -455,8 +455,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ConditionalExpr n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getCondition().accept(this, arg);
+            result = n.getThenExpr().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -466,12 +471,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getThenExpr().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getCondition().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -481,33 +481,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ConstructorDeclaration n, final A arg) {
         R result;
-        {
-            result = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getModifiers().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getParameters().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getReceiverParameter().isPresent()) {
-            result = n.getReceiverParameter().get().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getThrownExceptions().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -517,12 +497,32 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getAnnotations().accept(this, arg);
+            result = n.getThrownExceptions().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getReceiverParameter().isPresent()) {
+            result = n.getReceiverParameter().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getParameters().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getName().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getModifiers().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -532,13 +532,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ContinueStmt n, final A arg) {
         R result;
-        if (n.getLabel().isPresent()) {
-            result = n.getLabel().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getLabel().isPresent()) {
+            result = n.getLabel().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -548,8 +548,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final DoStmt n, final A arg) {
         R result;
-        {
-            result = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -558,8 +558,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -591,13 +591,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final EnclosedExpr n, final A arg) {
         R result;
-        {
-            result = n.getInner().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getInner().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -607,8 +607,18 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final EnumConstantDeclaration n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getArguments().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -618,17 +628,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getAnnotations().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getArguments().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -638,13 +638,23 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final EnumDeclaration n, final A arg) {
         R result;
-        {
-            result = n.getEntries().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getImplementedTypes().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getName().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getModifiers().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -654,22 +664,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getModifiers().accept(this, arg);
+            result = n.getImplementedTypes().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getAnnotations().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getEntries().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -679,13 +679,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ExplicitConstructorInvocationStmt n, final A arg) {
         R result;
-        {
-            result = n.getArguments().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getExpression().isPresent()) {
-            result = n.getExpression().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -694,8 +689,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getExpression().isPresent()) {
+            result = n.getExpression().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getArguments().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -705,13 +705,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ExpressionStmt n, final A arg) {
         R result;
-        {
-            result = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getExpression().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -721,13 +721,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final FieldAccessExpr n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getScope().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -736,8 +731,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getScope().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -747,8 +747,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final FieldDeclaration n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getModifiers().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -758,12 +763,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getAnnotations().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getModifiers().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -773,8 +773,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ForEachStmt n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getBody().accept(this, arg);
+            result = n.getVariable().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -784,12 +789,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getVariable().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -799,8 +799,18 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ForStmt n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getBody().accept(this, arg);
+            result = n.getUpdate().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getInitialization().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -810,17 +820,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getInitialization().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getUpdate().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -830,8 +830,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final IfStmt n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getCondition().accept(this, arg);
+            result = n.getThenStmt().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -841,12 +846,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getThenStmt().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getCondition().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -856,8 +856,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final InitializerDeclaration n, final A arg) {
         R result;
-        {
-            result = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -866,8 +866,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -877,8 +877,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final InstanceOfExpr n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getExpression().accept(this, arg);
+            result = n.getType().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -888,12 +893,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getType().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getExpression().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -925,8 +925,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final LabeledStmt n, final A arg) {
         R result;
-        {
-            result = n.getLabel().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -935,8 +935,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getLabel().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -957,13 +957,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final MarkerAnnotationExpr n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -973,8 +973,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final MemberValuePair n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -983,8 +983,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -994,18 +994,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final MethodCallExpr n, final A arg) {
         R result;
-        {
-            result = n.getArguments().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getScope().isPresent()) {
-            result = n.getScope().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1014,8 +1004,18 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getScope().isPresent()) {
+            result = n.getScope().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getName().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getArguments().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1025,38 +1025,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final MethodDeclaration n, final A arg) {
         R result;
-        if (n.getBody().isPresent()) {
-            result = n.getBody().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getType().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getModifiers().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getParameters().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getReceiverParameter().isPresent()) {
-            result = n.getReceiverParameter().get().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getThrownExceptions().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1066,12 +1041,37 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getAnnotations().accept(this, arg);
+            result = n.getThrownExceptions().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getReceiverParameter().isPresent()) {
+            result = n.getReceiverParameter().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getParameters().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getName().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getModifiers().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getType().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getBody().isPresent()) {
+            result = n.getBody().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1081,13 +1081,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final NameExpr n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1097,8 +1097,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final NormalAnnotationExpr n, final A arg) {
         R result;
-        {
-            result = n.getPairs().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1107,8 +1107,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getPairs().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1129,13 +1129,18 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ObjectCreationExpr n, final A arg) {
         R result;
-        if (n.getAnonymousClassBody().isPresent()) {
-            result = n.getAnonymousClassBody().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getTypeArguments().isPresent()) {
+            result = n.getTypeArguments().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getArguments().accept(this, arg);
+            result = n.getType().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1145,17 +1150,12 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getType().accept(this, arg);
+            result = n.getArguments().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getTypeArguments().isPresent()) {
-            result = n.getTypeArguments().get().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getAnonymousClassBody().isPresent()) {
+            result = n.getAnonymousClassBody().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1165,8 +1165,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final PackageDeclaration n, final A arg) {
         R result;
-        {
-            result = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1175,8 +1175,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1186,18 +1186,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final Parameter n, final A arg) {
         R result;
-        {
-            result = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
         {
-            result = n.getModifiers().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getName().accept(this, arg);
+            result = n.getVarArgsAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1207,12 +1202,17 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getVarArgsAnnotations().accept(this, arg);
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getModifiers().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1222,13 +1222,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final PrimitiveType n, final A arg) {
         R result;
-        {
-            result = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1238,13 +1238,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final Name n, final A arg) {
         R result;
-        if (n.getQualifier().isPresent()) {
-            result = n.getQualifier().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getQualifier().isPresent()) {
+            result = n.getQualifier().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1265,8 +1265,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ArrayType n, final A arg) {
         R result;
-        {
-            result = n.getComponentType().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1275,8 +1275,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getComponentType().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1286,8 +1286,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ArrayCreationLevel n, final A arg) {
         R result;
-        {
-            result = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1296,8 +1296,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1307,8 +1307,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final IntersectionType n, final A arg) {
         R result;
-        {
-            result = n.getElements().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1317,8 +1317,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getElements().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1328,8 +1328,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final UnionType n, final A arg) {
         R result;
-        {
-            result = n.getElements().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1338,8 +1338,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getElements().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1349,13 +1349,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ReturnStmt n, final A arg) {
         R result;
-        if (n.getExpression().isPresent()) {
-            result = n.getExpression().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getExpression().isPresent()) {
+            result = n.getExpression().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1365,8 +1365,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final SingleMemberAnnotationExpr n, final A arg) {
         R result;
-        {
-            result = n.getMemberValue().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1375,8 +1375,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getMemberValue().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1397,13 +1397,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final SuperExpr n, final A arg) {
         R result;
-        if (n.getTypeName().isPresent()) {
-            result = n.getTypeName().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getTypeName().isPresent()) {
+            result = n.getTypeName().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1413,8 +1413,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final SwitchEntry n, final A arg) {
         R result;
-        {
-            result = n.getLabels().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1423,8 +1423,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getLabels().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1434,8 +1434,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final SwitchStmt n, final A arg) {
         R result;
-        {
-            result = n.getEntries().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1444,8 +1444,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getEntries().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1455,8 +1455,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final SynchronizedStmt n, final A arg) {
         R result;
-        {
-            result = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1465,8 +1465,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1476,13 +1476,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ThisExpr n, final A arg) {
         R result;
-        if (n.getTypeName().isPresent()) {
-            result = n.getTypeName().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getTypeName().isPresent()) {
+            result = n.getTypeName().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1492,13 +1492,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ThrowStmt n, final A arg) {
         R result;
-        {
-            result = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getExpression().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1508,8 +1508,18 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final TryStmt n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getCatchClauses().accept(this, arg);
+            result = n.getTryBlock().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
+            result = n.getResources().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1519,17 +1529,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getResources().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getTryBlock().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getCatchClauses().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1539,13 +1539,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final LocalClassDeclarationStmt n, final A arg) {
         R result;
-        {
-            result = n.getClassDeclaration().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getClassDeclaration().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1555,8 +1555,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final TypeParameter n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getName().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1566,12 +1571,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getAnnotations().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1581,13 +1581,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final UnaryExpr n, final A arg) {
         R result;
-        {
-            result = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getExpression().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1597,13 +1597,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final UnknownType n, final A arg) {
         R result;
-        {
-            result = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1613,8 +1613,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final VariableDeclarationExpr n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getAnnotations().accept(this, arg);
+            result = n.getVariables().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1624,12 +1629,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getVariables().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1639,13 +1639,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final VariableDeclarator n, final A arg) {
         R result;
-        if (n.getInitializer().isPresent()) {
-            result = n.getInitializer().get().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1654,8 +1649,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getInitializer().isPresent()) {
+            result = n.getInitializer().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1665,13 +1665,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final VoidType n, final A arg) {
         R result;
-        {
-            result = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1681,8 +1681,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final WhileStmt n, final A arg) {
         R result;
-        {
-            result = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1691,8 +1691,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1702,13 +1702,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final WildcardType n, final A arg) {
         R result;
-        if (n.getExtendedType().isPresent()) {
-            result = n.getExtendedType().get().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getSuperType().isPresent()) {
-            result = n.getSuperType().get().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1717,8 +1712,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        if (n.getSuperType().isPresent()) {
+            result = n.getSuperType().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        if (n.getExtendedType().isPresent()) {
+            result = n.getExtendedType().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1728,8 +1728,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final LambdaExpr n, final A arg) {
         R result;
-        {
-            result = n.getBody().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1738,8 +1738,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getBody().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1749,8 +1749,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final MethodReferenceExpr n, final A arg) {
         R result;
-        {
-            result = n.getScope().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1759,8 +1759,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getScope().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1770,13 +1770,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final TypeExpr n, final A arg) {
         R result;
-        {
-            result = n.getType().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getType().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1786,13 +1786,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ImportDeclaration n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1835,8 +1835,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ModuleDeclaration n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getAnnotations().accept(this, arg);
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1846,12 +1851,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getName().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1861,8 +1861,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ModuleRequiresDirective n, final A arg) {
         R result;
-        {
-            result = n.getModifiers().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1871,8 +1871,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getModifiers().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1882,8 +1882,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override()
     public R visit(final ModuleExportsDirective n, final A arg) {
         R result;
-        {
-            result = n.getModuleNames().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1892,8 +1892,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getModuleNames().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1903,8 +1903,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override()
     public R visit(final ModuleProvidesDirective n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1913,8 +1913,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1924,13 +1924,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override()
     public R visit(final ModuleUsesDirective n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1940,8 +1940,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ModuleOpensDirective n, final A arg) {
         R result;
-        {
-            result = n.getModuleNames().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1950,8 +1950,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getModuleNames().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1972,8 +1972,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final ReceiverParameter n, final A arg) {
         R result;
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null)
+                return result;
+        }
         {
-            result = n.getAnnotations().accept(this, arg);
+            result = n.getType().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1983,12 +1988,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 return result;
         }
         {
-            result = n.getType().accept(this, arg);
-            if (result != null)
-                return result;
-        }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -1998,13 +1998,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final VarType n, final A arg) {
         R result;
-        {
-            result = n.getAnnotations().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getAnnotations().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -2025,8 +2025,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final SwitchExpr n, final A arg) {
         R result;
-        {
-            result = n.getEntries().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -2035,8 +2035,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getEntries().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -2046,13 +2046,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final YieldStmt n, final A arg) {
         R result;
-        {
-            result = n.getExpression().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getExpression().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -2073,8 +2073,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     @Override
     public R visit(final PatternExpr n, final A arg) {
         R result;
-        {
-            result = n.getName().accept(this, arg);
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
             if (result != null)
                 return result;
         }
@@ -2083,8 +2083,8 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             if (result != null)
                 return result;
         }
-        if (n.getComment().isPresent()) {
-            result = n.getComment().get().accept(this, arg);
+        {
+            result = n.getName().accept(this, arg);
             if (result != null)
                 return result;
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
@@ -47,107 +47,107 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final AnnotationDeclaration n, final Void arg) {
-        return (n.getMembers().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg));
     }
 
     public Integer visit(final AnnotationMemberDeclaration n, final Void arg) {
-        return (n.getDefaultValue().isPresent() ? n.getDefaultValue().get().accept(this, arg) : 0) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getDefaultValue().isPresent() ? n.getDefaultValue().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final ArrayAccessExpr n, final Void arg) {
-        return (n.getIndex().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getIndex().accept(this, arg));
     }
 
     public Integer visit(final ArrayCreationExpr n, final Void arg) {
-        return (n.getElementType().accept(this, arg)) * 31 + (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0) * 31 + (n.getLevels().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getLevels().accept(this, arg)) * 31 + (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0) * 31 + (n.getElementType().accept(this, arg));
     }
 
     public Integer visit(final ArrayCreationLevel n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getDimension().isPresent() ? n.getDimension().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getDimension().isPresent() ? n.getDimension().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final ArrayInitializerExpr n, final Void arg) {
-        return (n.getValues().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValues().accept(this, arg));
     }
 
     public Integer visit(final ArrayType n, final Void arg) {
-        return (n.getComponentType().accept(this, arg)) * 31 + (n.getOrigin().hashCode()) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getOrigin().hashCode()) * 31 + (n.getComponentType().accept(this, arg));
     }
 
     public Integer visit(final AssertStmt n, final Void arg) {
-        return (n.getCheck().accept(this, arg)) * 31 + (n.getMessage().isPresent() ? n.getMessage().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getMessage().isPresent() ? n.getMessage().get().accept(this, arg) : 0) * 31 + (n.getCheck().accept(this, arg));
     }
 
     public Integer visit(final AssignExpr n, final Void arg) {
-        return (n.getOperator().hashCode()) * 31 + (n.getTarget().accept(this, arg)) * 31 + (n.getValue().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().accept(this, arg)) * 31 + (n.getTarget().accept(this, arg)) * 31 + (n.getOperator().hashCode());
     }
 
     public Integer visit(final BinaryExpr n, final Void arg) {
-        return (n.getLeft().accept(this, arg)) * 31 + (n.getOperator().hashCode()) * 31 + (n.getRight().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getRight().accept(this, arg)) * 31 + (n.getOperator().hashCode()) * 31 + (n.getLeft().accept(this, arg));
     }
 
     public Integer visit(final BlockComment n, final Void arg) {
-        return (n.getContent().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getContent().hashCode());
     }
 
     public Integer visit(final BlockStmt n, final Void arg) {
-        return (n.getStatements().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getStatements().accept(this, arg));
     }
 
     public Integer visit(final BooleanLiteralExpr n, final Void arg) {
-        return (n.isValue() ? 1 : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.isValue() ? 1 : 0);
     }
 
     public Integer visit(final BreakStmt n, final Void arg) {
-        return (n.getLabel().isPresent() ? n.getLabel().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getLabel().isPresent() ? n.getLabel().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final CastExpr n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final CatchClause n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getParameter().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getParameter().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final CharLiteralExpr n, final Void arg) {
-        return (n.getValue().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().hashCode());
     }
 
     public Integer visit(final ClassExpr n, final Void arg) {
-        return (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg));
     }
 
     public Integer visit(final ClassOrInterfaceDeclaration n, final Void arg) {
-        return (n.getExtendedTypes().accept(this, arg)) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.isInterface() ? 1 : 0) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.isInterface() ? 1 : 0) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.getExtendedTypes().accept(this, arg));
     }
 
     public Integer visit(final ClassOrInterfaceType n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final CompilationUnit n, final Void arg) {
-        return (n.getImports().accept(this, arg)) * 31 + (n.getModule().isPresent() ? n.getModule().get().accept(this, arg) : 0) * 31 + (n.getPackageDeclaration().isPresent() ? n.getPackageDeclaration().get().accept(this, arg) : 0) * 31 + (n.getTypes().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypes().accept(this, arg)) * 31 + (n.getPackageDeclaration().isPresent() ? n.getPackageDeclaration().get().accept(this, arg) : 0) * 31 + (n.getModule().isPresent() ? n.getModule().get().accept(this, arg) : 0) * 31 + (n.getImports().accept(this, arg));
     }
 
     public Integer visit(final ConditionalExpr n, final Void arg) {
-        return (n.getCondition().accept(this, arg)) * 31 + (n.getElseExpr().accept(this, arg)) * 31 + (n.getThenExpr().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getThenExpr().accept(this, arg)) * 31 + (n.getElseExpr().accept(this, arg)) * 31 + (n.getCondition().accept(this, arg));
     }
 
     public Integer visit(final ConstructorDeclaration n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final ContinueStmt n, final Void arg) {
-        return (n.getLabel().isPresent() ? n.getLabel().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getLabel().isPresent() ? n.getLabel().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final DoStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getCondition().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getCondition().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final DoubleLiteralExpr n, final Void arg) {
-        return (n.getValue().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().hashCode());
     }
 
     public Integer visit(final EmptyStmt n, final Void arg) {
@@ -155,115 +155,115 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final EnclosedExpr n, final Void arg) {
-        return (n.getInner().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getInner().accept(this, arg));
     }
 
     public Integer visit(final EnumConstantDeclaration n, final Void arg) {
-        return (n.getArguments().accept(this, arg)) * 31 + (n.getClassBody().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getClassBody().accept(this, arg)) * 31 + (n.getArguments().accept(this, arg));
     }
 
     public Integer visit(final EnumDeclaration n, final Void arg) {
-        return (n.getEntries().accept(this, arg)) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.getEntries().accept(this, arg));
     }
 
     public Integer visit(final ExplicitConstructorInvocationStmt n, final Void arg) {
-        return (n.getArguments().accept(this, arg)) * 31 + (n.getExpression().isPresent() ? n.getExpression().get().accept(this, arg) : 0) * 31 + (n.isThis() ? 1 : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.isThis() ? 1 : 0) * 31 + (n.getExpression().isPresent() ? n.getExpression().get().accept(this, arg) : 0) * 31 + (n.getArguments().accept(this, arg));
     }
 
     public Integer visit(final ExpressionStmt n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final FieldAccessExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final FieldDeclaration n, final Void arg) {
-        return (n.getModifiers().accept(this, arg)) * 31 + (n.getVariables().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getVariables().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg));
     }
 
     public Integer visit(final ForStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getCompare().isPresent() ? n.getCompare().get().accept(this, arg) : 0) * 31 + (n.getInitialization().accept(this, arg)) * 31 + (n.getUpdate().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getUpdate().accept(this, arg)) * 31 + (n.getInitialization().accept(this, arg)) * 31 + (n.getCompare().isPresent() ? n.getCompare().get().accept(this, arg) : 0) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final ForEachStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getIterable().accept(this, arg)) * 31 + (n.getVariable().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getVariable().accept(this, arg)) * 31 + (n.getIterable().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final IfStmt n, final Void arg) {
-        return (n.getCondition().accept(this, arg)) * 31 + (n.getElseStmt().isPresent() ? n.getElseStmt().get().accept(this, arg) : 0) * 31 + (n.getThenStmt().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getThenStmt().accept(this, arg)) * 31 + (n.getElseStmt().isPresent() ? n.getElseStmt().get().accept(this, arg) : 0) * 31 + (n.getCondition().accept(this, arg));
     }
 
     public Integer visit(final ImportDeclaration n, final Void arg) {
-        return (n.isAsterisk() ? 1 : 0) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.isAsterisk() ? 1 : 0);
     }
 
     public Integer visit(final InitializerDeclaration n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final InstanceOfExpr n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getPattern().isPresent() ? n.getPattern().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getPattern().isPresent() ? n.getPattern().get().accept(this, arg) : 0) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final IntegerLiteralExpr n, final Void arg) {
-        return (n.getValue().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().hashCode());
     }
 
     public Integer visit(final IntersectionType n, final Void arg) {
-        return (n.getElements().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getElements().accept(this, arg));
     }
 
     public Integer visit(final JavadocComment n, final Void arg) {
-        return (n.getContent().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getContent().hashCode());
     }
 
     public Integer visit(final LabeledStmt n, final Void arg) {
-        return (n.getLabel().accept(this, arg)) * 31 + (n.getStatement().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getStatement().accept(this, arg)) * 31 + (n.getLabel().accept(this, arg));
     }
 
     public Integer visit(final LambdaExpr n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.isEnclosingParameters() ? 1 : 0) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.isEnclosingParameters() ? 1 : 0) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final LineComment n, final Void arg) {
-        return (n.getContent().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getContent().hashCode());
     }
 
     public Integer visit(final LocalClassDeclarationStmt n, final Void arg) {
-        return (n.getClassDeclaration().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getClassDeclaration().accept(this, arg));
     }
 
     public Integer visit(final LongLiteralExpr n, final Void arg) {
-        return (n.getValue().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().hashCode());
     }
 
     public Integer visit(final MarkerAnnotationExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final MemberValuePair n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getValue().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final MethodCallExpr n, final Void arg) {
-        return (n.getArguments().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getArguments().accept(this, arg));
     }
 
     public Integer visit(final MethodDeclaration n, final Void arg) {
-        return (n.getBody().isPresent() ? n.getBody().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getBody().isPresent() ? n.getBody().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final MethodReferenceExpr n, final Void arg) {
-        return (n.getIdentifier().hashCode()) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getIdentifier().hashCode());
     }
 
     public Integer visit(final NameExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final Name n, final Void arg) {
-        return (n.getIdentifier().hashCode()) * 31 + (n.getQualifier().isPresent() ? n.getQualifier().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getQualifier().isPresent() ? n.getQualifier().get().accept(this, arg) : 0) * 31 + (n.getIdentifier().hashCode());
     }
 
     public Integer visit(NodeList n, Void arg) {
@@ -275,7 +275,7 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final NormalAnnotationExpr n, final Void arg) {
-        return (n.getPairs().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getPairs().accept(this, arg));
     }
 
     public Integer visit(final NullLiteralExpr n, final Void arg) {
@@ -283,131 +283,131 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final ObjectCreationExpr n, final Void arg) {
-        return (n.getAnonymousClassBody().isPresent() ? n.getAnonymousClassBody().get().accept(this, arg) : 0) * 31 + (n.getArguments().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getArguments().accept(this, arg)) * 31 + (n.getAnonymousClassBody().isPresent() ? n.getAnonymousClassBody().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final PackageDeclaration n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final Parameter n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.isVarArgs() ? 1 : 0) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getVarArgsAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getVarArgsAnnotations().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.isVarArgs() ? 1 : 0) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final PrimitiveType n, final Void arg) {
-        return (n.getType().hashCode()) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getType().hashCode());
     }
 
     public Integer visit(final ReturnStmt n, final Void arg) {
-        return (n.getExpression().isPresent() ? n.getExpression().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getExpression().isPresent() ? n.getExpression().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final SimpleName n, final Void arg) {
-        return (n.getIdentifier().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getIdentifier().hashCode());
     }
 
     public Integer visit(final SingleMemberAnnotationExpr n, final Void arg) {
-        return (n.getMemberValue().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getMemberValue().accept(this, arg));
     }
 
     public Integer visit(final StringLiteralExpr n, final Void arg) {
-        return (n.getValue().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().hashCode());
     }
 
     public Integer visit(final SuperExpr n, final Void arg) {
-        return (n.getTypeName().isPresent() ? n.getTypeName().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypeName().isPresent() ? n.getTypeName().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final SwitchEntry n, final Void arg) {
-        return (n.getLabels().accept(this, arg)) * 31 + (n.getStatements().accept(this, arg)) * 31 + (n.getType().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().hashCode()) * 31 + (n.getStatements().accept(this, arg)) * 31 + (n.getLabels().accept(this, arg));
     }
 
     public Integer visit(final SwitchStmt n, final Void arg) {
-        return (n.getEntries().accept(this, arg)) * 31 + (n.getSelector().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getSelector().accept(this, arg)) * 31 + (n.getEntries().accept(this, arg));
     }
 
     public Integer visit(final SynchronizedStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getExpression().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getExpression().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final ThisExpr n, final Void arg) {
-        return (n.getTypeName().isPresent() ? n.getTypeName().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTypeName().isPresent() ? n.getTypeName().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final ThrowStmt n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final TryStmt n, final Void arg) {
-        return (n.getCatchClauses().accept(this, arg)) * 31 + (n.getFinallyBlock().isPresent() ? n.getFinallyBlock().get().accept(this, arg) : 0) * 31 + (n.getResources().accept(this, arg)) * 31 + (n.getTryBlock().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getTryBlock().accept(this, arg)) * 31 + (n.getResources().accept(this, arg)) * 31 + (n.getFinallyBlock().isPresent() ? n.getFinallyBlock().get().accept(this, arg) : 0) * 31 + (n.getCatchClauses().accept(this, arg));
     }
 
     public Integer visit(final TypeExpr n, final Void arg) {
-        return (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg));
     }
 
     public Integer visit(final TypeParameter n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getTypeBound().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeBound().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final UnaryExpr n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getOperator().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getOperator().hashCode()) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final UnionType n, final Void arg) {
-        return (n.getElements().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getElements().accept(this, arg));
     }
 
     public Integer visit(final UnknownType n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final VariableDeclarationExpr n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getVariables().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getVariables().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final VariableDeclarator n, final Void arg) {
-        return (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final VoidType n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final WhileStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getCondition().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getCondition().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final WildcardType n, final Void arg) {
-        return (n.getExtendedType().isPresent() ? n.getExtendedType().get().accept(this, arg) : 0) * 31 + (n.getSuperType().isPresent() ? n.getSuperType().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getSuperType().isPresent() ? n.getSuperType().get().accept(this, arg) : 0) * 31 + (n.getExtendedType().isPresent() ? n.getExtendedType().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final ModuleDeclaration n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getDirectives().accept(this, arg)) * 31 + (n.isOpen() ? 1 : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.isOpen() ? 1 : 0) * 31 + (n.getDirectives().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final ModuleRequiresDirective n, final Void arg) {
-        return (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg));
     }
 
     @Override()
     public Integer visit(final ModuleExportsDirective n, final Void arg) {
-        return (n.getModuleNames().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModuleNames().accept(this, arg));
     }
 
     @Override()
     public Integer visit(final ModuleProvidesDirective n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getWith().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getWith().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     @Override()
     public Integer visit(final ModuleUsesDirective n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg));
     }
 
     @Override
     public Integer visit(final ModuleOpensDirective n, final Void arg) {
-        return (n.getModuleNames().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModuleNames().accept(this, arg));
     }
 
     @Override
@@ -417,36 +417,36 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final ReceiverParameter n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     @Override
     public Integer visit(final VarType n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     @Override
     public Integer visit(final Modifier n, final Void arg) {
-        return (n.getKeyword().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getKeyword().hashCode());
     }
 
     @Override
     public Integer visit(final SwitchExpr n, final Void arg) {
-        return (n.getEntries().accept(this, arg)) * 31 + (n.getSelector().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getSelector().accept(this, arg)) * 31 + (n.getEntries().accept(this, arg));
     }
 
     @Override
     public Integer visit(final YieldStmt n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getExpression().accept(this, arg));
     }
 
     @Override
     public Integer visit(final TextBlockLiteralExpr n, final Void arg) {
-        return (n.getValue().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getValue().hashCode());
     }
 
     @Override
     public Integer visit(final PatternExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -54,124 +54,124 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final AnnotationDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        NodeList<BodyDeclaration<?>> members = modifyList(n.getMembers(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
+        NodeList<BodyDeclaration<?>> members = modifyList(n.getMembers(), arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setModifiers(modifiers);
-        n.setName(name);
-        n.setMembers(members);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setName(name);
+        n.setModifiers(modifiers);
+        n.setMembers(members);
         return n;
     }
 
     @Override
     public Visitable visit(final AnnotationMemberDeclaration n, final A arg) {
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        Type type = (Type) n.getType().accept(this, arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         Expression defaultValue = n.getDefaultValue().map(s -> (Expression) s.accept(this, arg)).orElse(null);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        Type type = (Type) n.getType().accept(this, arg);
-        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || type == null)
+        if (type == null || name == null)
             return null;
+        n.setComment(comment);
         n.setAnnotations(annotations);
+        n.setType(type);
+        n.setName(name);
         n.setModifiers(modifiers);
         n.setDefaultValue(defaultValue);
-        n.setName(name);
-        n.setType(type);
-        n.setComment(comment);
         return n;
     }
 
     @Override
     public Visitable visit(final ArrayAccessExpr n, final A arg) {
-        Expression index = (Expression) n.getIndex().accept(this, arg);
-        Expression name = (Expression) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (index == null || name == null)
+        Expression name = (Expression) n.getName().accept(this, arg);
+        Expression index = (Expression) n.getIndex().accept(this, arg);
+        if (name == null || index == null)
             return null;
-        n.setIndex(index);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setIndex(index);
         return n;
     }
 
     @Override
     public Visitable visit(final ArrayCreationExpr n, final A arg) {
-        Type elementType = (Type) n.getElementType().accept(this, arg);
-        ArrayInitializerExpr initializer = n.getInitializer().map(s -> (ArrayInitializerExpr) s.accept(this, arg)).orElse(null);
-        NodeList<ArrayCreationLevel> levels = modifyList(n.getLevels(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (elementType == null || levels.isEmpty())
+        NodeList<ArrayCreationLevel> levels = modifyList(n.getLevels(), arg);
+        ArrayInitializerExpr initializer = n.getInitializer().map(s -> (ArrayInitializerExpr) s.accept(this, arg)).orElse(null);
+        Type elementType = (Type) n.getElementType().accept(this, arg);
+        if (levels.isEmpty() || elementType == null)
             return null;
-        n.setElementType(elementType);
-        n.setInitializer(initializer);
-        n.setLevels(levels);
         n.setComment(comment);
+        n.setLevels(levels);
+        n.setInitializer(initializer);
+        n.setElementType(elementType);
         return n;
     }
 
     @Override
     public Visitable visit(final ArrayInitializerExpr n, final A arg) {
-        NodeList<Expression> values = modifyList(n.getValues(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setValues(values);
+        NodeList<Expression> values = modifyList(n.getValues(), arg);
         n.setComment(comment);
+        n.setValues(values);
         return n;
     }
 
     @Override
     public Visitable visit(final AssertStmt n, final A arg) {
-        Expression check = (Expression) n.getCheck().accept(this, arg);
-        Expression message = n.getMessage().map(s -> (Expression) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression message = n.getMessage().map(s -> (Expression) s.accept(this, arg)).orElse(null);
+        Expression check = (Expression) n.getCheck().accept(this, arg);
         if (check == null)
             return null;
-        n.setCheck(check);
-        n.setMessage(message);
         n.setComment(comment);
+        n.setMessage(message);
+        n.setCheck(check);
         return n;
     }
 
     @Override
     public Visitable visit(final AssignExpr n, final A arg) {
-        Expression target = (Expression) n.getTarget().accept(this, arg);
-        Expression value = (Expression) n.getValue().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (target == null || value == null)
+        Expression value = (Expression) n.getValue().accept(this, arg);
+        Expression target = (Expression) n.getTarget().accept(this, arg);
+        if (value == null || target == null)
             return null;
-        n.setTarget(target);
-        n.setValue(value);
         n.setComment(comment);
+        n.setValue(value);
+        n.setTarget(target);
         return n;
     }
 
     @Override
     public Visitable visit(final BinaryExpr n, final A arg) {
-        Expression left = (Expression) n.getLeft().accept(this, arg);
-        Expression right = (Expression) n.getRight().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression right = (Expression) n.getRight().accept(this, arg);
+        Expression left = (Expression) n.getLeft().accept(this, arg);
         if (left == null)
             return right;
         if (right == null)
             return left;
-        n.setLeft(left);
-        n.setRight(right);
         n.setComment(comment);
+        n.setRight(right);
+        n.setLeft(left);
         return n;
     }
 
     @Override
     public Visitable visit(final BlockStmt n, final A arg) {
-        NodeList<Statement> statements = modifyList(n.getStatements(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setStatements(statements);
+        NodeList<Statement> statements = modifyList(n.getStatements(), arg);
         n.setComment(comment);
+        n.setStatements(statements);
         return n;
     }
 
@@ -184,36 +184,36 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final BreakStmt n, final A arg) {
-        SimpleName label = n.getLabel().map(s -> (SimpleName) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setLabel(label);
+        SimpleName label = n.getLabel().map(s -> (SimpleName) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
+        n.setLabel(label);
         return n;
     }
 
     @Override
     public Visitable visit(final CastExpr n, final A arg) {
-        Expression expression = (Expression) n.getExpression().accept(this, arg);
-        Type type = (Type) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (expression == null || type == null)
+        Type type = (Type) n.getType().accept(this, arg);
+        Expression expression = (Expression) n.getExpression().accept(this, arg);
+        if (type == null || expression == null)
             return null;
-        n.setExpression(expression);
-        n.setType(type);
         n.setComment(comment);
+        n.setType(type);
+        n.setExpression(expression);
         return n;
     }
 
     @Override
     public Visitable visit(final CatchClause n, final A arg) {
-        BlockStmt body = (BlockStmt) n.getBody().accept(this, arg);
-        Parameter parameter = (Parameter) n.getParameter().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (body == null || parameter == null)
+        Parameter parameter = (Parameter) n.getParameter().accept(this, arg);
+        BlockStmt body = (BlockStmt) n.getBody().accept(this, arg);
+        if (parameter == null || body == null)
             return null;
-        n.setBody(body);
-        n.setParameter(parameter);
         n.setComment(comment);
+        n.setParameter(parameter);
+        n.setBody(body);
         return n;
     }
 
@@ -226,129 +226,129 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final ClassExpr n, final A arg) {
-        Type type = (Type) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Type type = (Type) n.getType().accept(this, arg);
         if (type == null)
             return null;
-        n.setType(type);
         n.setComment(comment);
+        n.setType(type);
         return n;
     }
 
     @Override
     public Visitable visit(final ClassOrInterfaceDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        NodeList<ClassOrInterfaceType> extendedTypes = modifyList(n.getExtendedTypes(), arg);
-        NodeList<ClassOrInterfaceType> implementedTypes = modifyList(n.getImplementedTypes(), arg);
-        NodeList<TypeParameter> typeParameters = modifyList(n.getTypeParameters(), arg);
-        NodeList<BodyDeclaration<?>> members = modifyList(n.getMembers(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
+        NodeList<BodyDeclaration<?>> members = modifyList(n.getMembers(), arg);
+        NodeList<TypeParameter> typeParameters = modifyList(n.getTypeParameters(), arg);
+        NodeList<ClassOrInterfaceType> implementedTypes = modifyList(n.getImplementedTypes(), arg);
+        NodeList<ClassOrInterfaceType> extendedTypes = modifyList(n.getExtendedTypes(), arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setModifiers(modifiers);
-        n.setExtendedTypes(extendedTypes);
-        n.setImplementedTypes(implementedTypes);
-        n.setTypeParameters(typeParameters);
-        n.setMembers(members);
-        n.setName(name);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setName(name);
+        n.setModifiers(modifiers);
+        n.setMembers(members);
+        n.setTypeParameters(typeParameters);
+        n.setImplementedTypes(implementedTypes);
+        n.setExtendedTypes(extendedTypes);
         return n;
     }
 
     @Override
     public Visitable visit(final ClassOrInterfaceType n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        ClassOrInterfaceType scope = n.getScope().map(s -> (ClassOrInterfaceType) s.accept(this, arg)).orElse(null);
-        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
+        ClassOrInterfaceType scope = n.getScope().map(s -> (ClassOrInterfaceType) s.accept(this, arg)).orElse(null);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setName(name);
-        n.setScope(scope);
-        n.setTypeArguments(typeArguments);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setTypeArguments(typeArguments);
+        n.setScope(scope);
+        n.setName(name);
         return n;
     }
 
     @Override
     public Visitable visit(final CompilationUnit n, final A arg) {
-        NodeList<ImportDeclaration> imports = modifyList(n.getImports(), arg);
-        ModuleDeclaration module = n.getModule().map(s -> (ModuleDeclaration) s.accept(this, arg)).orElse(null);
-        PackageDeclaration packageDeclaration = n.getPackageDeclaration().map(s -> (PackageDeclaration) s.accept(this, arg)).orElse(null);
-        NodeList<TypeDeclaration<?>> types = modifyList(n.getTypes(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setImports(imports);
-        n.setModule(module);
-        n.setPackageDeclaration(packageDeclaration);
-        n.setTypes(types);
+        NodeList<TypeDeclaration<?>> types = modifyList(n.getTypes(), arg);
+        PackageDeclaration packageDeclaration = n.getPackageDeclaration().map(s -> (PackageDeclaration) s.accept(this, arg)).orElse(null);
+        ModuleDeclaration module = n.getModule().map(s -> (ModuleDeclaration) s.accept(this, arg)).orElse(null);
+        NodeList<ImportDeclaration> imports = modifyList(n.getImports(), arg);
         n.setComment(comment);
+        n.setTypes(types);
+        n.setPackageDeclaration(packageDeclaration);
+        n.setModule(module);
+        n.setImports(imports);
         return n;
     }
 
     @Override
     public Visitable visit(final ConditionalExpr n, final A arg) {
-        Expression condition = (Expression) n.getCondition().accept(this, arg);
-        Expression elseExpr = (Expression) n.getElseExpr().accept(this, arg);
-        Expression thenExpr = (Expression) n.getThenExpr().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (condition == null || elseExpr == null || thenExpr == null)
+        Expression thenExpr = (Expression) n.getThenExpr().accept(this, arg);
+        Expression elseExpr = (Expression) n.getElseExpr().accept(this, arg);
+        Expression condition = (Expression) n.getCondition().accept(this, arg);
+        if (thenExpr == null || elseExpr == null || condition == null)
             return null;
-        n.setCondition(condition);
-        n.setElseExpr(elseExpr);
-        n.setThenExpr(thenExpr);
         n.setComment(comment);
+        n.setThenExpr(thenExpr);
+        n.setElseExpr(elseExpr);
+        n.setCondition(condition);
         return n;
     }
 
     @Override
     public Visitable visit(final ConstructorDeclaration n, final A arg) {
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        NodeList<TypeParameter> typeParameters = modifyList(n.getTypeParameters(), arg);
+        NodeList<ReferenceType> thrownExceptions = modifyList(n.getThrownExceptions(), arg);
+        ReceiverParameter receiverParameter = n.getReceiverParameter().map(s -> (ReceiverParameter) s.accept(this, arg)).orElse(null);
+        NodeList<Parameter> parameters = modifyList(n.getParameters(), arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         BlockStmt body = (BlockStmt) n.getBody().accept(this, arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        NodeList<Parameter> parameters = modifyList(n.getParameters(), arg);
-        ReceiverParameter receiverParameter = n.getReceiverParameter().map(s -> (ReceiverParameter) s.accept(this, arg)).orElse(null);
-        NodeList<ReferenceType> thrownExceptions = modifyList(n.getThrownExceptions(), arg);
-        NodeList<TypeParameter> typeParameters = modifyList(n.getTypeParameters(), arg);
-        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (body == null || name == null)
+        if (name == null || body == null)
             return null;
+        n.setComment(comment);
         n.setAnnotations(annotations);
+        n.setTypeParameters(typeParameters);
+        n.setThrownExceptions(thrownExceptions);
+        n.setReceiverParameter(receiverParameter);
+        n.setParameters(parameters);
+        n.setName(name);
         n.setModifiers(modifiers);
         n.setBody(body);
-        n.setName(name);
-        n.setParameters(parameters);
-        n.setReceiverParameter(receiverParameter);
-        n.setThrownExceptions(thrownExceptions);
-        n.setTypeParameters(typeParameters);
-        n.setComment(comment);
         return n;
     }
 
     @Override
     public Visitable visit(final ContinueStmt n, final A arg) {
-        SimpleName label = n.getLabel().map(s -> (SimpleName) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setLabel(label);
+        SimpleName label = n.getLabel().map(s -> (SimpleName) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
+        n.setLabel(label);
         return n;
     }
 
     @Override
     public Visitable visit(final DoStmt n, final A arg) {
-        Statement body = (Statement) n.getBody().accept(this, arg);
-        Expression condition = (Expression) n.getCondition().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (body == null || condition == null)
+        Expression condition = (Expression) n.getCondition().accept(this, arg);
+        Statement body = (Statement) n.getBody().accept(this, arg);
+        if (condition == null || body == null)
             return null;
-        n.setBody(body);
-        n.setCondition(condition);
         n.setComment(comment);
+        n.setCondition(condition);
+        n.setBody(body);
         return n;
     }
 
@@ -368,179 +368,179 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final EnclosedExpr n, final A arg) {
-        Expression inner = (Expression) n.getInner().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression inner = (Expression) n.getInner().accept(this, arg);
         if (inner == null)
             return null;
-        n.setInner(inner);
         n.setComment(comment);
+        n.setInner(inner);
         return n;
     }
 
     @Override
     public Visitable visit(final EnumConstantDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
-        NodeList<BodyDeclaration<?>> classBody = modifyList(n.getClassBody(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        NodeList<BodyDeclaration<?>> classBody = modifyList(n.getClassBody(), arg);
+        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setArguments(arguments);
-        n.setClassBody(classBody);
-        n.setName(name);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setName(name);
+        n.setClassBody(classBody);
+        n.setArguments(arguments);
         return n;
     }
 
     @Override
     public Visitable visit(final EnumDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        NodeList<EnumConstantDeclaration> entries = modifyList(n.getEntries(), arg);
-        NodeList<ClassOrInterfaceType> implementedTypes = modifyList(n.getImplementedTypes(), arg);
-        NodeList<BodyDeclaration<?>> members = modifyList(n.getMembers(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
+        NodeList<BodyDeclaration<?>> members = modifyList(n.getMembers(), arg);
+        NodeList<ClassOrInterfaceType> implementedTypes = modifyList(n.getImplementedTypes(), arg);
+        NodeList<EnumConstantDeclaration> entries = modifyList(n.getEntries(), arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setModifiers(modifiers);
-        n.setEntries(entries);
-        n.setImplementedTypes(implementedTypes);
-        n.setMembers(members);
-        n.setName(name);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setName(name);
+        n.setModifiers(modifiers);
+        n.setMembers(members);
+        n.setImplementedTypes(implementedTypes);
+        n.setEntries(entries);
         return n;
     }
 
     @Override
     public Visitable visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
-        Expression expression = n.getExpression().map(s -> (Expression) s.accept(this, arg)).orElse(null);
-        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setArguments(arguments);
-        n.setExpression(expression);
-        n.setTypeArguments(typeArguments);
+        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
+        Expression expression = n.getExpression().map(s -> (Expression) s.accept(this, arg)).orElse(null);
+        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
         n.setComment(comment);
+        n.setTypeArguments(typeArguments);
+        n.setExpression(expression);
+        n.setArguments(arguments);
         return n;
     }
 
     @Override
     public Visitable visit(final ExpressionStmt n, final A arg) {
-        Expression expression = (Expression) n.getExpression().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression expression = (Expression) n.getExpression().accept(this, arg);
         if (expression == null)
             return null;
-        n.setExpression(expression);
         n.setComment(comment);
+        n.setExpression(expression);
         return n;
     }
 
     @Override
     public Visitable visit(final FieldAccessExpr n, final A arg) {
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        Expression scope = (Expression) n.getScope().accept(this, arg);
-        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || scope == null)
+        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
+        Expression scope = (Expression) n.getScope().accept(this, arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        if (scope == null || name == null)
             return null;
-        n.setName(name);
-        n.setScope(scope);
-        n.setTypeArguments(typeArguments);
         n.setComment(comment);
+        n.setTypeArguments(typeArguments);
+        n.setScope(scope);
+        n.setName(name);
         return n;
     }
 
     @Override
     public Visitable visit(final FieldDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        NodeList<VariableDeclarator> variables = modifyList(n.getVariables(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        NodeList<VariableDeclarator> variables = modifyList(n.getVariables(), arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         if (variables.isEmpty())
             return null;
-        n.setAnnotations(annotations);
-        n.setModifiers(modifiers);
-        n.setVariables(variables);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setVariables(variables);
+        n.setModifiers(modifiers);
         return n;
     }
 
     @Override
     public Visitable visit(final ForEachStmt n, final A arg) {
-        Statement body = (Statement) n.getBody().accept(this, arg);
-        Expression iterable = (Expression) n.getIterable().accept(this, arg);
-        VariableDeclarationExpr variable = (VariableDeclarationExpr) n.getVariable().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (body == null || iterable == null || variable == null)
+        VariableDeclarationExpr variable = (VariableDeclarationExpr) n.getVariable().accept(this, arg);
+        Expression iterable = (Expression) n.getIterable().accept(this, arg);
+        Statement body = (Statement) n.getBody().accept(this, arg);
+        if (variable == null || iterable == null || body == null)
             return null;
-        n.setBody(body);
-        n.setIterable(iterable);
-        n.setVariable(variable);
         n.setComment(comment);
+        n.setVariable(variable);
+        n.setIterable(iterable);
+        n.setBody(body);
         return n;
     }
 
     @Override
     public Visitable visit(final ForStmt n, final A arg) {
-        Statement body = (Statement) n.getBody().accept(this, arg);
-        Expression compare = n.getCompare().map(s -> (Expression) s.accept(this, arg)).orElse(null);
-        NodeList<Expression> initialization = modifyList(n.getInitialization(), arg);
-        NodeList<Expression> update = modifyList(n.getUpdate(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<Expression> update = modifyList(n.getUpdate(), arg);
+        NodeList<Expression> initialization = modifyList(n.getInitialization(), arg);
+        Expression compare = n.getCompare().map(s -> (Expression) s.accept(this, arg)).orElse(null);
+        Statement body = (Statement) n.getBody().accept(this, arg);
         if (body == null)
             return null;
-        n.setBody(body);
-        n.setCompare(compare);
-        n.setInitialization(initialization);
-        n.setUpdate(update);
         n.setComment(comment);
+        n.setUpdate(update);
+        n.setInitialization(initialization);
+        n.setCompare(compare);
+        n.setBody(body);
         return n;
     }
 
     @Override
     public Visitable visit(final IfStmt n, final A arg) {
-        Expression condition = (Expression) n.getCondition().accept(this, arg);
-        Statement elseStmt = n.getElseStmt().map(s -> (Statement) s.accept(this, arg)).orElse(null);
-        Statement thenStmt = (Statement) n.getThenStmt().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (condition == null || thenStmt == null)
+        Statement thenStmt = (Statement) n.getThenStmt().accept(this, arg);
+        Statement elseStmt = n.getElseStmt().map(s -> (Statement) s.accept(this, arg)).orElse(null);
+        Expression condition = (Expression) n.getCondition().accept(this, arg);
+        if (thenStmt == null || condition == null)
             return null;
-        n.setCondition(condition);
-        n.setElseStmt(elseStmt);
-        n.setThenStmt(thenStmt);
         n.setComment(comment);
+        n.setThenStmt(thenStmt);
+        n.setElseStmt(elseStmt);
+        n.setCondition(condition);
         return n;
     }
 
     @Override
     public Visitable visit(final InitializerDeclaration n, final A arg) {
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         BlockStmt body = (BlockStmt) n.getBody().accept(this, arg);
-        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (body == null)
             return null;
+        n.setComment(comment);
         n.setAnnotations(annotations);
         n.setBody(body);
-        n.setComment(comment);
         return n;
     }
 
     @Override
     public Visitable visit(final InstanceOfExpr n, final A arg) {
-        Expression expression = (Expression) n.getExpression().accept(this, arg);
-        PatternExpr pattern = n.getPattern().map(s -> (PatternExpr) s.accept(this, arg)).orElse(null);
-        ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (expression == null || type == null)
+        ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
+        PatternExpr pattern = n.getPattern().map(s -> (PatternExpr) s.accept(this, arg)).orElse(null);
+        Expression expression = (Expression) n.getExpression().accept(this, arg);
+        if (type == null || expression == null)
             return null;
-        n.setExpression(expression);
-        n.setPattern(pattern);
-        n.setType(type);
         n.setComment(comment);
+        n.setType(type);
+        n.setPattern(pattern);
+        n.setExpression(expression);
         return n;
     }
 
@@ -560,14 +560,14 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final LabeledStmt n, final A arg) {
-        SimpleName label = (SimpleName) n.getLabel().accept(this, arg);
-        Statement statement = (Statement) n.getStatement().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (label == null || statement == null)
+        Statement statement = (Statement) n.getStatement().accept(this, arg);
+        SimpleName label = (SimpleName) n.getLabel().accept(this, arg);
+        if (statement == null || label == null)
             return null;
-        n.setLabel(label);
-        n.setStatement(statement);
         n.setComment(comment);
+        n.setStatement(statement);
+        n.setLabel(label);
         return n;
     }
 
@@ -580,93 +580,93 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final MarkerAnnotationExpr n, final A arg) {
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
         if (name == null)
             return null;
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
         return n;
     }
 
     @Override
     public Visitable visit(final MemberValuePair n, final A arg) {
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        Expression value = (Expression) n.getValue().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || value == null)
+        Expression value = (Expression) n.getValue().accept(this, arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        if (value == null || name == null)
             return null;
-        n.setName(name);
-        n.setValue(value);
         n.setComment(comment);
+        n.setValue(value);
+        n.setName(name);
         return n;
     }
 
     @Override
     public Visitable visit(final MethodCallExpr n, final A arg) {
-        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        Expression scope = n.getScope().map(s -> (Expression) s.accept(this, arg)).orElse(null);
-        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
+        Expression scope = n.getScope().map(s -> (Expression) s.accept(this, arg)).orElse(null);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
         if (name == null)
             return null;
-        n.setArguments(arguments);
-        n.setName(name);
-        n.setScope(scope);
-        n.setTypeArguments(typeArguments);
         n.setComment(comment);
+        n.setTypeArguments(typeArguments);
+        n.setScope(scope);
+        n.setName(name);
+        n.setArguments(arguments);
         return n;
     }
 
     @Override
     public Visitable visit(final MethodDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        BlockStmt body = n.getBody().map(s -> (BlockStmt) s.accept(this, arg)).orElse(null);
-        Type type = (Type) n.getType().accept(this, arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        NodeList<Parameter> parameters = modifyList(n.getParameters(), arg);
-        ReceiverParameter receiverParameter = n.getReceiverParameter().map(s -> (ReceiverParameter) s.accept(this, arg)).orElse(null);
-        NodeList<ReferenceType> thrownExceptions = modifyList(n.getThrownExceptions(), arg);
-        NodeList<TypeParameter> typeParameters = modifyList(n.getTypeParameters(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (type == null || name == null)
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        NodeList<TypeParameter> typeParameters = modifyList(n.getTypeParameters(), arg);
+        NodeList<ReferenceType> thrownExceptions = modifyList(n.getThrownExceptions(), arg);
+        ReceiverParameter receiverParameter = n.getReceiverParameter().map(s -> (ReceiverParameter) s.accept(this, arg)).orElse(null);
+        NodeList<Parameter> parameters = modifyList(n.getParameters(), arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
+        Type type = (Type) n.getType().accept(this, arg);
+        BlockStmt body = n.getBody().map(s -> (BlockStmt) s.accept(this, arg)).orElse(null);
+        if (name == null || type == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setModifiers(modifiers);
-        n.setBody(body);
-        n.setType(type);
-        n.setName(name);
-        n.setParameters(parameters);
-        n.setReceiverParameter(receiverParameter);
-        n.setThrownExceptions(thrownExceptions);
-        n.setTypeParameters(typeParameters);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setTypeParameters(typeParameters);
+        n.setThrownExceptions(thrownExceptions);
+        n.setReceiverParameter(receiverParameter);
+        n.setParameters(parameters);
+        n.setName(name);
+        n.setModifiers(modifiers);
+        n.setType(type);
+        n.setBody(body);
         return n;
     }
 
     @Override
     public Visitable visit(final NameExpr n, final A arg) {
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         if (name == null)
             return null;
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
         return n;
     }
 
     @Override
     public Visitable visit(final NormalAnnotationExpr n, final A arg) {
-        NodeList<MemberValuePair> pairs = modifyList(n.getPairs(), arg);
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
+        NodeList<MemberValuePair> pairs = modifyList(n.getPairs(), arg);
         if (name == null)
             return null;
-        n.setPairs(pairs);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setPairs(pairs);
         return n;
     }
 
@@ -679,70 +679,70 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final ObjectCreationExpr n, final A arg) {
-        NodeList<BodyDeclaration<?>> anonymousClassBody = modifyList(n.getAnonymousClassBody(), arg);
-        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
-        Expression scope = n.getScope().map(s -> (Expression) s.accept(this, arg)).orElse(null);
-        ClassOrInterfaceType type = (ClassOrInterfaceType) n.getType().accept(this, arg);
-        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
+        ClassOrInterfaceType type = (ClassOrInterfaceType) n.getType().accept(this, arg);
+        Expression scope = n.getScope().map(s -> (Expression) s.accept(this, arg)).orElse(null);
+        NodeList<Expression> arguments = modifyList(n.getArguments(), arg);
+        NodeList<BodyDeclaration<?>> anonymousClassBody = modifyList(n.getAnonymousClassBody(), arg);
         if (type == null)
             return null;
-        n.setAnonymousClassBody(anonymousClassBody);
-        n.setArguments(arguments);
-        n.setScope(scope);
-        n.setType(type);
-        n.setTypeArguments(typeArguments);
         n.setComment(comment);
+        n.setTypeArguments(typeArguments);
+        n.setType(type);
+        n.setScope(scope);
+        n.setArguments(arguments);
+        n.setAnonymousClassBody(anonymousClassBody);
         return n;
     }
 
     @Override
     public Visitable visit(final PackageDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setAnnotations(annotations);
         return n;
     }
 
     @Override
     public Visitable visit(final Parameter n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        Type type = (Type) n.getType().accept(this, arg);
-        NodeList<AnnotationExpr> varArgsAnnotations = modifyList(n.getVarArgsAnnotations(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || type == null)
+        NodeList<AnnotationExpr> varArgsAnnotations = modifyList(n.getVarArgsAnnotations(), arg);
+        Type type = (Type) n.getType().accept(this, arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        if (type == null || name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setModifiers(modifiers);
-        n.setName(name);
-        n.setType(type);
-        n.setVarArgsAnnotations(varArgsAnnotations);
         n.setComment(comment);
+        n.setVarArgsAnnotations(varArgsAnnotations);
+        n.setType(type);
+        n.setName(name);
+        n.setModifiers(modifiers);
+        n.setAnnotations(annotations);
         return n;
     }
 
     @Override
     public Visitable visit(final Name n, final A arg) {
-        Name qualifier = n.getQualifier().map(s -> (Name) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setQualifier(qualifier);
+        Name qualifier = n.getQualifier().map(s -> (Name) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
+        n.setQualifier(qualifier);
         return n;
     }
 
     @Override
     public Visitable visit(final PrimitiveType n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setAnnotations(annotations);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         n.setComment(comment);
+        n.setAnnotations(annotations);
         return n;
     }
 
@@ -755,73 +755,73 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final ArrayType n, final A arg) {
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         Type componentType = (Type) n.getComponentType().accept(this, arg);
-        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (componentType == null)
             return null;
+        n.setComment(comment);
         n.setAnnotations(annotations);
         n.setComponentType(componentType);
-        n.setComment(comment);
         return n;
     }
 
     @Override
     public Visitable visit(final ArrayCreationLevel n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        Expression dimension = n.getDimension().map(s -> (Expression) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setAnnotations(annotations);
-        n.setDimension(dimension);
+        Expression dimension = n.getDimension().map(s -> (Expression) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         n.setComment(comment);
+        n.setDimension(dimension);
+        n.setAnnotations(annotations);
         return n;
     }
 
     @Override
     public Visitable visit(final IntersectionType n, final A arg) {
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         NodeList<ReferenceType> elements = modifyList(n.getElements(), arg);
-        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (elements.isEmpty())
             return null;
+        n.setComment(comment);
         n.setAnnotations(annotations);
         n.setElements(elements);
-        n.setComment(comment);
         return n;
     }
 
     @Override
     public Visitable visit(final UnionType n, final A arg) {
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         NodeList<ReferenceType> elements = modifyList(n.getElements(), arg);
-        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (elements.isEmpty())
             return null;
+        n.setComment(comment);
         n.setAnnotations(annotations);
         n.setElements(elements);
-        n.setComment(comment);
         return n;
     }
 
     @Override
     public Visitable visit(final ReturnStmt n, final A arg) {
-        Expression expression = n.getExpression().map(s -> (Expression) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setExpression(expression);
+        Expression expression = n.getExpression().map(s -> (Expression) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
+        n.setExpression(expression);
         return n;
     }
 
     @Override
     public Visitable visit(final SingleMemberAnnotationExpr n, final A arg) {
-        Expression memberValue = (Expression) n.getMemberValue().accept(this, arg);
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (memberValue == null || name == null)
+        Name name = (Name) n.getName().accept(this, arg);
+        Expression memberValue = (Expression) n.getMemberValue().accept(this, arg);
+        if (name == null || memberValue == null)
             return null;
-        n.setMemberValue(memberValue);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setMemberValue(memberValue);
         return n;
     }
 
@@ -834,232 +834,232 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final SuperExpr n, final A arg) {
-        Name typeName = n.getTypeName().map(s -> (Name) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setTypeName(typeName);
+        Name typeName = n.getTypeName().map(s -> (Name) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
+        n.setTypeName(typeName);
         return n;
     }
 
     @Override
     public Visitable visit(final SwitchEntry n, final A arg) {
-        NodeList<Expression> labels = modifyList(n.getLabels(), arg);
-        NodeList<Statement> statements = modifyList(n.getStatements(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setLabels(labels);
-        n.setStatements(statements);
+        NodeList<Statement> statements = modifyList(n.getStatements(), arg);
+        NodeList<Expression> labels = modifyList(n.getLabels(), arg);
         n.setComment(comment);
+        n.setStatements(statements);
+        n.setLabels(labels);
         return n;
     }
 
     @Override
     public Visitable visit(final SwitchStmt n, final A arg) {
-        NodeList<SwitchEntry> entries = modifyList(n.getEntries(), arg);
-        Expression selector = (Expression) n.getSelector().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression selector = (Expression) n.getSelector().accept(this, arg);
+        NodeList<SwitchEntry> entries = modifyList(n.getEntries(), arg);
         if (selector == null)
             return null;
-        n.setEntries(entries);
-        n.setSelector(selector);
         n.setComment(comment);
+        n.setSelector(selector);
+        n.setEntries(entries);
         return n;
     }
 
     @Override
     public Visitable visit(final SynchronizedStmt n, final A arg) {
-        BlockStmt body = (BlockStmt) n.getBody().accept(this, arg);
-        Expression expression = (Expression) n.getExpression().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (body == null || expression == null)
+        Expression expression = (Expression) n.getExpression().accept(this, arg);
+        BlockStmt body = (BlockStmt) n.getBody().accept(this, arg);
+        if (expression == null || body == null)
             return null;
-        n.setBody(body);
-        n.setExpression(expression);
         n.setComment(comment);
+        n.setExpression(expression);
+        n.setBody(body);
         return n;
     }
 
     @Override
     public Visitable visit(final ThisExpr n, final A arg) {
-        Name typeName = n.getTypeName().map(s -> (Name) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setTypeName(typeName);
+        Name typeName = n.getTypeName().map(s -> (Name) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
+        n.setTypeName(typeName);
         return n;
     }
 
     @Override
     public Visitable visit(final ThrowStmt n, final A arg) {
-        Expression expression = (Expression) n.getExpression().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression expression = (Expression) n.getExpression().accept(this, arg);
         if (expression == null)
             return null;
-        n.setExpression(expression);
         n.setComment(comment);
+        n.setExpression(expression);
         return n;
     }
 
     @Override
     public Visitable visit(final TryStmt n, final A arg) {
-        NodeList<CatchClause> catchClauses = modifyList(n.getCatchClauses(), arg);
-        BlockStmt finallyBlock = n.getFinallyBlock().map(s -> (BlockStmt) s.accept(this, arg)).orElse(null);
-        NodeList<Expression> resources = modifyList(n.getResources(), arg);
-        BlockStmt tryBlock = (BlockStmt) n.getTryBlock().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        BlockStmt tryBlock = (BlockStmt) n.getTryBlock().accept(this, arg);
+        NodeList<Expression> resources = modifyList(n.getResources(), arg);
+        BlockStmt finallyBlock = n.getFinallyBlock().map(s -> (BlockStmt) s.accept(this, arg)).orElse(null);
+        NodeList<CatchClause> catchClauses = modifyList(n.getCatchClauses(), arg);
         if (tryBlock == null)
             return null;
-        n.setCatchClauses(catchClauses);
-        n.setFinallyBlock(finallyBlock);
-        n.setResources(resources);
-        n.setTryBlock(tryBlock);
         n.setComment(comment);
+        n.setTryBlock(tryBlock);
+        n.setResources(resources);
+        n.setFinallyBlock(finallyBlock);
+        n.setCatchClauses(catchClauses);
         return n;
     }
 
     @Override
     public Visitable visit(final LocalClassDeclarationStmt n, final A arg) {
-        ClassOrInterfaceDeclaration classDeclaration = (ClassOrInterfaceDeclaration) n.getClassDeclaration().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        ClassOrInterfaceDeclaration classDeclaration = (ClassOrInterfaceDeclaration) n.getClassDeclaration().accept(this, arg);
         if (classDeclaration == null)
             return null;
-        n.setClassDeclaration(classDeclaration);
         n.setComment(comment);
+        n.setClassDeclaration(classDeclaration);
         return n;
     }
 
     @Override
     public Visitable visit(final TypeParameter n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        NodeList<ClassOrInterfaceType> typeBound = modifyList(n.getTypeBound(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        NodeList<ClassOrInterfaceType> typeBound = modifyList(n.getTypeBound(), arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setName(name);
-        n.setTypeBound(typeBound);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setTypeBound(typeBound);
+        n.setName(name);
         return n;
     }
 
     @Override
     public Visitable visit(final UnaryExpr n, final A arg) {
-        Expression expression = (Expression) n.getExpression().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression expression = (Expression) n.getExpression().accept(this, arg);
         if (expression == null)
             return null;
-        n.setExpression(expression);
         n.setComment(comment);
+        n.setExpression(expression);
         return n;
     }
 
     @Override
     public Visitable visit(final UnknownType n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setAnnotations(annotations);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         n.setComment(comment);
+        n.setAnnotations(annotations);
         return n;
     }
 
     @Override
     public Visitable visit(final VariableDeclarationExpr n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        NodeList<VariableDeclarator> variables = modifyList(n.getVariables(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<VariableDeclarator> variables = modifyList(n.getVariables(), arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         if (variables.isEmpty())
             return null;
-        n.setAnnotations(annotations);
-        n.setModifiers(modifiers);
-        n.setVariables(variables);
         n.setComment(comment);
+        n.setVariables(variables);
+        n.setModifiers(modifiers);
+        n.setAnnotations(annotations);
         return n;
     }
 
     @Override
     public Visitable visit(final VariableDeclarator n, final A arg) {
-        Expression initializer = n.getInitializer().map(s -> (Expression) s.accept(this, arg)).orElse(null);
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        Type type = (Type) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || type == null)
+        Type type = (Type) n.getType().accept(this, arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        Expression initializer = n.getInitializer().map(s -> (Expression) s.accept(this, arg)).orElse(null);
+        if (type == null || name == null)
             return null;
-        n.setInitializer(initializer);
-        n.setName(name);
-        n.setType(type);
         n.setComment(comment);
+        n.setType(type);
+        n.setName(name);
+        n.setInitializer(initializer);
         return n;
     }
 
     @Override
     public Visitable visit(final VoidType n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setAnnotations(annotations);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         n.setComment(comment);
+        n.setAnnotations(annotations);
         return n;
     }
 
     @Override
     public Visitable visit(final WhileStmt n, final A arg) {
-        Statement body = (Statement) n.getBody().accept(this, arg);
-        Expression condition = (Expression) n.getCondition().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (body == null || condition == null)
+        Expression condition = (Expression) n.getCondition().accept(this, arg);
+        Statement body = (Statement) n.getBody().accept(this, arg);
+        if (condition == null || body == null)
             return null;
-        n.setBody(body);
-        n.setCondition(condition);
         n.setComment(comment);
+        n.setCondition(condition);
+        n.setBody(body);
         return n;
     }
 
     @Override
     public Visitable visit(final WildcardType n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        ReferenceType extendedType = n.getExtendedType().map(s -> (ReferenceType) s.accept(this, arg)).orElse(null);
-        ReferenceType superType = n.getSuperType().map(s -> (ReferenceType) s.accept(this, arg)).orElse(null);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setAnnotations(annotations);
-        n.setExtendedType(extendedType);
-        n.setSuperType(superType);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        ReferenceType superType = n.getSuperType().map(s -> (ReferenceType) s.accept(this, arg)).orElse(null);
+        ReferenceType extendedType = n.getExtendedType().map(s -> (ReferenceType) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
+        n.setAnnotations(annotations);
+        n.setSuperType(superType);
+        n.setExtendedType(extendedType);
         return n;
     }
 
     @Override
     public Visitable visit(final LambdaExpr n, final A arg) {
-        Statement body = (Statement) n.getBody().accept(this, arg);
-        NodeList<Parameter> parameters = modifyList(n.getParameters(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<Parameter> parameters = modifyList(n.getParameters(), arg);
+        Statement body = (Statement) n.getBody().accept(this, arg);
         if (body == null)
             return null;
-        n.setBody(body);
-        n.setParameters(parameters);
         n.setComment(comment);
+        n.setParameters(parameters);
+        n.setBody(body);
         return n;
     }
 
     @Override
     public Visitable visit(final MethodReferenceExpr n, final A arg) {
-        Expression scope = (Expression) n.getScope().accept(this, arg);
-        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<Type> typeArguments = modifyList(n.getTypeArguments(), arg);
+        Expression scope = (Expression) n.getScope().accept(this, arg);
         if (scope == null)
             return null;
-        n.setScope(scope);
-        n.setTypeArguments(typeArguments);
         n.setComment(comment);
+        n.setTypeArguments(typeArguments);
+        n.setScope(scope);
         return n;
     }
 
     @Override
     public Visitable visit(final TypeExpr n, final A arg) {
-        Type type = (Type) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Type type = (Type) n.getType().accept(this, arg);
         if (type == null)
             return null;
-        n.setType(type);
         n.setComment(comment);
+        n.setType(type);
         return n;
     }
 
@@ -1086,12 +1086,12 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Node visit(final ImportDeclaration n, final A arg) {
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
         if (name == null)
             return null;
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
         return n;
     }
 
@@ -1118,78 +1118,78 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     }
 
     public Visitable visit(final ModuleDeclaration n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        NodeList<ModuleDirective> directives = modifyList(n.getDirectives(), arg);
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
+        NodeList<ModuleDirective> directives = modifyList(n.getDirectives(), arg);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         if (name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setDirectives(directives);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setDirectives(directives);
+        n.setAnnotations(annotations);
         return n;
     }
 
     public Visitable visit(final ModuleRequiresDirective n, final A arg) {
-        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         if (name == null)
             return null;
-        n.setModifiers(modifiers);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setModifiers(modifiers);
         return n;
     }
 
     @Override()
     public Visitable visit(final ModuleExportsDirective n, final A arg) {
-        NodeList<Name> moduleNames = modifyList(n.getModuleNames(), arg);
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
+        NodeList<Name> moduleNames = modifyList(n.getModuleNames(), arg);
         if (name == null)
             return null;
-        n.setModuleNames(moduleNames);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setModuleNames(moduleNames);
         return n;
     }
 
     @Override()
     public Visitable visit(final ModuleProvidesDirective n, final A arg) {
-        Name name = (Name) n.getName().accept(this, arg);
-        NodeList<Name> with = modifyList(n.getWith(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        NodeList<Name> with = modifyList(n.getWith(), arg);
+        Name name = (Name) n.getName().accept(this, arg);
         if (name == null)
             return null;
-        n.setName(name);
-        n.setWith(with);
         n.setComment(comment);
+        n.setWith(with);
+        n.setName(name);
         return n;
     }
 
     @Override()
     public Visitable visit(final ModuleUsesDirective n, final A arg) {
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
         if (name == null)
             return null;
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
         return n;
     }
 
     @Override
     public Visitable visit(final ModuleOpensDirective n, final A arg) {
-        NodeList<Name> moduleNames = modifyList(n.getModuleNames(), arg);
-        Name name = (Name) n.getName().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Name name = (Name) n.getName().accept(this, arg);
+        NodeList<Name> moduleNames = modifyList(n.getModuleNames(), arg);
         if (name == null)
             return null;
-        n.setModuleNames(moduleNames);
-        n.setName(name);
         n.setComment(comment);
+        n.setName(name);
+        n.setModuleNames(moduleNames);
         return n;
     }
 
@@ -1202,25 +1202,25 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final ReceiverParameter n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
-        Name name = (Name) n.getName().accept(this, arg);
-        Type type = (Type) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || type == null)
+        Type type = (Type) n.getType().accept(this, arg);
+        Name name = (Name) n.getName().accept(this, arg);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
+        if (type == null || name == null)
             return null;
-        n.setAnnotations(annotations);
-        n.setName(name);
-        n.setType(type);
         n.setComment(comment);
+        n.setType(type);
+        n.setName(name);
+        n.setAnnotations(annotations);
         return n;
     }
 
     @Override
     public Visitable visit(final VarType n, final A arg) {
-        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        n.setAnnotations(annotations);
+        NodeList<AnnotationExpr> annotations = modifyList(n.getAnnotations(), arg);
         n.setComment(comment);
+        n.setAnnotations(annotations);
         return n;
     }
 
@@ -1233,25 +1233,25 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final SwitchExpr n, final A arg) {
-        NodeList<SwitchEntry> entries = modifyList(n.getEntries(), arg);
-        Expression selector = (Expression) n.getSelector().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression selector = (Expression) n.getSelector().accept(this, arg);
+        NodeList<SwitchEntry> entries = modifyList(n.getEntries(), arg);
         if (selector == null)
             return null;
-        n.setEntries(entries);
-        n.setSelector(selector);
         n.setComment(comment);
+        n.setSelector(selector);
+        n.setEntries(entries);
         return n;
     }
 
     @Override
     public Visitable visit(final YieldStmt n, final A arg) {
-        Expression expression = (Expression) n.getExpression().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+        Expression expression = (Expression) n.getExpression().accept(this, arg);
         if (expression == null)
             return null;
-        n.setExpression(expression);
         n.setComment(comment);
+        n.setExpression(expression);
         return n;
     }
 
@@ -1264,14 +1264,14 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final PatternExpr n, final A arg) {
-        SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
-        if (name == null || type == null)
+        ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
+        SimpleName name = (SimpleName) n.getName().accept(this, arg);
+        if (type == null || name == null)
             return null;
-        n.setName(name);
-        n.setType(type);
         n.setComment(comment);
+        n.setType(type);
+        n.setName(name);
         return n;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
+
 import java.util.Optional;
 
 public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable> {
@@ -91,13 +92,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final CompilationUnit n, final Visitable arg) {
         final CompilationUnit n2 = (CompilationUnit) arg;
-        if (!nodesEquals(n.getImports(), n2.getImports()))
-            return false;
-        if (!nodeEquals(n.getModule(), n2.getModule()))
+        if (!nodesEquals(n.getTypes(), n2.getTypes()))
             return false;
         if (!nodeEquals(n.getPackageDeclaration(), n2.getPackageDeclaration()))
             return false;
-        if (!nodesEquals(n.getTypes(), n2.getTypes()))
+        if (!nodeEquals(n.getModule(), n2.getModule()))
+            return false;
+        if (!nodesEquals(n.getImports(), n2.getImports()))
             return false;
         return true;
     }
@@ -105,9 +106,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final PackageDeclaration n, final Visitable arg) {
         final PackageDeclaration n2 = (PackageDeclaration) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -115,11 +116,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final TypeParameter n, final Visitable arg) {
         final TypeParameter n2 = (TypeParameter) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodesEquals(n.getTypeBound(), n2.getTypeBound()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -137,21 +138,21 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ClassOrInterfaceDeclaration n, final Visitable arg) {
         final ClassOrInterfaceDeclaration n2 = (ClassOrInterfaceDeclaration) arg;
-        if (!nodesEquals(n.getExtendedTypes(), n2.getExtendedTypes()))
-            return false;
-        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
-            return false;
-        if (!objEquals(n.isInterface(), n2.isInterface()))
-            return false;
-        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
-            return false;
-        if (!nodesEquals(n.getMembers(), n2.getMembers()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodesEquals(n.getMembers(), n2.getMembers()))
+            return false;
+        if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
+            return false;
+        if (!objEquals(n.isInterface(), n2.isInterface()))
+            return false;
+        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
+            return false;
+        if (!nodesEquals(n.getExtendedTypes(), n2.getExtendedTypes()))
             return false;
         return true;
     }
@@ -159,17 +160,17 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final EnumDeclaration n, final Visitable arg) {
         final EnumDeclaration n2 = (EnumDeclaration) arg;
-        if (!nodesEquals(n.getEntries(), n2.getEntries()))
-            return false;
-        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
-            return false;
-        if (!nodesEquals(n.getMembers(), n2.getMembers()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodesEquals(n.getMembers(), n2.getMembers()))
+            return false;
+        if (!nodesEquals(n.getImplementedTypes(), n2.getImplementedTypes()))
+            return false;
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
             return false;
         return true;
     }
@@ -177,13 +178,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final EnumConstantDeclaration n, final Visitable arg) {
         final EnumConstantDeclaration n2 = (EnumConstantDeclaration) arg;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodesEquals(n.getClassBody(), n2.getClassBody()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getClassBody(), n2.getClassBody()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
             return false;
         return true;
     }
@@ -191,13 +192,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final AnnotationDeclaration n, final Visitable arg) {
         final AnnotationDeclaration n2 = (AnnotationDeclaration) arg;
-        if (!nodesEquals(n.getMembers(), n2.getMembers()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodesEquals(n.getMembers(), n2.getMembers()))
             return false;
         return true;
     }
@@ -205,15 +206,15 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final AnnotationMemberDeclaration n, final Visitable arg) {
         final AnnotationMemberDeclaration n2 = (AnnotationMemberDeclaration) arg;
-        if (!nodeEquals(n.getDefaultValue(), n2.getDefaultValue()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodeEquals(n.getDefaultValue(), n2.getDefaultValue()))
             return false;
         return true;
     }
@@ -221,11 +222,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final FieldDeclaration n, final Visitable arg) {
         final FieldDeclaration n2 = (FieldDeclaration) arg;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodesEquals(n.getVariables(), n2.getVariables()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
             return false;
         return true;
     }
@@ -233,11 +234,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final VariableDeclarator n, final Visitable arg) {
         final VariableDeclarator n2 = (VariableDeclarator) arg;
-        if (!nodeEquals(n.getInitializer(), n2.getInitializer()))
+        if (!nodeEquals(n.getType(), n2.getType()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
+        if (!nodeEquals(n.getInitializer(), n2.getInitializer()))
             return false;
         return true;
     }
@@ -245,21 +246,21 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ConstructorDeclaration n, final Visitable arg) {
         final ConstructorDeclaration n2 = (ConstructorDeclaration) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodesEquals(n.getParameters(), n2.getParameters()))
-            return false;
-        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
-            return false;
-        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
+            return false;
+        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
+            return false;
+        if (!nodesEquals(n.getParameters(), n2.getParameters()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -267,23 +268,23 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final MethodDeclaration n, final Visitable arg) {
         final MethodDeclaration n2 = (MethodDeclaration) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodesEquals(n.getParameters(), n2.getParameters()))
-            return false;
-        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
-            return false;
-        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodesEquals(n.getTypeParameters(), n2.getTypeParameters()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getThrownExceptions(), n2.getThrownExceptions()))
+            return false;
+        if (!nodeEquals(n.getReceiverParameter(), n2.getReceiverParameter()))
+            return false;
+        if (!nodesEquals(n.getParameters(), n2.getParameters()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!nodeEquals(n.getType(), n2.getType()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -291,17 +292,17 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final Parameter n, final Visitable arg) {
         final Parameter n2 = (Parameter) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
-        if (!objEquals(n.isVarArgs(), n2.isVarArgs()))
-            return false;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodesEquals(n.getVarArgsAnnotations(), n2.getVarArgsAnnotations()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodesEquals(n.getVarArgsAnnotations(), n2.getVarArgsAnnotations()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
+        if (!objEquals(n.isVarArgs(), n2.isVarArgs()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -309,11 +310,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final InitializerDeclaration n, final Visitable arg) {
         final InitializerDeclaration n2 = (InitializerDeclaration) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!objEquals(n.isStatic(), n2.isStatic()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -326,13 +327,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ClassOrInterfaceType n, final Visitable arg) {
         final ClassOrInterfaceType n2 = (ClassOrInterfaceType) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
-        if (!nodeEquals(n.getScope(), n2.getScope()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getScope(), n2.getScope()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -340,9 +341,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final PrimitiveType n, final Visitable arg) {
         final PrimitiveType n2 = (PrimitiveType) arg;
-        if (!objEquals(n.getType(), n2.getType()))
-            return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+            return false;
+        if (!objEquals(n.getType(), n2.getType()))
             return false;
         return true;
     }
@@ -350,11 +351,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ArrayType n, final Visitable arg) {
         final ArrayType n2 = (ArrayType) arg;
-        if (!nodeEquals(n.getComponentType(), n2.getComponentType()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!objEquals(n.getOrigin(), n2.getOrigin()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getComponentType(), n2.getComponentType()))
             return false;
         return true;
     }
@@ -362,9 +363,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ArrayCreationLevel n, final Visitable arg) {
         final ArrayCreationLevel n2 = (ArrayCreationLevel) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
         if (!nodeEquals(n.getDimension(), n2.getDimension()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -372,9 +373,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final IntersectionType n, final Visitable arg) {
         final IntersectionType n2 = (IntersectionType) arg;
-        if (!nodesEquals(n.getElements(), n2.getElements()))
-            return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+            return false;
+        if (!nodesEquals(n.getElements(), n2.getElements()))
             return false;
         return true;
     }
@@ -382,9 +383,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final UnionType n, final Visitable arg) {
         final UnionType n2 = (UnionType) arg;
-        if (!nodesEquals(n.getElements(), n2.getElements()))
-            return false;
         if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+            return false;
+        if (!nodesEquals(n.getElements(), n2.getElements()))
             return false;
         return true;
     }
@@ -400,11 +401,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final WildcardType n, final Visitable arg) {
         final WildcardType n2 = (WildcardType) arg;
-        if (!nodeEquals(n.getExtendedType(), n2.getExtendedType()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         if (!nodeEquals(n.getSuperType(), n2.getSuperType()))
             return false;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getExtendedType(), n2.getExtendedType()))
             return false;
         return true;
     }
@@ -420,9 +421,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ArrayAccessExpr n, final Visitable arg) {
         final ArrayAccessExpr n2 = (ArrayAccessExpr) arg;
-        if (!nodeEquals(n.getIndex(), n2.getIndex()))
-            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodeEquals(n.getIndex(), n2.getIndex()))
             return false;
         return true;
     }
@@ -430,11 +431,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ArrayCreationExpr n, final Visitable arg) {
         final ArrayCreationExpr n2 = (ArrayCreationExpr) arg;
-        if (!nodeEquals(n.getElementType(), n2.getElementType()))
+        if (!nodesEquals(n.getLevels(), n2.getLevels()))
             return false;
         if (!nodeEquals(n.getInitializer(), n2.getInitializer()))
             return false;
-        if (!nodesEquals(n.getLevels(), n2.getLevels()))
+        if (!nodeEquals(n.getElementType(), n2.getElementType()))
             return false;
         return true;
     }
@@ -450,11 +451,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final AssignExpr n, final Visitable arg) {
         final AssignExpr n2 = (AssignExpr) arg;
-        if (!objEquals(n.getOperator(), n2.getOperator()))
+        if (!nodeEquals(n.getValue(), n2.getValue()))
             return false;
         if (!nodeEquals(n.getTarget(), n2.getTarget()))
             return false;
-        if (!nodeEquals(n.getValue(), n2.getValue()))
+        if (!objEquals(n.getOperator(), n2.getOperator()))
             return false;
         return true;
     }
@@ -462,11 +463,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final BinaryExpr n, final Visitable arg) {
         final BinaryExpr n2 = (BinaryExpr) arg;
-        if (!nodeEquals(n.getLeft(), n2.getLeft()))
+        if (!nodeEquals(n.getRight(), n2.getRight()))
             return false;
         if (!objEquals(n.getOperator(), n2.getOperator()))
             return false;
-        if (!nodeEquals(n.getRight(), n2.getRight()))
+        if (!nodeEquals(n.getLeft(), n2.getLeft()))
             return false;
         return true;
     }
@@ -474,9 +475,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final CastExpr n, final Visitable arg) {
         final CastExpr n2 = (CastExpr) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
         if (!nodeEquals(n.getType(), n2.getType()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -492,11 +493,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ConditionalExpr n, final Visitable arg) {
         final ConditionalExpr n2 = (ConditionalExpr) arg;
-        if (!nodeEquals(n.getCondition(), n2.getCondition()))
+        if (!nodeEquals(n.getThenExpr(), n2.getThenExpr()))
             return false;
         if (!nodeEquals(n.getElseExpr(), n2.getElseExpr()))
             return false;
-        if (!nodeEquals(n.getThenExpr(), n2.getThenExpr()))
+        if (!nodeEquals(n.getCondition(), n2.getCondition()))
             return false;
         return true;
     }
@@ -512,11 +513,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final FieldAccessExpr n, final Visitable arg) {
         final FieldAccessExpr n2 = (FieldAccessExpr) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
         if (!nodeEquals(n.getScope(), n2.getScope()))
             return false;
-        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -524,11 +525,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final InstanceOfExpr n, final Visitable arg) {
         final InstanceOfExpr n2 = (InstanceOfExpr) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
+        if (!nodeEquals(n.getType(), n2.getType()))
             return false;
         if (!nodeEquals(n.getPattern(), n2.getPattern()))
             return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -589,13 +590,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final MethodCallExpr n, final Visitable arg) {
         final MethodCallExpr n2 = (MethodCallExpr) arg;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
         if (!nodeEquals(n.getScope(), n2.getScope()))
             return false;
-        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
+        if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
             return false;
         return true;
     }
@@ -611,15 +612,15 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ObjectCreationExpr n, final Visitable arg) {
         final ObjectCreationExpr n2 = (ObjectCreationExpr) arg;
-        if (!nodesEquals(n.getAnonymousClassBody(), n2.getAnonymousClassBody()))
-            return false;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodeEquals(n.getScope(), n2.getScope()))
+        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))
             return false;
-        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
+        if (!nodeEquals(n.getScope(), n2.getScope()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
+            return false;
+        if (!nodesEquals(n.getAnonymousClassBody(), n2.getAnonymousClassBody()))
             return false;
         return true;
     }
@@ -627,9 +628,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final Name n, final Visitable arg) {
         final Name n2 = (Name) arg;
-        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
-            return false;
         if (!nodeEquals(n.getQualifier(), n2.getQualifier()))
+            return false;
+        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
             return false;
         return true;
     }
@@ -661,9 +662,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final UnaryExpr n, final Visitable arg) {
         final UnaryExpr n2 = (UnaryExpr) arg;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
-            return false;
         if (!objEquals(n.getOperator(), n2.getOperator()))
+            return false;
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
             return false;
         return true;
     }
@@ -671,11 +672,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final VariableDeclarationExpr n, final Visitable arg) {
         final VariableDeclarationExpr n2 = (VariableDeclarationExpr) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodesEquals(n.getVariables(), n2.getVariables()))
             return false;
         if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
             return false;
-        if (!nodesEquals(n.getVariables(), n2.getVariables()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -691,9 +692,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final SingleMemberAnnotationExpr n, final Visitable arg) {
         final SingleMemberAnnotationExpr n2 = (SingleMemberAnnotationExpr) arg;
-        if (!nodeEquals(n.getMemberValue(), n2.getMemberValue()))
-            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodeEquals(n.getMemberValue(), n2.getMemberValue()))
             return false;
         return true;
     }
@@ -701,9 +702,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final NormalAnnotationExpr n, final Visitable arg) {
         final NormalAnnotationExpr n2 = (NormalAnnotationExpr) arg;
-        if (!nodesEquals(n.getPairs(), n2.getPairs()))
-            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getPairs(), n2.getPairs()))
             return false;
         return true;
     }
@@ -711,9 +712,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final MemberValuePair n, final Visitable arg) {
         final MemberValuePair n2 = (MemberValuePair) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
         if (!nodeEquals(n.getValue(), n2.getValue()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -721,13 +722,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ExplicitConstructorInvocationStmt n, final Visitable arg) {
         final ExplicitConstructorInvocationStmt n2 = (ExplicitConstructorInvocationStmt) arg;
-        if (!nodesEquals(n.getArguments(), n2.getArguments()))
-            return false;
-        if (!nodeEquals(n.getExpression(), n2.getExpression()))
+        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
         if (!objEquals(n.isThis(), n2.isThis()))
             return false;
-        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
+        if (!nodeEquals(n.getExpression(), n2.getExpression()))
+            return false;
+        if (!nodesEquals(n.getArguments(), n2.getArguments()))
             return false;
         return true;
     }
@@ -743,9 +744,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final AssertStmt n, final Visitable arg) {
         final AssertStmt n2 = (AssertStmt) arg;
-        if (!nodeEquals(n.getCheck(), n2.getCheck()))
-            return false;
         if (!nodeEquals(n.getMessage(), n2.getMessage()))
+            return false;
+        if (!nodeEquals(n.getCheck(), n2.getCheck()))
             return false;
         return true;
     }
@@ -761,9 +762,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final LabeledStmt n, final Visitable arg) {
         final LabeledStmt n2 = (LabeledStmt) arg;
-        if (!nodeEquals(n.getLabel(), n2.getLabel()))
-            return false;
         if (!nodeEquals(n.getStatement(), n2.getStatement()))
+            return false;
+        if (!nodeEquals(n.getLabel(), n2.getLabel()))
             return false;
         return true;
     }
@@ -784,9 +785,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final SwitchStmt n, final Visitable arg) {
         final SwitchStmt n2 = (SwitchStmt) arg;
-        if (!nodesEquals(n.getEntries(), n2.getEntries()))
-            return false;
         if (!nodeEquals(n.getSelector(), n2.getSelector()))
+            return false;
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
             return false;
         return true;
     }
@@ -794,11 +795,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final SwitchEntry n, final Visitable arg) {
         final SwitchEntry n2 = (SwitchEntry) arg;
-        if (!nodesEquals(n.getLabels(), n2.getLabels()))
+        if (!objEquals(n.getType(), n2.getType()))
             return false;
         if (!nodesEquals(n.getStatements(), n2.getStatements()))
             return false;
-        if (!objEquals(n.getType(), n2.getType()))
+        if (!nodesEquals(n.getLabels(), n2.getLabels()))
             return false;
         return true;
     }
@@ -822,11 +823,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final IfStmt n, final Visitable arg) {
         final IfStmt n2 = (IfStmt) arg;
-        if (!nodeEquals(n.getCondition(), n2.getCondition()))
+        if (!nodeEquals(n.getThenStmt(), n2.getThenStmt()))
             return false;
         if (!nodeEquals(n.getElseStmt(), n2.getElseStmt()))
             return false;
-        if (!nodeEquals(n.getThenStmt(), n2.getThenStmt()))
+        if (!nodeEquals(n.getCondition(), n2.getCondition()))
             return false;
         return true;
     }
@@ -834,9 +835,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final WhileStmt n, final Visitable arg) {
         final WhileStmt n2 = (WhileStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
         if (!nodeEquals(n.getCondition(), n2.getCondition()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -852,9 +853,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final DoStmt n, final Visitable arg) {
         final DoStmt n2 = (DoStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
         if (!nodeEquals(n.getCondition(), n2.getCondition()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -862,11 +863,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ForEachStmt n, final Visitable arg) {
         final ForEachStmt n2 = (ForEachStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
+        if (!nodeEquals(n.getVariable(), n2.getVariable()))
             return false;
         if (!nodeEquals(n.getIterable(), n2.getIterable()))
             return false;
-        if (!nodeEquals(n.getVariable(), n2.getVariable()))
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -874,13 +875,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ForStmt n, final Visitable arg) {
         final ForStmt n2 = (ForStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
-        if (!nodeEquals(n.getCompare(), n2.getCompare()))
+        if (!nodesEquals(n.getUpdate(), n2.getUpdate()))
             return false;
         if (!nodesEquals(n.getInitialization(), n2.getInitialization()))
             return false;
-        if (!nodesEquals(n.getUpdate(), n2.getUpdate()))
+        if (!nodeEquals(n.getCompare(), n2.getCompare()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -896,9 +897,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final SynchronizedStmt n, final Visitable arg) {
         final SynchronizedStmt n2 = (SynchronizedStmt) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
         if (!nodeEquals(n.getExpression(), n2.getExpression()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -906,13 +907,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final TryStmt n, final Visitable arg) {
         final TryStmt n2 = (TryStmt) arg;
-        if (!nodesEquals(n.getCatchClauses(), n2.getCatchClauses()))
-            return false;
-        if (!nodeEquals(n.getFinallyBlock(), n2.getFinallyBlock()))
+        if (!nodeEquals(n.getTryBlock(), n2.getTryBlock()))
             return false;
         if (!nodesEquals(n.getResources(), n2.getResources()))
             return false;
-        if (!nodeEquals(n.getTryBlock(), n2.getTryBlock()))
+        if (!nodeEquals(n.getFinallyBlock(), n2.getFinallyBlock()))
+            return false;
+        if (!nodesEquals(n.getCatchClauses(), n2.getCatchClauses()))
             return false;
         return true;
     }
@@ -920,9 +921,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final CatchClause n, final Visitable arg) {
         final CatchClause n2 = (CatchClause) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
-            return false;
         if (!nodeEquals(n.getParameter(), n2.getParameter()))
+            return false;
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -930,11 +931,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final LambdaExpr n, final Visitable arg) {
         final LambdaExpr n2 = (LambdaExpr) arg;
-        if (!nodeEquals(n.getBody(), n2.getBody()))
+        if (!nodesEquals(n.getParameters(), n2.getParameters()))
             return false;
         if (!objEquals(n.isEnclosingParameters(), n2.isEnclosingParameters()))
             return false;
-        if (!nodesEquals(n.getParameters(), n2.getParameters()))
+        if (!nodeEquals(n.getBody(), n2.getBody()))
             return false;
         return true;
     }
@@ -942,11 +943,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final MethodReferenceExpr n, final Visitable arg) {
         final MethodReferenceExpr n2 = (MethodReferenceExpr) arg;
-        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
+        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
             return false;
         if (!nodeEquals(n.getScope(), n2.getScope()))
             return false;
-        if (!nodesEquals(n.getTypeArguments(), n2.getTypeArguments()))
+        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
             return false;
         return true;
     }
@@ -962,11 +963,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ImportDeclaration n, final Visitable arg) {
         final ImportDeclaration n2 = (ImportDeclaration) arg;
-        if (!objEquals(n.isAsterisk(), n2.isAsterisk()))
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         if (!objEquals(n.isStatic(), n2.isStatic()))
             return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!objEquals(n.isAsterisk(), n2.isAsterisk()))
             return false;
         return true;
     }
@@ -979,13 +980,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ModuleDeclaration n, final Visitable arg) {
         final ModuleDeclaration n2 = (ModuleDeclaration) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
-            return false;
-        if (!nodesEquals(n.getDirectives(), n2.getDirectives()))
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         if (!objEquals(n.isOpen(), n2.isOpen()))
             return false;
-        if (!nodeEquals(n.getName(), n2.getName()))
+        if (!nodesEquals(n.getDirectives(), n2.getDirectives()))
+            return false;
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -993,9 +994,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ModuleRequiresDirective n, final Visitable arg) {
         final ModuleRequiresDirective n2 = (ModuleRequiresDirective) arg;
-        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
-            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
             return false;
         return true;
     }
@@ -1003,9 +1004,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override()
     public Boolean visit(final ModuleExportsDirective n, final Visitable arg) {
         final ModuleExportsDirective n2 = (ModuleExportsDirective) arg;
-        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
-            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
             return false;
         return true;
     }
@@ -1013,9 +1014,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override()
     public Boolean visit(final ModuleProvidesDirective n, final Visitable arg) {
         final ModuleProvidesDirective n2 = (ModuleProvidesDirective) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
         if (!nodesEquals(n.getWith(), n2.getWith()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }
@@ -1031,9 +1032,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ModuleOpensDirective n, final Visitable arg) {
         final ModuleOpensDirective n2 = (ModuleOpensDirective) arg;
-        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
-            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
+            return false;
+        if (!nodesEquals(n.getModuleNames(), n2.getModuleNames()))
             return false;
         return true;
     }
@@ -1046,11 +1047,11 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final ReceiverParameter n, final Visitable arg) {
         final ReceiverParameter n2 = (ReceiverParameter) arg;
-        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
+        if (!nodeEquals(n.getType(), n2.getType()))
             return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
-        if (!nodeEquals(n.getType(), n2.getType()))
+        if (!nodesEquals(n.getAnnotations(), n2.getAnnotations()))
             return false;
         return true;
     }
@@ -1074,9 +1075,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final SwitchExpr n, final Visitable arg) {
         final SwitchExpr n2 = (SwitchExpr) arg;
-        if (!nodesEquals(n.getEntries(), n2.getEntries()))
-            return false;
         if (!nodeEquals(n.getSelector(), n2.getSelector()))
+            return false;
+        if (!nodesEquals(n.getEntries(), n2.getEntries()))
             return false;
         return true;
     }
@@ -1100,9 +1101,9 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final PatternExpr n, final Visitable arg) {
         final PatternExpr n2 = (PatternExpr) arg;
-        if (!nodeEquals(n.getName(), n2.getName()))
-            return false;
         if (!nodeEquals(n.getType(), n2.getType()))
+            return false;
+        if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         return true;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
@@ -39,23 +39,23 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final AnnotationDeclaration n, final Void arg) {
-        return (n.getMembers().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg));
     }
 
     public Integer visit(final AnnotationMemberDeclaration n, final Void arg) {
-        return (n.getDefaultValue().isPresent() ? n.getDefaultValue().get().accept(this, arg) : 0) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getDefaultValue().isPresent() ? n.getDefaultValue().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final ArrayAccessExpr n, final Void arg) {
-        return (n.getIndex().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.getIndex().accept(this, arg));
     }
 
     public Integer visit(final ArrayCreationExpr n, final Void arg) {
-        return (n.getElementType().accept(this, arg)) * 31 + (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0) * 31 + (n.getLevels().accept(this, arg));
+        return (n.getLevels().accept(this, arg)) * 31 + (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0) * 31 + (n.getElementType().accept(this, arg));
     }
 
     public Integer visit(final ArrayCreationLevel n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getDimension().isPresent() ? n.getDimension().get().accept(this, arg) : 0);
+        return (n.getDimension().isPresent() ? n.getDimension().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final ArrayInitializerExpr n, final Void arg) {
@@ -63,19 +63,19 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final ArrayType n, final Void arg) {
-        return (n.getComponentType().accept(this, arg)) * 31 + (n.getOrigin().hashCode()) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getOrigin().hashCode()) * 31 + (n.getComponentType().accept(this, arg));
     }
 
     public Integer visit(final AssertStmt n, final Void arg) {
-        return (n.getCheck().accept(this, arg)) * 31 + (n.getMessage().isPresent() ? n.getMessage().get().accept(this, arg) : 0);
+        return (n.getMessage().isPresent() ? n.getMessage().get().accept(this, arg) : 0) * 31 + (n.getCheck().accept(this, arg));
     }
 
     public Integer visit(final AssignExpr n, final Void arg) {
-        return (n.getOperator().hashCode()) * 31 + (n.getTarget().accept(this, arg)) * 31 + (n.getValue().accept(this, arg));
+        return (n.getValue().accept(this, arg)) * 31 + (n.getTarget().accept(this, arg)) * 31 + (n.getOperator().hashCode());
     }
 
     public Integer visit(final BinaryExpr n, final Void arg) {
-        return (n.getLeft().accept(this, arg)) * 31 + (n.getOperator().hashCode()) * 31 + (n.getRight().accept(this, arg));
+        return (n.getRight().accept(this, arg)) * 31 + (n.getOperator().hashCode()) * 31 + (n.getLeft().accept(this, arg));
     }
 
     public Integer visit(final BlockComment n, final Void arg) {
@@ -95,11 +95,11 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final CastExpr n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getType().accept(this, arg));
+        return (n.getType().accept(this, arg)) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final CatchClause n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getParameter().accept(this, arg));
+        return (n.getParameter().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final CharLiteralExpr n, final Void arg) {
@@ -111,23 +111,23 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final ClassOrInterfaceDeclaration n, final Void arg) {
-        return (n.getExtendedTypes().accept(this, arg)) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.isInterface() ? 1 : 0) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.isInterface() ? 1 : 0) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.getExtendedTypes().accept(this, arg));
     }
 
     public Integer visit(final ClassOrInterfaceType n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final CompilationUnit n, final Void arg) {
-        return (n.getImports().accept(this, arg)) * 31 + (n.getModule().isPresent() ? n.getModule().get().accept(this, arg) : 0) * 31 + (n.getPackageDeclaration().isPresent() ? n.getPackageDeclaration().get().accept(this, arg) : 0) * 31 + (n.getTypes().accept(this, arg));
+        return (n.getTypes().accept(this, arg)) * 31 + (n.getPackageDeclaration().isPresent() ? n.getPackageDeclaration().get().accept(this, arg) : 0) * 31 + (n.getModule().isPresent() ? n.getModule().get().accept(this, arg) : 0) * 31 + (n.getImports().accept(this, arg));
     }
 
     public Integer visit(final ConditionalExpr n, final Void arg) {
-        return (n.getCondition().accept(this, arg)) * 31 + (n.getElseExpr().accept(this, arg)) * 31 + (n.getThenExpr().accept(this, arg));
+        return (n.getThenExpr().accept(this, arg)) * 31 + (n.getElseExpr().accept(this, arg)) * 31 + (n.getCondition().accept(this, arg));
     }
 
     public Integer visit(final ConstructorDeclaration n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final ContinueStmt n, final Void arg) {
@@ -135,7 +135,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final DoStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getCondition().accept(this, arg));
+        return (n.getCondition().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final DoubleLiteralExpr n, final Void arg) {
@@ -151,15 +151,15 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final EnumConstantDeclaration n, final Void arg) {
-        return (n.getArguments().accept(this, arg)) * 31 + (n.getClassBody().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getClassBody().accept(this, arg)) * 31 + (n.getArguments().accept(this, arg));
     }
 
     public Integer visit(final EnumDeclaration n, final Void arg) {
-        return (n.getEntries().accept(this, arg)) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getMembers().accept(this, arg)) * 31 + (n.getImplementedTypes().accept(this, arg)) * 31 + (n.getEntries().accept(this, arg));
     }
 
     public Integer visit(final ExplicitConstructorInvocationStmt n, final Void arg) {
-        return (n.getArguments().accept(this, arg)) * 31 + (n.getExpression().isPresent() ? n.getExpression().get().accept(this, arg) : 0) * 31 + (n.isThis() ? 1 : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0);
+        return (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.isThis() ? 1 : 0) * 31 + (n.getExpression().isPresent() ? n.getExpression().get().accept(this, arg) : 0) * 31 + (n.getArguments().accept(this, arg));
     }
 
     public Integer visit(final ExpressionStmt n, final Void arg) {
@@ -167,35 +167,35 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final FieldAccessExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0);
+        return (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final FieldDeclaration n, final Void arg) {
-        return (n.getModifiers().accept(this, arg)) * 31 + (n.getVariables().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getVariables().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg));
     }
 
     public Integer visit(final ForStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getCompare().isPresent() ? n.getCompare().get().accept(this, arg) : 0) * 31 + (n.getInitialization().accept(this, arg)) * 31 + (n.getUpdate().accept(this, arg));
+        return (n.getUpdate().accept(this, arg)) * 31 + (n.getInitialization().accept(this, arg)) * 31 + (n.getCompare().isPresent() ? n.getCompare().get().accept(this, arg) : 0) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final ForEachStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getIterable().accept(this, arg)) * 31 + (n.getVariable().accept(this, arg));
+        return (n.getVariable().accept(this, arg)) * 31 + (n.getIterable().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final IfStmt n, final Void arg) {
-        return (n.getCondition().accept(this, arg)) * 31 + (n.getElseStmt().isPresent() ? n.getElseStmt().get().accept(this, arg) : 0) * 31 + (n.getThenStmt().accept(this, arg));
+        return (n.getThenStmt().accept(this, arg)) * 31 + (n.getElseStmt().isPresent() ? n.getElseStmt().get().accept(this, arg) : 0) * 31 + (n.getCondition().accept(this, arg));
     }
 
     public Integer visit(final ImportDeclaration n, final Void arg) {
-        return (n.isAsterisk() ? 1 : 0) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.isAsterisk() ? 1 : 0);
     }
 
     public Integer visit(final InitializerDeclaration n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.isStatic() ? 1 : 0) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final InstanceOfExpr n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getPattern().isPresent() ? n.getPattern().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg));
+        return (n.getType().accept(this, arg)) * 31 + (n.getPattern().isPresent() ? n.getPattern().get().accept(this, arg) : 0) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final IntegerLiteralExpr n, final Void arg) {
@@ -203,7 +203,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final IntersectionType n, final Void arg) {
-        return (n.getElements().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getElements().accept(this, arg));
     }
 
     public Integer visit(final JavadocComment n, final Void arg) {
@@ -211,11 +211,11 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final LabeledStmt n, final Void arg) {
-        return (n.getLabel().accept(this, arg)) * 31 + (n.getStatement().accept(this, arg));
+        return (n.getStatement().accept(this, arg)) * 31 + (n.getLabel().accept(this, arg));
     }
 
     public Integer visit(final LambdaExpr n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.isEnclosingParameters() ? 1 : 0) * 31 + (n.getParameters().accept(this, arg));
+        return (n.getParameters().accept(this, arg)) * 31 + (n.isEnclosingParameters() ? 1 : 0) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final LineComment n, final Void arg) {
@@ -235,19 +235,19 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final MemberValuePair n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getValue().accept(this, arg));
+        return (n.getValue().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final MethodCallExpr n, final Void arg) {
-        return (n.getArguments().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0);
+        return (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getArguments().accept(this, arg));
     }
 
     public Integer visit(final MethodDeclaration n, final Void arg) {
-        return (n.getBody().isPresent() ? n.getBody().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getReceiverParameter().isPresent() ? n.getReceiverParameter().get().accept(this, arg) : 0) * 31 + (n.getParameters().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getBody().isPresent() ? n.getBody().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final MethodReferenceExpr n, final Void arg) {
-        return (n.getIdentifier().hashCode()) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0);
+        return (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getScope().accept(this, arg)) * 31 + (n.getIdentifier().hashCode());
     }
 
     public Integer visit(final NameExpr n, final Void arg) {
@@ -255,7 +255,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final Name n, final Void arg) {
-        return (n.getIdentifier().hashCode()) * 31 + (n.getQualifier().isPresent() ? n.getQualifier().get().accept(this, arg) : 0);
+        return (n.getQualifier().isPresent() ? n.getQualifier().get().accept(this, arg) : 0) * 31 + (n.getIdentifier().hashCode());
     }
 
     public Integer visit(NodeList n, Void arg) {
@@ -267,7 +267,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final NormalAnnotationExpr n, final Void arg) {
-        return (n.getPairs().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.getPairs().accept(this, arg));
     }
 
     public Integer visit(final NullLiteralExpr n, final Void arg) {
@@ -275,19 +275,19 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final ObjectCreationExpr n, final Void arg) {
-        return (n.getAnonymousClassBody().isPresent() ? n.getAnonymousClassBody().get().accept(this, arg) : 0) * 31 + (n.getArguments().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0);
+        return (n.getTypeArguments().isPresent() ? n.getTypeArguments().get().accept(this, arg) : 0) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getScope().isPresent() ? n.getScope().get().accept(this, arg) : 0) * 31 + (n.getArguments().accept(this, arg)) * 31 + (n.getAnonymousClassBody().isPresent() ? n.getAnonymousClassBody().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final PackageDeclaration n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final Parameter n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.isVarArgs() ? 1 : 0) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getVarArgsAnnotations().accept(this, arg));
+        return (n.getVarArgsAnnotations().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.isVarArgs() ? 1 : 0) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final PrimitiveType n, final Void arg) {
-        return (n.getType().hashCode()) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getType().hashCode());
     }
 
     public Integer visit(final ReturnStmt n, final Void arg) {
@@ -299,7 +299,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final SingleMemberAnnotationExpr n, final Void arg) {
-        return (n.getMemberValue().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.getMemberValue().accept(this, arg));
     }
 
     public Integer visit(final StringLiteralExpr n, final Void arg) {
@@ -311,15 +311,15 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final SwitchEntry n, final Void arg) {
-        return (n.getLabels().accept(this, arg)) * 31 + (n.getStatements().accept(this, arg)) * 31 + (n.getType().hashCode());
+        return (n.getType().hashCode()) * 31 + (n.getStatements().accept(this, arg)) * 31 + (n.getLabels().accept(this, arg));
     }
 
     public Integer visit(final SwitchStmt n, final Void arg) {
-        return (n.getEntries().accept(this, arg)) * 31 + (n.getSelector().accept(this, arg));
+        return (n.getSelector().accept(this, arg)) * 31 + (n.getEntries().accept(this, arg));
     }
 
     public Integer visit(final SynchronizedStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getExpression().accept(this, arg));
+        return (n.getExpression().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final ThisExpr n, final Void arg) {
@@ -331,7 +331,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final TryStmt n, final Void arg) {
-        return (n.getCatchClauses().accept(this, arg)) * 31 + (n.getFinallyBlock().isPresent() ? n.getFinallyBlock().get().accept(this, arg) : 0) * 31 + (n.getResources().accept(this, arg)) * 31 + (n.getTryBlock().accept(this, arg));
+        return (n.getTryBlock().accept(this, arg)) * 31 + (n.getResources().accept(this, arg)) * 31 + (n.getFinallyBlock().isPresent() ? n.getFinallyBlock().get().accept(this, arg) : 0) * 31 + (n.getCatchClauses().accept(this, arg));
     }
 
     public Integer visit(final TypeExpr n, final Void arg) {
@@ -339,15 +339,15 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final TypeParameter n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getTypeBound().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getTypeBound().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     public Integer visit(final UnaryExpr n, final Void arg) {
-        return (n.getExpression().accept(this, arg)) * 31 + (n.getOperator().hashCode());
+        return (n.getOperator().hashCode()) * 31 + (n.getExpression().accept(this, arg));
     }
 
     public Integer visit(final UnionType n, final Void arg) {
-        return (n.getElements().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getElements().accept(this, arg));
     }
 
     public Integer visit(final UnknownType n, final Void arg) {
@@ -355,11 +355,11 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final VariableDeclarationExpr n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getVariables().accept(this, arg));
+        return (n.getVariables().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final VariableDeclarator n, final Void arg) {
-        return (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg));
+        return (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getInitializer().isPresent() ? n.getInitializer().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final VoidType n, final Void arg) {
@@ -367,29 +367,29 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final WhileStmt n, final Void arg) {
-        return (n.getBody().accept(this, arg)) * 31 + (n.getCondition().accept(this, arg));
+        return (n.getCondition().accept(this, arg)) * 31 + (n.getBody().accept(this, arg));
     }
 
     public Integer visit(final WildcardType n, final Void arg) {
-        return (n.getExtendedType().isPresent() ? n.getExtendedType().get().accept(this, arg) : 0) * 31 + (n.getSuperType().isPresent() ? n.getSuperType().get().accept(this, arg) : 0) * 31 + (n.getAnnotations().accept(this, arg));
+        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getSuperType().isPresent() ? n.getSuperType().get().accept(this, arg) : 0) * 31 + (n.getExtendedType().isPresent() ? n.getExtendedType().get().accept(this, arg) : 0);
     }
 
     public Integer visit(final ModuleDeclaration n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getDirectives().accept(this, arg)) * 31 + (n.isOpen() ? 1 : 0) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.isOpen() ? 1 : 0) * 31 + (n.getDirectives().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     public Integer visit(final ModuleRequiresDirective n, final Void arg) {
-        return (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg));
     }
 
     @Override()
     public Integer visit(final ModuleExportsDirective n, final Void arg) {
-        return (n.getModuleNames().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.getModuleNames().accept(this, arg));
     }
 
     @Override()
     public Integer visit(final ModuleProvidesDirective n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getWith().accept(this, arg));
+        return (n.getWith().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 
     @Override()
@@ -399,7 +399,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final ModuleOpensDirective n, final Void arg) {
-        return (n.getModuleNames().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
+        return (n.getName().accept(this, arg)) * 31 + (n.getModuleNames().accept(this, arg));
     }
 
     @Override
@@ -409,7 +409,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final ReceiverParameter n, final Void arg) {
-        return (n.getAnnotations().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg));
+        return (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
     @Override
@@ -424,7 +424,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final SwitchExpr n, final Void arg) {
-        return (n.getEntries().accept(this, arg)) * 31 + (n.getSelector().accept(this, arg));
+        return (n.getSelector().accept(this, arg)) * 31 + (n.getEntries().accept(this, arg));
     }
 
     @Override
@@ -439,6 +439,6 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final PatternExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg));
+        return (n.getType().accept(this, arg)) * 31 + (n.getName().accept(this, arg));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -40,63 +40,63 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final AnnotationDeclaration n, final A arg) {
-        n.getMembers().forEach(p -> p.accept(this, arg));
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getMembers().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final AnnotationMemberDeclaration n, final A arg) {
-        n.getDefaultValue().ifPresent(l -> l.accept(this, arg));
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getType().accept(this, arg);
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getDefaultValue().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final ArrayAccessExpr n, final A arg) {
-        n.getIndex().accept(this, arg);
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getIndex().accept(this, arg);
     }
 
     @Override
     public void visit(final ArrayCreationExpr n, final A arg) {
-        n.getElementType().accept(this, arg);
-        n.getInitializer().ifPresent(l -> l.accept(this, arg));
-        n.getLevels().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getLevels().forEach(p -> p.accept(this, arg));
+        n.getInitializer().ifPresent(l -> l.accept(this, arg));
+        n.getElementType().accept(this, arg);
     }
 
     @Override
     public void visit(final ArrayInitializerExpr n, final A arg) {
-        n.getValues().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getValues().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final AssertStmt n, final A arg) {
-        n.getCheck().accept(this, arg);
-        n.getMessage().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getMessage().ifPresent(l -> l.accept(this, arg));
+        n.getCheck().accept(this, arg);
     }
 
     @Override
     public void visit(final AssignExpr n, final A arg) {
-        n.getTarget().accept(this, arg);
-        n.getValue().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getValue().accept(this, arg);
+        n.getTarget().accept(this, arg);
     }
 
     @Override
     public void visit(final BinaryExpr n, final A arg) {
-        n.getLeft().accept(this, arg);
-        n.getRight().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getRight().accept(this, arg);
+        n.getLeft().accept(this, arg);
     }
 
     @Override
@@ -106,8 +106,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final BlockStmt n, final A arg) {
-        n.getStatements().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getStatements().forEach(p -> p.accept(this, arg));
     }
 
     @Override
@@ -117,22 +117,22 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final BreakStmt n, final A arg) {
-        n.getLabel().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getLabel().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final CastExpr n, final A arg) {
-        n.getExpression().accept(this, arg);
-        n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getExpression().accept(this, arg);
     }
 
     @Override
     public void visit(final CatchClause n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getParameter().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getParameter().accept(this, arg);
+        n.getBody().accept(this, arg);
     }
 
     @Override
@@ -142,72 +142,72 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final ClassExpr n, final A arg) {
-        n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getType().accept(this, arg);
     }
 
     @Override
     public void visit(final ClassOrInterfaceDeclaration n, final A arg) {
-        n.getExtendedTypes().forEach(p -> p.accept(this, arg));
-        n.getImplementedTypes().forEach(p -> p.accept(this, arg));
-        n.getTypeParameters().forEach(p -> p.accept(this, arg));
-        n.getMembers().forEach(p -> p.accept(this, arg));
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getMembers().forEach(p -> p.accept(this, arg));
+        n.getTypeParameters().forEach(p -> p.accept(this, arg));
+        n.getImplementedTypes().forEach(p -> p.accept(this, arg));
+        n.getExtendedTypes().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ClassOrInterfaceType n, final A arg) {
-        n.getName().accept(this, arg);
-        n.getScope().ifPresent(l -> l.accept(this, arg));
-        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
+        n.getScope().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final CompilationUnit n, final A arg) {
-        n.getImports().forEach(p -> p.accept(this, arg));
-        n.getModule().ifPresent(l -> l.accept(this, arg));
-        n.getPackageDeclaration().ifPresent(l -> l.accept(this, arg));
-        n.getTypes().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypes().forEach(p -> p.accept(this, arg));
+        n.getPackageDeclaration().ifPresent(l -> l.accept(this, arg));
+        n.getModule().ifPresent(l -> l.accept(this, arg));
+        n.getImports().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ConditionalExpr n, final A arg) {
-        n.getCondition().accept(this, arg);
-        n.getElseExpr().accept(this, arg);
-        n.getThenExpr().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getThenExpr().accept(this, arg);
+        n.getElseExpr().accept(this, arg);
+        n.getCondition().accept(this, arg);
     }
 
     @Override
     public void visit(final ConstructorDeclaration n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getParameters().forEach(p -> p.accept(this, arg));
-        n.getReceiverParameter().ifPresent(l -> l.accept(this, arg));
-        n.getThrownExceptions().forEach(p -> p.accept(this, arg));
-        n.getTypeParameters().forEach(p -> p.accept(this, arg));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getTypeParameters().forEach(p -> p.accept(this, arg));
+        n.getThrownExceptions().forEach(p -> p.accept(this, arg));
+        n.getReceiverParameter().ifPresent(l -> l.accept(this, arg));
+        n.getParameters().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getBody().accept(this, arg);
     }
 
     @Override
     public void visit(final ContinueStmt n, final A arg) {
-        n.getLabel().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getLabel().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final DoStmt n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getCondition().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getCondition().accept(this, arg);
+        n.getBody().accept(this, arg);
     }
 
     @Override
@@ -222,98 +222,98 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final EnclosedExpr n, final A arg) {
-        n.getInner().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getInner().accept(this, arg);
     }
 
     @Override
     public void visit(final EnumConstantDeclaration n, final A arg) {
-        n.getArguments().forEach(p -> p.accept(this, arg));
-        n.getClassBody().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getClassBody().forEach(p -> p.accept(this, arg));
+        n.getArguments().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final EnumDeclaration n, final A arg) {
-        n.getEntries().forEach(p -> p.accept(this, arg));
-        n.getImplementedTypes().forEach(p -> p.accept(this, arg));
-        n.getMembers().forEach(p -> p.accept(this, arg));
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getMembers().forEach(p -> p.accept(this, arg));
+        n.getImplementedTypes().forEach(p -> p.accept(this, arg));
+        n.getEntries().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-        n.getArguments().forEach(p -> p.accept(this, arg));
-        n.getExpression().ifPresent(l -> l.accept(this, arg));
-        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
+        n.getExpression().ifPresent(l -> l.accept(this, arg));
+        n.getArguments().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ExpressionStmt n, final A arg) {
-        n.getExpression().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getExpression().accept(this, arg);
     }
 
     @Override
     public void visit(final FieldAccessExpr n, final A arg) {
-        n.getName().accept(this, arg);
-        n.getScope().accept(this, arg);
-        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
+        n.getScope().accept(this, arg);
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final FieldDeclaration n, final A arg) {
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getVariables().forEach(p -> p.accept(this, arg));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getVariables().forEach(p -> p.accept(this, arg));
+        n.getModifiers().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ForEachStmt n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getIterable().accept(this, arg);
-        n.getVariable().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getVariable().accept(this, arg);
+        n.getIterable().accept(this, arg);
+        n.getBody().accept(this, arg);
     }
 
     @Override
     public void visit(final ForStmt n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getCompare().ifPresent(l -> l.accept(this, arg));
-        n.getInitialization().forEach(p -> p.accept(this, arg));
-        n.getUpdate().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getUpdate().forEach(p -> p.accept(this, arg));
+        n.getInitialization().forEach(p -> p.accept(this, arg));
+        n.getCompare().ifPresent(l -> l.accept(this, arg));
+        n.getBody().accept(this, arg);
     }
 
     @Override
     public void visit(final IfStmt n, final A arg) {
-        n.getCondition().accept(this, arg);
-        n.getElseStmt().ifPresent(l -> l.accept(this, arg));
-        n.getThenStmt().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getThenStmt().accept(this, arg);
+        n.getElseStmt().ifPresent(l -> l.accept(this, arg));
+        n.getCondition().accept(this, arg);
     }
 
     @Override
     public void visit(final InitializerDeclaration n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getBody().accept(this, arg);
     }
 
     @Override
     public void visit(final InstanceOfExpr n, final A arg) {
-        n.getExpression().accept(this, arg);
-        n.getPattern().ifPresent(l -> l.accept(this, arg));
-        n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getPattern().ifPresent(l -> l.accept(this, arg));
+        n.getExpression().accept(this, arg);
     }
 
     @Override
@@ -328,9 +328,9 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final LabeledStmt n, final A arg) {
-        n.getLabel().accept(this, arg);
-        n.getStatement().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getStatement().accept(this, arg);
+        n.getLabel().accept(this, arg);
     }
 
     @Override
@@ -345,51 +345,51 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final MarkerAnnotationExpr n, final A arg) {
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final MemberValuePair n, final A arg) {
-        n.getName().accept(this, arg);
-        n.getValue().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getValue().accept(this, arg);
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final MethodCallExpr n, final A arg) {
-        n.getArguments().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getScope().ifPresent(l -> l.accept(this, arg));
-        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
+        n.getScope().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getArguments().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final MethodDeclaration n, final A arg) {
-        n.getBody().ifPresent(l -> l.accept(this, arg));
-        n.getType().accept(this, arg);
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getParameters().forEach(p -> p.accept(this, arg));
-        n.getReceiverParameter().ifPresent(l -> l.accept(this, arg));
-        n.getThrownExceptions().forEach(p -> p.accept(this, arg));
-        n.getTypeParameters().forEach(p -> p.accept(this, arg));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getTypeParameters().forEach(p -> p.accept(this, arg));
+        n.getThrownExceptions().forEach(p -> p.accept(this, arg));
+        n.getReceiverParameter().ifPresent(l -> l.accept(this, arg));
+        n.getParameters().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getBody().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final NameExpr n, final A arg) {
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final NormalAnnotationExpr n, final A arg) {
-        n.getPairs().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getPairs().forEach(p -> p.accept(this, arg));
     }
 
     @Override
@@ -399,41 +399,41 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final ObjectCreationExpr n, final A arg) {
-        n.getAnonymousClassBody().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
-        n.getArguments().forEach(p -> p.accept(this, arg));
-        n.getScope().ifPresent(l -> l.accept(this, arg));
-        n.getType().accept(this, arg);
-        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
+        n.getType().accept(this, arg);
+        n.getScope().ifPresent(l -> l.accept(this, arg));
+        n.getArguments().forEach(p -> p.accept(this, arg));
+        n.getAnonymousClassBody().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
     }
 
     @Override
     public void visit(final PackageDeclaration n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final Parameter n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getType().accept(this, arg);
-        n.getVarArgsAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getVarArgsAnnotations().forEach(p -> p.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final PrimitiveType n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final Name n, final A arg) {
-        n.getQualifier().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getQualifier().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
@@ -443,43 +443,43 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final ArrayType n, final A arg) {
-        n.getComponentType().accept(this, arg);
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getComponentType().accept(this, arg);
     }
 
     @Override
     public void visit(final ArrayCreationLevel n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
-        n.getDimension().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getDimension().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final IntersectionType n, final A arg) {
-        n.getElements().forEach(p -> p.accept(this, arg));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getElements().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final UnionType n, final A arg) {
-        n.getElements().forEach(p -> p.accept(this, arg));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getElements().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ReturnStmt n, final A arg) {
-        n.getExpression().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getExpression().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final SingleMemberAnnotationExpr n, final A arg) {
-        n.getMemberValue().accept(this, arg);
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getMemberValue().accept(this, arg);
     }
 
     @Override
@@ -489,133 +489,133 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final SuperExpr n, final A arg) {
-        n.getTypeName().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypeName().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final SwitchEntry n, final A arg) {
-        n.getLabels().forEach(p -> p.accept(this, arg));
-        n.getStatements().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getStatements().forEach(p -> p.accept(this, arg));
+        n.getLabels().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final SwitchStmt n, final A arg) {
-        n.getEntries().forEach(p -> p.accept(this, arg));
-        n.getSelector().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getSelector().accept(this, arg);
+        n.getEntries().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final SynchronizedStmt n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getExpression().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getExpression().accept(this, arg);
+        n.getBody().accept(this, arg);
     }
 
     @Override
     public void visit(final ThisExpr n, final A arg) {
-        n.getTypeName().ifPresent(l -> l.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypeName().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final ThrowStmt n, final A arg) {
-        n.getExpression().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getExpression().accept(this, arg);
     }
 
     @Override
     public void visit(final TryStmt n, final A arg) {
-        n.getCatchClauses().forEach(p -> p.accept(this, arg));
-        n.getFinallyBlock().ifPresent(l -> l.accept(this, arg));
-        n.getResources().forEach(p -> p.accept(this, arg));
-        n.getTryBlock().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTryBlock().accept(this, arg);
+        n.getResources().forEach(p -> p.accept(this, arg));
+        n.getFinallyBlock().ifPresent(l -> l.accept(this, arg));
+        n.getCatchClauses().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final LocalClassDeclarationStmt n, final A arg) {
-        n.getClassDeclaration().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getClassDeclaration().accept(this, arg);
     }
 
     @Override
     public void visit(final TypeParameter n, final A arg) {
-        n.getName().accept(this, arg);
-        n.getTypeBound().forEach(p -> p.accept(this, arg));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getTypeBound().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final UnaryExpr n, final A arg) {
-        n.getExpression().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getExpression().accept(this, arg);
     }
 
     @Override
     public void visit(final UnknownType n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final VariableDeclarationExpr n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getVariables().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getVariables().forEach(p -> p.accept(this, arg));
+        n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final VariableDeclarator n, final A arg) {
-        n.getInitializer().ifPresent(l -> l.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getName().accept(this, arg);
+        n.getInitializer().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final VoidType n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final WhileStmt n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getCondition().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getCondition().accept(this, arg);
+        n.getBody().accept(this, arg);
     }
 
     @Override
     public void visit(final WildcardType n, final A arg) {
-        n.getExtendedType().ifPresent(l -> l.accept(this, arg));
-        n.getSuperType().ifPresent(l -> l.accept(this, arg));
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
+        n.getSuperType().ifPresent(l -> l.accept(this, arg));
+        n.getExtendedType().ifPresent(l -> l.accept(this, arg));
     }
 
     @Override
     public void visit(final LambdaExpr n, final A arg) {
-        n.getBody().accept(this, arg);
-        n.getParameters().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getParameters().forEach(p -> p.accept(this, arg));
+        n.getBody().accept(this, arg);
     }
 
     @Override
     public void visit(final MethodReferenceExpr n, final A arg) {
-        n.getScope().accept(this, arg);
-        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getTypeArguments().ifPresent(l -> l.forEach(v -> v.accept(this, arg)));
+        n.getScope().accept(this, arg);
     }
 
     @Override
     public void visit(final TypeExpr n, final A arg) {
-        n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getType().accept(this, arg);
     }
 
     @Override
@@ -627,48 +627,48 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final ImportDeclaration n, final A arg) {
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
     }
 
     public void visit(final ModuleDeclaration n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
-        n.getDirectives().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getDirectives().forEach(p -> p.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     public void visit(final ModuleRequiresDirective n, final A arg) {
-        n.getModifiers().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModifiers().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ModuleExportsDirective n, final A arg) {
-        n.getModuleNames().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModuleNames().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final ModuleProvidesDirective n, final A arg) {
-        n.getName().accept(this, arg);
-        n.getWith().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getWith().forEach(p -> p.accept(this, arg));
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final ModuleUsesDirective n, final A arg) {
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
     }
 
     @Override
     public void visit(final ModuleOpensDirective n, final A arg) {
-        n.getModuleNames().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getName().accept(this, arg);
+        n.getModuleNames().forEach(p -> p.accept(this, arg));
     }
 
     @Override
@@ -678,16 +678,16 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final ReceiverParameter n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
-        n.getName().accept(this, arg);
-        n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getName().accept(this, arg);
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
     public void visit(final VarType n, final A arg) {
-        n.getAnnotations().forEach(p -> p.accept(this, arg));
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getAnnotations().forEach(p -> p.accept(this, arg));
     }
 
     @Override
@@ -697,9 +697,9 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final SwitchExpr n, final A arg) {
-        n.getEntries().forEach(p -> p.accept(this, arg));
-        n.getSelector().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getSelector().accept(this, arg);
+        n.getEntries().forEach(p -> p.accept(this, arg));
     }
 
     @Override
@@ -709,14 +709,14 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final YieldStmt n, final A arg) {
-        n.getExpression().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getExpression().accept(this, arg);
     }
 
     @Override
     public void visit(final PatternExpr n, final A arg) {
-        n.getName().accept(this, arg);
-        n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));
+        n.getType().accept(this, arg);
+        n.getName().accept(this, arg);
     }
 }


### PR DESCRIPTION
Fixes #3016.

According to issue #3011 the order of visitors is not consistent, making it not work as expected. In that PR was suggested a fix for it, but it's replaced every time the generator is run. This PR fixes the issue by implementing it directly in the Generator.

Although #3011 only mentioned `ModifiersVisitor`, in this PR the other visitors were also updated to keep the visit order consistent between them. 