### PR TITLE
fixes #3255 -- bugfix grammar case when using `record` to as an identifier

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue3255Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue3255Test.java
@@ -1,0 +1,34 @@
+package com.github.javaparser.issues;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import org.junit.jupiter.api.Test;
+
+public class Issue3255Test {
+
+    @Test
+    public void test() {
+        CompilationUnit compilationUnit = StaticJavaParser.parse("class Test {\n" +
+                "    private void bad() {\n" +
+                "        String record = \"\";\n" +
+                "        record.getBytes();\n" +
+                "    }\n" +
+                "}");
+
+        System.out.println(compilationUnit);
+
+    }
+
+    @Test
+    public void test2() {
+        CompilationUnit compilationUnit = StaticJavaParser.parse("class Test {\n" +
+                "    private void bad() {\n" +
+                "        String record2 = \"\";\n" +
+                "        record2.getBytes();\n" +
+                "    }\n" +
+                "}");
+
+        System.out.println(compilationUnit);
+
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue3255Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue3255Test.java
@@ -1,34 +1,46 @@
 package com.github.javaparser.issues;
 
-import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.utils.LineSeparator;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue3255Test {
 
+    private static final String EOL = LineSeparator.SYSTEM.asRawString();
+
     @Test
     public void test() {
-        CompilationUnit compilationUnit = StaticJavaParser.parse("class Test {\n" +
-                "    private void bad() {\n" +
-                "        String record = \"\";\n" +
-                "        record.getBytes();\n" +
-                "    }\n" +
+        JavaParser javaParser = new JavaParser();
+        ParseResult<CompilationUnit> parseResult = javaParser.parse("class Test {" + EOL +
+                "    private void bad() {" + EOL +
+                "        String record = \"\";" + EOL +
+                "        record.getBytes();" + EOL +
+                "    }" + EOL +
                 "}");
 
-        System.out.println(compilationUnit);
+        assertEquals(0, parseResult.getProblems().size());
 
+        CompilationUnit compilationUnit = parseResult.getResult().get();
+        System.out.println(compilationUnit);
     }
 
     @Test
     public void test2() {
-        CompilationUnit compilationUnit = StaticJavaParser.parse("class Test {\n" +
-                "    private void bad() {\n" +
-                "        String record2 = \"\";\n" +
-                "        record2.getBytes();\n" +
-                "    }\n" +
+        JavaParser javaParser = new JavaParser();
+        ParseResult<CompilationUnit> parseResult = javaParser.parse("class Test {" + EOL +
+                "    private void bad() {" + EOL +
+                "        String record2 = \"\";" + EOL +
+                "        record2.getBytes();" + EOL +
+                "    }" + EOL +
                 "}");
 
-        System.out.println(compilationUnit);
+        assertEquals(0, parseResult.getProblems().size());
 
+        CompilationUnit compilationUnit = parseResult.getResult().get();
+        System.out.println(compilationUnit);
     }
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1373,6 +1373,7 @@ RecordDeclaration RecordDeclaration(ModifierHolder modifier):
     JavaToken begin = modifier.begin;
 }
 {
+    // Note that BlockStatement and ClassOrInterfaceBodyDeclaration have extended lookaheads that should be maintained
     // Note that `record` is a "restricted identifier", not a keyword - JLS 3.9 has more detail.
     "record" { begin = orIfInvalid(begin, token()); }
     name = SimpleName()
@@ -1890,7 +1891,7 @@ BodyDeclaration<?> ClassOrInterfaceBodyDeclaration():
         (
             ret = ClassOrInterfaceDeclaration(modifiers)
          |
-            LOOKAHEAD("record")
+            LOOKAHEAD("record" SimpleName() [ TypeParameters() ] Parameters() )
             ret = RecordDeclaration(modifiers)
          |
             LOOKAHEAD("enum")
@@ -4307,11 +4308,12 @@ Statement BlockStatement():
             modifier = Modifiers()
             typeDecl = ClassOrInterfaceDeclaration(modifier) { ret = new LocalClassDeclarationStmt(range(typeDecl, token()), typeDecl); }
          |
-            LOOKAHEAD( Modifiers() "record" )
+            // Extended lookahead required to allow for e.g. `record.toString()` where looking past "record" is required for disambiguation
+            LOOKAHEAD( Modifiers() "record" SimpleName() [ TypeParameters() ] Parameters() )
             modifier = Modifiers()
             recordDeclaration = RecordDeclaration(modifier) { ret = new LocalRecordDeclarationStmt(range(recordDeclaration, token()), recordDeclaration); }
          |
-            LOOKAHEAD(VariableDeclarationExpression() )
+            LOOKAHEAD( VariableDeclarationExpression() )
             expr = VariableDeclarationExpression()
             ";"
             { ret = new ExpressionStmt(range(expr, token()), expr); }


### PR DESCRIPTION
fixes #3255 