### PR TITLE
Created dedicated class pool for JarTypeSolver to avoid pollution

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
@@ -21,31 +21,21 @@
 
 package com.github.javaparser.symbolsolver.resolution.typesolvers;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.javassistmodel.JavassistFactory;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.utils.Log;
-
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.NotFoundException;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * Will let the symbol solver look inside a jar file while solving types.
@@ -54,11 +44,11 @@ import javassist.NotFoundException;
  */
 public class JarTypeSolver implements TypeSolver {
 
+    // Create a dedicated ClassPool for the JarTypeSolver to avoid pollution of the default.
+    private static final ClassPool CLASS_POOL = new ClassPool(false);
+
     private TypeSolver parent;
     private Map<String, ClasspathElement> classpathElements = new HashMap<>();
-    // Returns the default class pool. The returned object is always identical since this method is a singleton
-    // factory. The default class pool searches the system search path. This is a difference from the previous class pool instantiation.
-    private ClassPool classPool = ClassPool.getDefault();
     
     /*
      * ResourceRegistry is useful for freeing up resources.
@@ -158,8 +148,8 @@ public class JarTypeSolver implements TypeSolver {
 
     private void addPathToJar(String pathToJar) throws IOException {
         try {
-            classPool.appendClassPath(pathToJar);
-            classPool.appendSystemPath();
+            CLASS_POOL.appendClassPath(pathToJar);
+            CLASS_POOL.appendSystemPath();
         } catch (NotFoundException e) {
             throw new RuntimeException(e);
         }
@@ -239,7 +229,7 @@ public class JarTypeSolver implements TypeSolver {
 
         CtClass toCtClass() throws IOException {
             try (InputStream is = jarFile.getInputStream(entry)) {
-                return classPool.makeClass(is);
+                return CLASS_POOL.makeClass(is);
             }
         }
     }


### PR DESCRIPTION
While I was developing test code for the project, noticed that the default `ClassPool` was pointing to old classes. The problem was related with the `JarTypeSolver` using the default class pool to create new classes that override the old ones.

For more information, please see: https://github.com/javaparser/javaparser/pull/3142#issuecomment-793041340

This PR replaces the use of the default `ClassPool` with a dedicated `ClassPool`.