### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -7,8 +7,13 @@ on:
 
 name: Create Release from semantic versioning tag push
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: Create Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -18,6 +18,9 @@ on:
   # Enable manual triggering (important for contributors to enable a check on their fork)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   maven_test:
     strategy:

--- a/.github/workflows/prepare_release_changelog.yml
+++ b/.github/workflows/prepare_release_changelog.yml
@@ -6,9 +6,14 @@ on:
   ## (testing only) Trigger the workflow on any pull request
   #pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   generate_changelog:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: Generate Changelog
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/javaparser/javaparser/runs/8037021465?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for all GitHub actions workflows.

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>
