### PR TITLE
Layout api location insert

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithMembersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithMembersTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2022 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.nodeTypes;
+
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.observer.AstObserverAdapter;
+import com.github.javaparser.ast.observer.ObservableProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
+import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
+import static com.github.javaparser.ast.Modifier.Keyword.STATIC;
+import static com.github.javaparser.ast.Modifier.Keyword.SYNCHRONIZED;
+import static com.github.javaparser.ast.Modifier.createModifierList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NodeWithMembersTest {
+
+    @Test
+    void addFieldAtLocationWorks() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration(new NodeList<>(),
+                false, "Foo");
+        decl.addField("int", "bar");
+        decl.addField("int", "c");
+        decl.addMethod("testing");
+        decl.addMethod("stillTesting");
+        // This one below should add it at the end of the class overall
+        FieldDeclaration a1 = decl.addFieldAtLocation("String", "a1", decl.getMembers().size()-1,
+                NodeWithMembers.LocationType.ALL, true);
+        assertEquals(decl.getMember(decl.getMembers().size() -1), a1);
+
+        // Adding it at the end of just the fields! This notably should be in the "2" position in the class
+        FieldDeclaration a2 = decl.addFieldAtLocation("String", "a2", decl.getFields().size()-1,
+                NodeWithMembers.LocationType.FIELD, true);
+        assertEquals(decl.getMember(2), a2);
+    }
+
+    @Test
+    void addMethodAtLocationWorks() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration(new NodeList<>(),
+                false, "Foo");
+        decl.addField("int", "bar");
+        decl.addField("int", "c");
+        decl.addMethod("testing");
+        decl.addMethod("stillTesting");
+        // Adding it one before the last element in the class
+        MethodDeclaration a1 = decl.addMethodAtLocation("a1", decl.getMembers().size()-1,
+                NodeWithMembers.LocationType.ALL, false);
+        assertEquals(decl.getMember(decl.getMembers().size() - 2), a1);
+
+        // Adding it in between the other two methods
+        MethodDeclaration a2 = decl.addMethodAtLocation("a2", 1,
+                NodeWithMembers.LocationType.METHOD, true);
+        assertEquals(decl.getMethods().get(2), a2);
+    }
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithMembersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithMembersTest.java
@@ -57,10 +57,10 @@ class NodeWithMembersTest {
                 NodeWithMembers.LocationType.ALL, true);
         assertEquals(decl.getMember(decl.getMembers().size() -1), a1);
 
-        // Adding it at the end of just the fields! This notably should be in the "2" position in the class
+        // Adding it before the end of the fields! This notably should be in the "2" position in them
         FieldDeclaration a2 = decl.addFieldAtLocation("String", "a2", decl.getFields().size()-1,
-                NodeWithMembers.LocationType.FIELD, true);
-        assertEquals(decl.getMember(2), a2);
+                NodeWithMembers.LocationType.FIELD, false);
+        assertEquals(decl.getFields().get(2), a2);
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.type.VoidType;
 import java.util.List;
 import java.util.Optional;
 
+import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.StaticJavaParser.parseType;
 import static com.github.javaparser.ast.Modifier.Keyword;
 import static com.github.javaparser.ast.Modifier.Keyword.*;
@@ -157,6 +158,23 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
             getMembers().addBefore(fieldDeclaration, tempNode);
         }
         return fieldDeclaration;
