### PR TITLE
Fix surefire/jacoco configuration

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -26,7 +26,7 @@ jobs:
         ## Different JDK versions have different implementations etc. -- test on all combinations (ideally 8 to latest).
         ### exclude pre-8 (min development version jdk8)
         ### exclude post-12 (changes to jdk causes reflection tests to fail due to added methods #1701 )
-        jdk: [8,9,10,11,12,13,14,15, 16]
+        jdk: [8,9,10,11,12,13,14,15,16]
     env:
       OS: ${{ matrix.os }}
       JDK: ${{ matrix.jdk }}
@@ -79,7 +79,7 @@ jobs:
           fail_ci_if_error: false # optional (default = false)
           verbose: false # optional (default = false):
           flags: javaparser-core,AlsoSlowTests,${{ matrix.os }},jdk-${{ matrix.jdk }}
-          env_vars: AlsoSlowTests,OS,JDK
+          env_vars: OS,JDK
 
       - name: CodeCov - JavaParser Symbol Solver
         uses: codecov/codecov-action@v1
@@ -89,4 +89,4 @@ jobs:
           fail_ci_if_error: false # optional (default = false)
           verbose: false # optional (default = false):
           flags: javaparser-symbol-solver,AlsoSlowTests,${{ matrix.os }},jdk-${{ matrix.jdk }}
-          env_vars: AlsoSlowTests,OS,JDK
+          env_vars: OS,JDK

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ codecov:
 coverage:
   precision: 3
   round: down
-  range: "70...90" # Colour range - 70% coverage (and below) is solid red, 90% coverage (and above) is solid green.
+  range: "60...80" # Colour range - 60% coverage (and below) is solid red, 80% coverage (and above) is solid green.
 
 #  notify:
 #    gitter:
@@ -43,5 +43,5 @@ comment:
   behavior: default
   require_changes: false
   ### Do not comment until coverage reports for all builds have been received
-  ### Note: 24 = three OSs (mac, windows, ubuntu) x eight java levels (8,9,10,11,12,13,14,15)
-  after_n_builds: 24 
+  ### Note: 54 = three OSs (mac, windows, ubuntu) x nine java levels (8,9,10,11,12,13,14,15,16) x two modules (jp-core, jss)
+  after_n_builds: 54

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -39,7 +39,8 @@
                             <excludedGroups>com.github.javaparser.SlowTest</excludedGroups>
                             <parallel>methods</parallel>
                             <threadCount>4</threadCount>
-                            <argLine>-Xms256m -Xmx2g -verbose:gc</argLine>
+                            <!-- Note that <argLine> overwrites, not appends, hence need for `${argLine}` -->
+                            <argLine>-Xms256m -Xmx2g -verbose:gc ${argLine}</argLine>
                             <reportFormat>plain</reportFormat>
                             <failIfNoTests>true</failIfNoTests>
                         </configuration>
@@ -56,7 +57,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xms256m -Xmx2g -verbose:gc</argLine>
+                            <!-- Note that <argLine> overwrites, not appends, hence need for `${argLine}` -->
+                            <argLine>-Xms256m -Xmx2g -verbose:gc ${argLine}</argLine>
                             <reportFormat>plain</reportFormat>
                             <failIfNoTests>true</failIfNoTests>
                         </configuration>


### PR DESCRIPTION
Avoid replacing `argLine` when defining surefire plugin `argLine` options. 

This is required to enable jacoco to function correctly and produce `site` output.

Fixes #3190