### PR TITLE
Update TypeExtractor.java

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -665,8 +665,14 @@ public class TypeExtractor extends DefaultVisitorAdapter {
             Log.trace("getType on lambda expr %s", ()-> refMethod.getCorrespondingDeclaration().getName());
 
             // The type parameter referred here should be the java.util.stream.Stream.T
-            ResolvedType result = refMethod.getCorrespondingDeclaration().getParam(pos).getType();
-
+            ResolvedType result;
+            ResolvedMethodDeclaration cDeclaration = refMethod.getCorrespondingDeclaration();
+            if(pos >= cDeclaration.getNumberOfParams() && cDeclaration.getLastParam().getType().isArray()){
+                result = cDeclaration.getLastParam().getType();
+            }else{
+                result = cDeclaration.getParam(pos).getType();
+            }
+            
             if (solveLambdas) {
                 if (callExpr.hasScope()) {
                     Expression scope = callExpr.getScope().get();


### PR DESCRIPTION
Consider that the last parameter is a variable parameter.
 Prevent overflow.

Fixes #9999.
