### PR TITLE
Fix issue #3489 SourceRoot.tryToParse() fails if the root path ends with a directory that is not a java identifier

### DIFF
--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -136,7 +136,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
         </dependency>
     </dependencies>
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -21,20 +21,25 @@
 
 package com.github.javaparser.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SourceRootTest {
     private final Path root = CodeGenerationUtils.mavenModuleRoot(SourceRootTest.class).resolve("src/test/resources/com/github/javaparser/utils/");
@@ -87,4 +92,14 @@ class SourceRootTest {
         new SourceRoot(path).parse("source.root", "Y.java");
     });
 }
+
+    @Test
+    void isSensibleDirectoryToEnter() throws IOException {
+        try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class)) {
+            mockedFiles.when(() -> Files.isHidden(Mockito.any())).thenReturn(false);
+            mockedFiles.when(() -> Files.isDirectory(Mockito.any())).thenReturn(true);
+            SourceRoot root = new SourceRoot(Paths.get("tests/01"));
+            assertTrue(root.isSensibleDirectoryToEnter(root.getRoot()));
+        }
+    }
 }

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -188,7 +188,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.javaparser</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
+                <artifactId>mockito-inline</artifactId>
                 <version>4.4.0</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
Fixes #3489 
