### PR TITLE
[Fixes #3099] Added ability to solve type with a list of expected type arguments

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractMethodLikeDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractMethodLikeDeclarationContext.java
@@ -97,7 +97,7 @@ public abstract class AbstractMethodLikeDeclarationContext
     }
 
     @Override
-    public final SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
+    public final SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
         // TODO: Is null check required?
         if (wrappedNode.getTypeParameters() != null) {
             for (TypeParameter tp : wrappedNode.getTypeParameters()) {
@@ -119,7 +119,7 @@ public abstract class AbstractMethodLikeDeclarationContext
             }
         }
 
-        return solveTypeInParentContext(name);
+        return solveTypeInParentContext(name, typeArguments);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnnotationDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnnotationDeclarationContext.java
@@ -59,8 +59,8 @@ public class AnnotationDeclarationContext extends AbstractJavaParserContext<Anno
     }
 
     @Override
-    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
-        return javaParserTypeDeclarationAdapter.solveType(name);
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> resolvedTypes) {
+        return javaParserTypeDeclarationAdapter.solveType(name, resolvedTypes);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnonymousClassDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnonymousClassDeclarationContext.java
@@ -21,10 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
@@ -45,6 +41,10 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionClassDeclaration;
 import com.github.javaparser.symbolsolver.resolution.MethodResolutionLogic;
 import com.google.common.base.Preconditions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * A symbol resolution context for an object creation node.
@@ -122,7 +122,7 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
   }
 
   @Override
-  public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
+  public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
     List<TypeDeclaration> typeDeclarations = myDeclaration.findMembersOfKind(TypeDeclaration.class);
 
     Optional<SymbolReference<ResolvedTypeDeclaration>> exactMatch =
@@ -193,7 +193,7 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
       }
     }
 
-    return solveTypeInParentContext(name);
+    return solveTypeInParentContext(name, typeArguments);
   }
 
   @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
@@ -21,10 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.type.TypeParameter;
@@ -41,6 +37,10 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.resolution.Value;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Federico Tomassetti
@@ -102,8 +102,8 @@ public class ClassOrInterfaceDeclarationContext extends AbstractJavaParserContex
     }
 
     @Override
