### PR TITLE
attempting to fix indentation issue causing whitespace removed when modifiers removed

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -239,7 +239,7 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
         String result = LexicalPreservingPrinter.print(cu.findCompilationUnit().get());
         assertEqualsStringIgnoringEol("class X {\n" +
                 "  @Test\n" +
-                "void testCase() {\n" +
+                "  void testCase() {\n" +
                 "  }\n" +
                 "}\n", result);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -148,20 +148,11 @@ public class Difference {
                 hasOnlyWsBefore = false;
             }
         }
-        int res = nodeTextIndex;
-        if (hasOnlyWsBefore) {
-            for (int i = nodeTextIndex; i >= 0 && i < nodeText.getElements().size(); i--) {
-                if (nodeText.getElements().get(i).isNewline()) {
-                    break;
-                }
-                nodeText.removeElement(i);
-                res = i;
-            }
+        //TODO are there use-cases for removing more than just the first whitespace?
+        if (hasOnlyWsBefore && nodeTextIndex >= 0 && nodeTextIndex < nodeText.getElements().size()) {
+            nodeText.removeElement(nodeTextIndex);
         }
-        if (res < 0) {
-            throw new IllegalStateException();
-        }
-        return res;
+        return nodeTextIndex;
     }
 
     /**


### PR DESCRIPTION
Draft PR of branch showing that indentation cleanup can be simplified to address a strange case of white space being removed, and all other tests still pass. Hoping to figure out if there are other use-cases that aren't covered by tests that might break if this change is made.