### PR TITLE
Updated workflow to only run one job per PR

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -18,6 +18,12 @@ on:
   # Enable manual triggering (important for contributors to enable a check on their fork)
   workflow_dispatch:
 
+# If a build is running in the current branch, and the branch is updated, we cancel the previous build and start
+# a new one with the updated changes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   maven_test:
     strategy:


### PR DESCRIPTION
At the moment, if a contributor opens a PR and is constantly pushing changes to the branch multiple actions will be created for that PR, making the build process slow for everyone.

This PR suggests a change in this behavior, by only building the latest commit. If a build is in progress and the author submits a new change, the current build will be aborted and a new build will start with all the changes.