+    }
+
+    /**
+     * Add a field to this at the specified location, with options for before/after.
+     *
+     * @param type         the type of the field
+     * @param name         the name of the field
+     * @param position     the location in the to add the new one before/after
+     * @param locationType the type of location to insert the new field before/after
+     * @param after        whether the new field should be inserted before the specified point, or after it.
+     * @param modifiers    the modifiers like {@link Modifier.Keyword#PUBLIC}
+     * @return the {@link FieldDeclaration} created
+     */
+    default FieldDeclaration addFieldAtLocation(String type, String name, Integer position,
+                                                LocationType locationType, boolean after,
+                                                Modifier.Keyword... modifiers) {
+        return addFieldAtLocation(parseType(type), name, position, locationType, after, modifiers);
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -118,11 +118,12 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
     /**
      * Add a field to this at the specified location, with options for before/after.
      *
-     * @param type      the type of the field
-     * @param name      the name of the field
-     * @param position  the location in the to add the new one before/after
+     * @param type         the type of the field
+     * @param name         the name of the field
+     * @param position     the location in the to add the new one before/after
      * @param locationType the type of location to insert the new field before/after
-     * @param modifiers the modifiers like {@link Modifier.Keyword#PUBLIC}
+     * @param after        whether the new field should be inserted before the specified point, or after it.
+     * @param modifiers    the modifiers like {@link Modifier.Keyword#PUBLIC}
      * @return the {@link FieldDeclaration} created
      */
     default FieldDeclaration addFieldAtLocation(Type type, String name, Integer position,
@@ -320,11 +321,12 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
     /**
      * Add a field to this at the specified location, with options for before/after.
      *
-     * @param methodName      the name of the field
-     * @param position  the location in the to add the new one before/after
-     * @param locationType the type of location to insert the new field before/after
-     * @param modifiers the modifiers like {@link Modifier.Keyword#PUBLIC}
-     * @return the {@link FieldDeclaration} created
+     * @param methodName   the name of the method
+     * @param position     the location in the to add the new one before/after
+     * @param locationType the type of location to insert the new method before/after
+     * @param after        whether the new method should be inserted before the specified point, or after it.
+     * @param modifiers    the modifiers like {@link Modifier.Keyword#PUBLIC}
+     * @return the {@link MethodDeclaration} created
      */
     default MethodDeclaration addMethodAtLocation(String methodName, Integer position,
                                                 LocationType locationType, boolean after,

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -115,6 +115,50 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
     }
 
     /**
+     * Add a field to this after the nth field
+     *
+     * @param type      the type of the field
+     * @param name      the name of the field
+     * @param position  the location in the fields to add the new one after
+     * @param modifiers the modifiers like {@link Modifier.Keyword#PUBLIC}
+     * @return the {@link FieldDeclaration} created
+     */
+    default FieldDeclaration addFieldAfterField(Type type, String name, Integer position,
+                                               Modifier.Keyword... modifiers) {
+        FieldDeclaration fieldDeclaration = new FieldDeclaration();
+        VariableDeclarator variable = new VariableDeclarator(type, name);
+        fieldDeclaration.getVariables().add(variable);
+        fieldDeclaration.setModifiers(createModifierList(modifiers));
+        getMembers().addAfter(fieldDeclaration, getFields().get(position));
+        // getMembers().add(fieldDeclaration);
+        return fieldDeclaration;
+    }
+
+    /**
+     * Add a field to this after the field with the given afterName
+     *
+     * @param type      the type of the field
+     * @param name      the name of the field
+     * @param afterName the name of the field to add after
+     * @param modifiers the modifiers like {@link Modifier.Keyword#PUBLIC}
+     * @return the {@link FieldDeclaration} created
+     */
+    default FieldDeclaration addFieldAfterField(Type type, String name, String afterName,
+                                               Modifier.Keyword... modifiers) {
+        FieldDeclaration fieldDeclaration = new FieldDeclaration();
+        VariableDeclarator variable = new VariableDeclarator(type, name);
+        fieldDeclaration.getVariables().add(variable);
+        fieldDeclaration.setModifiers(createModifierList(modifiers));
+        //TODO: Check what error should be thrown in this situation!
+        if (getFieldByName(afterName).isPresent()) {
+            getMembers().addAfter(fieldDeclaration, getFieldByName(afterName).get());
+        } else {
+            throw new IllegalArgumentException("There is no field in " + getName().asString() + " called " + name);
+        }
+        return fieldDeclaration;
+    }
+
+    /**
      * Add a field to this and automatically add the import of the type if needed
      *
      * @param typeClass   the type of the field

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -116,11 +116,12 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
     }
 
     /**
-     * Add a field to this after the nth field
+     * Add a field to this at the specified location, with options for before/after.
      *
      * @param type      the type of the field
      * @param name      the name of the field
-     * @param position  the location in the fields to add the new one after
+     * @param position  the location in the to add the new one before/after
+     * @param locationType the type of location to insert the new field before/after
      * @param modifiers the modifiers like {@link Modifier.Keyword#PUBLIC}
      * @return the {@link FieldDeclaration} created
      */
@@ -133,7 +134,7 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
         fieldDeclaration.setModifiers(createModifierList(modifiers));
 
         // Switch statement based on how we want to calculate the location of the thing
-        BodyDeclaration tempNode = null;
+        BodyDeclaration<?> tempNode = null;
         switch (locationType){
             case ALL:
                 tempNode = getMembers().get(position);
@@ -148,11 +149,10 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
                 tempNode = getConstructors().get(position);
                 break;
         }
-        
         if (after) {
-            getMembers().addAfter(fieldDeclaration, (BodyDeclaration<?>) tempNode);
+            getMembers().addAfter(fieldDeclaration, tempNode);
         } else {
-            getMembers().addBefore(fieldDeclaration, (BodyDeclaration<?>) tempNode);
+            getMembers().addBefore(fieldDeclaration, tempNode);
         }
         return fieldDeclaration;
     }
@@ -314,6 +314,47 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
         methodDeclaration.setType(new VoidType());
         methodDeclaration.setModifiers(createModifierList(modifiers));
         getMembers().add(methodDeclaration);
+        return methodDeclaration;
+    }
+
+    /**
+     * Add a field to this at the specified location, with options for before/after.
+     *
+     * @param methodName      the name of the field
+     * @param position  the location in the to add the new one before/after
+     * @param locationType the type of location to insert the new field before/after
+     * @param modifiers the modifiers like {@link Modifier.Keyword#PUBLIC}
+     * @return the {@link FieldDeclaration} created
+     */
+    default MethodDeclaration addMethodAtLocation(String methodName, Integer position,
+                                                LocationType locationType, boolean after,
+                                                Modifier.Keyword... modifiers) {
+        MethodDeclaration methodDeclaration = new MethodDeclaration();
+        methodDeclaration.setName(methodName);
+        methodDeclaration.setType(new VoidType());
+        methodDeclaration.setModifiers(createModifierList(modifiers));
+
+        // Switch statement based on how we want to calculate the location of the thing
+        BodyDeclaration<?> tempNode = null;
+        switch (locationType){
+            case ALL:
+                tempNode = getMembers().get(position);
+                break;
+            case FIELD:
+                tempNode = getFields().get(position);
+                break;
+            case METHOD:
+                tempNode = getMethods().get(position);
+                break;
+            case CONSTRUCTOR:
+                tempNode = getConstructors().get(position);
+                break;
+        }
+        if (after) {
+            getMembers().addAfter(methodDeclaration, tempNode);
+        } else {
+            getMembers().addBefore(methodDeclaration, tempNode);
+        }
         return methodDeclaration;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
- * Copyright (C) 2011, 2013-2021 The JavaParser Team.
+ * Copyright (C) 2011, 2013-2022 The JavaParser Team.
  *
  * This file is part of JavaParser.
  *

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -59,6 +59,7 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
     }
 
     enum LocationType { ALL, FIELD, METHOD, CONSTRUCTOR}
