### PR TITLE
Fix: Fix the indentation generated by the LexicalPreservingPrinter wh…

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2620Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2620Test.java
@@ -74,9 +74,9 @@ public class Issue2620Test {
         // FIXME: Indentation is bad here.
         String expected = "" +
                 "    public class Foo { //comment" + eol +
-                "    private String newField;" + eol +
-                "    " + eol +
-                "    private String a;" + eol +
+                "        private String newField;" + eol +
+                "        " + eol +
+                "        private String a;" + eol +
                 "        private String b;" + eol +
                 "        private String c;" + eol +
                 "        private String d;" + eol +

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -533,7 +533,6 @@ public class Difference {
                 diffIndex++;
             } else if (kept.isNewLine() && originalTextToken.isSpaceOrTab()) {
                 originalIndex++;
-                diffIndex++;
             } else if (kept.isWhiteSpaceOrComment()) {
                 diffIndex++;
             } else if (originalTextToken.isWhiteSpaceOrComment()) {


### PR DESCRIPTION
…en inserting a new member in a block.

Fixes #9999.
