### PR TITLE
Issue 3064 conditional nested lambda

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3064Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3064Test.java
@@ -1,0 +1,43 @@
+package com.github.javaparser;
+
+import com.github.javaparser.ast.CompilationUnit;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3064Test {
+
+    @Test
+    public void test0() {
+        String str = "import java.util.function.Supplier;\n" +
+                "\n" +
+                "public class MyClass {\n" +
+                "\n" +
+                "    public MyClass() {\n" +
+                "        Supplier<String> aStringSupplier = false ? () -> \"\" : true ? () -> \"\" : () -> \"path\";\n" +
+                "    }\n" +
+                "}\n";
+
+        JavaParser parser = new JavaParser();
+        ParseResult<CompilationUnit> unitOpt = parser.parse(new StringReader(str));
+        unitOpt.getProblems().stream().forEach(p -> System.err.println(p.toString()));
+        CompilationUnit unit = unitOpt.getResult().orElseThrow(() -> new IllegalStateException("Could not parse file"));
+        System.out.println(unit.toString());
+
+        assertEquals(str, unit.toString());
+    }
+
+    @Test
+    public void test1() {
+        String str = "public class MyClass {\n" +
+                "    {\n" +
+                "        Supplier<String> aStringSupplier = false ? () -> \"F\" : true ? () -> \"T\" : () -> \"path\";\n" +
+                "    }\n" +
+                "}";
+        CompilationUnit unit = StaticJavaParser.parse(str);
+        assertEquals(str.replace("\n", ""), unit.toString().replace("\n", ""));
+    }
+
+}

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -2963,16 +2963,7 @@ Expression Expression():
             "->"
             lambdaBody = LambdaBody()
             {
-                if (ret instanceof CastExpr) {
-                    ret = generateLambda(ret, lambdaBody);
-                } else if (ret instanceof ConditionalExpr) {
-                    ConditionalExpr ce = (ConditionalExpr) ret;
-                    if(ce.getElseExpr() != null) {
-                        ce.setElseExpr(generateLambda(ce.getElseExpr(), lambdaBody));
-                    }
-                } else {
-                    ret = generateLambda(ret, lambdaBody);
-                }
+                ret = generateLambda(ret, lambdaBody);
             }
          |
             "::"
@@ -3045,7 +3036,7 @@ Expression ConditionalExpression():
         "?"
         left = Expression()
         ":"
-        right = ConditionalExpression()
+        right = Expression()
         // TODO: Examine further re: missing(?) {@code LambdaExpression} or whether it is permissive enough to include it.
         {
             ret = new ConditionalExpr(range(ret, token()), ret, left, right);


### PR DESCRIPTION
Fixes #3064 .

Lambda is given a body only when Expression is reached.
When multiple ternary operators are nested, it is not good to check only one level.

Change the syntactic definition of ConditionalExpression.
At the same time, we can delete the original judgment in Exp.

Add Tests.