### PR TITLE
Fix: #3216 LexicalPreservingPrinter add Wrong indentation when removing comments

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -1755,5 +1755,63 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         assertTransformedToString(expectedCode, cu);
 
     }
+    
+    // issue 3216 LexicalPreservingPrinter add Wrong indentation when removing comments
+    @Test
+    void removedIndentationLineCommentsPrinted() {
+		considerCode("public class Foo {\n" +
+    			"  //line \n" +
+    			"  void mymethod() {\n" +
+    			"  }\n" +
+    			"}");
+		String expected =
+				"public class Foo {\n" + 
+		    	"  void mymethod() {\n" +
+		    	"  }\n" +
+		    	"}";
+    	cu.getAllContainedComments().get(0).remove();
+    	System.out.println(LexicalPreservingPrinter.print(cu));
+    	assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
+    
+    // issue 3216 LexicalPreservingPrinter add Wrong indentation when removing comments
+    @Test
+    void removedIndentationBlockCommentsPrinted() {
+    	considerCode("public class Foo {\n" +
+    			"  /*\n" +
+    			"  *Block comment coming through\n" +
+    			"  */\n" +
+    			"  void mymethod() {\n" +
+    			"  }\n" +
+    			"}");
+    	String expected =
+    			"public class Foo {\n" +
+    	    	"  void mymethod() {\n" +
+    	    	"  }\n" +
+    	    	"}";
+    	cu.getAllContainedComments().get(0).remove();
+    	
+    	assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
+    
+ // issue 3216 LexicalPreservingPrinter add Wrong indentation when removing comments
+    @Test
+    void removedIndentationJavaDocCommentsPrinted() {
+        considerCode("public class Foo {\n" +
+                "  /**\n" +
+                "   *JavaDoc comment coming through\n" +
+                "   */\n" +
+                "  void mymethod() {\n" +
+                "  }\n" +
+                "}");
+        String expected =
+        		"public class Foo {\n" +
+                "  void mymethod() {\n" +
+                "  }\n" +
+                "}";
+        cu.getAllContainedComments().get(0).remove();
+
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
@@ -161,7 +161,7 @@ class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPres
     void removingJavadoc() {
         AnnotationMemberDeclaration it = consider("/**Cool this annotation!*/ int foo();");
         assertTrue(it.getJavadocComment().get().remove());
-        assertTransformedToString("@interface AD {  int foo(); }", it.getParentNode().get());
+        assertTransformedToString("@interface AD { int foo(); }", it.getParentNode().get());
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Added.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Added.java
@@ -101,13 +101,13 @@ public class Added implements DifferenceElement {
      */
     @Override
     public DifferenceElement replaceEolTokens(CsmElement lineSeparator) {
-        return isNewLineToken() ? new Added(lineSeparator) : this;
+        return isNewLine() ? new Added(lineSeparator) : this;
     }
 
     /*
      * Return true if the wrapped {@code CsmElement} is a new line token
      */
-    private boolean isNewLineToken() {
+    public boolean isNewLine() {
         return isToken() && ((CsmToken) element).isNewLine();
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -130,7 +130,7 @@ public class LexicalPreservingPrinter {
                 Optional<Node> parentNode = observedNode.getParentNode();
                 NodeText nodeText = parentNode.map(parent -> getOrCreateNodeText(parentNode.get())).// We're at the root node.
                 orElse(getOrCreateNodeText(observedNode));
-                if (oldValue == null) {
+                if (oldValue == null) { // this case corresponds to the addition of a comment
                     int index = parentNode.isPresent() ? // Find the position of the comment node and put in front of it the [...]
                     nodeText.findChild(observedNode) : // 
                     0;
@@ -139,18 +139,23 @@ public class LexicalPreservingPrinter {
                     LineSeparator lineSeparator = observedNode.getLineEndingStyleOrDefault(LineSeparator.SYSTEM);
                     nodeText.addElement(index, makeCommentToken((Comment) newValue));
                     nodeText.addToken(index + 1, eolTokenKind(lineSeparator), lineSeparator.asRawString());
-                } else if (newValue == null) {
+                } else if (newValue == null) { // this case corresponds to a deletion of a comment
                     if (oldValue instanceof Comment) {
                         if (((Comment) oldValue).isOrphan()) {
                             nodeText = getOrCreateNodeText(observedNode);
                         }
                         int index = getIndexOfComment((Comment) oldValue, nodeText);
                         nodeText.removeElement(index);
-                        if (nodeText.getElements().get(index).isNewline()) {
-                            nodeText.removeElement(index);
+                        if (isCompleteLine(nodeText.getElements(), index)) {
+                        	removeAllExtraCharacters(nodeText.getElements(), index);
+                        } else {
+                        	removeAllExtraCharactersStartingFrom(nodeText.getElements().listIterator(index));
                         }
+//                        if (nodeText.getElements().get(index).isNewline()) {
+//                            nodeText.removeElement(index);
+//                        }
                     } else {
-                        throw new UnsupportedOperationException();
+                        throw new UnsupportedOperationException("Trying to remove something that is not a comment!");
                     }
                 } else {
                     List<TokenTextElement> matchingTokens = findTokenTextElementForComment((Comment) oldValue, nodeText);
@@ -168,7 +173,68 @@ public class LexicalPreservingPrinter {
             }
             LEXICAL_DIFFERENCE_CALCULATOR.calculatePropertyChange(nodeText, observedNode, property, oldValue, newValue);
         }
+        
+        private boolean isCompleteLine(List<TextElement> elements , int index) {
+        	if (index <= 0 || index >= elements.size()) return false;
+        	boolean isCompleteLine=true;
+        	ListIterator<TextElement> iterator = elements.listIterator(index);
+        	// verify if elements after the index are only spaces or tabs 
+        	while(iterator.hasNext()) {
+        		TextElement textElement = iterator.next();
+        		if (textElement.isNewline()) break;
+        		if (textElement.isSpaceOrTab()) continue;
+        		isCompleteLine=false;
+        		break;
+        	}
+        	// verify if elements before the index are only spaces or tabs 
+        	iterator = elements.listIterator(index);
+        	while(iterator.hasPrevious() && isCompleteLine) {
+        		TextElement textElement = iterator.previous();
+        		if (textElement.isNewline()) break;
+        		if (textElement.isSpaceOrTab()) continue;
+        		isCompleteLine=false;
+        	}
+        	
+        	return isCompleteLine;
+        }
+        
+        private void removeAllExtraCharacters(List<TextElement> elements , int index) {
+        	if (index < 0 || index >= elements.size()) return;
+        	removeAllExtraCharactersStartingFrom(elements.listIterator(index));
+        	removeAllExtraCharactersBeforePosition(elements.listIterator(index));
+        }
 
+        /*
+         * Removes all spaces,tabs characters before this position
+         */
+		private void removeAllExtraCharactersBeforePosition(ListIterator<TextElement> iterator) {
+        	while(iterator.hasPrevious()) {
+        		TextElement textElement = iterator.previous();
+        		if (textElement.isSpaceOrTab()) {
+        			iterator.remove();
+        			continue;
+        		}
+        		break;
+        	}
+		}
+
+		/*
+		 * Removes all spaces,tabs or new line characters starting from this position
+		 */
+		private void removeAllExtraCharactersStartingFrom(ListIterator<TextElement> iterator) {
+        	while(iterator.hasNext()) {
+        		TextElement textElement = iterator.next();
+        		if (textElement.isSpaceOrTab()) {
+        			iterator.remove();
+        			continue;
+        		}
+        		if (textElement.isNewline()) {
+        			iterator.remove();
+        		}
+        		break;
+        	}
+		}
+        
         private TokenTextElement makeCommentToken(Comment newComment) {
             if (newComment.isJavadocComment()) {
                 return new TokenTextElement(JAVADOC_COMMENT, "/**" + newComment.getContent() + "*/");

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/RemovedGroup.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/RemovedGroup.java
@@ -159,7 +159,7 @@ final class RemovedGroup implements Iterable<Removed> {
             }
         } else if (startElement.isToken()) {
             CsmToken token = (CsmToken) startElement.getElement();
-            if (TokenTypes.isEndOfLineToken(token.getTokenType())) {
+            if (token.isNewLine()) {
                 hasOnlyWhitespace = true;
             }
         }


### PR DESCRIPTION
Fixes #3216 .
Fixed support for comment deletion especially when the comment appears on a separate line
