### PR TITLE
generate changelog for milestones - scripts included to do this by milestone id, milestone title, and a github action to add the output to a draft snapshot release

### DIFF
--- a/.github/workflows/prepare_release_changelog.yml
+++ b/.github/workflows/prepare_release_changelog.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
 
   ## (testing only) Trigger the workflow on any pull request
-  pull_request:
+  #pull_request:
 
 jobs:
 

--- a/.github/workflows/prepare_release_changelog.yml
+++ b/.github/workflows/prepare_release_changelog.yml
@@ -1,0 +1,79 @@
+name: Build Snapshot
+on:
+  push:
+    branches: [ master ]
+
+  ## (testing only) Trigger the workflow on any pull request
+  pull_request:
+
+jobs:
+
+  generate_changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    steps:
+
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v2.3.4
+
+      # Setup Java 11 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+
+      # Set environment variables
+      - name: Generate Changelog
+        id: vars
+        shell: bash
+        working-directory: ./scripts
+        run: |
+          ## By convention, the "next" milestone is named "next release"
+          ./run_generate_changelog_by_milestone_title.sh "next release"
+
+          SHA_LONG=$(git rev-parse HEAD)
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          CHANGELOG="$(<temp_changelog.md)"
+          RELEASE_TITLE="SNAPSHOT - $SHA_SHORT"
+          RELEASE_TAG_NAME="v_snapshot_$SHA_SHORT"
+
+          echo "::set-output name=sha_long::$SHA_LONG"
+          echo "::set-output name=sha_short::$SHA_SHORT"
+          echo "::set-output name=changelog::$CHANGELOG"
+          echo "::set-output name=release_title::$RELEASE_TITLE"
+          echo "::set-output name=release_tag_name::$RELEASE_TAG_NAME"
+
+
+      - name: Output variables
+        run: |
+          echo sha_short = ${{ steps.vars.outputs.sha_short }}
+          echo sha_long  = ${{ steps.vars.outputs.sha_long }}
+          echo changelog = "${{ steps.vars.outputs.changelog }}"
+          echo changelog = "${{ steps.vars.outputs.release_title }}"
+          echo changelog = "${{ steps.vars.outputs.release_tag_name }}"
+
+
+      # Remove old release drafts by using the curl request for the available releases with draft flag
+      - name: Remove Old Release Drafts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/{owner}/{repo}/releases \
+            --jq '.[] | select(.draft == true) | .id' \
+            | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
+
+
+      # Create new release draft - which is not publicly visible and requires manual acceptance
+      - name: Create Release Draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.vars.outputs.release_tag_name }}  \
+            --target ${{ steps.vars.outputs.sha_long }} \
+            --draft \
+            --prerelease \
+            --title "${{ steps.vars.outputs.release_title }}" \
+            --notes-file ./scripts/temp_changelog.md
+

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+temp_changelog.md

--- a/scripts/release-notes-config-id.yml
+++ b/scripts/release-notes-config-id.yml
@@ -1,0 +1,38 @@
+changelog:
+  repository: "javaparser/javaparser"
+  milestone-reference: "ID"
+  bulletStyle: "* "
+  defaultTitlePrefix: "### "
+  wrapIssueLinkInBrackets: true
+  includeIssueOrPrPrefix: true
+  includePrAuthor: true
+  excludePullRequests: false
+  excludeIssues: true
+  includeWildcardSection: true
+  sections:
+    - title: "Highlights"
+      labels: [ "PR: Noteworthy", "PR: Security", "PR: Deprecated", "PR: Deprecation" ]
+      group: "highlights"
+    - title: "API or Behaviour Change"
+      labels: [ "API or Behaviour Change" ]
+      group: "api change"
+    - title: "Added"
+      labels: [ "PR: Added" ]
+    - title: "Changed"
+      labels: [ "PR: Changed" ]
+    - title: "Deprecated"
+      labels: [ "PR: Deprecated", "PR: Deprecation" ]
+    - title: "Removed"
+      labels: [ "PR: Removed" ]
+    - title: "Fixed"
+      labels: [ "PR: Fixed", "PR: Bugfix",  "PR: Fix", "fix", "bug", "regression" ]
+    - title: "Security"
+      labels: [ "PR: Security" ]
+    - title: "Developer Changes"
+      labels: [ "PR: Build", "PR: Development", "builds / releases", "dependencies" ]
+    - title: "Uncategorised"
+      labels: [ "*" ]
+  contributors:
+    thankYouMessage: "Thank You to all contributors who worked on this release!"
+    exclude:
+      names: [ "dependabot[bot]", "renovate[bot]" ]

