### PR TITLE
Reduce mvn verbosity on GitHub actions (and switch to mvnw)

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -70,7 +70,7 @@ jobs:
       ### -P,--activate-profiles : Comma-delimited list of profiles to activate
       ### AlsoSlowTests : by default, only quick tests are run - the profile `AlsoSlowTests` runs the full test suite
       - name: Test with Maven (incl. slow tests)
-        run: mvn --errors clean test --activate-profiles AlsoSlowTests
+        run: ./mvnw -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B --errors clean test --activate-profiles AlsoSlowTests
 
 
       - name: CodeCov - JavaParser Core

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -70,6 +70,7 @@ jobs:
       ### -P,--activate-profiles : Comma-delimited list of profiles to activate
       ### AlsoSlowTests : by default, only quick tests are run - the profile `AlsoSlowTests` runs the full test suite
       - name: Test with Maven (incl. slow tests)
+        shell: bash
         run: ./mvnw -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B --errors clean test --activate-profiles AlsoSlowTests
 
 


### PR DESCRIPTION
When reading error output, it is time consuming to scroll through all download progress.

Example:

![grafik](https://user-images.githubusercontent.com/1366654/131876742-8546fc0d-43f3-4e3f-b757-9b1676bf57b1.png)

This PR a) reduces verbosity when running on GitHub actions and B) uses the contained Maven wrapper to ensure that always the same Maven version is used.