### PR TITLE
Speedup identifier validation (against 'strictfp', 'enum')

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java1_2Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java1_2Validator.java
@@ -35,6 +35,8 @@ public class Java1_2Validator extends Java1_1Validator {
     public Java1_2Validator() {
         super();
         replace(modifiersWithoutStrictfpAndDefaultAndStaticInterfaceMethodsAndPrivateInterfaceMethods, modifiersWithoutDefaultAndStaticInterfaceMethodsAndPrivateInterfaceMethods);
-        add(strictfpNotAllowed);
+        if (!Boolean.getBoolean("com.github.javaparser.performance.no-strictfp-identifier-validation")) {
+            add(strictfpNotAllowed);
+        }
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java5Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java5Validator.java
@@ -76,7 +76,9 @@ public class Java5Validator extends Java1_4Validator {
         super();
         replace(noGenerics, genericsWithoutDiamondOperator);
         add(noPrimitiveGenericArguments);
-        add(enumNotAllowed);
+        if (!Boolean.getBoolean("com.github.javaparser.performance.no-enum-identifier-validation")) {
+            add(enumNotAllowed);
+        }
         add(forEachStmt);
 
         // TODO validate annotations on classes, fields and methods but nowhere else


### PR DESCRIPTION
JavaParser does a very good job in validating a given source code against
the Java standard. E.g. it also validates every identifier if it is `strictfp` or
`enum` which are no legal identifier in Java (anymore).

However, this extra validation slows down the parsing, especially when
using the JavaParser to analyze large code bases that are known to be
legal Java code. This effect is that large that this validation was identified
as a significant performance issue when profiling the code in such a
setting.

To disable this identifier validation against `strictfp` and `enum` set the
system properties:
- com.github.javaparser.performance.no-strictfp-identifier-validation
- com.github.javaparser.performance.no-enum-identifier-validation

to the value `true` before loading the JavaParser, or more specifically,
before loading the ParserConfiguration class.