### PR TITLE
Fix some yield expressions not recognized

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -24,7 +24,8 @@ package com.github.javaparser.ast.expr;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.SwitchEntry;
-import org.junit.jupiter.api.Disabled;
+import com.github.javaparser.ast.stmt.SwitchStmt;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.*;
@@ -114,6 +115,101 @@ class SwitchExprTest {
                 "    default:\n" +
                 "        System.out.println(\"Neither Foo nor Bar, hmmm...\");\n" +
                 "        yield 0;\n" +
+                "};");
+    }
+
+    @Test
+    void yieldMethodCall() {
+        parseStatement("int randomNumber = switch (5) {\n" +
+                "    default -> {\n" +
+                "        yield a.randomNumberGenerator();\n" +
+                "    }\n" +
+                "    case 1 -> {\n" +
+                "        yield method();\n" +
+                "    }\n" +
+                "    case 2 -> {\n" +
+                "        yield method(args);\n" +
+                "    }\n" +
+                "    case 3 -> {\n" +
+                "        yield this.method();\n" +
+                "    }\n" +
+                "    case 4 -> {\n" +
+                "        yield Clazz.this.method(args);\n" +
+                "    }\n" +
+                "};");
+    }
+
+    @Test
+    void yieldExpression1() {
+        parseStatement("int randomNumber = switch (5) {\n" +
+                "    default -> {\n" +
+                "        yield 1 * 1;\n" +
+                "    }\n" +
+                "    case 1 -> {\n" +
+                "        yield (5 + 5);\n" +
+                "    }\n" +
+                "    case 2 -> {\n" +
+                "        yield (5 + 5) * 3;\n" +
+                "    }\n" +
+                "};");
+    }
+
+    @Test
+    void yieldExpression2() {
+        parseStatement("boolean b = switch (5) {\n" +
+                "    case 3 -> {\n" +
+                "        yield true || false;\n" +
+                "    }\n" +
+                "    default -> {\n" +
+                "        yield !true;\n" +
+                "    }\n" +
+                "};");
+    }
+
+    @Test
+    void yieldAssignment() {
+        parseStatement("int randomNumber = switch (5) {\n" +
+                "    default -> {\n" +
+                "        int x;\n" +
+                "        yield (x = 5);\n" +
+                "    }\n" +
+                "    case 'a' -> {\n" +
+                "        int x;\n" +
+                "        yield x = 3;\n" +
+                "    }\n" +
+                "};");
+    }
+
+    @Test
+    void yieldConditional() {
+        parseStatement("int randomNumber = switch (5) {\n" +
+                "    default -> {\n" +
+                "        yield x ? 1 : 2;\n" +
+                "    }\n" +
+                "    case 1 -> {\n" +
+                "        yield (x ? 1 : 2);\n" +
+                "    }\n" +
+                "    case 2 -> {\n" +
+                "        yield x < 0 ? 0 : x > y ? y : x;\n" +
+                "    }\n" +
+                "};");
+    }
+
+    @Test
+    void yieldYield() {
+        parseStatement("yield = switch (yield) {\n" +
+                "    default -> {\n" +
+                "        yield yield;\n" +
+                "    }\n" +
+                "    case yield -> {\n" +
+                "        yield Clazz.yield();\n" +
+                "    }\n" +
+                "    case enumValue2 -> {\n" +
+                "        yield yield = yield;\n" +
+                "    }\n" +
+                "    case enumValue3 -> {\n" +
+                "        yield yield == yield ? yield : yield;\n" +
+                "    }\n" +
                 "};");
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/YieldStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/YieldStmtTest.java
@@ -23,6 +23,11 @@ package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.ConditionalExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_12;
@@ -39,6 +44,48 @@ class YieldStmtTest {
     }
 
     @Test
+    void yield2() {
+        YieldStmt statement;
+        statement = parseStatement("yield (2 + 2);").asYieldStmt();
+        assertEquals(EnclosedExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield ((2 + 2) * 3);").asYieldStmt();
+        assertEquals(EnclosedExpr.class, statement.getExpression().getClass());
+    }
+
+    @Test
+    void yieldMethodCall() {
+        YieldStmt statement;
+        statement = parseStatement("yield a();").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield a(5, arg);").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield a.b();").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield a.b(5, arg);").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield this.b();").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield this.b(5, arg);").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield Clazz.this.b();").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield Clazz.this.b(5, arg);").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+    }
+
+    @Test
+    void yieldAssignment() {
+        YieldStmt statement = parseStatement("yield (x = 5);").asYieldStmt();
+        assertEquals(EnclosedExpr.class, statement.getExpression().getClass());
+    }
+
+    @Test
+    void yieldConditional() {
+        YieldStmt statement = parseStatement("yield x ? 5 : 6;").asYieldStmt();
+        assertEquals(ConditionalExpr.class, statement.getExpression().getClass());
+    }
+
+    @Test
     void threadYieldShouldNotBreak() {
         parseStatement("Thread.yield();").asExpressionStmt().getExpression().asMethodCallExpr();
     }
