### PR TITLE
Fix Java 11+ AST postprocessing

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -28,10 +28,10 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.validator.*;
 import com.github.javaparser.ast.validator.language_level_validations.*;
+import com.github.javaparser.ast.validator.postprocessors.*;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.utils.LineSeparator;
-import com.github.javaparser.ast.validator.postprocessors.Java10PostProcessor;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -101,16 +101,16 @@ public class ParserConfiguration {
         /**
          * Java 11
          */
-        JAVA_11(new Java11Validator(), null),
+        JAVA_11(new Java11Validator(), new Java11PostProcessor()),
         /**
          * Java 11 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
          */
-        JAVA_11_PREVIEW(new Java11PreviewValidator(), null),
+        JAVA_11_PREVIEW(new Java11PreviewValidator(), new Java11PostProcessor()),
         /**
          * Java 12
          */
-        JAVA_12(new Java12Validator(), null),
+        JAVA_12(new Java12Validator(), new Java12PostProcessor()),
         /**
          * Java 12 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
@@ -118,11 +118,11 @@ public class ParserConfiguration {
          *     <li>Switch expressions are permitted, with a single label only and no yield.</li>
          * </ul>
          */
-        JAVA_12_PREVIEW(new Java12PreviewValidator(), null),
+        JAVA_12_PREVIEW(new Java12PreviewValidator(), new Java12PostProcessor()),
         /**
          * Java 13
          */
-        JAVA_13(new Java13Validator(), null),
+        JAVA_13(new Java13Validator(), new Java13PostProcessor()),
         /**
          * Java 13 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
@@ -130,43 +130,43 @@ public class ParserConfiguration {
          *     <li>Switch expressions are permitted, with a single label only.</li>
          * </ul>
          */
-        JAVA_13_PREVIEW(new Java13PreviewValidator(), null),
+        JAVA_13_PREVIEW(new Java13PreviewValidator(), new Java13PostProcessor()),
         /**
          * Java 14
          */
-        JAVA_14(new Java14Validator(), null),
+        JAVA_14(new Java14Validator(), new Java14PostProcessor()),
         /**
          * Java 14 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
          */
-        JAVA_14_PREVIEW(new Java14PreviewValidator(), null),
+        JAVA_14_PREVIEW(new Java14PreviewValidator(), new Java14PostProcessor()),
         /**
          * Java 15
          */
-        JAVA_15(new Java15Validator(), null),
+        JAVA_15(new Java15Validator(), new Java15PostProcessor()),
         /**
          * Java 15 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
          */
-        JAVA_15_PREVIEW(new Java15PreviewValidator(), null),
+        JAVA_15_PREVIEW(new Java15PreviewValidator(), new Java15PostProcessor()),
         /**
          * Java 16
          */
-        JAVA_16(new Java16Validator(), null),
+        JAVA_16(new Java16Validator(), new Java16PostProcessor()),
         /**
          * Java 16 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
          */
-        JAVA_16_PREVIEW(new Java16PreviewValidator(), null),
+        JAVA_16_PREVIEW(new Java16PreviewValidator(), new Java16PostProcessor()),
         /**
          * Java 16
          */
-        JAVA_17(new Java17Validator(), null),
+        JAVA_17(new Java17Validator(), new Java17PostProcessor()),
         /**
          * Java 16 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
          */
-        JAVA_17_PREVIEW(new Java17PreviewValidator(), null);
+        JAVA_17_PREVIEW(new Java17PreviewValidator(), new Java17PostProcessor());
 
         /**
          * Does no post processing or validation. Only for people wanting the fastest parsing.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java11PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java11PostProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.VarType;
+
+import static com.github.javaparser.ParseResult.PostProcessor;
+
+/**
+ * Processes the generic AST into a Java 11 AST and validates it.
+ */
+public class Java11PostProcessor extends Java10PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java12PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java12PostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Processes the generic AST into a Java 12 AST and validates it.
+ */
+public class Java12PostProcessor extends Java11PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java13PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java13PostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Processes the generic AST into a Java 13 AST and validates it.
+ */
+public class Java13PostProcessor extends Java12PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java14PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java14PostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Processes the generic AST into a Java 14 AST and validates it.
+ */
+public class Java14PostProcessor extends Java13PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java15PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java15PostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Processes the generic AST into a Java 15 AST and validates it.
+ */
+public class Java15PostProcessor extends Java14PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java16PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java16PostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Processes the generic AST into a Java 16 AST and validates it.
+ */
+public class Java16PostProcessor extends Java15PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java17PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java17PostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Processes the generic AST into a Java 17 AST and validates it.
+ */
+public class Java17PostProcessor extends Java16PostProcessor {
+}


### PR DESCRIPTION
Postprocessor configuration was missing, so the "var" type was only working in Java 10.