### PR TITLE
Fix String Index out of range in TextBlockLiteralExpr

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/TextBlockLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/TextBlockLiteralExprTest.java
@@ -192,4 +192,13 @@ class TextBlockLiteralExprTest {
                 "green \n" +
                 "blue  \n", textBlock.translateEscapes());
     }
+
+    @Test
+    void whiteSpaceLineShorterThanMiniumCommonPrefix() {
+        TextBlockLiteralExpr textBlock = parseStatement("String text = \"\"\" \n" +
+                "  Hello\n" +
+                "  World\"\"\";").findFirst(TextBlockLiteralExpr.class).get();
+        assertEquals("\nHello\n" +
+                "World", textBlock.translateEscapes());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TextBlockLiteralExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TextBlockLiteralExpr.java
@@ -151,7 +151,7 @@ public class TextBlockLiteralExpr extends LiteralStringValueExpr {
         /* Remove the common white space prefix from each non-blank line in the list of individual lines. */
         /* Remove all trailing white space from all lines in the modified list of individual lines from step 5. 
         This step collapses wholly-whitespace lines in the modified list so that they are empty, but does not discard them. */
-        return Arrays.stream(rawLines).map(l -> l.substring(commonWhiteSpacePrefixSize)).map(this::trimTrailing);
+        return Arrays.stream(rawLines).map(l -> l.length() < commonWhiteSpacePrefixSize ? l : l.substring(commonWhiteSpacePrefixSize)).map(this::trimTrailing);
     }
 
     /**


### PR DESCRIPTION
Fix calling stripIndentOfLines() on textblocks will produce
StringIndexOutOfBoundsException if there are white lines shorter than
the minimum common white space prefix.
For example (star * denotes a single white space):

"""*
**Hello
**World"""

The reason is the calculation of commonWhiteSpacePrefixSize excludes the
white lines but the final return still tries to get substring of all
lines. Once the commonWhiteSpacePrefixSize is greater than the length of
some white lines, StringIndexOutOfBoundsException will occur.
