### PR TITLE
Fixes Issue #3308 -- stackoverflow when resolving the `FieldAccessExpr` of an `ArrayAccessExpr`

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -57,7 +57,9 @@ public class JavaParserFactory {
         }
 
         // TODO: Is order important here?
-        if (node instanceof AnnotationDeclaration) {
+        if (node instanceof ArrayAccessExpr) {
+            return new ArrayAccessExprContext((ArrayAccessExpr) node, typeSolver);
+        } else if (node instanceof AnnotationDeclaration) {
             return new AnnotationDeclarationContext((AnnotationDeclaration) node, typeSolver);
         } else if (node instanceof BinaryExpr) {
             return new BinaryExprContext((BinaryExpr) node, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ArrayAccessExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ArrayAccessExprContext.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2020 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.expr.ArrayAccessExpr;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+
+/**
+ * <p>
+ *     Required to prevent recursive access to the "parent node" (not necessarily the same as the "parent context").
+ * </p><p>
+ *     Consider, for example, this code where the cursor is currently at the node of type {@code ArrayAccessExpr}:
+ * </p>
+ * <pre>{@code
+ *     var1.perPriority[index].recovered
+ *     ^^^^^^^^^^^^^^^^^^^^^^^             - ArrayAccessExpr
+ * }</pre>
+ *
+ * <p><b>The AST for this snippet:</b></p>
+ *
+ * <pre>{@code
+ *                            FieldAccessExpr                       // This FieldAccessExpr is accessing the field `recovered`
+ *                             /           \
+ *               **ArrayAccessExpr**      SimpleName(recovered)
+ *                  /          \
+ *          FieldAccessExpr  NameExpr(index)                        // This FieldAccessExpr is accessing the field `perPriority`
+ *            /         \
+ *    NameExpr(var1)   SimpleName (perPriority)
+ * }</pre>
+ *
+ * <p><b>In this example:</b></p>
+ * <ul>
+ *     <li>
+ *         The parent node for {@code ArrayAccessExpr} is {@code FieldAccessExpr} ({@code variable1.perPriority[index].recovered}).
+ * <pre>{@code
+ *     // "Parent Node" of the ArrayAccessExpr
+ *     var.perPriority[index].recovered
+ *     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   - FieldAccessExpr
+ *     ^^^^^^^^^^^^^^^^^^^^^^             - ArrayAccessExpr
+ *                            ^^^^^^^^^   - SimpleName
+ * }</pre>
+ *     </li>
+ *     <li>
+ *         The parent context is the {@code FieldAccessExpr} to the left of the outer array-access, which is actually a child node.
+ * <pre>{@code
+ *
+ *     // "Parent Context" of the ArrayAccessExpr
+ *     var1.perPriority[index].recovered
+ *     ^^^^^^^^^^^^^^^^^^^^^^^             - ArrayAccessExpr
+ *     ^^^^^^^^^^^^^^^^                    - FieldAccessExpr
+ *                      ^^^^^              - NameExpr
+ * }</pre>
+ *     </li>
+ * </ul>
+ *
+ *
+ *
+ *
+ * @author Roger Howell
+ */
+public class ArrayAccessExprContext extends AbstractJavaParserContext<ArrayAccessExpr> {
+
+    public ArrayAccessExprContext(ArrayAccessExpr wrappedNode, TypeSolver typeSolver) {
+        super(wrappedNode, typeSolver);
+    }
+
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbolInParentContext(String name) {
+        /*
+         * Simple implementation, included explicitly here for clarity:
+         * - Delegate to parent context per the documentation for ArrayAccessExprContext
+         * - Required to prevent recursive access to the "parent node" (not necessarily the same as the "parent context")
+         */
+        return super.solveSymbolInParentContext(name);
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3308Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3308Test.java
@@ -3,21 +3,22 @@ package com.github.javaparser.symbolsolver;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.expr.ArrayAccessExpr;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
-import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class Issue3308Test {
 
     @Test
-    void test() {
+    void shallowArray() {
         StaticJavaParser.getConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_9);
         CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
         combinedTypeSolver.add(new ReflectionTypeSolver());
@@ -39,28 +40,30 @@ public class Issue3308Test {
                 "}";
 
         CompilationUnit node = StaticJavaParser.parse(classStr);
-//        List<ArrayAccessExpr> all = node.findAll(ArrayAccessExpr.class);
-//        List<NameExpr> all = node.findAll(NameExpr.class);
         List<FieldAccessExpr> all = node.findAll(FieldAccessExpr.class);
-        all.remove(0);
-        all.forEach(a -> {
-            System.out.println("a = " + a);
-            System.out.println("a.getName() = " + a.getName());
-            try {
-                ResolvedValueDeclaration resolved = a.resolve();
-                System.out.println("resolved = " + resolved);
-            } catch (Exception e) {
-                System.out.println("e = " + e);
-            }
-            System.out.println();
-        });
+        assertEquals(2, all.size());
+
+        ResolvedValueDeclaration resolved;
+        FieldAccessExpr fieldAccessExpr;
+
+        fieldAccessExpr = all.get(0);
+        Assertions.assertEquals("recovered", fieldAccessExpr.getNameAsString());
+        resolved = fieldAccessExpr.resolve();
+        assertTrue(resolved.getType().isPrimitive());
+        assertEquals("java.lang.Integer", resolved.getType().asPrimitive().getBoxTypeQName());
+
+
+        fieldAccessExpr = all.get(1);
+        Assertions.assertEquals("perPriority", fieldAccessExpr.getNameAsString());
+        resolved = fieldAccessExpr.resolve();
+        assertTrue(resolved.getType().isArray());
     }
 
 
 
 
     @Test
-    void test2() {
+    void deepArray() {
         StaticJavaParser.getConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_9);
         CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
         combinedTypeSolver.add(new ReflectionTypeSolver());
@@ -82,21 +85,24 @@ public class Issue3308Test {
                 "}";
 
         CompilationUnit node = StaticJavaParser.parse(classStr);
-        List<ArrayAccessExpr> all = node.findAll(ArrayAccessExpr.class);
-//        List<NameExpr> all = node.findAll(NameExpr.class);
-//        List<FieldAccessExpr> all = node.findAll(FieldAccessExpr.class);
-        all.remove(0);
-        all.forEach(a -> {
-            System.out.println("a = " + a);
-            System.out.println("a.getName() = " + a.getName());
-//            try {
-//                ResolvedValueDeclaration resolved = a.resolve();
-//                System.out.println("resolved = " + resolved);
-//            } catch (Exception e) {
-//                System.out.println("e = " + e);
-//            }
-            System.out.println();
-        });
+        List<FieldAccessExpr> all = node.findAll(FieldAccessExpr.class);
+        assertEquals(2, all.size());
+
+        ResolvedValueDeclaration resolved;
+        FieldAccessExpr fieldAccessExpr;
+
+        fieldAccessExpr = all.get(0);
+        Assertions.assertEquals("recovered", fieldAccessExpr.getNameAsString());
+        resolved = fieldAccessExpr.resolve();
+        assertTrue(resolved.getType().isPrimitive());
+        assertEquals("java.lang.Integer", resolved.getType().asPrimitive().getBoxTypeQName());
+
+
+        fieldAccessExpr = all.get(1);
+        Assertions.assertEquals("perPriority", fieldAccessExpr.getNameAsString());
+        resolved = fieldAccessExpr.resolve();
+        assertTrue(resolved.getType().isArray());
+
     }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3308Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3308Test.java
@@ -1,0 +1,59 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.ArrayAccessExpr;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class Issue3308Test {
+
+    @Test
+    void test() {
+        StaticJavaParser.getConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_9);
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver());
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver));
+        String classStr = "public class JavaParser {\n" +
+                "\n" +
+                "    public void bad (int index) {\n" +
+                "        LastRecovered recovered = new LastRecovered();\n" +
+                "        recovered.perPriority[index].recovered = 10;\n" +
+                "    }\n" +
+                "\n" +
+                "    private class LastRecovered {\n" +
+                "        LastRecoveredEntry[] perPriority = new LastRecoveredEntry[10];\n" +
+                "    }\n" +
+                "\n" +
+                "    private class LastRecoveredEntry {\n" +
+                "        private int recovered = 0;\n" +
+                "    }\n" +
+                "}";
+
+        CompilationUnit node = StaticJavaParser.parse(classStr);
+//        List<ArrayAccessExpr> all = node.findAll(ArrayAccessExpr.class);
+//        List<NameExpr> all = node.findAll(NameExpr.class);
+        List<FieldAccessExpr> all = node.findAll(FieldAccessExpr.class);
+        all.remove(0);
+        all.forEach(a -> {
+            System.out.println("a = " + a);
+            System.out.println("a.getName() = " + a.getName());
+            try {
+                ResolvedValueDeclaration resolved = a.resolve();
+                System.out.println("resolved = " + resolved);
+            } catch (Exception e) {
+                System.out.println("e = " + e);
+            }
+            System.out.println();
+        });
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3308Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3308Test.java
@@ -56,4 +56,47 @@ public class Issue3308Test {
         });
     }
 
+
+
+
+    @Test
+    void test2() {
+        StaticJavaParser.getConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_9);
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver());
+        StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver));
+        String classStr = "class JavaParser {\n" +
+                "\n" +
+                "    public void bad (int index) {\n" +
+                "        LastRecovered recovered = new LastRecovered();\n" +
+                "        recovered.perPriority[index][0][0][0].recovered = 10;\n" +
+                "    }\n" +
+                "\n" +
+                "    private class LastRecovered {\n" +
+                "        LastRecoveredEntry[][][][] perPriority = new LastRecoveredEntry[10][10][10][10];\n" +
+                "    }\n" +
+                "\n" +
+                "    private class LastRecoveredEntry {\n" +
+                "        private int recovered = 0;\n" +
+                "    }\n" +
+                "}";
+
+        CompilationUnit node = StaticJavaParser.parse(classStr);
+        List<ArrayAccessExpr> all = node.findAll(ArrayAccessExpr.class);
+//        List<NameExpr> all = node.findAll(NameExpr.class);
+//        List<FieldAccessExpr> all = node.findAll(FieldAccessExpr.class);
+        all.remove(0);
+        all.forEach(a -> {
+            System.out.println("a = " + a);
+            System.out.println("a.getName() = " + a.getName());
+//            try {
+//                ResolvedValueDeclaration resolved = a.resolve();
+//                System.out.println("resolved = " + resolved);
+//            } catch (Exception e) {
+//                System.out.println("e = " + e);
+//            }
+            System.out.println();
+        });
+    }
+
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
@@ -22,6 +22,7 @@
 package com.github.javaparser.symbolsolver;
 
 import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
