### PR TITLE
Fast Name Node equals

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.parse;
@@ -650,6 +651,7 @@ class HashCodeVisitorTest {
 		verify(node, times(1)).getComment();
 	}
 
+	@Disabled // for Name nodes the hash code is directly implemented in the class Name
 	@Test
 	void testVisitName() {
 		Name node = spy(new Name());

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -331,7 +331,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     }
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         return HashCodeVisitor.hashCode(this);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -771,14 +771,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
 
     @Override
     public Boolean visit(final Name n, final Visitable arg) {
-        final Name n2 = (Name) arg;
-        if (!objEquals(n.getIdentifier(), n2.getIdentifier()))
-            return false;
-        if (!nodeEquals(n.getQualifier(), n2.getQualifier()))
-            return false;
-        if (!nodeEquals(n.getComment(), n2.getComment()))
-            return false;
-        return true;
+        return n.equals(arg);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
@@ -267,7 +267,7 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     }
 
     public Integer visit(final Name n, final Void arg) {
-        return (n.getIdentifier().hashCode()) * 31 + (n.getQualifier().isPresent() ? n.getQualifier().get().accept(this, arg) : 0) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return n.hashCode();
     }
 
     public Integer visit(NodeList n, Void arg) {


### PR DESCRIPTION
When analyzing Java code using the JavaParser comparing
Name nodes using the equals method is a very frequent operation.
This comparison is done through the generic approach implemented in
JavaParser via the EqualsVisitor and HashCodeVisitor. In that process
the nullable field values of Name (identifier and qualifier) are wrapped
in an Optional before the actual comparison takes place. (*)

Creating multiple Optionals for every comparison between Name nodes
has a significant performance impact and also puts pressure on the
memory used (the Optionals will only have a very short live time but
will trigger frequent garbage collections, especially when working
on large code bases).

To avoid these extra Optionals the comparison between Name nodes
is now implemented by directly working on the field values, and checking
for null if necessary. This implementation in Name also speeds up the code
by avoiding overhead introduced by the Visitor pattern.

---
(*) A similar wrapping in Optional also occurs for the comment property,
inherited from Node. In this refactoring, however, the comment property
is not considered. First, this way less code is involved in the refactoring.
Secondly, it can be assumed that most Name nodes that are not equal
will already differ in the identifier and qualifier, so the comment check
is rarely executed.
