### PR TITLE
Move Method Refactoring done to solve Feature Envy Design Smell

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -38,8 +38,10 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.DerivedProperty;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.LambdaExprMetaModel;
+
 import java.util.Optional;
 import java.util.function.Consumer;
+
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -204,11 +206,7 @@ public class LambdaExpr extends Expression implements NodeWithParameters<LambdaE
      */
     @DerivedProperty
     public Optional<Expression> getExpressionBody() {
-        if (body.isExpressionStmt()) {
-            return Optional.of(body.asExpressionStmt().getExpression());
-        } else {
-            return Optional.empty();
-        }
+        body.getExpressionBody();
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/Statement.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.StatementMetaModel;
@@ -480,5 +481,14 @@ public abstract class Statement extends Node {
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifYieldStmt(Consumer<YieldStmt> action) {
+    }
+
+    //this method is called from LambdaExpr
+    public Optional<Expression> getExpressionBody() {
+        if (isExpressionStmt()) {
+            return Optional.of(asExpressionStmt().getExpression());
+        } else {
+            return Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
Fixes #9999.
getExpressionBody method of class LambdaExpr was more interested in the methods of the class Statement, so I have done the move method refactoring to solve this 'Feature Envy' design smell.  I have tested no code is breaking because of this change.