### PR TITLE
fix Log.error() throwing NullPointerException

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/LogTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/LogTest.java
@@ -83,6 +83,7 @@ class LogTest {
         Log.error("a%sc", () -> "b");
         Log.error(new Throwable("!!!"), "abc");
         Log.error(new Throwable("!!!"), "a%sc%s", () -> "b", () -> "d");
-        assertEquals("EabcMnullEabcMnullEabcM!!!EabcdM!!!", testAdapter.output);
+        Log.error(new Throwable("!!!"));
+        assertEquals("EabcMnullEabcMnullEabcM!!!EabcdM!!!EnullM!!!", testAdapter.output);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Log.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Log.java
@@ -142,7 +142,7 @@ public class Log {
      * For drawing attention to an error.
      */
     public static void error(Throwable throwable) {
-        CURRENT_ADAPTER.error(() -> throwable, null);
+        CURRENT_ADAPTER.error(() -> throwable, () -> null);
     }
 
     /**


### PR DESCRIPTION
Playing around with JavaParser, I noticed that Log.error(Throwable) always throws a NullPointerException with the StandardOutStandardErrorAdapter assigned because it expects a non null message supplier, but Log.error() would pass it null.

I fixed the problem by letting Log.error() pass a null-returning supplier instead of null, since the API javadoc says message suppliers are allowed to return null. According to the StandardOutStandardErrorAdapter implementation this should work.