### PR TITLE
Renaming PACKAGE_PRIVATE to NONE (this refers to the discussion in the issue #2242)

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/AccessSpecifier.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/AccessSpecifier.java
@@ -33,7 +33,7 @@ public enum AccessSpecifier {
     PUBLIC("public"),
     PRIVATE("private"),
     PROTECTED("protected"),
-    PACKAGE_PRIVATE("");
+    NONE("");
 
     private String codeRepresenation;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithModifiers.java
@@ -115,6 +115,6 @@ public interface NodeWithModifiers<N extends Node> {
                     return AccessSpecifier.PRIVATE;
             }
         }
-        return AccessSpecifier.PACKAGE_PRIVATE;
+        return AccessSpecifier.NONE;
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistFactory.java
@@ -85,7 +85,7 @@ public class JavassistFactory {
     } else if (Modifier.isPrivate(modifiers)) {
       return AccessSpecifier.PRIVATE;
     } else {
-      return AccessSpecifier.PACKAGE_PRIVATE;
+      return AccessSpecifier.NONE;
     }
   }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionFactory.java
@@ -128,7 +128,7 @@ public class ReflectionFactory {
         } else if (Modifier.isPrivate(modifiers)) {
             return AccessSpecifier.PRIVATE;
         } else {
-            return AccessSpecifier.PACKAGE_PRIVATE;
+            return AccessSpecifier.NONE;
         }
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -192,7 +192,7 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         TypeSolver typeResolver = new ReflectionTypeSolver();
         ResolvedReferenceTypeDeclaration string = new ReflectionClassDeclaration(String.class, typeResolver);
         List<ResolvedMethodDeclaration> methods = string.getDeclaredMethods().stream()
-                .filter(m -> m.accessSpecifier() != AccessSpecifier.PRIVATE && m.accessSpecifier() != AccessSpecifier.PACKAGE_PRIVATE)
+                .filter(m -> m.accessSpecifier() != AccessSpecifier.PRIVATE && m.accessSpecifier() != AccessSpecifier.NONE)
                 .sorted((a, b) -> a.getName().compareTo(b.getName()))
                 .collect(Collectors.toList());
         int foundCount = 0;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
@@ -119,7 +119,7 @@ class EnumResolutionTest extends AbstractResolutionTest {
             assertEquals(AccessSpecifier.PRIVATE, ((JavaParserEnumDeclaration) ed_private.resolve()).accessSpecifier());
 
             EnumDeclaration ed_default = Navigator.findType(clazz, "EnumDefault").get().toEnumDeclaration().get();
-            assertEquals(AccessSpecifier.PACKAGE_PRIVATE, ((JavaParserEnumDeclaration) ed_default.resolve()).accessSpecifier());
+            assertEquals(AccessSpecifier.NONE, ((JavaParserEnumDeclaration) ed_default.resolve()).accessSpecifier());
         } finally {
             StaticJavaParser.setConfiguration(new ParserConfiguration());
         }


### PR DESCRIPTION
This PR aims to reduce this ambiguity but it must be followed by another PR to obtain the visibility of the method.

