### PR TITLE
Fix issue #3173: Add isAnnotation() and asAnnotation() methods for ResolvedTypeDeclaration

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedAnnotationDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedAnnotationDeclaration.java
@@ -31,5 +31,15 @@ import java.util.List;
 public interface ResolvedAnnotationDeclaration extends ResolvedReferenceTypeDeclaration,
         AssociableToAST<AnnotationDeclaration> {
 
+    @Override
+    default boolean isAnnotation() {
+        return true;
+    }
+
+    @Override
+    default ResolvedAnnotationDeclaration asAnnotation() {
+        return this;
+    }
+
     List<ResolvedAnnotationMemberDeclaration> getAnnotationMembers();
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeDeclaration.java
@@ -97,6 +97,13 @@ public interface ResolvedTypeDeclaration extends ResolvedDeclaration {
     }
 
     /**
+     * Is this the declaration of an annotation?
+     */
+    default boolean isAnnotation() {
+        return false;
+    }
+
+    /**
      * Is this the declaration of a type parameter?
      */
     default boolean isTypeParameter() {
@@ -155,6 +162,13 @@ public interface ResolvedTypeDeclaration extends ResolvedDeclaration {
      */
     default ResolvedEnumDeclaration asEnum() {
         throw new UnsupportedOperationException(String.format("%s is not an enum", this));
+    }
+
+    /**
+     * Return this as a AnnotationDeclaration or throw UnsupportedOperationException.
+     */
+    default ResolvedAnnotationDeclaration asAnnotation() {
+        throw new UnsupportedOperationException(String.format("%s is not an annotation", this));
     }
 
     /**

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3173Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3173Test.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Issue3173Test extends AbstractResolutionTest {
 
     @Test
-    void test() {
+    public void test() {
         ParserConfiguration config = new ParserConfiguration();
         config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
         StaticJavaParser.setConfiguration(config);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3173Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3173Test.java
@@ -1,0 +1,38 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue3173Test extends AbstractResolutionTest {
+
+    @Test
+    void test() {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+
+        String s =
+                "public class Program {\n" +
+                        "\n" +
+                        "    public @interface AnnotationClass {\n" +
+                        "    }\n" +
+                        "}";
+
+        CompilationUnit cu = StaticJavaParser.parse(s);
+        List<AnnotationDeclaration> annDecls = cu.findAll(AnnotationDeclaration.class);
+        annDecls.forEach(annDecl -> {
+            assertTrue(annDecl.resolve().isAnnotation());
+            assertEquals("AnnotationClass", annDecl.resolve().asAnnotation().getName());
+        });
+    }
+}


### PR DESCRIPTION
Fix issue #3173: Add isAnnotation() and asAnnotation() methods for ResolvedTypeDeclaration.

Fixes #3173.