-    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
-        return javaParserTypeDeclarationAdapter.solveType(name);
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
+        return javaParserTypeDeclarationAdapter.solveType(name, typeArguments);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationExtendsContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationExtendsContext.java
@@ -24,9 +24,12 @@ package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypeParameter;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+
+import java.util.List;
 
 /**
  * Limited version of ClassOrInterfaceDeclarationContext that only resolves type parameters for use by
@@ -38,13 +41,13 @@ public class ClassOrInterfaceDeclarationExtendsContext extends AbstractJavaParse
     }
 
     @Override
-    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
         for (TypeParameter typeParameter : wrappedNode.getTypeParameters()) {
             if (typeParameter.getName().getId().equals(name)) {
                 return SymbolReference.solved(new JavaParserTypeParameter(typeParameter, typeSolver));
             }
         }
 
-        return super.solveType(name);
+        return super.solveType(name, typeArguments);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -120,7 +120,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
     }
 
     @Override
-    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
 
         if (wrappedNode.getTypes() != null) {
             // Look for types in this compilation unit. For instance, if the given name is "A", there may be a class or

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
@@ -68,8 +68,8 @@ public class EnumDeclarationContext extends AbstractJavaParserContext<EnumDeclar
     }
 
     @Override
-    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
-        return javaParserTypeDeclarationAdapter.solveType(name);
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> resolvedTypes) {
+        return javaParserTypeDeclarationAdapter.solveType(name, resolvedTypes);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
@@ -69,8 +69,8 @@ public class FieldAccessContext extends AbstractJavaParserContext<FieldAccessExp
     }
 
     @Override
-    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
-        return JavaParserFactory.getContext(demandParentNode(wrappedNode), typeSolver).solveType(name);
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
+        return JavaParserFactory.getContext(demandParentNode(wrappedNode), typeSolver).solveType(name, typeArguments);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -117,7 +117,7 @@ public class JavaParserTypeDeclarationAdapter {
             }
         }
 
-        // Check if the node implements other types
+        // Check if the node extends other types
         if (wrappedNode instanceof NodeWithExtends) {
             NodeWithExtends<?> nodeWithExtends = (NodeWithExtends<?>) wrappedNode;
             for (ClassOrInterfaceType extendedType : nodeWithExtends.getExtendedTypes()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
@@ -48,7 +48,7 @@ public class ObjectCreationContext extends AbstractJavaParserContext<ObjectCreat
     }
 
     @Override
-    public SymbolReference<ResolvedTypeDeclaration> solveType(String name) {
+    public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
         if (wrappedNode.hasScope()) {
             Expression scope = wrappedNode.getScope().get();
             ResolvedType scopeType = JavaParserFacade.get(typeSolver).getType(scope);
@@ -67,7 +67,7 @@ public class ObjectCreationContext extends AbstractJavaParserContext<ObjectCreat
         while (parentNode instanceof ObjectCreationExpr) {
             parentNode = demandParentNode(parentNode);
         }
-        return JavaParserFactory.getContext(parentNode, typeSolver).solveType(name);
+        return JavaParserFactory.getContext(parentNode, typeSolver).solveType(name, typeArguments);
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3099Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3099Test.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Issue3099Test extends AbstractResolutionTest {
+
+	@Test
+	void illegalArgumentExceptionWhenSolvingName() throws IOException {
+
+		// Setup symbol solver
+		JavaParserTypeSolver javaParserTypeSolver = new JavaParserTypeSolver(adaptPath("src/test/resources/issue3099/"));
+		StaticJavaParser.getConfiguration()
+				.setSymbolResolver(new JavaSymbolSolver(
+						new CombinedTypeSolver(new ReflectionTypeSolver(), javaParserTypeSolver))
+				);
+
+		// Parse the File
+		Path filePath = adaptPath("src/test/resources/issue3099/com/example/Beta.java");
+		CompilationUnit cu = StaticJavaParser.parse(filePath);
+
+		// Get the expected inner class
+		List<ClassOrInterfaceDeclaration> classes = cu.findAll(ClassOrInterfaceDeclaration.class);
+		assertEquals(2, classes.size());
+		ResolvedReferenceTypeDeclaration innerInterface = classes.get(1).resolve();
+		assertTrue(innerInterface.isInterface());
+
+		// Check if the value is present
+		Optional<ResolvedReferenceType> resolvedType = cu.findFirst(VariableDeclarator.class)
+				.map(VariableDeclarator::getType)
+				.map(Type::resolve)
+				.filter(ResolvedType::isReferenceType)
+				.map(ResolvedType::asReferenceType);
+		assertTrue(resolvedType.isPresent());
+		assertEquals(innerInterface, resolvedType.get().getTypeDeclaration().orElse(null));
+	}
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContextTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClassOrInterfaceDeclarationContextTest {
+
+    private final TypeSolver typeSolver = new ReflectionTypeSolver();
+    private JavaParser javaParser;
+
+    @BeforeEach
+    void beforeEach() {
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        javaParser = new JavaParser();
+    }
+
+    @Test
+    void testSolveWithoutTypeArguments() {
+        CompilationUnit alphaCU = parse("class Alpha { class Foo {} }");
+        ClassOrInterfaceDeclaration alpha = Navigator.demandClass(alphaCU, "Alpha");
+        ClassOrInterfaceDeclarationContext alphaContext = new ClassOrInterfaceDeclarationContext(alpha, typeSolver);
+
+        assertTrue(alphaContext.solveType("Foo").isSolved());
+        assertTrue(alphaContext.solveType("Foo", Collections.emptyList()).isSolved());
+        assertFalse(alphaContext.solveType("Foo", Collections.singletonList(ResolvedPrimitiveType.INT)).isSolved());
+    }
+
+    @Test
+    void testSolveWithTypeArguments() {
+        CompilationUnit betaCU = parse("class Beta { class Foo<T> {} }");
+        ClassOrInterfaceDeclaration beta = Navigator.demandClassOrInterface(betaCU, "Beta");
+        ClassOrInterfaceDeclarationContext betaContext = new ClassOrInterfaceDeclarationContext(beta, typeSolver);
+
+        assertTrue(betaContext.solveType("Foo").isSolved());
+        assertFalse(betaContext.solveType("Foo", Collections.emptyList()).isSolved());
+        assertTrue(betaContext.solveType("Foo", Collections.singletonList(ResolvedPrimitiveType.INT)).isSolved());
+    }
+
+    private CompilationUnit parse(String sourceCode) {
+        return javaParser.parse(sourceCode).getResult().orElseThrow(AssertionError::new);
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue3099/com/example/Alpha.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue3099/com/example/Alpha.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.example;
+
+interface Alpha {
+  interface CustomInterface {}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue3099/com/example/Beta.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue3099/com/example/Beta.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.example;
+
+class Beta implements Alpha.CustomInterface {
+  
+  public interface CustomInterface<T> {}
+
+  private final CustomInterface<Object> instanceOfBetaInnerClass;
+
+}


### PR DESCRIPTION
Currently, when JP SS is trying to solve a type, it doesn't take into consideration the number of type arguments it expects to find. This have been an issue that was reported in #3099 where we can have two different classes/interfaces with the same name. In this scenario JP SS will return the first one it finds, and not the one that fits the expected type.

This PRs adds a new method in context to solve a type with the expected type arguments. If the type arguments is provided it will only find a type where the type arguments matchs the expected.

#### Examples
Lets imagine we have two declarations of `Foo`. We have com `Alpha.Foo` and `Beta.Foo<T>` where `Foo` is a inner class of `Alpha ` and `Foo<T>` is a inner class of `Beta`. If we want to solve `Alpha.Foo` without arguments we can solve it like:
```java
context.solveType("Foo", Collections.emptyList());
```
if we want to resolve it as `Beta.Foo<T>`  we execute:
```java
List<ResolvedType> expectedTypeArguments = ...;
context.solveType("Foo", expectedTypeArguments);
```

If we just want it to be resolved and don't care how many arguments it has we can use:
```java
context.solveType("Foo"); // or context.solveType("Foo", null);
```

#### Implementation notes
- The logic that was previously in `ClassOrInterfaceDeclarationContext` was moved to `JavaParserTypeDeclarationAdapter`, because `AnnotationDeclarationContext` should also follow the same rules;
- `JavaParserTypeDeclarationAdapter` was reordered to match the expected behavior (the same order that was previously in `ClassOrInterfaceDeclarationContext`).

#### Related Issues
- Fixes #3099 by checking if the type parameters match the expected.
