### PR TITLE
Fix pretty printing of generic records

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/RecordDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/RecordDeclarationTest.java
@@ -114,6 +114,19 @@ public class RecordDeclarationTest {
         assertEqualsStringIgnoringEol(expected, cu.toString());
     }
 
+    @Test
+    void genericRecordPrints() {
+        String s = "record Point<X,Y>(X x, Y y) { }";
+        CompilationUnit cu = TestParser.parseCompilationUnit(s);
+        assertOneRecordDeclaration(cu);
+
+        String expected = "" +
+                "record Point<X, Y>(X x, Y y) {\n" +
+                "}\n" +
+                "";
+        assertEqualsStringIgnoringEol(expected, cu.toString());
+    }
+
     /**
      * https://openjdk.java.net/jeps/395#Restrictions-on-record
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -438,6 +438,8 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
 
         n.getName().accept(this, arg);
 
+        printTypeParameters(n.getTypeParameters(), arg);
+
         printer.print("(");
         if (!isNullOrEmpty(n.getParameters())) {
             for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext(); ) {
@@ -449,9 +451,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
             }
         }
         printer.print(")");
-
-        printTypeParameters(n.getTypeParameters(), arg);
-
+        
         if (!n.getImplementedTypes().isEmpty()) {
             printer.print(" implements ");
             for (final Iterator<ClassOrInterfaceType> i = n.getImplementedTypes().iterator(); i.hasNext(); ) {


### PR DESCRIPTION
The pretty printer for generic records (those with type parameters) currently prints the parameters in the wrong place.  They should be after the class name but before the record header; the javaparser library is currently printing them after the record header.  This PR adds a failing test to show the problem, then adds the (fairly trivial) fix for the problem.