### PR TITLE
Fix issue 2360 Symbol Solver is missing promotion of byte, char, and short in unary expressions

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -630,7 +630,7 @@ public class TypeExtractor extends DefaultVisitorAdapter {
         switch (node.getOperator()) {
             case MINUS:
             case PLUS:
-                return node.getExpression().accept(this, solveLambdas);
+                return ResolvedPrimitiveType.unp(node.getExpression().accept(this, solveLambdas));
             case LOGICAL_COMPLEMENT:
                 return ResolvedPrimitiveType.BOOLEAN;
             case POSTFIX_DECREMENT:

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2360.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2360.java
@@ -1,0 +1,93 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+class Issue2360 extends AbstractSymbolResolutionTest {
+
+    @Test
+    void testUnaryExprResolvedViaUnaryNumericPromotion_char() {
+        String source = "public class Test\n" + 
+                "{\n" + 
+                "   public class InnerClass\n" + 
+                "   {\n" + 
+                "       public InnerClass(char c) {}\n" + 
+                "       public InnerClass(int i) {}\n" + 
+                "   }\n" + 
+                "    \n" + 
+                "   public Test() {\n" + 
+                "     new InnerClass(+'.'); \n" + 
+                "   }\n" + 
+                "}";
+        
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+
+        CompilationUnit cu = StaticJavaParser.parse(source);
+        ObjectCreationExpr expr = cu.findFirst(ObjectCreationExpr.class).get();
+        ResolvedConstructorDeclaration rcd = expr.resolve();
+        assertEquals("InnerClass(int)", rcd.getSignature());
+    }
+    
+    @Test
+    void testUnaryExprResolvedViaUnaryNumericPromotion_byte() {
+        String source = "public class Test\n" + 
+                "{\n" + 
+                "   public class InnerClass\n" + 
+                "   {\n" + 
+                "       public InnerClass(char c) {}\n" + 
+                "       public InnerClass(int i) {}\n" + 
+                "   }\n" + 
+                "    \n" + 
+                "   public Test() {\n" + 
+                "     byte b = 0;\n" +
+                "     new InnerClass(+b); \n" + 
+                "   }\n" + 
+                "}";
+        
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+
+        CompilationUnit cu = StaticJavaParser.parse(source);
+        ObjectCreationExpr expr = cu.findFirst(ObjectCreationExpr.class).get();
+        ResolvedConstructorDeclaration rcd = expr.resolve();
+        assertEquals("InnerClass(int)", rcd.getSignature());
+    }
+    
+    @Test
+    void testUnaryExprResolvedViaUnaryNumericPromotion_short() {
+        String source = "public class Test\n" + 
+                "{\n" + 
+                "   public class InnerClass\n" + 
+                "   {\n" + 
+                "       public InnerClass(char c) {}\n" + 
+                "       public InnerClass(int i) {}\n" + 
+                "   }\n" + 
+                "    \n" + 
+                "   public Test() {\n" + 
+                "     short b = 0;\n" +
+                "     new InnerClass(+b); \n" + 
+                "   }\n" + 
+                "}";
+        
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+
+        CompilationUnit cu = StaticJavaParser.parse(source);
+        ObjectCreationExpr expr = cu.findFirst(ObjectCreationExpr.class).get();
+        ResolvedConstructorDeclaration rcd = expr.resolve();
+        assertEquals("InnerClass(int)", rcd.getSignature());
+    }
+    
+}


### PR DESCRIPTION
Fixes #2360.
