### PR TITLE
Remove white space after a comment during comment deletion.

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/CommentRemovalSpacing.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/CommentRemovalSpacing.java
@@ -1,0 +1,41 @@
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+
+class CommentRemovalSpacing {
+
+	@Test
+    void commentWhitespaceIsRemovedWithComment() {
+        String src = 
+                "public class Test {\n" + 
+                "  /**" +
+                "   * Hello." +
+                "   */     " +
+                "       " +
+                "  @MyAnnotation\n" +
+                "  public void foo(Bar x, Bar y) {\n" + 
+                "  }\n" + 
+                "}";
+        String expectedResult = 
+                "public class Test {\n" + 
+                "  @MyAnnotation\n" +
+                "  public void foo(Bar x, Bar y) {\n" + 
+                "  }\n" + 
+                "}";
+        
+        StaticJavaParser.setConfiguration(new ParserConfiguration().setLexicalPreservationEnabled(true));
+        CompilationUnit cu = StaticJavaParser.parse(src);
+        LexicalPreservingPrinter.setup(cu);
+        MethodDeclaration method = cu.findFirst(MethodDeclaration.class).get();
+        method.getJavadocComment().get().remove();
+        assertEquals(expectedResult, LexicalPreservingPrinter.print(cu));
+    }
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -41,6 +41,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.github.javaparser.JavaToken;
 import com.github.javaparser.Range;
@@ -166,7 +168,12 @@ public class LexicalPreservingPrinter {
                         }
                         int index = getIndexOfComment((Comment) oldValue, nodeText);
                         nodeText.removeElement(index);
-                        if (nodeText.getElements().get(index).isNewline()) {
+                        Function<NodeText, Boolean> keepRemoving = 	(n) -> {
+                        	List<TextElement> elements = n.getElements();
+                        	TextElement node = elements.get(index);
+                        	return index < elements.size() && (node.isNewline() || node.isWhiteSpace());
+                        };
+                        while (keepRemoving.apply(nodeText)) {
                             nodeText.removeElement(index);
                         }
                     } else {


### PR DESCRIPTION
This change is to remove all whitespace tokens after a comment removal. Without this, if you removed a comment from this:
``` java
public class Test {
  /**
  * Hello
  */
  @MyAnnotation
  public void foo(Bar x, Bar y) {
  }
}
```
you would get:
``` java
public class Test {
    @MyAnnotation
  public void foo(Bar x, Bar y) {
  }
}
```
with the `@MyAnnotation` shifted over by the amount of whitespace between the end of the comment and the start of the next non-whitespace token. With this change, all that whitespace is 'eaten up' and the `@MyAnnotation` shows up with the correct indentation.