### PR TITLE
Remove unused JUnit Pioneer dependency

### DIFF
--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -185,10 +185,6 @@
             <artifactId>junit-jupiter-params</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.junit-pioneer</groupId>
-            <artifactId>junit-pioneer</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -375,13 +375,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.junit-pioneer</groupId>
-                <artifactId>junit-pioneer</artifactId>
-                <!-- TODO: Not yet upgrading to v1.0.0 (causes some tests to not execute - see #2891 and #2893) -->
-                <version>0.5.6</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>3.8.0</version>


### PR DESCRIPTION
Turns out that despite the fuss, we're not actually using JUnit Pioneer :scream: 

Let's remove it! :-1: 

Fixes #3147