--- a/scripts/release-notes-config-title.yml
+++ b/scripts/release-notes-config-title.yml
@@ -1,0 +1,38 @@
+changelog:
+  repository: "javaparser/javaparser"
+  milestone-reference: "TITLE"
+  bulletStyle: "* "
+  defaultTitlePrefix: "### "
+  wrapIssueLinkInBrackets: true
+  includeIssueOrPrPrefix: true
+  includePrAuthor: true
+  excludePullRequests: false
+  excludeIssues: true
+  includeWildcardSection: true
+  sections:
+    - title: "Highlights"
+      labels: [ "PR: Noteworthy", "PR: Security", "PR: Deprecated", "PR: Deprecation" ]
+      group: "highlights"
+    - title: "API or Behaviour Change"
+      labels: [ "API or Behaviour Change" ]
+      group: "api change"
+    - title: "Added"
+      labels: [ "PR: Added" ]
+    - title: "Changed"
+      labels: [ "PR: Changed" ]
+    - title: "Deprecated"
+      labels: [ "PR: Deprecated", "PR: Deprecation" ]
+    - title: "Removed"
+      labels: [ "PR: Removed" ]
+    - title: "Fixed"
+      labels: [ "PR: Fixed", "PR: Bugfix",  "PR: Fix", "fix", "bug", "regression" ]
+    - title: "Security"
+      labels: [ "PR: Security" ]
+    - title: "Developer Changes"
+      labels: [ "PR: Build", "PR: Development", "builds / releases", "dependencies" ]
+    - title: "Uncategorised"
+      labels: [ "*" ]
+  contributors:
+    thankYouMessage: "Thank You to all contributors who worked on this release!"
+    exclude:
+      names: [ "dependabot[bot]", "renovate[bot]" ]

--- a/scripts/run_generate_changelog_by_milestone_id.sh
+++ b/scripts/run_generate_changelog_by_milestone_id.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+##
+## Note this script uses a custom build/fork of the Spring github-changelog-generator, based on v0.0.6 / 0.0.7-SNAPSHOT
+## https://github.com/spring-io/github-changelog-generator
+##
+## This fork is available at https://github.com/MysterAitch/github-changelog-generator
+##
+## For clarity, the jar is named to explicitly indicate that this is the forked version not the original.
+##
+
+
+## Exit if number of given parameters is incorrect (expecting 1 - the milestone id)
+if [ "$#" -ne 1 ]; then
+  echo "[JavaParser-ERROR]: No arguments supplied. Exiting." >&2
+  echo "[JavaParser-ERROR]: Expected Usage: $0 MILESTONE_ID" >&2
+  exit 3
+fi
+
+## Variables
+CHANGELOG_ID=$1
+
+#CHANGELOG_GENERATOR_JAR=./github-changelog-generator.jar
+CHANGELOG_GENERATOR_JAR=./github-changelog-generator_mysteraitch.jar
+CONFIG_FILE_LOCATION="release-notes-config-id.yml"
+OUTPUT_FILE=temp_changelog.md ## TODO: Consider making the output file configurable.
+
+
+echo "[JavaParser]"
+echo "[JavaParser]"
+echo "[JavaParser]: This script runs a preconfigured $CHANGELOG_GENERATOR_JAR"
+echo "[JavaParser]: "
+echo "[JavaParser]: Expected Usage: $0 MILESTONE_ID"
+echo "[JavaParser]: Where the MILESTONE_ID is the number within the milestone URL"
+echo "[JavaParser]:     e.g. $0 182"
+#echo "[JavaParser]: e.g. https://github.com/javaparser/javaparser/milestone/182"
+echo "[JavaParser]"
+echo "[JavaParser]: - A changelog specific to that milestone will then be output to $OUTPUT_FILE"
+echo "[JavaParser]: - A changelog specific to that milestone will then be output to the console"
+echo "[JavaParser]"
+
+echo "[JavaParser]: About to clear $OUTPUT_FILE ready for populating."
+echo "[JavaParser]"
+set -x
+## Empty out the changelog:
+ # shellcheck disable=SC2188
+ > $OUTPUT_FILE
+
+## Run the changelog generator tool, to generate a changelog.
+java -jar $CHANGELOG_GENERATOR_JAR --spring.config.location="$CONFIG_FILE_LOCATION" "$CHANGELOG_ID" $OUTPUT_FILE
+CHANGELOG_GENERATOR_EXIT_CODE=$?
+set +x
+
+## If the generator failed (e.g. due to an invalid milestone reference), exit this script.
+if [ $CHANGELOG_GENERATOR_EXIT_CODE -ne 0 ]; then
+  echo "[JavaParser-ERROR]: Generation of the changelog failed. Exiting." >&2
+  exit 4
+fi
+
+
+## Also display the generated changelog to the console.
+CHANGELOG_CONTENTS=$(<$OUTPUT_FILE)
+
+echo "[JavaParser]"
+echo "[JavaParser]"
+echo "[JavaParser]"
+echo "[JavaParser]: The changelog for milestone ID $CHANGELOG_ID (also stored within $OUTPUT_FILE)"
+echo "[JavaParser]"
+echo ""
+echo "$CHANGELOG_CONTENTS"

