### PR TITLE
#2625: Add messages to thrown exceptions

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -1040,8 +1040,7 @@ public class Difference {
                 return childTextElement.getChild() == csmChild.getChild();
             }
         } else {
-            throw new UnsupportedOperationException("CsmElement is neither an instance of CsmToken or CsmChild. Throw" +
-                    " in isCorrespondingElement method in Difference class.");
+            throw new UnsupportedOperationException("CsmElement is " + csmElement.getClass());
         }
 
         return false;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -1040,7 +1040,8 @@ public class Difference {
                 return childTextElement.getChild() == csmChild.getChild();
             }
         } else {
-            throw new UnsupportedOperationException("CsmElement is " + csmElement.getClass());
+            throw new UnsupportedOperationException("Operation only supported for instance of CsmToken and CsmChild. " +
+                    "The CsmElement is " + csmElement.getClass());
         }
 
         return false;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -1040,7 +1040,8 @@ public class Difference {
                 return childTextElement.getChild() == csmChild.getChild();
             }
         } else {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("CsmElement is neither an instance of CsmToken or CsmChild. Throw" +
+                    " in isCorrespondingElement method in Difference class.");
         }
 
         return false;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -97,7 +97,8 @@ class LexicalDifferenceCalculator {
 
         @Override
         public void prettyPrint(Node node, SourcePrinter printer) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("prettyPrint method is not supported in " +
+                    "LexicalDifferenceCalculator class.");
         }
 
         @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -170,7 +170,7 @@ public class LexicalPreservingPrinter {
                             nodeText.removeElement(index);
                         }
                     } else {
-                        throw new UnsupportedOperationException("Object is " + oldValue.getClass());
+                        throw new UnsupportedOperationException("Object is not an instance of Comment. Object is " + oldValue.getClass());
                     }
                 } else {
                     List<TokenTextElement> matchingTokens = findTokenTextElementForComment((Comment) oldValue, nodeText);
@@ -331,7 +331,8 @@ public class LexicalPreservingPrinter {
             } else if (type == AstObserver.ListChangeType.ADDITION) {
                 differenceElements = LEXICAL_DIFFERENCE_CALCULATOR.calculateListAdditionDifference(findNodeListName(changedList), changedList, index, nodeAddedOrRemoved);
             } else {
-                throw new UnsupportedOperationException("ListChangeType is " + type.name());
+                throw new UnsupportedOperationException("ListChangeType is not listed in ENUM of Removal and " +
+                        "Addition. The ListChangeType is " + type.name());
             }
 
             Difference difference = new Difference(differenceElements, nodeText, changedList.getParentNodeForChildren());

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -170,7 +170,7 @@ public class LexicalPreservingPrinter {
                             nodeText.removeElement(index);
                         }
                     } else {
-                        throw new UnsupportedOperationException();
+                        throw new UnsupportedOperationException("Object is " + oldValue.getClass());
                     }
                 } else {
                     List<TokenTextElement> matchingTokens = findTokenTextElementForComment((Comment) oldValue, nodeText);
@@ -331,7 +331,7 @@ public class LexicalPreservingPrinter {
             } else if (type == AstObserver.ListChangeType.ADDITION) {
                 differenceElements = LEXICAL_DIFFERENCE_CALCULATOR.calculateListAdditionDifference(findNodeListName(changedList), changedList, index, nodeAddedOrRemoved);
             } else {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("ListChangeType is " + type.name());
             }
 
             Difference difference = new Difference(differenceElements, nodeText, changedList.getParentNodeForChildren());

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
@@ -142,7 +142,7 @@ class NodeText {
                             elements.remove(i);
                         }
                     } else {
-                        throw new UnsupportedOperationException();
+                        throw new UnsupportedOperationException("TextElement size is 0 or negative.");
                     }
                 }
                 return;

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeParameterDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeParameterDeclaration.java
@@ -93,12 +93,14 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
 
             @Override
             public Optional<ResolvedReferenceTypeDeclaration> containerType() {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("containerType method is unsupported in " +
+                        "ResolvedTypeParameterDeclaration class.");
             }
 
             @Override
             public ResolvedReferenceType object() {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("object method is unsupported in " +
+                        "ResolvedTypeParameterDeclaration class.");
             }
         };
     }
@@ -134,7 +136,8 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
      * This is unsupported because there is no package for a Type Parameter, only for its container.
      */
     default String getPackageName() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("getPackageName method is unsupported in " +
+                "ResolvedTypeParameterDeclaration class.");
     }
 
     /**
@@ -142,7 +145,8 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
      * This is unsupported because there is no class for a Type Parameter, only for its container.
      */
     default String getClassName() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("getClassName method is unsupported in " +
+                "ResolvedTypeParameterDeclaration class.");
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedWildcard.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedWildcard.java
@@ -106,7 +106,7 @@ public class ResolvedWildcard implements ResolvedType {
         } else if (type == BoundType.EXTENDS) {
             return "? extends " + boundedType.describe();
         } else {
-            throw new UnsupportedOperationException("BoundType is " + type.name());
+            throw new UnsupportedOperationException("The BoundType is not null, Super or Extends. BoundType is " + type.name());
         }
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedWildcard.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedWildcard.java
@@ -106,7 +106,7 @@ public class ResolvedWildcard implements ResolvedType {
         } else if (type == BoundType.EXTENDS) {
             return "? extends " + boundedType.describe();
         } else {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("BoundType is " + type.name());
         }
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -486,7 +486,7 @@ public class JavaParserFacade {
         }
 
         if (!result.isPresent()) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("There is no MethodUsage present upon converting to MethodUsage.");
         }
 
         return result.get();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/LambdaArgumentTypePlaceholder.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/LambdaArgumentTypePlaceholder.java
@@ -57,7 +57,8 @@ public class LambdaArgumentTypePlaceholder implements ResolvedType {
 
     @Override
     public String describe() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("describe function is not supported in LambdaArgumentTypePlaceholder " +
+                "class.");
     }
 
     @Override
@@ -71,7 +72,8 @@ public class LambdaArgumentTypePlaceholder implements ResolvedType {
 
     @Override
     public boolean isAssignableBy(ResolvedType other) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("isAssignableBy function is not supported in LambdaArgumentTypePlaceholder " +
+                "class.");
     }
 
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -453,7 +453,7 @@ public class TypeExtractor extends DefaultVisitorAdapter {
     @Override
     public ResolvedType visit(VariableDeclarationExpr node, Boolean solveLambdas) {
         if (node.getVariables().size() != 1) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("The number of variables in VariableDeclarationExpr node is not 1");
         }
         return facade.convertToUsageVariableType(node.getVariables().get(0));
     }
@@ -569,7 +569,8 @@ public class TypeExtractor extends DefaultVisitorAdapter {
 
 
             } else {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("The Statement of LambdaExpr is not an instance of " +
+                        "ExpressionStmt and BlockStmt. The Statement is " + lambdaExpr.getBody().getClass());
             }
 
             ResolvedType formalType = functionalMethod.get().returnType();


### PR DESCRIPTION
Fix #2625. I added about 15 messages to `new UnsupportedOperationException()` calls. This is an incremental improvement to the issue.