@@ -34,7 +35,13 @@ import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class Issue343Test extends AbstractResolutionTest{
+/**
+ * Note this issue number refers to the archived `javasymbolsolver` repository,
+ * whose issues prior to it being integrated into JavaParser itself are numbered separately:
+ *
+ * https://github.com/javaparser/javasymbolsolver/issues/343
+ */
+class Issue343Test extends AbstractResolutionTest {
 
     private TypeSolver typeResolver;
     private JavaParserFacade javaParserFacade;
@@ -61,13 +68,13 @@ class Issue343Test extends AbstractResolutionTest{
 
     @Test
     void toResolveDoubleWeNeedTheAST() {
-        assertThrows(IllegalStateException.class, () -> getExpressionType(typeResolver, parseExpression("new Double[]{2.0d, 3.0d}[1]")));
+        assertThrows(UnsolvedSymbolException.class, () -> getExpressionType(typeResolver, parseExpression("new Double[]{2.0d, 3.0d}[1]")));
     }
 
 
     @Test
     void toResolveFloatWeNeedTheAST() {
-        assertThrows(IllegalStateException.class, () -> getExpressionType(typeResolver, parseExpression("new Float[]{2.0d, 3.0d}[1]")));
+        assertThrows(UnsolvedSymbolException.class, () -> getExpressionType(typeResolver, parseExpression("new Float[]{2.0d, 3.0d}[1]")));
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
@@ -67,7 +67,7 @@ class Issue343Test extends AbstractResolutionTest{
 
     @Test
     void toResolveFloatWeNeedTheAST() {
-        assertThrows(IllegalStateException.class, () -> getExpressionType(typeResolver, parseExpression("new Float[]{2.0d, 3.0d}")));
+        assertThrows(IllegalStateException.class, () -> getExpressionType(typeResolver, parseExpression("new Float[]{2.0d, 3.0d}[1]")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #3308 

This PR inserts a new context for `ArrayAccessExpr`, so that the _parent context_ is used instead of the _parent node_ when attempting to solve.