### PR TITLE
Name Node string caching

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -33,7 +33,12 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.NameMetaModel;
 import com.github.javaparser.metamodel.NonEmptyProperty;
 import com.github.javaparser.metamodel.OptionalProperty;
+
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.WeakHashMap;
+
 import static com.github.javaparser.utils.Utils.assertNonEmpty;
 
 /**
@@ -49,6 +54,11 @@ import static com.github.javaparser.utils.Utils.assertNonEmpty;
  * @see SimpleName
  */
 public class Name extends Node implements NodeWithIdentifier<Name> {
+
+    private final static Map<Name,String> asStringOfName =
+            Boolean.getBoolean("com.github.javaparser.performance.cache-node-name-string")
+                    ? new WeakHashMap<>()
+                    : null;
 
     @NonEmptyProperty
     private String identifier;
@@ -105,6 +115,9 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
         }
         notifyPropertyChange(ObservableProperty.IDENTIFIER, this.identifier, identifier);
         this.identifier = identifier;
+        if (asStringOfName != null) {
+            asStringOfName.remove(this); // clear cached value for asString
+        }
         return this;
     }
 
@@ -112,6 +125,12 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
      * @return the complete qualified name. Only the identifiers and the dots, so no comments or whitespace.
      */
     public String asString() {
+        return asStringOfName == null
+                ? calcAsString()
+                : asStringOfName.computeIfAbsent(this, n -> calcAsString());
+    }
+
+    private String calcAsString() {
         if (qualifier != null) {
             return qualifier.asString() + "." + identifier;
         }
@@ -132,6 +151,9 @@ public class Name extends Node implements NodeWithIdentifier<Name> {
         if (this.qualifier != null)
             this.qualifier.setParentNode(null);
         this.qualifier = qualifier;
+        if (asStringOfName != null) {
+            asStringOfName.remove(this); // clear cached value for asString
+        }
         setAsParentNodeOf(qualifier);
         return this;
     }


### PR DESCRIPTION
The method `Name.asString()` is frequently used. However, calculating
its value can be quite expensive, especially when used with qualified
identifiers. In that case calling asString will always create a new
String object from the concatenation of the different parts of the
qualified name and the "." strings. This takes a considerable
amount of time and also puts pressure on the memory used.

On the other hand, recalculating the asString() value is not
necessary when we cache its value and re-use the value the
next time it is needed (and invalidate the cache when required.)

To enable this cache set the system property

- com.github.javaparser.performance.cache-node-name-string

to `true` before loading the JavaParser, or more specifically,
before loading the Name class.
