### PR TITLE
More unit tests for JavaToken and CodeGenerationUtils

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaTokenTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaTokenTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser;
 
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import org.junit.jupiter.api.Test;
 
@@ -34,9 +35,8 @@ import static com.github.javaparser.JavaToken.Category.OPERATOR;
 import static com.github.javaparser.JavaToken.Category.WHITESPACE_NO_EOL;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.Range.range;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.github.javaparser.StaticJavaParser.parse;
+import static org.junit.jupiter.api.Assertions.*;
 
 class JavaTokenTest {
 
@@ -123,6 +123,43 @@ class JavaTokenTest {
                             "\n - token #" + jpTokenNumber + " - JavaToken (generated using JP Generators)."
             );
         }
+    }
+
+    @Test
+    void testDeleteToken() {
+        ParseResult<Expression> result = new JavaParser().parse(ParseStart.EXPRESSION, provider("1+/*2*/1\n"));
+        TokenRange tokenRange = result.getResult().get().getTokenRange().get();
+
+        JavaToken tokenToBeDeleted = tokenRange.getBegin().getNextToken().get();
+        tokenToBeDeleted.deleteToken();
+        JavaToken nextTokenAfterDelete = tokenRange.getBegin().getNextToken().get();
+        JavaToken previous = nextTokenAfterDelete.getPreviousToken().get();
+
+        assertNotEquals(tokenToBeDeleted, nextTokenAfterDelete);
+        assertEquals("/*2*/", nextTokenAfterDelete.getText());
+        assertEquals("1", previous.getText());
+    }
+
+    @Test
+    void testFindLastToken() {
+        ParseResult<Expression> result = new JavaParser().parse(ParseStart.EXPRESSION, provider("1 +/*2*/3 "));
+        TokenRange tokenRange = result.getResult().get().getTokenRange().get();
+        Iterator<JavaToken> iterator = tokenRange.iterator();
+        assertToken("", range(1, 10, 1, 10), EOF, WHITESPACE_NO_EOL, iterator.next().findLastToken());
+
+        // getEnd token in TokenRange is not the same as the last token from findLastToken()
+        // assertEquals(tokenRange.getEnd(), tokenRange.getBegin().findLastToken());
+    }
+
+    @Test
+    void testFindFirstToken() {
+        ParseResult<Expression> result = new JavaParser().parse(ParseStart.EXPRESSION, provider("1 +/*2*/3+4"));
+        Iterator<JavaToken> iterator = result.getResult().get().getTokenRange().get().iterator();
+        iterator.next();
+        iterator.next();
+        iterator.next();
+        assertEquals("/*2*/", iterator.next().getText());
+        assertToken("1", range(1, 1, 1, 1), INTEGER_LITERAL, LITERAL, iterator.next().findFirstToken());
     }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/CodeGenerationUtilsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/CodeGenerationUtilsTest.java
@@ -47,12 +47,10 @@ class CodeGenerationUtilsTest {
         assertEquals("value", getterToPropertyName("getValue"));
         assertEquals("blue", getterToPropertyName("isBlue"));
         assertEquals("value", getterToPropertyName("hasValue"));
-        try {
-            getterToPropertyName("value");
-            fail("Expected an IllegalArgumentException to be thrown");
-        } catch (IllegalArgumentException e) {
-            assertEquals("Unexpected getterName 'value'", e.getMessage());
-        }
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> getterToPropertyName("value"));
+        assertEquals("Unexpected getterName 'value'", thrown.getMessage());
     }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/CodeGenerationUtilsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/CodeGenerationUtilsTest.java
@@ -42,4 +42,17 @@ class CodeGenerationUtilsTest {
         assertEquals("getIsBlue", getterName(Boolean.class, "isBlue"));
     }
 
+    @Test
+    void testGetterToPropertyName() {
+        assertEquals("value", getterToPropertyName("getValue"));
+        assertEquals("blue", getterToPropertyName("isBlue"));
+        assertEquals("value", getterToPropertyName("hasValue"));
+        try {
+            getterToPropertyName("value");
+            fail("Expected an IllegalArgumentException to be thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Unexpected getterName 'value'", e.getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION
Unit tests to contribute to #820. 

Hello, I'm one of the students in the group @flanbino was talked about on this issue.

I have created more unit tests for JavaToken and CodeGenerationUtils classes. In the JavaTokenTest, for testFindLastToken, I am unsure of the intended output.  It does not appear to be currently used in the implementation of JavaParser, findLastToken() is used in one of the unused methods in TokenRange, toTokenRange(), however, I am unsure if it's supposed to reflect the getEnd() JavaToken in TokenRange class or just always be EOF, hence it is commented out as the test proposed will fail since it is based that findLastToken would return the same value as getEnd() which is currently not the case.

If you would like this any of these tests to be changed I'd be happy to make any changes from the suggested reviews.