### PR TITLE
Fix Issue #1950 Unambigous ambiguity call with <Void> generics and lambda's

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1950Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1950Test.java
@@ -1,0 +1,51 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue1950Test extends AbstractResolutionTest {
+
+    @Test
+    public void test() {
+
+        TypeSolver typeSolver = new ReflectionTypeSolver(false);
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        StaticJavaParser.setConfiguration(config);
+
+        String s = "import java.util.concurrent.Callable;\n" +
+                "class Foo { \n" +
+                "  void foo() {\n" +
+                "     method(()->{});\n" +
+                "  }\n" +
+                "  public void method(Runnable lambda) {\n" +
+                "  }\n" +
+                "  public <T> void method(Callable<T> lambda) {\n" +
+                "  }\n" +
+                "}";
+        CompilationUnit cu = StaticJavaParser.parse(s);
+        MethodCallExpr mce = cu.findFirst(MethodCallExpr.class).get();
+        
+        ResolvedMethodDeclaration resolved = mce.resolve();
+        
+        // 15.12.2.5. Choosing the Most Specific Method
+        // One applicable method m1 is more specific than another applicable method m2, for an invocation with argument
+        // expressions e1, ..., ek, if any of the following are true:
+        // m2 is generic, and m1 is inferred to be more specific than m2 for argument expressions e1, ..., ek by §18.5.4.
+        assertEquals("java.lang.Runnable", resolved.getParam(0).getType().describe());
+        assertTrue(!resolved.isGeneric());
+
+    }
+
+}


### PR DESCRIPTION
Fixes #1950 .

Chapter 15.12.2.5. in JLS defines how to choose the Most Specific Method
The context is defined as this "One applicable method m1 is more specific than another applicable method m2, for an invocation with argument expressions e1, ..., ek, if any of the following are true:".
First, m2 is generic, and m1 is inferred to be more specific than m2 for argument expressions e1, ..., ek by §18.5.4."
Probably this part 18.5.4. More Specific Method Inference should be verified too should be verified too
...