@@ -52,5 +99,25 @@ class YieldStmtTest {
                 "        yield();\n" +
                 "    }\n" +
                 "}\n", compilationUnit.toString());
+    }
+
+    @Test
+    void keywordShouldNotInterfereWithIdentifiers2() {
+        CompilationUnit compilationUnit = parseCompilationUnit("enum X { yield, }");
+        assertEqualsStringIgnoringEol("enum X {\n" +
+                "\n" +
+                "    yield\n" +
+                "}\n", compilationUnit.toString());
+    }
+
+    @Test
+    void keywordShouldNotInterfereWithIdentifiers3() {
+        YieldStmt statement;
+        statement = parseStatement("yield yield;").asYieldStmt();
+        assertEquals(NameExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield Clazz.yield();").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
+        statement = parseStatement("yield yield.yield();").asYieldStmt();
+        assertEquals(MethodCallExpr.class, statement.getExpression().getClass());
     }
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -4311,6 +4311,11 @@ Statement BlockStatement():
             modifier = Modifiers()
             recordDeclaration = RecordDeclaration(modifier) { ret = new LocalRecordDeclarationStmt(range(recordDeclaration, token()), recordDeclaration); }
          |
+            // try yield statement separate from more general Statement() because yield is not a keyword but
+            // just a restricted identifier and a yield statement can be confused with VariableDeclarationExpression sometimes
+            LOOKAHEAD( YieldStatement() )
+            ret = YieldStatement()
+         |
             LOOKAHEAD( VariableDeclarationExpression() )
             expr = VariableDeclarationExpression()
             ";"


### PR DESCRIPTION
Existing parser fails to recognize some yield expressions. Especially yielding the result of a method call or the result of a conditional expression.
E.g. the following snippet currently fails:
```
int x = switch (5) {
    default -> {
        yield getX();
    }
};
```

The problem I found is that yield is not a keyword but just a restricted identifier or since Java 17 called contextual keyword. Javaparser currently tries to parse the statement as `VariableDeclarationExpression`.

This pull request is a minimal change to fix the problem of yield statements not recognized. For a better solution I think javaparser would need to better different between Identifier and TypeIdentifier according to https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.8
Then the `VariableDeclarationExpression` would start with a type which cannot be the name "yield".
If a class could be named "yield" a statement like `yield x = null;` is ambiguous and could be a local variable declaration plus initialization or a yield statement whose expression is an assignment.
But I expect this to be a notably larger and riskier change.

PS: if someone wants to try the `SwitchExprTest.yieldYield` example, the following code compiles:
```
public class Main {

    public enum X {
        yield,
    }

    public static void main(String[] args) {
        X yield = X.yield;
        yield = switch (yield) {
        default -> {
            yield yield = yield;
        }
        case yield -> {
            yield yield == yield ? yield : yield;
        }
        };
    }
}
```