### PR TITLE
Issue #3419 - Fixed bug in `Difference.java` 

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -21,72 +21,35 @@
 
 package com.github.javaparser.printer.lexicalpreservation;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
-import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
-import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
-import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.junit.jupiter.api.Test;
-
 import com.github.javaparser.GeneratedJavaParserConstants;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.ArrayCreationLevel;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.ImportDeclaration;
-import com.github.javaparser.ast.Modifier;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.AnnotationDeclaration;
-import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.InitializerDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.*;
+import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.LineComment;
-import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.ast.expr.ArrayCreationExpr;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.BinaryExpr;
-import com.github.javaparser.ast.expr.BooleanLiteralExpr;
-import com.github.javaparser.ast.expr.CharLiteralExpr;
-import com.github.javaparser.ast.expr.DoubleLiteralExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.IntegerLiteralExpr;
-import com.github.javaparser.ast.expr.LongLiteralExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.SimpleName;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
-import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
-import com.github.javaparser.ast.expr.ThisExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
-import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.stmt.CatchClause;
-import com.github.javaparser.ast.stmt.ExpressionStmt;
-import com.github.javaparser.ast.stmt.IfStmt;
-import com.github.javaparser.ast.stmt.Statement;
-import com.github.javaparser.ast.stmt.TryStmt;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.UnionType;
 import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
+import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
+import static org.junit.jupiter.api.Assertions.*;
 
 class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     private NodeText getTextForNode(Node node) {
@@ -1518,4 +1481,92 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         final String actual = LexicalPreservingPrinter.print(b);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void testArrayPreservation_WithSingleLanguageStyle() {
+
+        // Given
+        considerCode("class Test {\n" +
+                    "  int[] foo;\n" +
+                    "}");
+
+        // When
+        FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
+        fooField.addMarkerAnnotation("Nullable");
+
+        // Assert
+        String expectedCode =   "class Test {\n" +
+                                "  @Nullable\n" +
+                                "  int[] foo;\n" +
+                                "}";
+        assertTransformedToString(expectedCode, cu);
+    }
+
+    @Test
+    void testArrayPreservation_WithMultipleLanguageStyle() {
+
+        // Given
+        considerCode("class Test {\n" +
+                    "  int[][] foo;\n" +
+                    "}");
+
+        // When
+        FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
+        fooField.addMarkerAnnotation("Nullable");
+
+        // Assert
+        String expectedCode =   "class Test {\n" +
+                                "  @Nullable\n" +
+                                "  int[][] foo;\n" +
+                                "}";
+        assertTransformedToString(expectedCode, cu);
+    }
+
+    @Test
+    void testArrayPreservation_WithSingleCLanguageStyle() {
+
+        // Given
+        considerCode("class Test {\n" +
+                    "  int foo[];\n" +
+                    "}");
+
+        // When
+        FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
+        fooField.addMarkerAnnotation("Nullable");
+
+        // Assert
+        String expectedCode =   "class Test {\n" +
+                                "  @Nullable\n" +
+                                "  int foo[];\n" +
+                                "}";
+        assertTransformedToString(expectedCode, cu);
+    }
+
+    /**
+     * Given a field that have arrays declared in C style and
+     * When a marker annotation is added to the code
+     * Assert that the result matches the expected.
+     *
+     * Issue: 3419
+     */
+    @Test
+    void testArrayPreservation_WithMultipleCLanguageStyle() {
+
+        // Given
+        considerCode("class Test {\n" +
+                     "  int foo[][];\n" +
+                     "}");
+
+        // When
+        FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
+        fooField.addMarkerAnnotation("Nullable");
+
+        // Assert
+        String expectedCode =   "class Test {\n" +
+                                "  @Nullable\n" +
+                                "  int foo[][];\n" +
+                                "}";
+        assertTransformedToString(expectedCode, cu);
+    }
+
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1574,8 +1574,8 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
         // Given
         considerCode("class Test {\n" +
-                "  int[]foo;\n" +
-                "}");
+                     "  int[]foo;\n" +
+                     "}");
 
         // When
         FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
@@ -1583,9 +1583,9 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
         // Assert
         String expectedCode =   "class Test {\n" +
-                "  @Nullable\n" +
-                "  int[]foo;\n" +
-                "}";
+                                "  @Nullable\n" +
+                                "  int[]foo;\n" +
+                                 "}";
         assertTransformedToString(expectedCode, cu);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1594,8 +1594,8 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
         // Given
         considerCode("class Test {\n" +
-                "  int[][]foo;\n" +
-                "}");
+                     "  int[][]foo;\n" +
+                     "}");
 
         // When
         FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
