### PR TITLE
chore: replace travis badge with github actions badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 # JavaParser
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.javaparser/javaparser-core.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.github.javaparser%22%20AND%20a%3A%22javaparser-core%22)
-[![Build Status](https://travis-ci.org/javaparser/javaparser.svg?branch=master)](https://travis-ci.org/javaparser/javaparser)
+[![Build Status](https://github.com/javaparser/javaparser/actions/workflows/maven_tests.yml/badge.svg?branch=master)](https://github.com/javaparser/javaparser/actions?query=branch%3Amaster+)
 [![Coverage Status](https://coveralls.io/repos/javaparser/javaparser/badge.svg?branch=master&service=github)](https://coveralls.io/github/javaparser/javaparser?branch=master)
 [![Join the chat at https://gitter.im/javaparser/javaparser](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/javaparser/javaparser?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License LGPL-3/Apache-2.0](https://img.shields.io/badge/license-LGPL--3%2FApache--2.0-blue.svg)](LICENSE)


### PR DESCRIPTION
Same with title.

| | screenshot |
| :--: | :--: |
| Before | <img src="https://user-images.githubusercontent.com/14012511/174326431-6d1422ed-d830-45c2-abc7-d5d6cc2f521a.png" width="800px" /> |
| After |  <img src="https://user-images.githubusercontent.com/14012511/174326724-da2a5b54-b4f8-453e-8557-d49e0ac002fc.png" width="800px" /> |

cc @jlerbsc