### PR TITLE
Add a missing `hashCode()` method

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
@@ -28,6 +28,7 @@ import javassist.bytecode.SignatureAttribute;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -63,6 +64,11 @@ public class JavassistTypeParameter implements ResolvedTypeParameterDeclaration 
         }
         // TODO check bounds
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQualifiedName(), declaredOnType(), declaredOnMethod());
     }
 
     @Override


### PR DESCRIPTION
This was also caught by Error Prone.  Adds a `hashCode()` method to match the `equals()` method in the class.  Went for simplicity, but if this `hashCode()` is performance-critical I can optimize.
