### PR TITLE
Fix: #3441 LexicalPreservingPrinter prints wrong output with line com…

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3441Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3441Test.java
@@ -1,0 +1,60 @@
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2019 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.stmt.SwitchEntry;
+import com.github.javaparser.utils.TestUtils;
+
+public class Issue3441Test extends AbstractLexicalPreservingTest {
+
+	@Test
+	void test() {
+		    considerCode( 
+		    		"public class Foo {\n" +
+		    	     "    void bar() {\n" +
+		    	     "        stmt1(); // comment 1\n" +
+		    	     "        stmt2(); // comment 2\n" +
+		    	     "    }\n" +
+		    	     "}");
+		    String expected = 
+		    		"public class Foo {\n" +
+		   	    	"    void bar() {\n" +
+		   	    	"        stmt2(); // comment 2\n" +
+		   	    	"    }\n" +
+		   	    	"}";
+		    
+		BlockStmt block = cu.findFirst(BlockStmt.class).get();
+	    Statement stmt = block.getStatements().get(0);
+	    
+	    block.remove(stmt);
+	    
+	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+	}
+    
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -97,6 +97,55 @@ public class Difference {
         }
         return res;
     }
+    
+    /*
+     * Returns the position of the next element in the list starting from @{code fromIndex} which is a comment (Ignoring spaces)
+     * or -1 if it's not a comment.
+     */
+    private int posOfNextComment(int fromIndex, List<TextElement> elements) {
+        if (!isValidIndex(fromIndex, elements))
+            return -1;
+        ReadOnlyListIterator<TextElement> iterator = new ReadOnlyListIterator(elements, fromIndex);
+        // search for the next consecutive space characters
+        while (iterator.hasNext()) {
+            TextElement element = iterator.next();
+            if (element.isSpaceOrTab()) {
+                continue;
+            }
+            if (element.isComment()) {
+            	return iterator.index();
+            }
+            break;
+        }
+        return -1;
+    }
+    
+    /*
+     * Returns true if the next element in the list (starting from @{code fromIndex}) is a comment
+     */
+    private boolean isFollowedByComment(int fromIndex, List<TextElement> elements) {
+    	return posOfNextComment(fromIndex, elements) != -1;
+    }
+    
+    /*
+     * Removes all elements in the list starting from @{code fromIndex}) ending to @{code toIndex})
+     */
+    private void removeElements(int fromIndex, int toIndex, List<TextElement> elements) {
+    	if (!(isValidIndex(fromIndex, elements) && isValidIndex(toIndex, elements) && fromIndex <= toIndex))
+            return;
+        ListIterator<TextElement> iterator = elements.listIterator(fromIndex);
+        // removing elements
+        int count = fromIndex;
+        while (iterator.hasNext() && count <= toIndex) {
+        	TextElement element = iterator.next();
+            iterator.remove();
+            count++;
+        }
+    }
+    
+    private boolean isValidIndex(int index, List<?> elements) {
+    	return index >= 0 && index <= elements.size();
+    }
 
     /*
      * Returns the position of the last new line character or -1 if there is no eol in the specified list of TextElement 
@@ -460,6 +509,12 @@ public class Difference {
                             originalElements.remove(originalIndex--);
                         }
                     }
+                }
+                // We need to know if, in the original list of elements, the deleted child node is immediately followed by a comment.
+                // If so, it should also be deleted.
+                if (isFollowedByComment(originalIndex, originalElements)) {
+                	int indexOfNextComment = posOfNextComment(originalIndex, originalElements);
+                	removeElements(originalIndex, indexOfNextComment, originalElements);
                 }
                 diffIndex++;
             }


### PR DESCRIPTION
…ments

Fixes #3441 .
When we delete a child element, we need to check if we should delete the comment associated with this element.
