### PR TITLE
Fixed name resolution in casted lambda expressions

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
@@ -170,6 +171,32 @@ public class LambdaExprContext extends AbstractJavaParserContext<LambdaExpr> {
                             } else {
                                 throw new UnsupportedOperationException();
                             }
+                        }
+                    } else if (parentNode instanceof CastExpr) {
+                        CastExpr castExpr = (CastExpr) parentNode;
+                        ResolvedType t = JavaParserFacade.get(typeSolver).convertToUsage(castExpr.getType());
+                        Optional<MethodUsage> functionalMethod = FunctionalInterfaceLogic.getFunctionalMethod(t);
+
+                        if (functionalMethod.isPresent()) {
+                            ResolvedType lambdaType = functionalMethod.get().getParamType(index);
+
+                            // Replace parameter from declarator
+                            Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes = new HashMap<>();
+                            if (lambdaType.isReferenceType()) {
+                                for (com.github.javaparser.utils.Pair<ResolvedTypeParameterDeclaration, ResolvedType> entry : lambdaType.asReferenceType().getTypeParametersMap()) {
+                                    if (entry.b.isTypeVariable() && entry.b.asTypeParameter().declaredOnType()) {
+                                        ResolvedType ot = t.asReferenceType().typeParametersMap().getValue(entry.a);
+                                        lambdaType = lambdaType.replaceTypeVariables(entry.a, ot, inferredTypes);
+                                    }
+                                }
+                            } else if (lambdaType.isTypeVariable() && lambdaType.asTypeParameter().declaredOnType()) {
+                                lambdaType = t.asReferenceType().typeParametersMap().getValue(lambdaType.asTypeParameter());
+                            }
+
+                            Value value = new Value(lambdaType, name);
+                            return Optional.of(value);
+                        } else {
+                            throw new UnsupportedOperationException();
                         }
                     } else {
                         throw new UnsupportedOperationException();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/LambdaExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/LambdaExprContextResolutionTest.java
@@ -24,6 +24,7 @@ package com.github.javaparser.symbolsolver.resolution.javaparser.contexts;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.ReturnStmt;
@@ -104,6 +105,27 @@ class LambdaExprContextResolutionTest extends AbstractResolutionTest {
         MethodDeclaration method = Navigator.demandMethod(clazz, "testFunctionalVar");
         VariableDeclarator varDecl = Navigator.demandVariableDeclaration(method, "a").get();
         LambdaExpr lambdaExpr = (LambdaExpr) varDecl.getInitializer().get();
+
+        Path src = adaptPath("src/test/resources");
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver());
+        combinedTypeSolver.add(new JavaParserTypeSolver(src, new LeanParserConfiguration()));
+
+        Context context = new LambdaExprContext(lambdaExpr, combinedTypeSolver);
+
+        Optional<Value> ref = context.solveSymbolAsValue("p");
+        assertTrue(ref.isPresent());
+        assertEquals("java.lang.String", ref.get().getType().describe());
+    }
+
+    @Test
+    void solveParameterOfLambdaInCast() {
+        CompilationUnit cu = parseSample("Lambda");
+
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "testCast");
+        VariableDeclarator varDecl = Navigator.demandVariableDeclaration(method, "a").get();
+        LambdaExpr lambdaExpr = ((CastExpr) varDecl.getInitializer().get()).getExpression().asLambdaExpr();
 
         Path src = adaptPath("src/test/resources");
         CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();

--- a/javaparser-symbol-solver-testing/src/test/resources/Lambda.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Lambda.java.txt
@@ -53,4 +53,8 @@ public class Agenda {
     	Lambda a = p -> p.toLowerCase();
     }
 
+    public void testCast(){
+        Object a = (Lambda) p -> p.toLowerCase();
+    }
+
 }


### PR DESCRIPTION
Fixes name resolution in constructs like `Object a = (Lambda) p -> p.toLowerCase();`
