### PR TITLE
Added additional tests to cover isAssignableBy method in JavassistClassDeclaration

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
@@ -24,12 +24,15 @@ package com.github.javaparser.symbolsolver.javassistmodel;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.javaparsermodel.LambdaArgumentTypePlaceholder;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclarationTest;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.model.typesystem.NullType;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -38,6 +41,7 @@ import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -228,6 +232,13 @@ class JavassistClassDeclarationTest extends AbstractClassDeclarationTest {
     void testGetSuperclass() {
         JavassistClassDeclaration compilationUnit = (JavassistClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
         assertEquals("com.github.javaparser.ast.Node", compilationUnit.getSuperClass().orElseThrow(() -> new RuntimeException("super class unexpectedly empty")).getQualifiedName());
+    }
+
+    @Test
+    void testGetSuperclassOfJavaLangObject() throws NotFoundException {
+        CtClass javaLangObject = ClassPool.getDefault().get("java.lang.Object");
+        JavassistClassDeclaration objectDeclaration = new JavassistClassDeclaration(javaLangObject, typeSolver);
+        assertFalse(objectDeclaration.getSuperClass().isPresent());
     }
 
     @Test
@@ -497,6 +508,43 @@ class JavassistClassDeclarationTest extends AbstractClassDeclarationTest {
         ancestor = constructorDeclaration.getAllAncestors().get(11);
         assertEquals("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt", ancestor.getQualifiedName());
         assertEquals("com.github.javaparser.ast.body.ConstructorDeclaration", ancestor.typeParametersMap().getValueBySignature("com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.T").get().asReferenceType().getQualifiedName());
+    }
+
+    @Nested
+    class TestIsAssignableBy {
+        @Test
+        void whenNullTypeIsProvided() {
+            JavassistClassDeclaration cu = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+            assertTrue(cu.isAssignableBy(NullType.INSTANCE));
+        }
+
+        @Test
+        void whenLambdaArgumentTypePlaceholderIsProvided() {
+            JavassistClassDeclaration cu = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+            assertFalse(cu.isAssignableBy(new LambdaArgumentTypePlaceholder(0)));
+        }
+
+        @Test
+        void whenEqualTypeIsProvided() {
+            JavassistClassDeclaration cu = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+            assertTrue(cu.isAssignableBy(cu));
+        }
+
+        @Test
+        void whenSuperClassIsProvided() {
+            ResolvedReferenceTypeDeclaration node = newTypeSolver.solveType("com.github.javaparser.ast.Node");
+            JavassistClassDeclaration cu = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
+            assertTrue(cu.isAssignableBy(node));
+        }
+
+        @Test
+        void whenInterfaceIsProvided() {
+            JavassistInterfaceDeclaration nodeWithImplements = (JavassistInterfaceDeclaration) newTypeSolver.solveType(
+                    "com.github.javaparser.ast.nodeTypes.NodeWithImplements");
+            JavassistClassDeclaration classDeclaration = (JavassistClassDeclaration) newTypeSolver.solveType(
+                    "com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
+            assertTrue(classDeclaration.isAssignableBy(nodeWithImplements));
+        }
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
@@ -41,6 +41,7 @@ import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -537,6 +538,8 @@ class JavassistClassDeclarationTest extends AbstractClassDeclarationTest {
             assertTrue(cu.isAssignableBy(node));
         }
 
+        @Disabled("JavassistInterfaceDeclaration doesn't implement isAssignableBy yet." +
+                  "See https://github.com/javaparser/javaparser/issues/2761")
         @Test
         void whenInterfaceIsProvided() {
             JavassistInterfaceDeclaration nodeWithImplements = (JavassistInterfaceDeclaration) newTypeSolver.solveType(

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
@@ -538,8 +538,6 @@ class JavassistClassDeclarationTest extends AbstractClassDeclarationTest {
             assertTrue(cu.isAssignableBy(node));
         }
 
-        @Disabled("JavassistInterfaceDeclaration doesn't implement isAssignableBy yet." +
-                  "See https://github.com/javaparser/javaparser/issues/2761")
         @Test
         void whenInterfaceIsProvided() {
             JavassistInterfaceDeclaration nodeWithImplements = (JavassistInterfaceDeclaration) newTypeSolver.solveType(


### PR DESCRIPTION
Previously, method `JavassistClassDeclaration#isAssignableBy(ResolvedType)` was not covered by tests. This PR adds coverage to this method.
