### PR TITLE
Issue 3200 this exp in anonymous class

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -628,17 +628,10 @@ public class JavaParserFacade {
      */
     protected Node findContainingTypeDeclOrObjectCreationExpr(Node node, String className) {
         Node parent = node;
-        boolean detachFlag = false;
         while (true) {
             parent = demandParentNode(parent);
             if (parent instanceof BodyDeclaration) {
                 if (parent instanceof TypeDeclaration && ((TypeDeclaration<?>) parent).getFullyQualifiedName().get().endsWith(className)) {
-                    return parent;
-                } else {
-                    detachFlag = true;
-                }
-            } else if (parent instanceof ObjectCreationExpr) {
-                if (detachFlag) {
                     return parent;
                 }
             }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3200Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3200Test.java
@@ -1,0 +1,77 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3200Test {
+
+    @Test
+    public void test0() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class Test {\n" +
+                "    private void bad() {\n" +
+                "        Test test = new Test();\n" +
+                "        test.setRunnable(\"\", new Runnable() {\n" +
+                "            @Override\n" +
+                "            public void run() {\n" +
+                "                getContext(Test.this);\n" +
+                "            }\n" +
+                "        });\n" +
+                "    }\n" +
+                "\n" +
+                "    private void getContext(Test test) {\n" +
+                "    }\n" +
+                "\n" +
+                "    private void setRunnable(String str, Runnable runnable) {\n" +
+                "    }\n" +
+                "}";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+        List<MethodCallExpr> mce = cu.findAll(MethodCallExpr.class);
+        assertEquals("Test.setRunnable(java.lang.String, java.lang.Runnable)",
+                mce.get(0).resolve().getQualifiedSignature());
+        assertEquals("Test.getContext(Test)", mce.get(1).resolve().getQualifiedSignature());
+    }
+
+    @Test
+    public void test1() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class Test {\n" +
+                "    class Inner { }" +
+                "    void getContext(Test test) {  }\n" +
+                "    {\n" +
+                "        new Inner () {\n" +
+                "            {\n" +
+                "                getContext(Test.this);\n" +
+                "            }\n" +
+                "        };\n" +
+                "    }\n" +
+                "}";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+        MethodCallExpr mce = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rmd = mce.resolve();
+        String sig = rmd.getQualifiedSignature();
+        assertEquals("Test.getContext(Test)", sig);
+    }
+
+}
+


### PR DESCRIPTION
Fixes #3200.

Problem: The main class "this" expression in the anonymous class does not get the type correctly as a function argument.

Reason: When parsing the type of "this" argument, it will loop through to get the parent node. If it is a declaration statement, it will determine whether the name of its type is the same as the name of type "this", but it will exit when the object creation statement is obtained.
So it exits in the anonymous class creation statement, resulting in retrieving the type of the anonymous class.
Personally, I don't think it's right.

Modification: Removes the code that gets the object creation statement to exit.