### PR TITLE
Fixed prettyprinting new switch-statements (and switch-expressions).

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -1394,8 +1394,10 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         printOrphanCommentsBeforeThisChildNode(n);
         printComment(n.getComment(), arg);
 
+        final String separator = (n.getType() == SwitchEntry.Type.STATEMENT_GROUP) ? ":" : " ->"; // old/new switch
+
         if (isNullOrEmpty(n.getLabels())) {
-            printer.print("default:");
+            printer.print("default" + separator);
         } else {
             printer.print("case ");
             for (final Iterator<Expression> i = n.getLabels().iterator(); i.hasNext(); ) {
@@ -1405,7 +1407,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
                     printer.print(", ");
                 }
             }
-            printer.print(":");
+            printer.print(separator);
         }
         printer.println();
         printer.indent();

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -1366,8 +1366,9 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         printOrphanCommentsBeforeThisChildNode(n);
         printComment(n.getComment(), arg);
 
+        final String separator = (n.getType() == SwitchEntry.Type.STATEMENT_GROUP) ? ":" : " ->"; // old/new switch
         if (isNullOrEmpty(n.getLabels())) {
-            printer.print("default:");
+            printer.print("default" + separator);
         } else {
             printer.print("case ");
             for (final Iterator<Expression> i = n.getLabels().iterator(); i.hasNext(); ) {
@@ -1377,7 +1378,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
                     printer.print(", ");
                 }
             }
-            printer.print(":");
+            printer.print(separator);
         }
         printer.println();
         printer.indent();


### PR DESCRIPTION
If the type of a SwitchEntry is STATEMENT_GROUP then it is an entry in an old switch-statement,
otherwise it is an entry in a new switch, and " ->" shall be used instead of ":".
