### PR TITLE
Check if ancestor also for super class

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -339,9 +339,19 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
             return ancestors;
         }
 
+        Optional<String> qualifiedName = wrappedNode.getFullyQualifiedName();
+        if (!qualifiedName.isPresent()) {
+            return ancestors;
+        }
+
         try {
             // If a superclass is found, add it as an ancestor
-            getSuperClass().ifPresent(ancestors::add);
+            Optional<ResolvedReferenceType> superClass = getSuperClass();
+            if (superClass.isPresent()) {
+                if (isAncestor(superClass.get(), qualifiedName.get())) {
+                    ancestors.add(superClass.get());
+                }
+            }
         } catch (UnsolvedSymbolException e) {
             // in case we could not resolve the super class, we may still be able to resolve (some of) the
             // implemented interfaces and so we continue gracefully with an (incomplete) list of ancestors
@@ -356,18 +366,8 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
             try {
                 // If an implemented interface is found, add it as an ancestor
                 ResolvedReferenceType rrt = toReferenceType(implemented);
-                Optional<ResolvedReferenceTypeDeclaration> resolvedReferenceTypeDeclaration = rrt.getTypeDeclaration();
-                if (resolvedReferenceTypeDeclaration.isPresent()) {
-
-                    ResolvedTypeDeclaration rtd = resolvedReferenceTypeDeclaration.get().asType();
-                    Optional<String> qualifiedName = wrappedNode.getFullyQualifiedName();
-                    if (qualifiedName.isPresent()) {
-
-                        // do not consider an inner or nested class as an ancestor
-                        if (!rtd.getQualifiedName().contains(qualifiedName.get())) {
-                            ancestors.add(rrt);
-                        }
-                    }
+                if (isAncestor(rrt, qualifiedName.get())) {
+                    ancestors.add(rrt);
                 }
             } catch (UnsolvedSymbolException e) {
                 // in case we could not resolve some implemented interface, we may still be able to resolve the
@@ -382,6 +382,16 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration impleme
         }
 
         return ancestors;
+    }
+
+    private boolean isAncestor(ResolvedReferenceType candidateAncestor, String ownQualifiedName) {
+        Optional<ResolvedReferenceTypeDeclaration> resolvedReferenceTypeDeclaration = candidateAncestor.getTypeDeclaration();
+        if (resolvedReferenceTypeDeclaration.isPresent()) {
+            ResolvedTypeDeclaration rtd = resolvedReferenceTypeDeclaration.get().asType();
+            // do not consider an inner or nested class as an ancestor
+            return !rtd.getQualifiedName().contains(ownQualifiedName);
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This is an improvement of the fix done in #2956
It also might be fixing #2471 , I didn't get the chance to test.

I encountered this bug and tested it against https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java , where the following class snippet gets into an infinite loop over ancestors:

```java
public static class Option extends Suggestion.Entry.Option {
...
}
```