### PR TITLE
Issue 3112 anonymous class nested

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -79,7 +79,7 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
 
         superTypeDeclaration =
                 JavaParserFactory.getContext(wrappedNode.getParentNode().get(), typeSolver)
-                        .solveType(superTypeName)
+                        .solveTypeInParentContext(superTypeName)
                         .getCorrespondingDeclaration();
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3112Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3112Test.java
@@ -1,0 +1,63 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class Issue3112Test {
+
+    @Test
+    public void test0() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class MyClass {\n" +
+                "   class Inner1 {\n" +
+                "       class Inner2 {\n" +
+                "       }\n" +
+                "   }\n" +
+                "   {\n" +
+                "       new Inner1(){}.new Inner2();\n" +
+                "   }\n" +
+                "}\n";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+        List<ObjectCreationExpr> local = cu.findAll(ObjectCreationExpr.class);
+        local.forEach(lcl -> assertFalse(lcl.getType().resolve().getTypeDeclaration().get().isInterface()));
+    }
+
+    @Test
+    public void test1() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class MyClass {\n" +
+                "   class Inner1 {\n" +
+                "       class Inner2 {\n" +
+                "           class Inner3 {\n" +
+                "           }\n" +
+                "       }\n" +
+                "   }\n" +
+                "   {\n" +
+                "       new Inner1(){}.new Inner2(){}.new Inner3();\n" +
+                "   }\n" +
+                "}\n";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+        List<ObjectCreationExpr> local = cu.findAll(ObjectCreationExpr.class);
+        local.forEach(lcl -> assertFalse(lcl.getType().resolve().getTypeDeclaration().get().isInterface()));
+    }
+}


### PR DESCRIPTION
Fixes #3112 .

Anonymous classes nested exceptions.

In ObjectCreationContext.java, function solveType will override the one in Context.java, so that can not correctly obtain the super class declaration of the anonymous class.

Changed the function called when creating an object of JavaParserAnonymousClassDeclaration to prevent recursion.
