### PR TITLE
Fix for ReflectionAnnotationDeclaration getClassName()

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -96,7 +96,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration imp
     public String getClassName() {
         String qualifiedName = getQualifiedName();
         if(qualifiedName.contains(".")) {
-            return qualifiedName.substring(qualifiedName.lastIndexOf("."), qualifiedName.length());
+            return qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1);
         } else {
             return qualifiedName;
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclarationTest.java
@@ -99,6 +99,14 @@ class ReflectionAnnotationDeclarationTest {
   }
   
   @Test
+  void getClassName_shouldReturnCorrectValue() {
+    ReflectionAnnotationDeclaration annotation =
+        (ReflectionAnnotationDeclaration) typeSolver.solveType(
+            "com.github.javaparser.symbolsolver.reflectionmodel.WithField");
+    assertEquals("WithField", annotation.getClassName());
+  }
+  
+  @Test
   void isAnnotationNotInheritable() {
     ReflectionAnnotationDeclaration
         annotation = (ReflectionAnnotationDeclaration) typeSolver.solveType(


### PR DESCRIPTION
I've noticed that the returned ClassName for ReflectionAnnotationDeclaration contains a dot.
In the initial commit for the PR (#1833) the dot was stripped, in the merged commit however the method was changed. And the classname was not returned correctly.

I've adjusted the method getClassName() to strip the dot.

I've added the following testcase:
```java
  @Test
  void getClassName_shouldReturnCorrectValue() {
    ReflectionAnnotationDeclaration annotation =
        (ReflectionAnnotationDeclaration) typeSolver.solveType(
            "com.github.javaparser.symbolsolver.reflectionmodel.WithField");
    assertEquals("WithField", annotation.getClassName());
  }
```

Previously the method returned ".WithField" instead of "WithField"