### PR TITLE
Fix: #3750 Lexical preserving corrupts source

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3746Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3746Test.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.utils.LineSeparator;
+
+public class Issue3746Test extends AbstractLexicalPreservingTest {
+
+	@Test
+    void test() {
+        considerCode(
+                "public class MyClass {\n"
+                        + " String s0;\n"
+                        + " // Comment\n"
+                        + " String s1;\n"
+                        + "}");
+
+        considerCode("class A {\n"
+				+ "  void foo() {\n"
+				+ "    int first = 1;\n"
+				+ "    int second = 2;\n"
+				+ "  }\n"
+				+ "}"
+				);
+    	
+    	String expected = 
+    			"class A {\n"
+    			+ "  void foo() {\n"
+    			+ "    foo();\n"
+    			+ "    int second = 2;\n"
+    			+ "  }\n"
+    			+ "}";
+    	BlockStmt block = cu.findAll(BlockStmt.class).get(0);
+    	ExpressionStmt newStmt = new ExpressionStmt(new MethodCallExpr("foo"));
+		block.addStatement(1,newStmt);
+		block.getStatement(0).remove();
+		assertEquals(expected, LexicalPreservingPrinter.print(cu));
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3750Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3750Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.utils.LineSeparator;
+
+public class Issue3750Test extends AbstractLexicalPreservingTest {
+
+	@Test
+    void test() {
+        considerCode(
+                "public class MyClass {\n"
+                        + " String s0;\n"
+                        + " // Comment\n"
+                        + " String s1;\n"
+                        + "}");
+
+        List<FieldDeclaration> fields = cu.findAll(FieldDeclaration.class);
+        FieldDeclaration field = fields.get(0);
+        
+        String expected = 
+        		"public class MyClass {\n"
+                        + " // Comment\n"
+                        + " String s1;\n"
+                        + "}";
+
+        field.remove();
+
+        assertEquals(expected, LexicalPreservingPrinter.print(cu));
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -361,7 +361,6 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         ClassOrInterfaceDeclaration c = cu.getClassByName("A").get();
         c.getMembers().remove(0);
         assertEquals("class /*a comment*/ A {\t\t" + SYSTEM_EOL +
-                SYSTEM_EOL +
                 "         void foo(int p  ) { return  'z'  \t; }}", LexicalPreservingPrinter.print(c));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -419,6 +419,10 @@ public class Difference {
             diffIndex++;
         } else if (originalElementIsToken && originalElement.isWhiteSpaceOrComment()) {
             originalIndex++;
+            // skip the newline token which may be generated unnecessarily by the concrete syntax pattern
+            if (removed.isNewLine()) { 
+            	diffIndex++;
+            }
         } else if (originalElement.isLiteral()) {
             nodeText.removeElement(originalIndex);
             diffIndex++;
@@ -463,6 +467,11 @@ public class Difference {
                         // If the current element is not a space itself we remove the space in front of (before) it
                         nodeText.removeElement(originalIndex - 1);
                         originalIndex--;
+                    }
+                    // Remove remaining newline character if needed
+                    if (nodeText.getTextElement(originalIndex).isNewline()) {
+                    	nodeText.removeElement(originalIndex);
+                    	originalIndex = originalIndex > 0 ? originalIndex-- : 0;
                     }
                 }
             }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
@@ -52,7 +52,12 @@ class DifferenceElementCalculator {
             // verify that the node content and the position are equal
             // because we can have nodes with the same content but in different lines
             // in this case we consider that nodes are not equals
-            return this.node.equals(cpi.node) && this.node.hasRange() && cpi.node.hasRange() && this.node.getRange().get().contains(cpi.node.getRange().get());
+            // If the nodes have no declared position they are considered equal.
+            return this.node.equals(cpi.node) 
+            		&& (this.node.hasRange() == false && cpi.node.hasRange() == false
+            			||	(this.node.hasRange() && cpi.node.hasRange() && this.node.getRange().get().contains(cpi.node.getRange().get())
+            			)
+            		);
         }
 
         @Override


### PR DESCRIPTION
Fixes #3750 .
Fix how to handle newlines in the LexicalPreservationPrinter when deleting an element.