### PR TITLE
Accept final in instanceof pattern

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/InstanceOfExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/InstanceOfExprTest.java
@@ -64,6 +64,23 @@ class InstanceOfExprTest {
     }
 
     @Test
+    void annotationsOnTheType_finalPatternExpression() {
+        InstanceOfExpr expr = TestParser.parseExpression(LanguageLevel.JAVA_14_PREVIEW, "obj instanceof @A final @DA String s");
+
+        assertThat(expr.getType().getAnnotations())
+                .containsExactly(
+                        new MarkerAnnotationExpr("A"),
+                        new MarkerAnnotationExpr("DA"));
+    }
+
+    @Test
+    void annotationsOnTheType_finalPatternExpression_prettyPrinter() {
+        InstanceOfExpr expr = TestParser.parseExpression(LanguageLevel.JAVA_14_PREVIEW, "obj instanceof @A final @DA String s");
+
+        assertEquals("obj instanceof final @A @DA String s", expr.toString());
+    }
+
+    @Test
     void annotationsOnTheType_referenceTypeExpression() {
         InstanceOfExpr expr = TestParser.parseExpression(LanguageLevel.JAVA_14, "obj instanceof @A @DA String");
 
@@ -86,6 +103,7 @@ class InstanceOfExprTest {
         PatternExpr patternExpr = expr.getPattern().get();
         assertEquals("String", patternExpr.getType().asString());
         assertEquals("s", patternExpr.getName().asString());
+        assertFalse(patternExpr.isFinal());
 
         //
         assertTrue(expr.getName().isPresent());
@@ -113,6 +131,32 @@ class InstanceOfExprTest {
         assertFalse(expr.getName().isPresent());
     }
 
+    @Test
+    void instanceOf_finalPatternExpression() {
+        String x = "obj instanceof final String s";
+        InstanceOfExpr expr = TestParser.parseExpression(LanguageLevel.JAVA_14_PREVIEW, x);
+
+        assertEquals("obj", expr.getExpression().toString());
+        assertEquals("String", expr.getType().asString());
+        assertTrue(expr.getPattern().isPresent());
+
+        PatternExpr patternExpr = expr.getPattern().get();
+        assertEquals("String", patternExpr.getType().asString());
+        assertEquals("s", patternExpr.getName().asString());
+        assertTrue(patternExpr.isFinal());
+
+        //
+        assertTrue(expr.getName().isPresent());
+        assertEquals("s", expr.getName().get().asString());
+    }
+
+    @Test
+    void instanceOf_finalPatternExpression_prettyPrinter() {
+        String x = "obj instanceof final String s";
+        InstanceOfExpr expr = TestParser.parseExpression(LanguageLevel.JAVA_14_PREVIEW, x);
+
+        assertEquals("obj instanceof final String s", expr.toString());
+    }
 
 
     /*

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
@@ -713,6 +713,7 @@ class HashCodeVisitorTest {
 	void testVisitPatternExpr() {
 		PatternExpr node = spy(new PatternExpr());
 		HashCodeVisitor.hashCode(node);
+		verify(node, times(1)).getModifiers();
 		verify(node, times(1)).getName();
 		verify(node, times(1)).getType();
 		verify(node, times(1)).getComment();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/PatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/PatternExpr.java
@@ -23,9 +23,12 @@ package com.github.javaparser.ast.expr;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
+import com.github.javaparser.ast.nodeTypes.modifiers.NodeWithFinalModifier;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
@@ -72,27 +75,30 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8181287">JEP305: https://bugs.openjdk.java.net/browse/JDK-8181287</a>
  * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.20">https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.20</a>
  */
-public class PatternExpr extends Expression implements NodeWithSimpleName<PatternExpr>, NodeWithType<PatternExpr, ReferenceType> {
+public class PatternExpr extends Expression implements NodeWithSimpleName<PatternExpr>, NodeWithType<PatternExpr, ReferenceType>, NodeWithFinalModifier<PatternExpr> {
+
+    private NodeList<Modifier> modifiers;
 
     private SimpleName name;
 
     private ReferenceType type;
 
     public PatternExpr() {
-        this(null, new ClassOrInterfaceType(), new SimpleName());
+        this(null, new NodeList<>(), new ClassOrInterfaceType(), new SimpleName());
     }
 
     @AllFieldsConstructor
-    public PatternExpr(final ReferenceType type, SimpleName name) {
-        this(null, type, name);
+    public PatternExpr(final NodeList<Modifier> modifiers, final ReferenceType type, SimpleName name) {
+        this(null, modifiers, type, name);
     }
 
     /**
      * This constructor is used by the parser and is considered private.
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public PatternExpr(TokenRange tokenRange, ReferenceType type, SimpleName name) {
+    public PatternExpr(TokenRange tokenRange, NodeList<Modifier> modifiers, ReferenceType type, SimpleName name) {
         super(tokenRange);
+        setModifiers(modifiers);
         setType(type);
         setName(name);
         customInitialization();
@@ -178,6 +184,12 @@ public class PatternExpr extends Expression implements NodeWithSimpleName<Patter
         if (node == null) {
             return false;
         }
+        for (int i = 0; i < modifiers.size(); i++) {
+            if (modifiers.get(i) == node) {
+                modifiers.set(i, (Modifier) replacementNode);
+                return true;
+            }
+        }
         if (node == name) {
             setName((SimpleName) replacementNode);
             return true;
@@ -199,5 +211,39 @@ public class PatternExpr extends Expression implements NodeWithSimpleName<Patter
     @Generated("com.github.javaparser.generator.core.node.GetMetaModelGenerator")
     public PatternExprMetaModel getMetaModel() {
         return JavaParserMetaModel.patternExprMetaModel;
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    public NodeList<Modifier> getModifiers() {
+        return modifiers;
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    public PatternExpr setModifiers(final NodeList<Modifier> modifiers) {
+        assertNotNull(modifiers);
+        if (modifiers == this.modifiers) {
+            return this;
+        }
+        notifyPropertyChange(ObservableProperty.MODIFIERS, this.modifiers, modifiers);
+        if (this.modifiers != null)
+            this.modifiers.setParentNode(null);
+        this.modifiers = modifiers;
+        setAsParentNodeOf(modifiers);
+        return this;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")
+    public boolean remove(Node node) {
+        if (node == null) {
+            return false;
+        }
+        for (int i = 0; i < modifiers.size(); i++) {
+            if (modifiers.get(i) == node) {
+                modifiers.remove(i);
+                return true;
+            }
+        }
+        return super.remove(node);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -1244,10 +1244,11 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final PatternExpr n, final Object arg) {
+        NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
         SimpleName name = cloneNode(n.getName(), arg);
         ReferenceType type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        PatternExpr r = new PatternExpr(n.getTokenRange().orElse(null), type, name);
+        PatternExpr r = new PatternExpr(n.getTokenRange().orElse(null), modifiers, type, name);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
         copyData(n, r);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -1353,6 +1353,8 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     @Override
     public Boolean visit(final PatternExpr n, final Visitable arg) {
         final PatternExpr n2 = (PatternExpr) arg;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
@@ -2102,6 +2102,11 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
         List<R> result = new ArrayList<>();
         List<R> tmp;
         {
+            tmp = n.getModifiers().accept(this, arg);
+            if (tmp != null)
+                result.addAll(tmp);
+        }
+        {
             tmp = n.getName().accept(this, arg);
             if (tmp != null)
                 result.addAll(tmp);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -2090,6 +2090,11 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     public R visit(final PatternExpr n, final A arg) {
         R result;
         {
+            result = n.getModifiers().accept(this, arg);
+            if (result != null)
+                return result;
+        }
+        {
             result = n.getName().accept(this, arg);
             if (result != null)
                 return result;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
@@ -451,7 +451,7 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final PatternExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+        return (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg)) * 31 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -1319,11 +1319,13 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
 
     @Override
     public Visitable visit(final PatternExpr n, final A arg) {
+        NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         SimpleName name = (SimpleName) n.getName().accept(this, arg);
         ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (name == null || type == null)
             return null;
+        n.setModifiers(modifiers);
         n.setName(name);
         n.setType(type);
         n.setComment(comment);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
@@ -1108,6 +1108,8 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     @Override
     public Boolean visit(final PatternExpr n, final Visitable arg) {
         final PatternExpr n2 = (PatternExpr) arg;
+        if (!nodesEquals(n.getModifiers(), n2.getModifiers()))
+            return false;
         if (!nodeEquals(n.getName(), n2.getName()))
             return false;
         if (!nodeEquals(n.getType(), n2.getType()))

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
@@ -443,7 +443,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final PatternExpr n, final Void arg) {
-        return (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg));
+        return (n.getModifiers().accept(this, arg)) * 31 + (n.getName().accept(this, arg)) * 31 + (n.getType().accept(this, arg));
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -721,6 +721,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final PatternExpr n, final A arg) {
+        n.getModifiers().forEach(p -> p.accept(this, arg));
         n.getName().accept(this, arg);
         n.getType().accept(this, arg);
         n.getComment().ifPresent(l -> l.accept(this, arg));

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -202,6 +202,7 @@ public final class JavaParserMetaModel {
         objectCreationExprMetaModel.getConstructorParameters().add(objectCreationExprMetaModel.typeArgumentsPropertyMetaModel);
         objectCreationExprMetaModel.getConstructorParameters().add(objectCreationExprMetaModel.argumentsPropertyMetaModel);
         objectCreationExprMetaModel.getConstructorParameters().add(objectCreationExprMetaModel.anonymousClassBodyPropertyMetaModel);
+        patternExprMetaModel.getConstructorParameters().add(patternExprMetaModel.modifiersPropertyMetaModel);
         patternExprMetaModel.getConstructorParameters().add(patternExprMetaModel.typePropertyMetaModel);
         patternExprMetaModel.getConstructorParameters().add(patternExprMetaModel.namePropertyMetaModel);
         singleMemberAnnotationExprMetaModel.getConstructorParameters().add(annotationExprMetaModel.namePropertyMetaModel);
@@ -662,6 +663,8 @@ public final class JavaParserMetaModel {
         objectCreationExprMetaModel.getDeclaredPropertyMetaModels().add(objectCreationExprMetaModel.typeArgumentsPropertyMetaModel);
         objectCreationExprMetaModel.usingDiamondOperatorPropertyMetaModel = new PropertyMetaModel(objectCreationExprMetaModel, "usingDiamondOperator", boolean.class, Optional.empty(), false, false, false, false);
         objectCreationExprMetaModel.getDerivedPropertyMetaModels().add(objectCreationExprMetaModel.usingDiamondOperatorPropertyMetaModel);
+        patternExprMetaModel.modifiersPropertyMetaModel = new PropertyMetaModel(patternExprMetaModel, "modifiers", com.github.javaparser.ast.Modifier.class, Optional.of(modifierMetaModel), false, false, true, false);
+        patternExprMetaModel.getDeclaredPropertyMetaModels().add(patternExprMetaModel.modifiersPropertyMetaModel);
         patternExprMetaModel.namePropertyMetaModel = new PropertyMetaModel(patternExprMetaModel, "name", com.github.javaparser.ast.expr.SimpleName.class, Optional.of(simpleNameMetaModel), false, false, false, false);
         patternExprMetaModel.getDeclaredPropertyMetaModels().add(patternExprMetaModel.namePropertyMetaModel);
         patternExprMetaModel.typePropertyMetaModel = new PropertyMetaModel(patternExprMetaModel, "type", com.github.javaparser.ast.type.ReferenceType.class, Optional.of(referenceTypeMetaModel), false, false, false, false);

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/PatternExprMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/PatternExprMetaModel.java
@@ -41,6 +41,8 @@ public class PatternExprMetaModel extends ExpressionMetaModel {
         super(superBaseNodeMetaModel, PatternExpr.class, "PatternExpr", "com.github.javaparser.ast.expr", false, false);
     }
 
+    public PropertyMetaModel modifiersPropertyMetaModel;
+
     public PropertyMetaModel namePropertyMetaModel;
 
     public PropertyMetaModel typePropertyMetaModel;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -854,15 +854,16 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         printComment(n.getComment(), arg);
         n.getExpression().accept(this, arg);
         printer.print(" instanceof ");
-        n.getType().accept(this, arg);
-        if(n.getName().isPresent()) {
-            printer.print(" ");
-            n.getName().get().accept(this, arg);
+        if (n.getPattern().isPresent()) {
+            n.getPattern().get().accept(this, arg);
+        } else {
+            n.getType().accept(this, arg);
         }
     }
 
     @Override
     public void visit(final PatternExpr n, final Void arg) {
+        printModifiers(n.getModifiers());
         n.getType().accept(this, arg);
         printer.print(" ");
         n.getName().accept(this, arg);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -825,15 +825,16 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         printComment(n.getComment(), arg);
         n.getExpression().accept(this, arg);
         printer.print(" instanceof ");
-        n.getType().accept(this, arg);
-        if(n.getName().isPresent()) {
-            printer.print(" ");
-            n.getName().get().accept(this, arg);
+        if (n.getPattern().isPresent()) {
+            n.getPattern().get().accept(this, arg);
+        } else {
+            n.getType().accept(this, arg);
         }
     }
 
     @Override
     public void visit(final PatternExpr n, final Void arg) {
+        printModifiers(n.getModifiers());
         n.getType().accept(this, arg);
         printer.print(" ");
         n.getName().accept(this, arg);

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -3278,13 +3278,15 @@ Expression EqualityExpression():
  */
 PatternExpr PatternExpression():
 {
+    ModifierHolder modifier;
     ReferenceType type;
     SimpleName name;
 }
 {
-    type = AnnotatedReferenceType()
+    modifier = Modifiers()
+    type = ReferenceType(modifier.annotations)
     name = SimpleName()
-    { return new PatternExpr(range(type, token()), type, name); }
+    { return new PatternExpr(range(type, token()), modifier.modifiers, type, name); }
 }
 
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -896,6 +896,13 @@ class ContextTest extends AbstractSymbolResolutionTest {
             assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(enclosedExpr, "s", message);
         }
 
+        @Test
+        void patternExprPrint() {
+            InstanceOfExpr instanceOfExpr = parse(ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW, "a instanceof final String s",
+                    ParseStart.EXPRESSION).asInstanceOfExpr();
+            assertEquals("final String s", instanceOfExpr.getPattern().get().toString());
+        }
+
 
         @Nested
         class PatternExprNegationTests {


### PR DESCRIPTION
Javaparser does not accept final in an instanceof pattern but from my understanding of JLS it should be possible.
The following snippet is rejected by javaparser with an unexpected token "final" error but the same code can be compiled with javac and Eclipse compiler.

```
Object o = null;
if (o instanceof final String str) {
   // use string
}
```