+
     @SuppressWarnings("unchecked")
     default N setMember(int i, BodyDeclaration<?> member) {
         getMembers().set(i, member);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -134,7 +134,7 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
         fieldDeclaration.getVariables().add(variable);
         fieldDeclaration.setModifiers(createModifierList(modifiers));
 
-        // Switch statement based on how we want to calculate the location of the thing
+        // Switch statement to determine how we want to calculate the location to insert the method at
         BodyDeclaration<?> tempNode = null;
         switch (locationType){
             case ALL:
@@ -336,7 +336,7 @@ public interface NodeWithMembers<N extends Node> extends NodeWithSimpleName<N> {
         methodDeclaration.setType(new VoidType());
         methodDeclaration.setModifiers(createModifierList(modifiers));
 
-        // Switch statement based on how we want to calculate the location of the thing
+        // Switch statement to determine how we want to calculate the location to insert the method at
         BodyDeclaration<?> tempNode = null;
         switch (locationType){
             case ALL:


### PR DESCRIPTION
Fixes #2458 using a more generic solution, as requested recently.

Implements `addFieldAtLocation` and `addMethodAtLocation` methods in `NodeWithMembers` that allow for inserting a new FieldDeclaration/MethodDeclaration at a specified point relative to the other pre-existing elements in the `NodeList`. Uses a new enum `NodeWithMembers.LocationType` to specify what sublist to position relative to.

Includes unit tests in `NodeWithMembersTest` for the two methods.
