### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -7,8 +7,13 @@ on:
 
 name: Create Release from semantic versioning tag push
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: Create Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -18,6 +18,9 @@ on:
   # Enable manual triggering (important for contributors to enable a check on their fork)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   maven_test:
     strategy:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
