### PR TITLE
Implemented isAssignableBy for VoidType - now return `false` instead of throwing `UnsupportedOperationException`

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedVoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedVoidType.java
@@ -39,7 +39,18 @@ public class ResolvedVoidType implements ResolvedType {
 
     @Override
     public boolean isAssignableBy(ResolvedType other) {
-        throw new UnsupportedOperationException();
+        // According to https://docs.oracle.com/javase/specs/jls/se16/html/jls-14.html#jls-14.8:
+        // """
+        // Note that the Java programming language does not allow a "cast to void" - void is not a type - so the
+        // traditional C trick of writing an expression statement such as:
+        //
+        // (void)... ;  // incorrect!
+        //
+        // does not work.
+        // """
+        //
+        // In short, nothing can be assign to "void".
+        return false;
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/VoidTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/VoidTypeTest.java
@@ -37,7 +37,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class VoidTypeTest {
@@ -116,36 +117,11 @@ class VoidTypeTest {
 
     @Test
     void testIsAssignableBy() {
-        try {
-            assertEquals(false, ResolvedVoidType.INSTANCE.isAssignableBy(NullType.INSTANCE));
-            fail();
-        } catch (UnsupportedOperationException e) {
-
-        }
-        try {
-            assertEquals(false, ResolvedVoidType.INSTANCE.isAssignableBy(OBJECT));
-            fail();
-        } catch (UnsupportedOperationException e) {
-
-        }
-        try {
-            assertEquals(false, ResolvedVoidType.INSTANCE.isAssignableBy(STRING));
-            fail();
-        } catch (UnsupportedOperationException e) {
-
-        }
-        try {
-            assertEquals(false, ResolvedVoidType.INSTANCE.isAssignableBy(ResolvedPrimitiveType.BOOLEAN));
-            fail();
-        } catch (UnsupportedOperationException e) {
-
-        }
-        try {
-            assertEquals(false, ResolvedVoidType.INSTANCE.isAssignableBy(ResolvedVoidType.INSTANCE));
-            fail();
-        } catch (UnsupportedOperationException e) {
-
-        }
+        assertFalse(ResolvedVoidType.INSTANCE.isAssignableBy(NullType.INSTANCE));
+        assertFalse(ResolvedVoidType.INSTANCE.isAssignableBy(OBJECT));
+        assertFalse(ResolvedVoidType.INSTANCE.isAssignableBy(STRING));
+        assertFalse(ResolvedVoidType.INSTANCE.isAssignableBy(ResolvedPrimitiveType.BOOLEAN));
+        assertFalse(ResolvedVoidType.INSTANCE.isAssignableBy(ResolvedVoidType.INSTANCE));
     }
 
 }


### PR DESCRIPTION
According to https://docs.oracle.com/javase/specs/jls/se16/html/jls-14.html#jls-14.8:

> Note that the Java programming language does not allow a "cast to void" - void is not a type - so the
> traditional C trick of writing an expression statement such as:
>
> (void)... ;  // incorrect!
>
> does not work.

In short, nothing can be assign to "void".
