### PR TITLE
Fix issue #1827 Issue resolving a constructor of a class using generics

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeImpl.java
@@ -117,8 +117,8 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
         if (other instanceof LambdaArgumentTypePlaceholder) {
             return FunctionalInterfaceLogic.isFunctionalInterfaceType(this);
         }
-        if (other instanceof ReferenceTypeImpl) {
-            ReferenceTypeImpl otherRef = (ReferenceTypeImpl) other;
+        if (other.isReferenceType()) {
+            ResolvedReferenceType otherRef =  other.asReferenceType();
             if (compareConsideringTypeParameters(otherRef)) {
                 return true;
             }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1827Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1827Test.java
@@ -1,0 +1,50 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue1827Test extends AbstractResolutionTest {
+
+    @Test
+    public void solveParametrizedParametersConstructor() {
+        
+        String src = "public class ParametrizedParametersConstructor {\n"
+                + "    public void foo() {\n"
+                + "        EClass arg = new EClass();\n"
+                + "        ParametrizedClass<String> pc = new ParametrizedClass<>(arg, arg);\n"
+                + "    }\n"
+                + "\n"
+                + "    class EClass implements BaseType<String> {\n"
+                + "    }\n"
+                + "}\n"
+                + "\n"
+                + "class ParametrizedClass<T> {\n"
+                + "    public ParametrizedClass(BaseType<T> arg1, BaseType<T> arg2) {\n"
+                + "    }\n"
+                + "}\n"
+                + "\n"
+                + "interface BaseType<T> {\n"
+                + "}";
+        
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
+        StaticJavaParser
+                .getConfiguration()
+                .setSymbolResolver(symbolSolver);
+        CompilationUnit cu = StaticJavaParser.parse(src);
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ParametrizedParametersConstructor");
+        ObjectCreationExpr oce = clazz.findAll(ObjectCreationExpr.class).get(1); // new ParametrizedClass<>(arg, arg)
+        assertDoesNotThrow(() -> oce.resolve());
+    }
+
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/LazyTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/LazyTypeTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.model.typesystem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.AbstractSymbolResolutionTest;
+import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionClassDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+class LazyTypeTest extends AbstractSymbolResolutionTest {
+
+    private ResolvedType foo;
+    private ResolvedType bar;
+    private ResolvedType baz;
+    private ResolvedType lazyFoo;
+    private ResolvedType lazyBar;
+    private ResolvedType lazyBaz;
+    private TypeSolver typeSolver;
+    
+    class Foo {}
+    
+    class Bar {}
+
+    class Baz extends Foo {}
+
+    @BeforeEach
+    void setup() {
+        typeSolver = new ReflectionTypeSolver();
+        foo = new ReferenceTypeImpl(new ReflectionClassDeclaration(Foo.class, typeSolver), typeSolver);
+        bar = new ReferenceTypeImpl(new ReflectionClassDeclaration(Bar.class, typeSolver), typeSolver);
+        baz = new ReferenceTypeImpl(new ReflectionClassDeclaration(Baz.class, typeSolver), typeSolver);
+        lazyFoo = lazy(foo);
+        lazyBar = lazy(bar);
+        lazyBaz = lazy(baz);
+    }
+
+    private ResolvedType lazy(ResolvedType type) {
+        return new LazyType(v -> type);
+    }
+    
+    @Test
+    void testIsAssignable() {
+        assertEquals(true, foo.isAssignableBy(foo));
+        assertEquals(true, foo.isAssignableBy(baz));
+        assertEquals(false, foo.isAssignableBy(bar));
+        
+        assertEquals(true, lazyFoo.isAssignableBy(lazyFoo));
+        assertEquals(true, lazyFoo.isAssignableBy(lazyBaz));
+        assertEquals(false, lazyFoo.isAssignableBy(lazyBar));
+        
+        assertEquals(true, foo.isAssignableBy(lazyFoo));
+        assertEquals(true, foo.isAssignableBy(lazyBaz));
+        assertEquals(false, foo.isAssignableBy(lazyBar));
+        
+    }
+
+}


### PR DESCRIPTION
Fixes #1827.
ReferenceTypeImpl.isAssignableBy(..) doesn't work well with lazy types.
