### PR TITLE
Refactor the javassist implementation to delegate to the typesolver instead of using its own classpool

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -59,7 +59,7 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
         }
         this.ctClass = ctClass;
         this.typeSolver = typeSolver;
-        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver);
+        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver, this);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationDeclaration.java
@@ -100,7 +100,7 @@ public class JavassistAnnotationDeclaration extends AbstractTypeDeclaration impl
 
     @Override
     public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
-        throw new UnsupportedOperationException();
+        return javassistTypeDeclarationAdapter.getAncestors(acceptIncompleteList);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -136,7 +136,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration implemen
     @Deprecated
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameterValues) {
-        return JavassistUtils.getMethodUsage(ctClass, name, argumentsTypes, typeSolver, getTypeParameters(), typeParameterValues);
+        return JavassistUtils.solveMethodAsUsage(name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }
 
     @Deprecated

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -78,7 +78,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration implemen
         }
         this.ctClass = ctClass;
         this.typeSolver = typeSolver;
-        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver);
+        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver, this);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -277,19 +277,21 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration implemen
         if (type.describe().equals(this.getQualifiedName())) {
             return true;
         }
-        try {
-            if (this.ctClass.getSuperclass() != null
-                    && new JavassistClassDeclaration(this.ctClass.getSuperclass(), typeSolver).isAssignableBy(type)) {
+
+        Optional<ResolvedReferenceType> superClassOpt = getSuperClass();
+        if (superClassOpt.isPresent()) {
+            ResolvedReferenceType superClass = superClassOpt.get();
+            if (superClass.isAssignableBy(type)) {
                 return true;
             }
-            for (CtClass interfaze : ctClass.getInterfaces()) {
-                if (new JavassistInterfaceDeclaration(interfaze, typeSolver).isAssignableBy(type)) {
-                    return true;
-                }
-            }
-        } catch (NotFoundException e) {
-            throw new RuntimeException(e);
         }
+
+        for (ResolvedReferenceType interfaceType : getInterfaces()) {
+            if (interfaceType.isAssignableBy(type)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistConstructorDeclaration.java
@@ -22,20 +22,14 @@
 package com.github.javaparser.symbolsolver.javassistmodel;
 
 import com.github.javaparser.ast.AccessSpecifier;
-import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import javassist.CtConstructor;
-import javassist.NotFoundException;
-import javassist.bytecode.*;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * @author Fred Lefévère-Laoide
@@ -43,10 +37,12 @@ import java.util.stream.Collectors;
 public class JavassistConstructorDeclaration implements ResolvedConstructorDeclaration {
     private final CtConstructor ctConstructor;
     private final TypeSolver typeSolver;
+    private final JavassistMethodLikeDeclarationAdapter methodLikeAdaper;
 
     public JavassistConstructorDeclaration(CtConstructor ctConstructor, TypeSolver typeSolver) {
         this.ctConstructor = ctConstructor;
         this.typeSolver = typeSolver;
+        this.methodLikeAdaper = new JavassistMethodLikeDeclarationAdapter(ctConstructor, typeSolver, this);
     }
 
     @Override
@@ -78,54 +74,23 @@ public class JavassistConstructorDeclaration implements ResolvedConstructorDecla
     }
 
     @Override
-    public ResolvedClassDeclaration declaringType() {
-        return new JavassistClassDeclaration(ctConstructor.getDeclaringClass(), typeSolver);
+    public ResolvedReferenceTypeDeclaration declaringType() {
+        return JavassistFactory.toTypeDeclaration(ctConstructor.getDeclaringClass(), typeSolver);
     }
 
     @Override
     public int getNumberOfParams() {
-        try {
-            return ctConstructor.getParameterTypes().length;
-        } catch (NotFoundException e) {
-            throw new RuntimeException(e);
-        }
+        return methodLikeAdaper.getNumberOfParams();
     }
 
     @Override
     public ResolvedParameterDeclaration getParam(int i) {
-        try {
-            boolean variadic = false;
-            if ((ctConstructor.getModifiers() & javassist.Modifier.VARARGS) > 0) {
-                variadic = i == (ctConstructor.getParameterTypes().length - 1);
-            }
-            Optional<String> paramName = JavassistUtils.extractParameterName(ctConstructor, i);
-            if (ctConstructor.getGenericSignature() != null) {
-                SignatureAttribute.MethodSignature methodSignature = SignatureAttribute.toMethodSignature(ctConstructor.getGenericSignature());
-                SignatureAttribute.Type signatureType = methodSignature.getParameterTypes()[i];
-                return new JavassistParameterDeclaration(JavassistUtils.signatureTypeToType(signatureType,
-                        typeSolver, this), typeSolver, variadic, paramName.orElse(null));
-            } else {
-                return new JavassistParameterDeclaration(ctConstructor.getParameterTypes()[i], typeSolver, variadic,
-                        paramName.orElse(null));
-            }
-        } catch (NotFoundException e) {
-            throw new RuntimeException(e);
-        } catch (BadBytecode badBytecode) {
-            throw new RuntimeException(badBytecode);
-        }
+        return methodLikeAdaper.getParam(i);
     }
 
     @Override
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
-        try {
-            if (ctConstructor.getGenericSignature() == null) {
-                return Collections.emptyList();
-            }
-            SignatureAttribute.MethodSignature methodSignature = SignatureAttribute.toMethodSignature(ctConstructor.getGenericSignature());
-            return Arrays.stream(methodSignature.getTypeParameters()).map((jasTp) -> new JavassistTypeParameter(jasTp, this, typeSolver)).collect(Collectors.toList());
-        } catch (BadBytecode badBytecode) {
-            throw new RuntimeException(badBytecode);
-        }
+        return methodLikeAdaper.getTypeParameters();
     }
 
     @Override
@@ -135,24 +100,12 @@ public class JavassistConstructorDeclaration implements ResolvedConstructorDecla
 
     @Override
     public int getNumberOfSpecifiedExceptions() {
-        try {
-            return ctConstructor.getExceptionTypes().length;
-        } catch (NotFoundException e) {
-            throw new RuntimeException(e);
-        }
+        return methodLikeAdaper.getNumberOfSpecifiedExceptions();
     }
 
     @Override
     public ResolvedType getSpecifiedException(int index) {
-        if (index < 0 || index >= getNumberOfSpecifiedExceptions()) {
-            throw new IllegalArgumentException(String.format("No exception with index %d. Number of exceptions: %d",
-                    index, getNumberOfSpecifiedExceptions()));
-        }
-        try {
-            return JavassistFactory.typeUsageFor(ctConstructor.getExceptionTypes()[index], typeSolver);
-        } catch (NotFoundException e) {
-            throw new RuntimeException(e);
-        }
+        return methodLikeAdaper.getSpecifiedException(index);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -96,34 +96,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
 
     @Override
     public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
-        // Direct ancestors of an enum are java.lang.Enum and interfaces
-        List<ResolvedReferenceType> ancestors = new ArrayList<>();
-
-        String superClassName = ctClass.getClassFile().getSuperclass();
-
-        if (superClassName != null) {
-            try {
-                ancestors.add(new ReferenceTypeImpl(typeSolver.solveType(superClassName), typeSolver));
-            } catch (UnsolvedSymbolException e) {
-                if (!acceptIncompleteList) {
-                    // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
-                    throw e;
-                }
-            }
-        }
-
-        for (String interfazeName : ctClass.getClassFile().getInterfaces()) {
-            try {
-                ancestors.add(new ReferenceTypeImpl(typeSolver.solveType(interfazeName), typeSolver));
-            } catch (UnsolvedSymbolException e) {
-                if (!acceptIncompleteList) {
-                    // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
-                    throw e;
-                }
-            }
-        }
-
-        return ancestors;
+        return javassistTypeDeclarationAdapter.getAncestors(acceptIncompleteList);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -67,7 +67,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
         }
         this.ctClass = ctClass;
         this.typeSolver = typeSolver;
-        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver);
+        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver, this);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -33,7 +33,6 @@ import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.logic.MethodResolutionCapability;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.symbolsolver.resolution.MethodResolutionLogic;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import javassist.CtClass;
@@ -193,7 +192,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
 
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameterValues) {
-        return JavassistUtils.getMethodUsage(ctClass, name, argumentsTypes, typeSolver, getTypeParameters(), typeParameterValues);
+        return JavassistUtils.solveMethodAsUsage(name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFieldDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFieldDeclaration.java
@@ -52,7 +52,7 @@ public class JavassistFieldDeclaration implements ResolvedFieldDeclaration {
             if (signature == null) {
                 signature = ctField.getSignature();
             }
-            SignatureAttribute.Type genericSignatureType = SignatureAttribute.toFieldSignature(signature);
+            SignatureAttribute.Type genericSignatureType = SignatureAttribute.toTypeSignature(signature);
             return JavassistUtils.signatureTypeToType(genericSignatureType, typeSolver, (ResolvedTypeParametrizable) declaringType());
         } catch (BadBytecode e) {
             throw new RuntimeException(e);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFieldDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFieldDeclaration.java
@@ -28,7 +28,6 @@ import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import javassist.CtField;
-import javassist.NotFoundException;
 import javassist.bytecode.BadBytecode;
 import javassist.bytecode.SignatureAttribute;
 
@@ -49,13 +48,13 @@ public class JavassistFieldDeclaration implements ResolvedFieldDeclaration {
     @Override
     public ResolvedType getType() {
         try {
-            if (ctField.getGenericSignature() != null && declaringType() instanceof ResolvedTypeParametrizable) {
-                javassist.bytecode.SignatureAttribute.Type genericSignatureType = SignatureAttribute.toFieldSignature(ctField.getGenericSignature());
-                return JavassistUtils.signatureTypeToType(genericSignatureType, typeSolver, (ResolvedTypeParametrizable) declaringType());
-            } else {
-                return JavassistFactory.typeUsageFor(ctField.getType(), typeSolver);
+            String signature = ctField.getGenericSignature();
+            if (signature == null) {
+                signature = ctField.getSignature();
             }
-        } catch (NotFoundException | BadBytecode e) {
+            SignatureAttribute.Type genericSignatureType = SignatureAttribute.toFieldSignature(signature);
+            return JavassistUtils.signatureTypeToType(genericSignatureType, typeSolver, (ResolvedTypeParametrizable) declaringType());
+        } catch (BadBytecode e) {
             throw new RuntimeException(e);
         }
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -116,8 +116,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
     @Deprecated
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameterValues) {
-
-        return JavassistUtils.getMethodUsage(ctClass, name, argumentsTypes, typeSolver, getTypeParameters(), typeParameterValues);
+        return JavassistUtils.solveMethodAsUsage(name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -91,8 +91,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
 
     @Override
     public List<ResolvedReferenceType> getInterfacesExtended() {
-        return Arrays.stream(ctClass.getClassFile().getInterfaces()).map(i -> typeSolver.solveType(i))
-                .map(i -> new ReferenceTypeImpl(i, typeSolver)).collect(Collectors.toList());
+        return javassistTypeDeclarationAdapter.getInterfaces();
     }
 
     @Override
@@ -177,41 +176,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
 
     @Override
     public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
-        List<ResolvedReferenceType> ancestors = new ArrayList<>();
-        if (ctClass.getGenericSignature() == null) {
-            for (String superInterface : ctClass.getClassFile().getInterfaces()) {
-                try {
-                    ancestors.add(new ReferenceTypeImpl(typeSolver.solveType(JavassistUtils.internalNameToCanonicalName(superInterface)), typeSolver));
-                } catch (UnsolvedSymbolException e) {
-                    if (!acceptIncompleteList) {
-                        // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
-                        throw e;
-                    }
-                }
-            }
-        } else {
-            try {
-                SignatureAttribute.ClassSignature classSignature = SignatureAttribute.toClassSignature(ctClass.getGenericSignature());
-                for (SignatureAttribute.ClassType superInterface : classSignature.getInterfaces()) {
-                    try {
-                        ancestors.add(JavassistUtils.signatureTypeToType(superInterface, typeSolver, this).asReferenceType());
-                    } catch (UnsolvedSymbolException e) {
-                        if (!acceptIncompleteList) {
-                            // we only throw an exception if we require a complete list; otherwise, we attempt to continue gracefully
-                            throw e;
-                        }
-                    }
-                }
-            } catch (BadBytecode e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        // Remove all {@code java.lang.Object}, then add precisely one.
-        ancestors.removeIf(ResolvedReferenceType::isJavaLangObject);
-        ancestors.add(new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject(), typeSolver));
-
-        return ancestors;
+        return javassistTypeDeclarationAdapter.getAncestors(acceptIncompleteList);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -86,7 +86,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
         }
         this.ctClass = ctClass;
         this.typeSolver = typeSolver;
-        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver);
+        this.javassistTypeDeclarationAdapter = new JavassistTypeDeclarationAdapter(ctClass, typeSolver, this);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodLikeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodLikeDeclarationAdapter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2020 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javassistmodel;
+
+import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import javassist.CtBehavior;
+import javassist.bytecode.BadBytecode;
+import javassist.bytecode.SignatureAttribute;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class JavassistMethodLikeDeclarationAdapter {
+
+    private CtBehavior ctBehavior;
+    private TypeSolver typeSolver;
+    private ResolvedMethodLikeDeclaration declaration;
+
+    private SignatureAttribute.MethodSignature methodSignature;
+
+    public JavassistMethodLikeDeclarationAdapter(CtBehavior ctBehavior, TypeSolver typeSolver, ResolvedMethodLikeDeclaration declaration) {
+        this.ctBehavior = ctBehavior;
+        this.typeSolver = typeSolver;
+        this.declaration = declaration;
+
+        try {
+            String signature = ctBehavior.getGenericSignature();
+            if (signature == null) {
+                signature = ctBehavior.getSignature();
+            }
+            methodSignature = SignatureAttribute.toMethodSignature(signature);
+        } catch (BadBytecode e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public int getNumberOfParams() {
+        return methodSignature.getParameterTypes().length;
+    }
+
+    public ResolvedParameterDeclaration getParam(int i) {
+        boolean variadic = false;
+        if ((ctBehavior.getModifiers() & javassist.Modifier.VARARGS) > 0) {
+            variadic = i == (methodSignature.getParameterTypes().length - 1);
+        }
+
+        Optional<String> paramName = JavassistUtils.extractParameterName(ctBehavior, i);
+        ResolvedType type = JavassistUtils.signatureTypeToType(methodSignature.getParameterTypes()[i], typeSolver, declaration);
+        return new JavassistParameterDeclaration(type, typeSolver, variadic, paramName.orElse(null));
+    }
+
+    public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+        if (ctBehavior.getGenericSignature() == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(methodSignature.getTypeParameters())
+                .map(jasTp -> new JavassistTypeParameter(jasTp, declaration, typeSolver))
+                .collect(Collectors.toList());
+    }
+
+    public int getNumberOfSpecifiedExceptions() {
+        return methodSignature.getExceptionTypes().length;
+    }
+
+    public ResolvedType getSpecifiedException(int index) {
+        if (index < 0 || index >= getNumberOfSpecifiedExceptions()) {
+            throw new IllegalArgumentException(String.format("No exception with index %d. Number of exceptions: %d",
+                    index, getNumberOfSpecifiedExceptions()));
+        }
+
+        return JavassistUtils.signatureTypeToType(methodSignature.getExceptionTypes()[index], typeSolver, declaration);
+    }
+
+    public ResolvedType getReturnType() {
+        return JavassistUtils.signatureTypeToType(methodSignature.getReturnType(), typeSolver, declaration);
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodLikeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistMethodLikeDeclarationAdapter.java
@@ -30,10 +30,7 @@ import javassist.CtBehavior;
 import javassist.bytecode.BadBytecode;
 import javassist.bytecode.SignatureAttribute;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class JavassistMethodLikeDeclarationAdapter {
@@ -77,7 +74,7 @@ public class JavassistMethodLikeDeclarationAdapter {
 
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
         if (ctBehavior.getGenericSignature() == null) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
         return Arrays.stream(methodSignature.getTypeParameters())
                 .map(jasTp -> new JavassistTypeParameter(jasTp, declaration, typeSolver))

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
@@ -22,8 +22,10 @@
 package com.github.javaparser.symbolsolver.javassistmodel;
 
 import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import javassist.CtClass;
+import javassist.CtField;
 import javassist.NotFoundException;
 import javassist.bytecode.AccessFlag;
 import javassist.bytecode.BadBytecode;
@@ -37,68 +39,70 @@ import java.util.stream.Collectors;
  */
 public class JavassistTypeDeclarationAdapter {
 
-  private CtClass ctClass;
-  private TypeSolver typeSolver;
+    private CtClass ctClass;
+    private TypeSolver typeSolver;
+    private ResolvedReferenceTypeDeclaration typeDeclaration;
 
-  public JavassistTypeDeclarationAdapter(CtClass ctClass, TypeSolver typeSolver) {
-    this.ctClass = ctClass;
-    this.typeSolver = typeSolver;
-  }
-
-  public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
-    return Arrays.stream(ctClass.getDeclaredMethods())
-        .filter(m -> ((m.getMethodInfo().getAccessFlags() & AccessFlag.BRIDGE) == 0)
-                  && ((m.getMethodInfo().getAccessFlags() & AccessFlag.SYNTHETIC) == 0))
-        .map(m -> new JavassistMethodDeclaration(m, typeSolver)).collect(Collectors.toSet());
-  }
-
-  public List<ResolvedConstructorDeclaration> getConstructors() {
-    return Arrays.stream(ctClass.getConstructors())
-        .filter(m -> (m.getMethodInfo().getAccessFlags() & AccessFlag.SYNTHETIC) == 0)
-        .map(m -> new JavassistConstructorDeclaration(m, typeSolver)).collect(Collectors.toList());
-  }
-
-  public List<ResolvedFieldDeclaration> getDeclaredFields() {
-    List<ResolvedFieldDeclaration> fieldDecls = new ArrayList<>();
-    collectDeclaredFields(ctClass, fieldDecls);
-    return fieldDecls;
-  }
-
-  private void collectDeclaredFields(CtClass ctClass, List<ResolvedFieldDeclaration> fieldDecls) {
-    if (ctClass != null) {
-      Arrays.stream(ctClass.getDeclaredFields())
-          .forEach(f -> fieldDecls.add(new JavassistFieldDeclaration(f, typeSolver)));
-      try {
-        collectDeclaredFields(ctClass.getSuperclass(), fieldDecls);
-      } catch (NotFoundException e) {
-        // We'll stop here
-      }
+    public JavassistTypeDeclarationAdapter(CtClass ctClass, TypeSolver typeSolver, ResolvedReferenceTypeDeclaration typeDeclaration) {
+        this.ctClass = ctClass;
+        this.typeSolver = typeSolver;
+        this.typeDeclaration = typeDeclaration;
     }
-  }
 
-  public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
-    if (null == ctClass.getGenericSignature()) {
-      return Collections.emptyList();
-    } else {
-      try {
-        SignatureAttribute.ClassSignature classSignature =
-            SignatureAttribute.toClassSignature(ctClass.getGenericSignature());
-        return Arrays.<SignatureAttribute.TypeParameter>stream(classSignature.getParameters())
-            .map((tp) -> new JavassistTypeParameter(tp, JavassistFactory.toTypeDeclaration(ctClass, typeSolver), typeSolver))
-            .collect(Collectors.toList());
-      } catch (BadBytecode badBytecode) {
-        throw new RuntimeException(badBytecode);
-      }
+    public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
+        return Arrays.stream(ctClass.getDeclaredMethods())
+                .filter(m -> ((m.getMethodInfo().getAccessFlags() & AccessFlag.BRIDGE) == 0)
+                        && ((m.getMethodInfo().getAccessFlags() & AccessFlag.SYNTHETIC) == 0))
+                .map(m -> new JavassistMethodDeclaration(m, typeSolver)).collect(Collectors.toSet());
     }
-  }
 
-  public Optional<ResolvedReferenceTypeDeclaration> containerType() {
-    try {
-      return ctClass.getDeclaringClass() == null ?
-          Optional.empty() :
-          Optional.of(JavassistFactory.toTypeDeclaration(ctClass.getDeclaringClass(), typeSolver));
-    } catch (NotFoundException e) {
-      throw new RuntimeException(e);
+    public List<ResolvedConstructorDeclaration> getConstructors() {
+        return Arrays.stream(ctClass.getConstructors())
+                .filter(m -> (m.getMethodInfo().getAccessFlags() & AccessFlag.SYNTHETIC) == 0)
+                .map(m -> new JavassistConstructorDeclaration(m, typeSolver)).collect(Collectors.toList());
     }
-  }
+
+    public List<ResolvedFieldDeclaration> getDeclaredFields() {
+        List<ResolvedFieldDeclaration> fields = new ArrayList<>();
+
+        // First consider fields declared on this class
+        for (CtField field : ctClass.getDeclaredFields()) {
+            fields.add(new JavassistFieldDeclaration(field, typeSolver));
+        }
+
+        // Then consider fields inherited from ancestors
+        for (ResolvedReferenceType ancestor : typeDeclaration.getAllAncestors()) {
+            ancestor.getTypeDeclaration().ifPresent(ancestorTypeDeclaration -> {
+                fields.addAll(ancestorTypeDeclaration.getAllFields());
+            });
+        }
+
+        return fields;
+    }
+
+    public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+        if (null == ctClass.getGenericSignature()) {
+            return Collections.emptyList();
+        } else {
+            try {
+                SignatureAttribute.ClassSignature classSignature =
+                        SignatureAttribute.toClassSignature(ctClass.getGenericSignature());
+                return Arrays.<SignatureAttribute.TypeParameter>stream(classSignature.getParameters())
+                        .map((tp) -> new JavassistTypeParameter(tp, JavassistFactory.toTypeDeclaration(ctClass, typeSolver), typeSolver))
+                        .collect(Collectors.toList());
+            } catch (BadBytecode badBytecode) {
+                throw new RuntimeException(badBytecode);
+            }
+        }
+    }
+
+    public Optional<ResolvedReferenceTypeDeclaration> containerType() {
+        try {
+            return ctClass.getDeclaringClass() == null ?
+                    Optional.empty() :
+                    Optional.of(JavassistFactory.toTypeDeclaration(ctClass.getDeclaringClass(), typeSolver));
+        } catch (NotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclarationTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -156,6 +157,12 @@ class JavassistInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
     void testGetAncestorsWithGenericAncestors() {
         JavassistInterfaceDeclaration compilationUnit = (JavassistInterfaceDeclaration) anotherTypeSolver.solveType("com.github.javaparser.test.GenericChildInterface");
         List<ResolvedReferenceType> ancestors = compilationUnit.getAncestors();
+        ancestors.sort(new Comparator<ResolvedReferenceType>() {
+            @Override
+            public int compare(ResolvedReferenceType o1, ResolvedReferenceType o2) {
+                return o1.describe().compareTo(o2.describe());
+            }
+        });
         assertEquals(2, ancestors.size());
         assertEquals("com.github.javaparser.test.GenericInterface<S>", ancestors.get(0).describe()); // Type should be 'S', from the GenericChildInterface
         assertEquals("java.lang.Object", ancestors.get(1).describe());


### PR DESCRIPTION
Fixes #1615, #1771, #2761, #2762, #3138, #3140