### PR TITLE
Faster line-separator handling when reading files

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/LineEndingProcessingProvider.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/LineEndingProcessingProvider.java
@@ -123,27 +123,35 @@ public class LineEndingProcessingProvider implements Provider {
                     break;
                 }
             } else {
-                String str = String.valueOf((char) ch);
-                Optional<LineSeparator> lookup = LineSeparator.lookup(str);
 
-                if (lookup.isPresent()) {
-                    LineSeparator lineSeparator = lookup.get();
+                // only do the expensive LineSeparator handling when there is a
+                // chance the character could be part of a line separator.
+                if (ch == '\n' || ch == '\r') {
+                    String str = String.valueOf((char) ch);
+                    Optional<LineSeparator> lookup = LineSeparator.lookup(str);
 
-                    // Track the number of times this character is found..
-                    eolCounts.putIfAbsent(lineSeparator, 0);
-                    eolCounts.put(lineSeparator, eolCounts.get(lineSeparator) + 1);
+                    if (lookup.isPresent()) {
+                        LineSeparator lineSeparator = lookup.get();
 
-                    // Handle line separators of length two (specifically CRLF)
-                    // TODO: Make this more generic than just CRLF (e.g. track the previous char rather than the previous line separator
-                    if (lineSeparator == LineSeparator.LF) {
-                        if (previousLineSeparator == LineSeparator.CR) {
-                            eolCounts.putIfAbsent(LineSeparator.CRLF, 0);
-                            eolCounts.put(LineSeparator.CRLF, eolCounts.get(LineSeparator.CRLF) + 1);
+                        // Track the number of times this character is found..
+                        eolCounts.putIfAbsent(lineSeparator, 0);
+                        eolCounts.put(lineSeparator, eolCounts.get(lineSeparator) + 1);
+
+                        // Handle line separators of length two (specifically CRLF)
+                        // TODO: Make this more generic than just CRLF (e.g. track the previous char rather than the previous line separator
+                        if (lineSeparator == LineSeparator.LF) {
+                            if (previousLineSeparator == LineSeparator.CR) {
+                                eolCounts.putIfAbsent(LineSeparator.CRLF, 0);
+                                eolCounts.put(LineSeparator.CRLF, eolCounts.get(LineSeparator.CRLF) + 1);
+                            }
                         }
-                    }
 
-                    // If "this" (current) char <strong>is</strong> a line separator, set the next loop's "previous" to this
-                    previousLineSeparator = lineSeparator;
+                        // If "this" (current) char <strong>is</strong> a line separator, set the next loop's "previous" to this
+                        previousLineSeparator = lineSeparator;
+                    } else {
+                        // If "this" (current) char <strong>is not</strong> a line separator, set the next loop's "previous" to null
+                        previousLineSeparator = null;
+                    }
                 } else {
                     // If "this" (current) char <strong>is not</strong> a line separator, set the next loop's "previous" to null
                     previousLineSeparator = null;


### PR DESCRIPTION
In the old code every character read from a file was checked for
"line separator" in a quite expensive procedure, involving:

- creating a string from the char
- calling the method LineSeparator.lookup(String)
  - calling up to three time "...asRawString()"
  - doing up to three String comparisons
  - creating an Optional
- checking the Optional if it holds a "line separator"

These operations were executed for *every* character read.

In the new solution this detailed/expensive line separator code
is only executed when the char read from the buffer could actually
be part of a line separator (i.e. is a '\n' or '\r')

*Background*

This problem was detected when profiling the execution of
JavaParser code when analysing a large code base and running
into performance (and memory) issues.

*Test*

No extra test code required as the functionality is not changed
but the performance is improved.
