### PR TITLE
Fix: #3725 JavaParserFacade var type in for-each loop cannot be resolved

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
@@ -179,4 +179,72 @@ class JavaParserFacadeResolutionTest extends AbstractResolutionTest {
         assertTrue(resolvedType.isReferenceType());
         assertEquals(clazz.getCanonicalName(), resolvedType.asReferenceType().getQualifiedName());
     }
+
+    // See issue 3725
+    @Test
+    void resolveVarTypeInForEachLoopFromArrayExpression() {
+        String sourceCode = "" +
+                "import java.util.Arrays;\n" +
+                "\n" +
+                "public class Main {\n" +
+                "    public static void main(String[] args) {\n" +
+                "        for (var s:args) {\n" +
+                "            s.hashCode();\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+
+        Expression toStringCallScope = scopeOfFirstHashCodeCall(sourceCode);
+
+        // Before fixing the bug the next line failed with
+        // "java.lang.IllegalStateException: Cannot resolve `var` which has no initializer."
+        ResolvedType resolvedType = toStringCallScope.calculateResolvedType();
+
+        assertEquals("java.lang.String", resolvedType.describe());
+    }
+
+    // See issue 3725
+    @Test
+    void resolveVarTypeInForEachLoopFromIterableExpression() {
+        String sourceCode = "" +
+                "import java.util.Arrays;\n" +
+                "\n" +
+                "public class Main {\n" +
+                "    public static void main(String[] args) {\n" +
+                "        for (var s: Arrays.asList(args)) {\n" +
+                "            s.hashCode();\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+
+        Expression toStringCallScope = scopeOfFirstHashCodeCall(sourceCode);
+
+        // Before fixing the bug the next line failed with
+        // "java.lang.IllegalStateException: Cannot resolve `var` which has no initializer."
+        ResolvedType resolvedType = toStringCallScope.calculateResolvedType();
+
+        assertEquals("java.lang.String", resolvedType.describe());
+    }
+
+    /**
+     * Private helper method that returns the scope of the first
+     * {@code hashCode} method call in the given sourceCode.
+     * <p>
+     * The sourceCode is processed with a Java 15 parser and a
+     * ReflectionTypeSolver.
+     */
+    private static Expression scopeOfFirstHashCodeCall(String sourceCode) {
+        // Parse the source code with Java 15 (and ReflectionTypeSolver)
+        JavaSymbolSolver symbolResolver =
+                new JavaSymbolSolver(new ReflectionTypeSolver());
+        JavaParser parser = new JavaParser(new ParserConfiguration()
+                .setSymbolResolver(symbolResolver)
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_15));
+        CompilationUnit cu = parser.parse(sourceCode).getResult().get();
+
+        MethodCallExpr toStringCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(mce -> mce.getNameAsString().equals("hashCode"))
+                .findFirst().get();
+        return toStringCall.getScope().get();
+    }
 }


### PR DESCRIPTION
Before this fix it was not possible to resolve the type of the variable used in a for-each loop when the type of the variable was defined as `var`. This was because the original code only took care of the `var with initializer` case (e.g. `var i = "hello";`).

The fix now also covers the usage of a `var` in a for-each loop, e.g. as in `for (var s: names) {...}`. The expression at the right side of the `:` must either be an array or an Iterable.

The bug was originally reported in https://github.com/javaparser/javaparser/issues/3725

Fixes #3725 .
