### PR TITLE
Add erasure on parametrized type

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeParameterDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeParameterDeclaration.java
@@ -22,10 +22,11 @@
 package com.github.javaparser.resolution.declarations;
 
 
-import com.github.javaparser.resolution.types.ResolvedType;
-
 import java.util.List;
 import java.util.Optional;
+
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
 
 /**
  * Declaration of a type parameter.
@@ -92,6 +93,11 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
 
             @Override
             public Optional<ResolvedReferenceTypeDeclaration> containerType() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ResolvedReferenceType object() {
                 throw new UnsupportedOperationException();
             }
         };
@@ -221,7 +227,26 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
         }
         throw new IllegalStateException();
     }
-
+    
+    /**
+     * Return true if the Type variable is bounded
+     */
+    default boolean isBounded() {
+        return !isUnbounded();
+    }
+    
+    /**
+     * Return true if the Type variable is unbounded
+     */
+    default boolean isUnbounded() {
+        return getBounds().isEmpty();
+    }
+    
+    /*
+     * Return an Object ResolvedType
+     */
+    ResolvedReferenceType object();
+    
     /**
      * A Bound on a Type Parameter.
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
@@ -21,9 +21,9 @@
 
 package com.github.javaparser.resolution.types;
 
-import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
-
 import java.util.Map;
+
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 
 /**
  * Array Type.
@@ -108,6 +108,15 @@ public class ResolvedArrayType implements ResolvedType {
         } else {
             return new ResolvedArrayType(baseTypeReplaced);
         }
+    }
+    
+    ///
+    /// Erasure
+    ///
+    // The erasure of an array type T[] is |T|[].
+    @Override
+    public ResolvedType erasure() {
+        return new ResolvedArrayType(baseType.erasure());
     }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedType.java
@@ -215,4 +215,26 @@ public interface ResolvedType {
         return Arrays.stream(ResolvedPrimitiveType.getNumericPrimitiveTypes()).anyMatch(rpt-> rpt.isAssignableBy(this));
     }
     
+    ///
+    /// Erasure
+    ///
+    // Type erasure is a mapping from types (possibly including parameterized types and type variables) to types (that
+    /// are never parameterized types or type variables). We write |T| for the erasure of type T. The erasure mapping
+    /// is defined as follows:
+    //
+    // The erasure of a parameterized type (§4.5) G<T1,...,Tn> is |G|.
+    //
+    // The erasure of a nested type T.C is |T|.C.
+    //
+    // The erasure of an array type T[] is |T|[].
+    //
+    // The erasure of a type variable (§4.4) is the erasure of its leftmost bound.
+    //
+    // The erasure of every other type is the type itself.
+    
+    default ResolvedType erasure() {
+        return this;
+    }
+    
+    
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedTypeVariable.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedTypeVariable.java
@@ -21,10 +21,10 @@
 
 package com.github.javaparser.resolution.types;
 
-import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
-
 import java.util.List;
 import java.util.Map;
+
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 
 /**
  * From JLS 4.4: A type variable is introduced by the declaration of a type parameter of a generic class,
@@ -125,5 +125,18 @@ public class ResolvedTypeVariable implements ResolvedType {
     @Override
     public boolean mention(List<ResolvedTypeParameterDeclaration> typeParameters) {
         return typeParameters.contains(typeParameter);
+    }
+    
+    ///
+    /// Erasure
+    ///
+    // The erasure of a type variable (§4.4) is the erasure of its leftmost bound.
+    //
+    @Override
+    public ResolvedType erasure() {
+        if (typeParameter.isBounded()) {
+            return typeParameter.getBounds().get(0).getType();
+        }
+        return typeParameter.object();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -21,6 +21,13 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -48,13 +55,6 @@ import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * An anonymous class declaration representation.

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
@@ -21,10 +21,24 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import static com.github.javaparser.symbolsolver.javaparser.Navigator.demandParentNode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.core.resolution.Context;
@@ -33,11 +47,6 @@ import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.model.resolution.SymbolReference;
 import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static com.github.javaparser.symbolsolver.javaparser.Navigator.demandParentNode;
 
 /**
  * @author Federico Tomassetti
@@ -230,5 +239,10 @@ public class JavaParserTypeParameter extends AbstractTypeDeclaration implements 
     @Override
     public List<ResolvedConstructorDeclaration> getConstructors() {
         return Collections.emptyList();
+    }
+    
+    @Override
+    public ResolvedReferenceType object() {
+        return new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject(), typeSolver);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
@@ -21,15 +21,20 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
-import com.github.javaparser.resolution.declarations.*;
-import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-
-import javassist.bytecode.SignatureAttribute;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+
+import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
+
+import javassist.bytecode.SignatureAttribute;
 
 /**
  * @author Federico Tomassetti
@@ -122,5 +127,10 @@ public class JavassistTypeParameter implements ResolvedTypeParameterDeclaration 
             return Optional.of((ResolvedReferenceTypeDeclaration) container);
         }
         return Optional.empty();
+    }
+    
+    @Override
+    public ResolvedReferenceType object() {
+        return new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject(), typeSolver);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
@@ -21,12 +21,6 @@
 
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
-import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
-import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.Method;
@@ -35,6 +29,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl;
 
 /**
  * @author Federico Tomassetti
@@ -131,5 +133,10 @@ public class ReflectionTypeParameter implements ResolvedTypeParameterDeclaration
             return Optional.of((ResolvedReferenceTypeDeclaration) container);
         }
         return Optional.empty();
+    }
+    
+    @Override
+    public ResolvedReferenceType object() {
+        return new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject(), typeSolver);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -926,13 +926,10 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
     // The erasure of a type variable (§4.4) is the erasure of its leftmost bound.
     void erasure_type_variable() {
         List<ResolvedType> types = declaredTypes(
-                "class A<T extends Number> {}",
-                "class A<java.lang.Number> {}");
+                "class A<T extends Number> {}");
         ResolvedType rt = types.get(0);
-        ResolvedType rt2 = types.get(1);
         String expected =  "A<java.lang.Number>";
         assertEquals(expected, rt.erasure().describe());
-        assertEquals(rt2, rt.erasure());
     }
     
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -36,20 +36,7 @@ import java.net.ProtocolException;
 import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.nio.file.FileSystemException;
-import java.util.AbstractCollection;
-import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.RandomAccess;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -59,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseStart;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.StringProvider;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -67,6 +55,8 @@ import com.github.javaparser.resolution.declarations.ResolvedInterfaceDeclaratio
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration.Bound;
+import com.github.javaparser.resolution.types.ResolvedArrayType;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -81,6 +71,7 @@ import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionClassDeclara
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionInterfaceDeclaration;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
@@ -129,6 +120,12 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
                 new ReferenceTypeImpl(new ReflectionClassDeclaration(ClassCastException.class, typeSolver), typeSolver),
                 new ReferenceTypeImpl(new ReflectionClassDeclaration(AssertionError.class, typeSolver), typeSolver)
         ));
+        
+        // minimal initialization of JavaParser
+        ParserConfiguration configuration = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        // Setup parser
+        StaticJavaParser.setConfiguration(configuration);
     }
 
     @Test
@@ -884,4 +881,148 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
         assertTrue(rtB.getAllFieldsVisibleToInheritors().stream().anyMatch(f -> f.getName().equals("l")));
         assertTrue(rtB.getAllFieldsVisibleToInheritors().stream().anyMatch(f -> f.getName().equals("b")));
     }
+    
+    @Test
+    void erasure_non_generic_type() {
+        List<ResolvedType> types = declaredTypes(
+                "class A {}");
+        ResolvedType expected = types.get(0);
+        assertEquals(expected, types.get(0).erasure());
+    }
+    
+    @Test
+    // The erasure of a parameterized type
+    void erasure_rawtype() {
+        List<ResolvedType> types = declaredTypes(
+                "class A<String> {}");
+        ResolvedType rt = types.get(0);
+        String expected = "A";
+        ResolvedType erasedType = rt.erasure();
+        assertTrue(rt.asReferenceType().isRawType());
+        assertTrue(erasedType.asReferenceType().typeParametersValues().isEmpty());
+        assertEquals(expected, erasedType.describe());
+    }
+
+    @Test
+    // The erasure of an array type T[] is |T|[].
+    void erasure_arraytype() {
+        // create a type : List <String>
+        ResolvedType genericList = array(genericType(List.class.getCanonicalName(), String.class.getCanonicalName()));
+        String expected = "java.util.List[]";
+        assertEquals(expected, genericList.erasure().describe());
+    }
+    
+    @Test
+    // The erasure of an array type T[] is |T|[].
+    void erasure_arraytype_with_bound() {
+        // create a type : List <T extends Serializable>
+        ResolvedTypeVariable typeArguments = parametrizedType("T", Serializable.class.getCanonicalName());
+        ResolvedType genericList = array(genericType(List.class.getCanonicalName(), typeArguments));
+        String expected = "java.util.List<java.io.Serializable>[]";
+        assertEquals(expected, genericList.erasure().describe());
+    }
+    
+    @Test
+    // The erasure of a type variable (§4.4) is the erasure of its leftmost bound.
+    void erasure_type_variable() {
+        List<ResolvedType> types = declaredTypes(
+                "class A<T extends Number> {}",
+                "class A<java.lang.Number> {}");
+        ResolvedType rt = types.get(0);
+        ResolvedType rt2 = types.get(1);
+        String expected =  "A<java.lang.Number>";
+        assertEquals(expected, rt.erasure().describe());
+        assertEquals(rt2, rt.erasure());
+    }
+    
+    @Test
+    // The erasure of a nested type T.C is |T|.C.
+    void erasure_nested_type() {
+        List<ResolvedType> types = declaredTypes(
+                "class A<T> {" +
+                        "  class C{}" +
+                        "}",
+                "class A {" +
+                        "  class C{}" +
+                        "}");
+        ResolvedType typeA = types.get(0);
+        ResolvedType typeC = types.get(1);
+        // ResolvedType expectedErasedAType= types.get(2);
+        ResolvedType expectedErasedCType = types.get(3);
+        String expectedA = "A";
+        String expectedC = "A.C";
+        assertEquals(expectedA, typeA.erasure().describe());
+        assertEquals(expectedC, typeC.erasure().describe());
+        // this type declaration are not equals because the type returned by typeA.erasure() always contains original
+        // typeParameters
+        // assertEquals(expectedErasedAType, typeA.erasure());
+        assertEquals(expectedErasedCType, typeC.erasure());
+    }
+    
+    // return a generic type with type arguments (arguments can be bounded)
+    private ResolvedType genericType(String type, ResolvedType... parameterTypes) {
+        return type(type, toList(parameterTypes));
+    }
+    
+    // return a generic type with type arguments
+    private ResolvedType genericType(String type, String... parameterTypes) {
+        return new ReferenceTypeImpl(typeSolver.solveType(type), types(parameterTypes), typeSolver);
+    }
+    
+    // return a list of types
+    private List<ResolvedType> types(String... types) {
+        return Arrays.stream(types).map(type -> type(type)).collect(Collectors.toList());
+    }
+
+    // return the specified type
+    private ResolvedType type(String type) {
+        return type(type, new ArrayList<>());
+    }
+    
+    private ResolvedType type(String type, List<ResolvedType> typeArguments) {
+        return new ReferenceTypeImpl(typeSolver.solveType(type), typeArguments, typeSolver);
+    }
+    
+    // return a type parameter
+    private ResolvedTypeVariable parametrizedType(String type, String parameterType) {
+        return new ResolvedTypeVariable(ResolvedTypeParameterDeclaration.onType(parameterType, type + "." + parameterType,
+                Arrays.asList((extendBound(parameterType)))));
+    }
+
+    // rturn an extend bound
+    private Bound extendBound(String type) {
+        return Bound.extendsBound(type(type));
+    }
+
+    private Set<ResolvedType> toSet(ResolvedType... resolvedTypes) {
+        return new HashSet<>(toList(resolvedTypes));
+    }
+    
+    private List<ResolvedType> toList(ResolvedType... resolvedTypes) {
+        return Arrays.asList(resolvedTypes);
+    }
+    
+    // return an array type from the base type
+    private ResolvedType array(ResolvedType baseType) {
+        return new ResolvedArrayType(baseType);
+    }
+    
+    // return a list of types from the declared types (using a static parser) 
+    private List<ResolvedType> declaredTypes(String... lines) {
+        CompilationUnit tree = treeOf(lines);
+        List<ResolvedType> results = Lists.newLinkedList();
+        for (ClassOrInterfaceDeclaration classTree : tree.findAll(ClassOrInterfaceDeclaration.class)) {
+            results.add(new ReferenceTypeImpl(classTree.resolve(), typeSolver));
+        }
+        return results;
+    }
+
+    private CompilationUnit treeOf(String... lines) {
+        StringBuilder builder = new StringBuilder();
+        for (String line : lines) {
+            builder.append(line).append(System.lineSeparator());
+        }
+        return StaticJavaParser.parse(builder.toString());
+    }
+    
 }


### PR DESCRIPTION
Type erasure

Type erasure is a mapping from types (possibly including parameterized types and type variables) to types (that are never parameterized types or type variables). We write |T| for the erasure of type T. The erasure mapping is defined as follows:
The erasure of a parameterized type (§4.5) G<T1,...,Tn> is |G|.
The erasure of a nested type T.C is |T|.C.
The erasure of an array type T[] is |T|[].
The erasure of a type variable (§4.4) is the erasure of its leftmost bound.
The erasure of every other type is the type itself.
