### PR TITLE
Memory optimization for JarTypeSolver (Up to 42% less memory)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationMemberDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistAnnotationMemberDeclaration.java
@@ -21,10 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
-
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
 import com.github.javaparser.ast.expr.CharLiteralExpr;
 import com.github.javaparser.ast.expr.DoubleLiteralExpr;
@@ -34,16 +30,14 @@ import com.github.javaparser.ast.expr.LongLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
-import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
-
-import javassist.CtClass;
 import javassist.CtMethod;
-import javassist.NotFoundException;
 import javassist.bytecode.AnnotationDefaultAttribute;
+import javassist.bytecode.BadBytecode;
+import javassist.bytecode.SignatureAttribute;
 import javassist.bytecode.annotation.BooleanMemberValue;
 import javassist.bytecode.annotation.CharMemberValue;
 import javassist.bytecode.annotation.DoubleMemberValue;
@@ -51,6 +45,10 @@ import javassist.bytecode.annotation.IntegerMemberValue;
 import javassist.bytecode.annotation.LongMemberValue;
 import javassist.bytecode.annotation.MemberValue;
 import javassist.bytecode.annotation.StringMemberValue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @author Malte Skoruppa
@@ -88,16 +86,15 @@ public class JavassistAnnotationMemberDeclaration implements ResolvedAnnotationM
     @Override
     public ResolvedType getType() {
         try {
-            CtClass returnType = annotationMember.getReturnType();
-            if (returnType.isPrimitive()) {
-                return ResolvedPrimitiveType.byName(returnType.getName());
+            String descriptor = annotationMember.getMethodInfo().getDescriptor();
+            SignatureAttribute.MethodSignature signature = SignatureAttribute.toMethodSignature(descriptor);
+            SymbolReference<ResolvedReferenceTypeDeclaration> returnType = typeSolver.tryToSolveType(signature.getReturnType().jvmTypeName());
+            if (returnType.isSolved()) {
+                return new ReferenceTypeImpl(returnType.getCorrespondingDeclaration(), typeSolver);
             }
-            SymbolReference<ResolvedReferenceTypeDeclaration> rrtd = typeSolver.tryToSolveType(returnType.getName());
-            if (rrtd.isSolved()) {
-                return new ReferenceTypeImpl(rrtd.getCorrespondingDeclaration(), typeSolver);
-            }
-        } catch (NotFoundException e) {
-            // nothing to do
+        } catch (BadBytecode e) {
+            // We don't expect this to happen, but we handle it anyway.
+            throw new IllegalStateException("An invalid descriptor was received from JavaAssist.", e);
         }
         throw new UnsupportedOperationException(String.format("Obtaining the type of the annotation member %s is not supported yet.", annotationMember.getLongName()));
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
@@ -276,7 +276,7 @@ public class JarTypeSolver implements TypeSolver {
             // The names in stored key should always be resolved.
             // But if for some reason this happen, the user is notified.
             throw new IllegalStateException(String.format(
-                    "Unable to get class witj name %s from class pool." +
+                    "Unable to get class with name %s from class pool." +
                     "This was not suppose to happen, please report at https://github.com/javaparser/javaparser/issues",
                     storedKey));
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
@@ -24,6 +24,7 @@ package com.github.javaparser.symbolsolver.resolution.typesolvers;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -144,6 +145,24 @@ class JarTypeSolverTest extends AbstractTypeSolverTest<JarTypeSolver> {
     void whenTheJarIsNotFoundShouldThrowAFileNotFoundException(@TempDir Path tempDirectory) {
         Path pathToJar = tempDirectory.resolve("a_non_existing_file.jar");
         assertThrows(FileNotFoundException.class, () -> new JarTypeSolver(pathToJar));
+    }
+
+    @Test
+    void theJarTypeShouldCacheTheListOfKnownTypes() throws IOException {
+        String typeA = "foo.bar.A";
+        String typeB = "foo.zum.B";
+
+        Path pathToJar1 = adaptPath("src/test/resources/jar1.jar");
+        JarTypeSolver jarTypeSolver1 = new JarTypeSolver(pathToJar1);
+        assertEquals(Sets.newHashSet(typeA), jarTypeSolver1.getKnownClasses());
+        assertTrue(jarTypeSolver1.tryToSolveType(typeA).isSolved());
+        assertFalse(jarTypeSolver1.tryToSolveType(typeB).isSolved());
+
+        Path pathToJar2 = adaptPath("src/test/resources/jar2.jar");
+        JarTypeSolver jarTypeSolver2 = new JarTypeSolver(pathToJar2);
+        assertEquals(Sets.newHashSet(typeB), jarTypeSolver2.getKnownClasses());
+        assertTrue(jarTypeSolver2.tryToSolveType(typeB).isSolved());
+        assertFalse(jarTypeSolver2.tryToSolveType(typeA).isSolved());
     }
 
 }


### PR DESCRIPTION
Currently JarTypeSolver consumes a lot of memory. In this PR suggests an alternative way to get the same behavior in a lighter way with a comparison between both methodologies.

The ideia follows a simple principle, that our `ClassPool` contains ONLY all the types declared in the Jar.
Note that JRE type are not included, if the user want to resolve JRE types he needs to include a ReflectionTypeSolver (Previously the JarTypeSolver also included JRE into the class pool). To check if a type is declared we just need to check if that qualified name is present in the `ClassPool`. This logic is very similar how `ClassLoaderTypeSolver` works.

**Why was field `classpathElements` removed?**

This map was used to keep the reference between the qualified name and the corresponding declaration. Now this functionality was delegated to `ClassPool` to reduce the complexity.

**Why was the class `ClasspathElement` removed?**

This is related to the previous question. Since we have delegated this task to `ClassPool` we don't need this anymore.

**Why was class `ResourceRegistry` removed?**

The `ResourceRegistry` was used to free the resources when the VM finish. Once again, we no longer need this, since we have delegated it to `ClassPool`.

**So if we don't have JRE types here, how does it resolve those types?**

When we have a Javassist declaration we should resolve the fully qualified name using the typesolver instead of relying on javassist itself. For more details see: https://github.com/javaparser/javaparser/issues/2762#issuecomment-798793403

#### Evaluation

To evaluate the algorithms was used the Unit test below, to generate a memory dump to compare the memory usage of each methodology.

```java
@Test
void testMemoryStress() throws IOException {
  
   Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
   CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
   for (int i = 0 ; i < 10000 ; i++) {
       combinedTypeSolver.add(new JarTypeSolver(pathToJar));
   }
   
}
```

| Name                                                     |Total Memory Usage |
|:---------------------------------------------------------|------------------:|
| Current methodology                                      |          1 037 MB |
| Proposed methodology                                     |            416 MB |
| **Total:**                                               |       **-621 MB** |

As we can see from the results the memory consumption is reduced in approximately **60%**.

The report can be analysed at [Methodology comparison.pdf](https://github.com/javaparser/javaparser/files/6191046/Methodology.comparison.pdf)


