### PR TITLE
add the EnumExpression

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaultsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaultsTest.java
@@ -58,7 +58,13 @@ class VoidVisitorWithDefaultsTest {
 
         argument = new Object();
         visitor = spy(
-            new VoidVisitorWithDefaults<Object>() {}
+            new VoidVisitorWithDefaults<Object>() {
+
+				@Override
+				public void visit(EnumExpression n, Object arg) {
+					// TODO Auto-generated method stub
+					
+				}}
         );
     }
 

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
-        <version>3.24.1-SNAPSHOT</version>
+        <version>3.24.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnumExpression.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnumExpression.java
@@ -1,0 +1,33 @@
+package com.github.javaparser.ast.expr;
+
+import com.github.javaparser.ast.visitor.GenericVisitor;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+
+public class EnumExpression extends LiteralExpr {
+	private Enum value;
+
+	public EnumExpression(Enum enumeration) {
+		this.value = enumeration;
+	}
+
+	@Override
+	public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+		return v.visit(this, arg);
+	}
+
+	@Override
+	public <A> void accept(VoidVisitor<A> v, A arg) {
+		v.visit(this, arg);
+
+	}
+
+	public void setValue(Enum value) {
+		this.value = value;
+	}
+
+	public Enum getValue() {
+
+		return value;
+	}
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/NoUnderscoresInIntegerLiteralsValidator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/NoUnderscoresInIntegerLiteralsValidator.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.ast.validator.language_level_validations.chunks;
 
+import com.github.javaparser.ast.expr.EnumExpression;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.LiteralStringValueExpr;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
@@ -45,4 +46,10 @@ public class NoUnderscoresInIntegerLiteralsValidator extends VisitorValidator {
             arg.report(n, "Underscores in literal values are not supported.");
         }
     }
+    @Override
+	public void visit(EnumExpression n, ProblemReporter arg) {
+        if (n.getValue().toString().contains("_")) {
+            arg.report(n, "Underscores in literal values are not supported.");
+        }
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -1287,4 +1287,13 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         copyData(n, r);
         return r;
     }
+    @Override
+	public Visitable visit(EnumExpression n, Object arg) {
+		Comment comment = cloneNode(n.getComment(), arg);
+		EnumExpression r = new EnumExpression(n.getValue());
+		r.setComment(comment);
+		n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
+		copyData(n, r);
+		return r;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -1405,4 +1405,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
             return false;
         return true;
     }
+	@Override
+	public Boolean visit(EnumExpression n, Visitable arg) {
+		final StringLiteralExpr n2 = (StringLiteralExpr) arg;
+		if (!objEquals(n.getValue(), n2.getValue()))
+			return false;
+		if (!nodeEquals(n.getComment(), n2.getComment()))
+			return false;
+		return true;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
@@ -241,4 +241,5 @@ public interface GenericVisitor<R, A> {
     R visit(TextBlockLiteralExpr n, A arg);
 
     R visit(PatternExpr n, A arg);
+    R visit(EnumExpression n, A arg);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
@@ -462,4 +462,9 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     public Integer visit(final CompactConstructorDeclaration n, final Void arg) {
         return (n.getBody().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
     }
+
+	@Override
+	public Integer visit(EnumExpression n, Void arg) {
+		   return (n.getValue().hashCode()) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -1329,4 +1329,10 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
         n.setComment(comment);
         return n;
     }
+	@Override
+	public Visitable visit(EnumExpression n, A arg) {
+		Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
+		n.setComment(comment);
+		return n;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
@@ -1154,4 +1154,12 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
             return false;
         return true;
     }
+
+	@Override
+	public Boolean visit(EnumExpression n, Visitable arg) {
+		 final StringLiteralExpr n2 = (StringLiteralExpr) arg;
+	        if (!objEquals(n.getValue(), n2.getValue()))
+	            return false;
+	        return true;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
@@ -454,4 +454,8 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     public Integer visit(final CompactConstructorDeclaration n, final Void arg) {
         return (n.getBody().accept(this, arg)) * 31 + (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getThrownExceptions().accept(this, arg)) * 31 + (n.getTypeParameters().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
+	@Override
+	public Integer visit(EnumExpression n, Void arg) {
+		return (n.getValue().hashCode());
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
@@ -542,4 +542,8 @@ public class ObjectIdentityEqualsVisitor implements GenericVisitor<Boolean, Visi
     public Boolean visit(final CompactConstructorDeclaration n, final Visitable arg) {
         return n == arg;
     }
+    @Override
+	public Boolean visit(EnumExpression n, Visitable arg) {
+		return n == arg;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
@@ -454,4 +454,8 @@ public class ObjectIdentityHashCodeVisitor implements GenericVisitor<Integer, Vo
     public Integer visit(final CompactConstructorDeclaration n, final Void arg) {
         return n.hashCode();
     }
+	@Override
+	public Integer visit(EnumExpression n, Void arg) {
+		return n.hashCode();
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
@@ -50,7 +50,7 @@ public interface VoidVisitor<A> {
     void visit(ArrayCreationLevel n, A arg);
 
     void visit(ArrayInitializerExpr n, A arg);
-
+    void visit(EnumExpression n, A arg);
     void visit(ArrayType n, A arg);
 
     void visit(AssertStmt n, A arg);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -320,7 +320,10 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     public void visit(final IntegerLiteralExpr n, final A arg) {
         n.getComment().ifPresent(l -> l.accept(this, arg));
     }
-
+    @Override
+    public void visit(final EnumExpression n, final A arg) {
+        n.getComment().ifPresent(l -> l.accept(this, arg));
+    }
     @Override
     public void visit(final JavadocComment n, final A arg) {
         n.getComment().ifPresent(l -> l.accept(this, arg));

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -75,6 +75,7 @@ import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.ast.expr.ConditionalExpr;
 import com.github.javaparser.ast.expr.DoubleLiteralExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.EnumExpression;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.InstanceOfExpr;
@@ -2035,4 +2036,13 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
     private Optional<ConfigurationOption> getOption(ConfigOption cOption) {
         return configuration.get(new DefaultConfigurationOption(cOption));
     }
+
+	@Override
+	public void visit(EnumExpression n, Void arg) {
+		printOrphanCommentsBeforeThisChildNode(n);
+		printComment(n.getComment(), arg);
+
+		printer.print(n.getValue().toString());
+		
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -62,6 +62,7 @@ import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.ast.expr.ConditionalExpr;
 import com.github.javaparser.ast.expr.DoubleLiteralExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.EnumExpression;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.InstanceOfExpr;
@@ -2002,4 +2003,12 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         if(expr)
             printer.unindent();
     }
+    @Override
+	public void visit(EnumExpression n, Void arg) {
+		printOrphanCommentsBeforeThisChildNode(n);
+		printComment(n.getComment(), arg);
+
+		printer.print(n.getValue().toString());
+
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.24.1-SNAPSHOT</version>
+    <version>3.24.2-SNAPSHOT</version>
 
     <name>javaparser-parent</name>
     <url>https://github.com/javaparser</url>


### PR DESCRIPTION
Fixes #9999.
Hi ,

I have added an EnumExpression class to handle Enumeration .
For example:Suppose we have this part of code:
private MyEntity entity;

We need to add this annotation @Transactional(propagation = MANDATORY)  to the entity object.
The actual Expression does not allow to add an enumeration (Mandatory for example) .
For that .I have added the EnumExpression to handle it

