### PR TITLE
Fix issue #3728 ParseProblemException

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/version/Java10PostProcessorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/version/Java10PostProcessorTest.java
@@ -21,19 +21,20 @@
 
 package com.github.javaparser.version;
 
+import static com.github.javaparser.ParseStart.STATEMENT;
+import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_10;
+import static com.github.javaparser.Providers.provider;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.VarType;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static com.github.javaparser.ParseStart.STATEMENT;
-import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_10;
-import static com.github.javaparser.Providers.provider;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class Java10PostProcessorTest {
     public static final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_10));
@@ -45,5 +46,14 @@ class Java10PostProcessorTest {
         List<VarType> allVarTypes = result.getResult().get().findAll(VarType.class);
 
         assertEquals(1, allVarTypes.size());
+    }
+    
+    @Test
+    void expressionThatShouldNotBeInterpretedAsAVarType() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("var.class.getName();"));
+
+        List<VarType> allVarTypes = result.getResult().get().findAll(VarType.class);
+
+        assertEquals(0, allVarTypes.size());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java10PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java10PostProcessor.java
@@ -20,10 +20,15 @@
  */
 package com.github.javaparser.ast.validator.postprocessors;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Processor;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.VarType;
 
@@ -31,20 +36,35 @@ import com.github.javaparser.ast.type.VarType;
  * Processes the generic AST into a Java 10 AST and validates it.
  */
 public class Java10PostProcessor extends PostProcessors {
+    
+    // List of parent contexts in which a var type must not be detected.
+    // for example: in this statement var.class.getCanonicalName(), var must not be considered as a VarType
+    private static List<Class> FORBIDEN_PARENT_CONTEXT_TO_DETECT_POTENTIAL_VAR_TYPE = new ArrayList<>();
+    static {
+        FORBIDEN_PARENT_CONTEXT_TO_DETECT_POTENTIAL_VAR_TYPE.addAll(Arrays.asList(ClassExpr.class));
+    }
 
     protected final Processor varNodeCreator = new Processor() {
 
         @Override
         public void postProcess(ParseResult<? extends Node> result, ParserConfiguration configuration) {
             result.getResult().ifPresent(node -> {
-                node.findAll(ClassOrInterfaceType.class).forEach(n -> {
-                    if (n.getNameAsString().equals("var")) {
-                        n.replace(new VarType(n.getTokenRange().orElse(null)));
-                    }
+                node.findAll(ClassOrInterfaceType.class)
+                    .forEach(n -> {
+                        if (n.getNameAsString().equals("var")
+                                && !matchForbiddenContext(n)) {
+                            n.replace(new VarType(n.getTokenRange().orElse(null)));
+                        }
                 });
             });
         }
+        
+        private boolean matchForbiddenContext(ClassOrInterfaceType cit) {
+            return cit.getParentNode().isPresent()
+                    && FORBIDEN_PARENT_CONTEXT_TO_DETECT_POTENTIAL_VAR_TYPE.stream().anyMatch(cl -> cl.isInstance(cit.getParentNode().get()));
+        }
     };
+    
 
     public Java10PostProcessor() {
         add(varNodeCreator);


### PR DESCRIPTION
Fixes #3728 . VarType must not be detected on the context of a ClassExpr.
Note : The VarType is detected in the Java10 post processor versus the parser grammar.