@@ -1603,9 +1603,9 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
         // Assert
         String expectedCode =   "class Test {\n" +
-                "  @Nullable\n" +
-                "  int[][]foo;\n" +
-                "}";
+                                "  @Nullable\n" +
+                                "  int[][]foo;\n" +
+                                "}";
         assertTransformedToString(expectedCode, cu);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1569,4 +1569,44 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         assertTransformedToString(expectedCode, cu);
     }
 
+    @Test
+    void testArrayPreservation_WithSingleBracketWithoutSpace() {
+
+        // Given
+        considerCode("class Test {\n" +
+                "  int[]foo;\n" +
+                "}");
+
+        // When
+        FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
+        fooField.addMarkerAnnotation("Nullable");
+
+        // Assert
+        String expectedCode =   "class Test {\n" +
+                "  @Nullable\n" +
+                "  int[]foo;\n" +
+                "}";
+        assertTransformedToString(expectedCode, cu);
+    }
+
+    @Test
+    void testArrayPreservation_WithMultipleBracketWithoutSpace() {
+
+        // Given
+        considerCode("class Test {\n" +
+                "  int[][]foo;\n" +
+                "}");
+
+        // When
+        FieldDeclaration fooField = cu.findFirst(FieldDeclaration.class).orElseThrow(AssertionError::new);
+        fooField.addMarkerAnnotation("Nullable");
+
+        // Assert
+        String expectedCode =   "class Test {\n" +
+                "  @Nullable\n" +
+                "  int[][]foo;\n" +
+                "}";
+        assertTransformedToString(expectedCode, cu);
+    }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -210,14 +210,7 @@ public class Difference {
         if (diffIndex < diffElements.size() && originalIndex >= originalElements.size()) {
             DifferenceElement diffElement = diffElements.get(diffIndex);
             if (diffElement instanceof Kept) {
-                Kept kept = (Kept) diffElement;
-
-                if (kept.isWhiteSpaceOrComment() || kept.isIndent() || kept.isUnindent()) {
-                    diffIndex++;
-                } else {
-                    throw new IllegalStateException("Cannot keep element because we reached the end of nodetext: "
-                            + nodeText + ". Difference: " + this);
-                }
+                diffIndex++;
             } else if (diffElement instanceof Added) {
                 Added addedElement = (Added) diffElement;
 
@@ -564,27 +557,27 @@ public class Difference {
             throw new UnsupportedOperationException("kept " + kept.getElement() + " vs " + originalElement);
         }
     }
-    
-    
+
+
     /*
      * Returns the array level if the DifferenceElement is a CsmChild representing an ArrayType else 0
      */
     private int getArrayLevel(DifferenceElement element) {
         CsmElement csmElem = element.getElement();
-        if (csmElem instanceof LexicalDifferenceCalculator.CsmChild && 
+        if (csmElem instanceof LexicalDifferenceCalculator.CsmChild &&
                 ((LexicalDifferenceCalculator.CsmChild) csmElem).getChild() instanceof ArrayType) {
             Node child = ((LexicalDifferenceCalculator.CsmChild) csmElem).getChild();
             return ((ArrayType)child).getArrayLevel();
         }
         return 0;
     }
-    
+
     /*
      * Returns true if the DifferenceElement is a CsmChild representing an ArrayType
      */
     private boolean isArrayType(DifferenceElement element) {
         CsmElement csmElem = element.getElement();
-        return csmElem instanceof LexicalDifferenceCalculator.CsmChild && 
+        return csmElem instanceof LexicalDifferenceCalculator.CsmChild &&
                 ((LexicalDifferenceCalculator.CsmChild) csmElem).getChild() instanceof ArrayType;
     }
 
@@ -640,7 +633,7 @@ public class Difference {
         // recursively analyze token to skip
         return step += getIndexToNextTokenElement(new TokenTextElement(nextToken), nestedDiamondOperator);
     }
-    
+
     /*
      * Returns the number of tokens to skip in originalElements list to synchronize it with the DiffElements list
      */
@@ -672,7 +665,7 @@ public class Difference {
     private boolean isDiamondOperator(Kind kind) {
         return kind.GT.equals(kind) || kind.LT.equals(kind);
     }
-    
+
     /*
      * Returns true if the token is a bracket
      */


### PR DESCRIPTION
When the Differences class was calculating the diference, it was expecting a SPACE after the identifier name.

This PR fixes #3419 by removing that restriction.
