### PR TITLE
Fix maven wrapper not found in generator scripts

### DIFF
--- a/run_core_generators.sh
+++ b/run_core_generators.sh
@@ -7,7 +7,7 @@
 pushd javaparser-core-generators
 
 # Generate code
-./mvnw --errors --show-version -B clean package -P run-generators -DskipTests
+../mvnw --errors --show-version -B clean package -P run-generators -DskipTests
 
 # Go back to previous directory
 popd

--- a/run_core_metamodel_generator.sh
+++ b/run_core_metamodel_generator.sh
@@ -12,7 +12,7 @@ fi
 pushd javaparser-core-metamodel-generator
 
 # Generate code
-./mvnw --errors --show-version -B clean package -P run-generators -DskipTests
+../mvnw --errors --show-version -B clean package -P run-generators -DskipTests
 
 # Go back to previous directory
 popd


### PR DESCRIPTION
I assume since commit 54fe277ca4e5b9ce5b342a3a2aef6335e70a6e02 the two helper scripts `run_core_generators.sh` and `run_core_metamodel_generator.sh` do not work correctly anymore but produce the following error:
```
./run_core_generators.sh: line 10: ./mvnw: No such file or directory
```
The other helper scripts should be fine.