### PR TITLE
Fix issue #3159 JavaParserSymbolDeclaration is used to represent variables, but #isVariable() always returns false

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclaration.java
@@ -21,6 +21,8 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import static com.github.javaparser.symbolsolver.javaparser.Navigator.demandParentNode;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.Parameter;
@@ -38,8 +40,6 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-
-import static com.github.javaparser.symbolsolver.javaparser.Navigator.demandParentNode;
 
 /**
  * This should not be used to represent fields of parameters.
@@ -126,6 +126,14 @@ public class JavaParserSymbolDeclaration implements ResolvedValueDeclaration {
     public boolean isPattern() {
 //        return getWrappedNode() instanceof PatternExpr;
         return false;
+    }
+    
+    /**
+     * Does this declaration represents a variable?
+     */
+    @Override
+    public boolean isVariable() {
+        return getWrappedNode() instanceof VariableDeclarator;
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3159Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3159Test.java
@@ -1,0 +1,40 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue3159Test extends AbstractResolutionTest {
+
+    @Test
+    public void test() throws IOException {
+        String code = "class Test {\n" +
+                "  void f() {\n" +
+                "    int a = 0;\n" +
+                "    while (a < 10) {}\n" +
+                "  }\n" +
+                "}";
+        
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        NameExpr mce = cu.findFirst(NameExpr.class).get();
+
+        ResolvedValueDeclaration v = mce.resolve();
+        // verify that the symbol declaration represents a variable
+        assertTrue(v.isVariable());
+    }
+
+}


### PR DESCRIPTION
Fixes #3159 .
