### PR TITLE
Suggestion to restructure APIs

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserAdapterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserAdapterTest.java
@@ -1,0 +1,267 @@
+package com.github.javaparser;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.modules.ModuleDeclaration;
+import com.github.javaparser.ast.modules.ModuleDirective;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.CharArrayReader;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class JavaParserAdapterTest {
+
+    private final JavaParser javaParser = Mockito.spy(JavaParser.class);
+
+    private final JavaParserAdapter adapter = new JavaParserAdapter(javaParser);
+
+    @Test
+    void of_withValidParser() {
+        JavaParserAdapter actualAdapter = JavaParserAdapter.of(javaParser);
+        assertSame(javaParser, actualAdapter.getParser());
+        assertSame(javaParser.getParserConfiguration(), adapter.getParserConfiguration());
+    }
+
+    @Test
+    void parse_withSourceCode() {
+
+        CompilationUnit cu = adapter.parse("class A {}");
+
+        Optional<ClassOrInterfaceDeclaration> classA = cu.findFirst(ClassOrInterfaceDeclaration.class);
+        assertTrue(classA.isPresent());
+        assertEquals("A", classA.get().getNameAsString());
+
+        Mockito.verify(javaParser).parse("class A {}");
+    }
+
+    @Test
+    void parse_withInvalidSourceCode() {
+        assertThrows(ParseProblemException.class, () -> adapter.parse("class A"));
+    }
+
+    @Test
+    void parse_withSourceCodeFromInputStream() {
+
+        InputStream is = new ByteArrayInputStream("class A {}".getBytes(StandardCharsets.UTF_8));
+
+        CompilationUnit cu = adapter.parse(is);
+
+        Optional<ClassOrInterfaceDeclaration> classA = cu.findFirst(ClassOrInterfaceDeclaration.class);
+        assertTrue(classA.isPresent());
+        assertEquals("A", classA.get().getNameAsString());
+
+        Mockito.verify(javaParser).parse(is);
+    }
+
+    @Test
+    void parse_withSourceCodeFromReader() {
+
+        Reader reader = new CharArrayReader("class A {}".toCharArray());
+
+        CompilationUnit cu = adapter.parse(reader);
+
+        Optional<ClassOrInterfaceDeclaration> classA = cu.findFirst(ClassOrInterfaceDeclaration.class);
+        assertTrue(classA.isPresent());
+        assertEquals("A", classA.get().getNameAsString());
+
+        Mockito.verify(javaParser).parse(reader);
+    }
+
+    @Test
+    void parseBlock_withValidSource() {
+        BlockStmt block = adapter.parseBlock("{ System.out.println(\"Hello world!\"); }");
+
+        assertEquals(1, block.getStatements().size());
+
+        Mockito.verify(javaParser).parseBlock("{ System.out.println(\"Hello world!\"); }");
+    }
+
+    @Test
+    void parseStatement_withValidSource() {
+        Statement statement = adapter.parseStatement("break;");
+
+        assertTrue(statement.isBreakStmt());
+
+        Mockito.verify(javaParser).parseStatement("break;");
+    }
+
+    @Test
+    void parseImport_withValidSource() {
+        ImportDeclaration importDecl = adapter.parseImport("import java.util.Optional;");
+
+        assertEquals("Optional", importDecl.getName().getIdentifier());
+
+        Mockito.verify(javaParser).parseImport("import java.util.Optional;");
+    }
+
+    @Test
+    void parseExpression_withValidSource() {
+        Expression expression = adapter.parseExpression("System.out.println(\"Hello world!\")");
+
+        assertTrue(expression.isMethodCallExpr());
+
+        Mockito.verify(javaParser).parseExpression("System.out.println(\"Hello world!\")");
+    }
+
+    @Test
+    void parseAnnotation_withValidSource() {
+        AnnotationExpr annotation = adapter.parseAnnotation("@Test");
+
+        assertEquals("Test", annotation.getNameAsString());
+
+        Mockito.verify(javaParser).parseAnnotation("@Test");
+    }
+
+    @Test
+    void parseAnnotationBodyDeclaration_withValidSource() {
+        BodyDeclaration<?> annotationBody = adapter.parseAnnotationBodyDeclaration("@interface Test{}");
+
+        assertTrue(annotationBody.isAnnotationDeclaration());
+
+        Mockito.verify(javaParser).parseAnnotationBodyDeclaration("@interface Test{}");
+    }
+
+    @Test
+    void parseBodyDeclaration_withValidSource() {
+        BodyDeclaration<?> interfaceBody = adapter.parseBodyDeclaration("interface CustomInterface {}");
+
+        assertTrue(interfaceBody.isClassOrInterfaceDeclaration());
+
+        Mockito.verify(javaParser).parseBodyDeclaration("interface CustomInterface {}");
+    }
+
+    @Test
+    void parseClassOrInterfaceType_withValidSource() {
+        ClassOrInterfaceType customType = adapter.parseClassOrInterfaceType("CustomInterface");
+
+        assertTrue(customType.isClassOrInterfaceType());
+
+        Mockito.verify(javaParser).parseClassOrInterfaceType("CustomInterface");
+    }
+
+    @Test
+    void parseType_withValidSource() {
+        Type customType = adapter.parseType("int");
+
+        assertTrue(customType.isPrimitiveType());
+
+        Mockito.verify(javaParser).parseType("int");
+    }
+
+    @Test
+    void parseVariableDeclarationExpr_withValidSource() {
+        VariableDeclarationExpr variable = adapter.parseVariableDeclarationExpr("final int x = 0");
+
+        assertTrue(variable.isFinal());
+
+        Mockito.verify(javaParser).parseVariableDeclarationExpr("final int x = 0");
+    }
+
+    @Test
+    void parseExplicitConstructorInvocationStmt_withValidSource() {
+        ExplicitConstructorInvocationStmt statement = adapter.parseExplicitConstructorInvocationStmt("super();");
+
+        assertTrue(statement.getArguments().isEmpty());
+
+        Mockito.verify(javaParser).parseExplicitConstructorInvocationStmt("super();");
+    }
+
+    @Test
+    void parseName_withValidSource() {
+        Name name = adapter.parseName("com.github.javaparser.JavaParser");
+
+        assertEquals("JavaParser", name.getIdentifier());
+
+        Mockito.verify(javaParser).parseName("com.github.javaparser.JavaParser");
+    }
+
+    @Test
+    void parseSimpleName_withValidSource() {
+        SimpleName name = adapter.parseSimpleName("JavaParser");
+
+        assertEquals("JavaParser", name.getIdentifier());
+
+        Mockito.verify(javaParser).parseSimpleName("JavaParser");
+    }
+
+    @Test
+    void parseParameter_withValidSource() {
+        Parameter parameter = adapter.parseParameter("String foo");
+
+        assertEquals("foo", parameter.getNameAsString());
+
+        Mockito.verify(javaParser).parseParameter("String foo");
+    }
+
+    @Test
+    void parsePackageDeclaration_withValidSource() {
+        PackageDeclaration packageDeclaration = adapter.parsePackageDeclaration("package com.github.javaparser;");
+
+        assertEquals("com.github.javaparser", packageDeclaration.getNameAsString());
+
+        Mockito.verify(javaParser).parsePackageDeclaration("package com.github.javaparser;");
+    }
+
+    @Test
+    void parseTypeDeclaration_withValidSource() {
+        TypeDeclaration<?> typeDeclaration = adapter.parseTypeDeclaration("class A {}");
+
+        assertEquals("A", typeDeclaration.getNameAsString());
+
+        Mockito.verify(javaParser).parseTypeDeclaration("class A {}");
+    }
+
+    @Test
+    void parseModuleDeclaration_withValidSource() {
+        ModuleDeclaration moduleDeclaration = adapter.parseModuleDeclaration("module X {}");
+
+        assertEquals("X", moduleDeclaration.getNameAsString());
+
+        Mockito.verify(javaParser).parseModuleDeclaration("module X {}");
+    }
+
+    @Test
+    void parseModuleDirective_withValidSource() {
+        ModuleDirective moduleDirective = adapter.parseModuleDirective("opens X;");
+
+        assertTrue(moduleDirective.isModuleOpensDirective());
+
+        Mockito.verify(javaParser).parseModuleDirective("opens X;");
+    }
+
+    @Test
+    void parseTypeParameter_withValidSource() {
+        TypeParameter typeParameter = adapter.parseTypeParameter("T extends Object");
+
+        assertEquals("T", typeParameter.getNameAsString());
+
+        Mockito.verify(javaParser).parseTypeParameter("T extends Object");
+    }
+
+    @Test
+    void parseMethodDeclaration_withValidSource() {
+        MethodDeclaration methodDeclaration = adapter.parseMethodDeclaration("void test() {}");
+
+        assertEquals("test", methodDeclaration.getNameAsString());
+
+        Mockito.verify(javaParser).parseMethodDeclaration("void test() {}");
+    }
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParserAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParserAdapter.java
@@ -1,0 +1,178 @@
+package com.github.javaparser;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.modules.ModuleDeclaration;
+import com.github.javaparser.ast.modules.ModuleDirective;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.javadoc.Javadoc;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class JavaParserAdapter {
+
+    /**
+     * Wraps the {@link JavaParser}.
+     *
+     * @param parser The java parser to be used.
+     *
+     * @return The created QuickJavaParser.
+     */
+    public static JavaParserAdapter of(JavaParser parser) {
+        return new JavaParserAdapter(parser);
+    }
+
+    private final JavaParser parser;
+
+    public JavaParserAdapter(JavaParser parser) {
+        this.parser = Objects.requireNonNull(parser, "A non-null parser should be provided.");
+    }
+
+    public JavaParser getParser() {
+        return parser;
+    }
+
+    /**
+     * Helper function to handle the result in a simpler way.
+     *
+     * @param result The result to be handled.
+     *
+     * @param <T> The return type.
+     *
+     * @return The parsed value.
+     */
+    private <T extends Node> T handleResult(ParseResult<T> result) {
+        if (result.isSuccessful()) {
+            return result.getResult().orElse(null);
+        }
+
+        throw new ParseProblemException(result.getProblems());
+    }
+    
+    public ParserConfiguration getParserConfiguration() {
+        return parser.getParserConfiguration();
+    }
+    
+    public CompilationUnit parse(InputStream in) {
+        return handleResult(getParser().parse(in));
+    }
+    
+    public CompilationUnit parse(File file) throws FileNotFoundException {
+        return handleResult(getParser().parse(file));
+    }
+    
+    public CompilationUnit parse(Path path) throws IOException {
+        return handleResult(getParser().parse(path));
+    }
+    
+    public CompilationUnit parse(Reader reader) {
+        return handleResult(getParser().parse(reader));
+    }
+    
+    public CompilationUnit parse(String code) {
+        return handleResult(getParser().parse(code));
+    }
+    
+    public CompilationUnit parseResource(String path) throws IOException {
+        return handleResult(getParser().parseResource(path));
+    }
+    
+    public BlockStmt parseBlock(String blockStatement) {
+        return handleResult(getParser().parseBlock(blockStatement));
+    }
+    
+    public Statement parseStatement(String statement) {
+        return handleResult(getParser().parseStatement(statement));
+    }
+    
+    public ImportDeclaration parseImport(String importDeclaration) {
+        return handleResult(getParser().parseImport(importDeclaration));
+    }
+    
+    public <T extends Expression> T parseExpression(String expression) {
+        return handleResult(getParser().parseExpression(expression));
+    }
+    
+    public AnnotationExpr parseAnnotation(String annotation) {
+        return handleResult(getParser().parseAnnotation(annotation));
+    }
+    
+    public BodyDeclaration<?> parseAnnotationBodyDeclaration(String body) {
+        return handleResult(getParser().parseAnnotationBodyDeclaration(body));
+    }
+    
+    public BodyDeclaration<?> parseBodyDeclaration(String body) {
+        return handleResult(getParser().parseBodyDeclaration(body));
+    }
+    
+    public ClassOrInterfaceType parseClassOrInterfaceType(String type) {
+        return handleResult(getParser().parseClassOrInterfaceType(type));
+    }
+    
+    public Type parseType(String type) {
+        return handleResult(getParser().parseType(type));
+    }
+    
+    public VariableDeclarationExpr parseVariableDeclarationExpr(String declaration) {
+        return handleResult(getParser().parseVariableDeclarationExpr(declaration));
+    }
+    
+    public Javadoc parseJavadoc(String content) {
+        return JavadocParser.parse(content);
+    }
+    
+    public ExplicitConstructorInvocationStmt parseExplicitConstructorInvocationStmt(String statement) {
+        return handleResult(getParser().parseExplicitConstructorInvocationStmt(statement));
+    }
+
+    public Name parseName(String qualifiedName) {
+        return handleResult(getParser().parseName(qualifiedName));
+    }
+    
+    public SimpleName parseSimpleName(String name) {
+        return handleResult(getParser().parseSimpleName(name));
+    }
+
+    public Parameter parseParameter(String parameter) {
+        return handleResult(getParser().parseParameter(parameter));
+    }
+    
+    public PackageDeclaration parsePackageDeclaration(String packageDeclaration) {
+        return handleResult(getParser().parsePackageDeclaration(packageDeclaration));
+    }
+    
+    public TypeDeclaration<?> parseTypeDeclaration(String typeDeclaration) {
+        return handleResult(getParser().parseTypeDeclaration(typeDeclaration));
+    }
+
+    public ModuleDeclaration parseModuleDeclaration(String moduleDeclaration) {
+        return handleResult(getParser().parseModuleDeclaration(moduleDeclaration));
+    }
+
+    public ModuleDirective parseModuleDirective(String moduleDirective) {
+        return handleResult(getParser().parseModuleDirective(moduleDirective));
+    }
+
+    public TypeParameter parseTypeParameter(String typeParameter) {
+        return handleResult(getParser().parseTypeParameter(typeParameter));
+    }
+    
+    public MethodDeclaration parseMethodDeclaration(String methodDeclaration) {
+        return handleResult(getParser().parseMethodDeclaration(methodDeclaration));
+    }
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -51,10 +51,7 @@ import java.nio.file.Path;
 public final class StaticJavaParser {
 
     // use ThreadLocal to resolve possible concurrency issues.
-    private static ThreadLocal<ParserConfiguration> localConfiguration = ThreadLocal.withInitial(() -> new ParserConfiguration());
-
-    private StaticJavaParser() {
-    }
+    private static final ThreadLocal<ParserConfiguration> localConfiguration = ThreadLocal.withInitial(ParserConfiguration::new);
 
     /**
      * Get the configuration for the parse... methods. Deprecated method.
@@ -80,10 +77,6 @@ public final class StaticJavaParser {
     public static void setConfiguration(@NotNull ParserConfiguration configuration) {
         Preconditions.checkNotNull(configuration, "Parameter configuration can't be null.");
         localConfiguration.set(configuration);
-    }
-
-    private static JavaParser newParser() {
-        return new JavaParser(getConfiguration());
     }
 
     /**
@@ -113,7 +106,7 @@ public final class StaticJavaParser {
      */
     public static CompilationUnit parse(@NotNull final InputStream in) {
         Preconditions.checkNotNull(in, "Parameter in can't be null.");
-        return handleResult(newParser().parse(in));
+        return newParserAdapted().parse(in);
     }
 
     /**
@@ -145,7 +138,7 @@ public final class StaticJavaParser {
      */
     public static CompilationUnit parse(@NotNull final File file) throws FileNotFoundException {
         Preconditions.checkNotNull(file, "Parameter file can't be null.");
-        return handleResult(newParser().parse(file));
+        return newParserAdapted().parse(file);
     }
 
     /**
@@ -177,7 +170,7 @@ public final class StaticJavaParser {
      */
     public static CompilationUnit parse(@NotNull final Path path) throws IOException {
         Preconditions.checkNotNull(path, "Parameter path can't be null.");
-        return handleResult(newParser().parse(path));
+        return newParserAdapted().parse(path);
     }
 
     /**
@@ -192,7 +185,7 @@ public final class StaticJavaParser {
      */
     public static CompilationUnit parseResource(@NotNull final String path) throws IOException {
         Preconditions.checkNotNull(path, "Parameter path can't be null.");
-        return handleResult(newParser().parseResource(path));
+        return newParserAdapted().parseResource(path);
     }
 
     /**
@@ -244,7 +237,7 @@ public final class StaticJavaParser {
      */
     public static CompilationUnit parse(@NotNull final Reader reader) {
         Preconditions.checkNotNull(reader, "Parameter reader can't be null.");
-        return handleResult(newParser().parse(reader));
+        return newParserAdapted().parse(reader);
     }
 
     /**
@@ -257,7 +250,7 @@ public final class StaticJavaParser {
      */
     public static CompilationUnit parse(@NotNull String code) {
         Preconditions.checkNotNull(code, "Parameter code can't be null.");
-        return handleResult(newParser().parse(code));
+        return newParserAdapted().parse(code);
     }
 
     /**
@@ -270,7 +263,7 @@ public final class StaticJavaParser {
      */
     public static BlockStmt parseBlock(@NotNull final String blockStatement) {
         Preconditions.checkNotNull(blockStatement, "Parameter blockStatement can't be null.");
-        return handleResult(newParser().parseBlock(blockStatement));
+        return newParserAdapted().parseBlock(blockStatement);
     }
 
     /**
@@ -283,14 +276,7 @@ public final class StaticJavaParser {
      */
     public static Statement parseStatement(@NotNull final String statement) {
         Preconditions.checkNotNull(statement, "Parameter statement can't be null.");
-        return handleResult(newParser().parseStatement(statement));
-    }
-
-    private static <T extends Node> T handleResult(ParseResult<T> result) {
-        if (result.isSuccessful()) {
-            return result.getResult().get();
-        }
-        throw new ParseProblemException(result.getProblems());
+        return newParserAdapted().parseStatement(statement);
     }
 
     /**
@@ -303,7 +289,7 @@ public final class StaticJavaParser {
      */
     public static ImportDeclaration parseImport(@NotNull final String importDeclaration) {
         Preconditions.checkNotNull(importDeclaration, "Parameter importDeclaration can't be null.");
-        return handleResult(newParser().parseImport(importDeclaration));
+        return newParserAdapted().parseImport(importDeclaration);
     }
 
     /**
@@ -316,7 +302,7 @@ public final class StaticJavaParser {
      */
     public static <T extends Expression> T parseExpression(@NotNull final String expression) {
         Preconditions.checkNotNull(expression, "Parameter expression can't be null.");
-        return handleResult(newParser().parseExpression(expression));
+        return newParserAdapted().parseExpression(expression);
     }
 
     /**
@@ -329,7 +315,7 @@ public final class StaticJavaParser {
      */
     public static AnnotationExpr parseAnnotation(@NotNull final String annotation) {
         Preconditions.checkNotNull(annotation, "Parameter annotation can't be null.");
-        return handleResult(newParser().parseAnnotation(annotation));
+        return newParserAdapted().parseAnnotation(annotation);
     }
 
     /**
@@ -342,7 +328,7 @@ public final class StaticJavaParser {
      */
     public static BodyDeclaration<?> parseAnnotationBodyDeclaration(@NotNull final String body) {
         Preconditions.checkNotNull(body, "Parameter body can't be null.");
-        return handleResult(newParser().parseAnnotationBodyDeclaration(body));
+        return newParserAdapted().parseAnnotationBodyDeclaration(body);
     }
 
     /**
@@ -355,7 +341,7 @@ public final class StaticJavaParser {
      */
     public static BodyDeclaration<?> parseBodyDeclaration(@NotNull String body) {
         Preconditions.checkNotNull(body, "Parameter body can't be null.");
-        return handleResult(newParser().parseBodyDeclaration(body));
+        return newParserAdapted().parseBodyDeclaration(body);
     }
 
     /**
@@ -367,7 +353,7 @@ public final class StaticJavaParser {
      */
     public static ClassOrInterfaceType parseClassOrInterfaceType(@NotNull String type) {
         Preconditions.checkNotNull(type, "Parameter type can't be null.");
-        return handleResult(newParser().parseClassOrInterfaceType(type));
+        return newParserAdapted().parseClassOrInterfaceType(type);
     }
 
     /**
@@ -379,7 +365,7 @@ public final class StaticJavaParser {
      */
     public static Type parseType(@NotNull String type) {
         Preconditions.checkNotNull(type, "Parameter type can't be null.");
-        return handleResult(newParser().parseType(type));
+        return newParserAdapted().parseType(type);
     }
 
     /**
@@ -392,7 +378,7 @@ public final class StaticJavaParser {
      */
     public static VariableDeclarationExpr parseVariableDeclarationExpr(@NotNull String declaration) {
         Preconditions.checkNotNull(declaration, "Parameter declaration can't be null.");
-        return handleResult(newParser().parseVariableDeclarationExpr(declaration));
+        return newParserAdapted().parseVariableDeclarationExpr(declaration);
     }
 
     /**
@@ -417,7 +403,7 @@ public final class StaticJavaParser {
      */
     public static ExplicitConstructorInvocationStmt parseExplicitConstructorInvocationStmt(@NotNull String statement) {
         Preconditions.checkNotNull(statement, "Parameter statement can't be null.");
-        return handleResult(newParser().parseExplicitConstructorInvocationStmt(statement));
+        return newParserAdapted().parseExplicitConstructorInvocationStmt(statement);
     }
 
     /**
@@ -429,7 +415,7 @@ public final class StaticJavaParser {
      */
     public static Name parseName(@NotNull String qualifiedName) {
         Preconditions.checkNotNull(qualifiedName, "Parameter qualifiedName can't be null.");
-        return handleResult(newParser().parseName(qualifiedName));
+        return newParserAdapted().parseName(qualifiedName);
     }
 
     /**
@@ -441,7 +427,7 @@ public final class StaticJavaParser {
      */
     public static SimpleName parseSimpleName(@NotNull String name) {
         Preconditions.checkNotNull(name, "Parameter name can't be null.");
-        return handleResult(newParser().parseSimpleName(name));
+        return newParserAdapted().parseSimpleName(name);
     }
 
     /**
@@ -453,7 +439,7 @@ public final class StaticJavaParser {
      */
     public static Parameter parseParameter(@NotNull String parameter) {
         Preconditions.checkNotNull(parameter, "Parameter parameter can't be null.");
-        return handleResult(newParser().parseParameter(parameter));
+        return newParserAdapted().parseParameter(parameter);
     }
 
     /**
@@ -465,7 +451,7 @@ public final class StaticJavaParser {
      */
     public static PackageDeclaration parsePackageDeclaration(@NotNull String packageDeclaration) {
         Preconditions.checkNotNull(packageDeclaration, "Parameter packageDeclaration can't be null.");
-        return handleResult(newParser().parsePackageDeclaration(packageDeclaration));
+        return newParserAdapted().parsePackageDeclaration(packageDeclaration);
     }
 
     /**
@@ -477,7 +463,7 @@ public final class StaticJavaParser {
      */
     public static TypeDeclaration<?> parseTypeDeclaration(@NotNull String typeDeclaration) {
         Preconditions.checkNotNull(typeDeclaration, "Parameter typeDeclaration can't be null.");
-        return handleResult(newParser().parseTypeDeclaration(typeDeclaration));
+        return newParserAdapted().parseTypeDeclaration(typeDeclaration);
     }
 
     /**
@@ -490,7 +476,7 @@ public final class StaticJavaParser {
      */
     public static ModuleDeclaration parseModuleDeclaration(@NotNull String moduleDeclaration) {
         Preconditions.checkNotNull(moduleDeclaration, "Parameter moduleDeclaration can't be null.");
-        return handleResult(newParser().parseModuleDeclaration(moduleDeclaration));
+        return newParserAdapted().parseModuleDeclaration(moduleDeclaration);
     }
 
     /**
@@ -503,7 +489,7 @@ public final class StaticJavaParser {
      */
     public static ModuleDirective parseModuleDirective(@NotNull String moduleDirective) {
         Preconditions.checkNotNull(moduleDirective, "Parameter moduleDirective can't be null.");
-        return handleResult(newParser().parseModuleDirective(moduleDirective));
+        return newParserAdapted().parseModuleDirective(moduleDirective);
     }
 
     /**
@@ -515,7 +501,7 @@ public final class StaticJavaParser {
      */
     public static TypeParameter parseTypeParameter(@NotNull String typeParameter) {
         Preconditions.checkNotNull(typeParameter, "Parameter typeParameter can't be null.");
-        return handleResult(newParser().parseTypeParameter(typeParameter));
+        return newParserAdapted().parseTypeParameter(typeParameter);
     }
 
     /**
@@ -528,6 +514,28 @@ public final class StaticJavaParser {
      */
     public static MethodDeclaration parseMethodDeclaration(@NotNull String methodDeclaration) {
         Preconditions.checkNotNull(methodDeclaration, "Parameter methodDeclaration can't be null.");
-        return handleResult(newParser().parseMethodDeclaration(methodDeclaration));
+        return newParserAdapted().parseMethodDeclaration(methodDeclaration);
     }
+
+    // Private methods
+
+    private static JavaParser newParser() {
+        return new JavaParser(getParserConfiguration());
+    }
+
+    private static JavaParserAdapter newParserAdapted() {
+        return new JavaParserAdapter(newParser());
+    }
+
+    @Deprecated
+    private static <T extends Node> T handleResult(ParseResult<T> result) {
+        if (result.isSuccessful()) {
+            return result.getResult().get();
+        }
+        throw new ParseProblemException(result.getProblems());
+    }
+
+    private StaticJavaParser() {
+    }
+
 }


### PR DESCRIPTION
## Motiviation

By looking into thee documentation provided @Matozoid at issue #3108, it's clear that we have two ways of interacting with JavaParser

- Quick API
- Full API

Both APIS have strong and weak points regarding. Looking at Full API (JavaParser) we can reuse the same instance for each parse, allowing to improve the performance and in some cases reduce resources footprint. But this comes with a cost, of having a API that may difficult the on-boarding of new members to it's complexity.

Looking on the other hand, we have Quick API (StaticJavaParser) that is really straight forward to use, and makes the process of on-boarding new members really simple. Unfortunately StaticJavaParser has some downsides, for example each time we whant to parse something a new parser has to be created, maybe due to concurrency.


 **What if we could have the best of both worlds?**

Having the flexibility of JavaParser but being able to use API like StaticJavaParser... 🤔

That's what this PR suggests!

---

## What was done

Previously if the use want to use Quick API the only option he had was to use StaticJavaParser and to use Full API was to use JavaParser.
The change started here, by allowing the user to decide which API he wants to use JavaParser with. For example:
```java
// FullJavaParser
JavaParser fullParser = new JavaParser();
ParseResult<CompilationUnit> fullCu = fullParser.parse("class A {}");

// QuickJavaParser
QuickJavaParser quickParser = new QuickJavaParserAdapter(fullParser);
CompilationUnit quickCu = quickParser.parse("class A {}");

// StaticJavaParser
CompilationUnit staticCu = StaticJavaParser.parse("class A {}");
```

Suggestion and feedback are welcome!

Let me know your thoughts!

---

Fixes #3108.