--- a/scripts/run_generate_changelog_by_milestone_title.sh
+++ b/scripts/run_generate_changelog_by_milestone_title.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+##
+## Note this script uses a custom build/fork of the Spring github-changelog-generator, based on v0.0.6 / 0.0.7-SNAPSHOT
+## https://github.com/spring-io/github-changelog-generator
+##
+## This fork is available at https://github.com/MysterAitch/github-changelog-generator
+##
+## For clarity, the jar is named to explicitly indicate that this is the forked version not the original.
+##
+
+
+## Exit if number of given parameters is incorrect (expecting 1 - the milestone title)
+if [ "$#" -ne 1 ]; then
+  echo "[JavaParser-ERROR]: No arguments supplied. Exiting." >&2
+  echo "[JavaParser-ERROR]: Expected Usage: $0 \"MILESTONE_TITLE\"" >&2
+  exit 3
+fi
+
+## Variables
+CHANGELOG_TITLE=$1
+
+#CHANGELOG_GENERATOR_JAR=./github-changelog-generator.jar
+CHANGELOG_GENERATOR_JAR=./github-changelog-generator_mysteraitch.jar
+CONFIG_FILE_LOCATION="release-notes-config-title.yml"
+OUTPUT_FILE=temp_changelog.md ## TODO: Consider making the output file configurable.
+
+
+echo "[JavaParser]"
+echo "[JavaParser]"
+echo "[JavaParser]: This script runs a preconfigured $CHANGELOG_GENERATOR_JAR"
+echo "[JavaParser]: "
+echo "[JavaParser]: Expected Usage: $0 MILESTONE_TITLE"
+echo "[JavaParser]: Where the MILESTONE_TITLE is the title of the milestone"
+echo "[JavaParser]:     e.g. $0 \"next release\""
+#echo "[JavaParser]: e.g. https://github.com/javaparser/javaparser/milestone/182"
+echo "[JavaParser]"
+echo "[JavaParser]: - A changelog specific to that milestone will then be output to $OUTPUT_FILE"
+echo "[JavaParser]: - A changelog specific to that milestone will then be output to the console"
+echo "[JavaParser]"
+
+echo "[JavaParser]: About to clear $OUTPUT_FILE ready for populating."
+echo "[JavaParser]"
+set -x
+## Empty out the changelog:
+ # shellcheck disable=SC2188
+ > $OUTPUT_FILE
+
+## Run the changelog generator tool, to generate a changelog.
+java -jar $CHANGELOG_GENERATOR_JAR --spring.config.location="$CONFIG_FILE_LOCATION" "$CHANGELOG_TITLE" $OUTPUT_FILE
+CHANGELOG_GENERATOR_EXIT_CODE=$?
+set +x
+
+## If the generator failed (e.g. due to an invalid milestone reference), exit this script.
+if [ $CHANGELOG_GENERATOR_EXIT_CODE -ne 0 ]; then
+  echo "[JavaParser-ERROR]: Generation of the changelog failed. Exiting." >&2
+  exit 4
+fi
+
+
+## Also display the generated changelog to the console.
+CHANGELOG_CONTENTS=$(<$OUTPUT_FILE)
+
+echo "[JavaParser]"
+echo "[JavaParser]"
+echo "[JavaParser]"
+echo "[JavaParser]: The changelog for milestone title $CHANGELOG_TITLE (also stored within $OUTPUT_FILE)"
+echo "[JavaParser]"
+echo ""
+echo "$CHANGELOG_CONTENTS"


### PR DESCRIPTION
This PR causes a snapshot / draft release to be created on each push to master branch, visible only to those with write access to the repo.

I have already been running locally when producing the last few releases -- switching branch, generating the readme, copying the generated file contents across, switching to an "update readme" branch, pushing that, then switching to master to produce the release.

---

A few notes: 

It requires PRs to be attached to the "next release" milestone, and to be suitably labelled to be placed under the correct headings in the changelog (labels prefixed with `PR: ` -- see the config yml files for details).

![Screenshot from 2021-10-05 12-11-21](https://user-images.githubusercontent.com/1537214/136012250-dc8da21e-c191-4b4d-8c23-3f7f591193c6.png)


There is potential scope to extend this / use a different tool entirely, but that can be done in a future PR rather than having this open/draft one linger more! :+1: 


Partial automation towards #3176
Supersedes PR #3177 (this is a squashed version of that one).

