### PR TITLE
Call `orElse()` instead of `orElseGet()`

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
@@ -48,7 +48,7 @@ public class ListAdditionChange implements Change {
             Object currentRawValue = new NoChange().getValue(property, node);
             if (currentRawValue instanceof Optional) {
                 Optional<?> optional = (Optional<?>) currentRawValue;
-                currentRawValue = optional.orElseGet(null);
+                currentRawValue = optional.orElse(null);
             }
             if (!(currentRawValue instanceof NodeList)) {
                 throw new IllegalStateException("Expected NodeList, found " + currentRawValue.getClass().getCanonicalName());

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListRemovalChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListRemovalChange.java
@@ -46,7 +46,7 @@ public class ListRemovalChange implements Change {
             Object currentRawValue = new NoChange().getValue(property, node);
             if (currentRawValue instanceof Optional) {
                 Optional<?> optional = (Optional<?>) currentRawValue;
-                currentRawValue = optional.orElseGet(null);
+                currentRawValue = optional.orElse(null);
             }
             if (!(currentRawValue instanceof NodeList)) {
                 throw new IllegalStateException("Expected NodeList, found " + currentRawValue.getClass().getCanonicalName());

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
@@ -48,7 +48,7 @@ public class ListReplacementChange implements Change {
             Object currentRawValue = new NoChange().getValue(property, node);
             if (currentRawValue instanceof Optional) {
                 Optional<?> optional = (Optional<?>) currentRawValue;
-                currentRawValue = optional.orElseGet(null);
+                currentRawValue = optional.orElse(null);
             }
             if (!(currentRawValue instanceof NodeList)) {
                 throw new IllegalStateException("Expected NodeList, found " + currentRawValue.getClass().getCanonicalName());


### PR DESCRIPTION
If an `Optional` is not present, `orElseGet()` will fail with an NPE if passed `null`:

https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#orElseGet-java.util.function.Supplier-

Probably `orElse()` is what was desired here.
