### PR TITLE
Fix: #3195 Resolved methods in outer classes not inferred correcly

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
@@ -52,6 +52,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.resolution.types.ResolvedVoidType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.javaparser.Navigator;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.MethodCallExprContext;
 import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver;
@@ -191,5 +192,28 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
 		}
 
 		assertEquals(0, errorCount, "Expected zero UnsolvedSymbolException s");
+	}
+	
+	@Test
+	void solveVariadicStaticGenericMethodCallCanInferFromArguments() {
+		ParserConfiguration config = new ParserConfiguration()
+				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
+		StaticJavaParser.setConfiguration(config);
+		MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", "variadicStaticGenericMethod");
+
+		ResolvedType resolvedType = methodCallExpr.calculateResolvedType();
+        assertEquals("java.lang.String", resolvedType.describe());
+	}
+	
+	// Related to issue #3195
+	@Test
+	void solveVariadicStaticGenericMethodCallCanInferFromArguments2() {
+		ParserConfiguration config = new ParserConfiguration()
+				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
+		StaticJavaParser.setConfiguration(config);
+		MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", "asList");
+
+		ResolvedType resolvedType = methodCallExpr.calculateResolvedType();
+        assertEquals("java.util.List<java.lang.String>", resolvedType.describe());
 	}
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/MethodCalls.java.txt
@@ -1,4 +1,5 @@
 import java.util.List;
+import java.util.Arrays;
 import java.lang.Class;
 
 class MethodCalls {
@@ -65,6 +66,8 @@ class MethodCalls {
 
     static <T> T staticGenericMethod0() { return null; }
     static <T> T staticGenericMethod1(T x) { return x; }
+    
+    static <T> T variadicStaticGenericMethod(T... x) { return null; }
 
     static class GenericClass<T> {}
 
@@ -78,5 +81,9 @@ class MethodCalls {
         MethodCalls.staticGenericMethod1("Hello");
 
         MethodCalls.variadicWithGenericArg(1, new GenericClass<Long>());
+        
+        MethodCalls.variadicStaticGenericMethod("Hello1", "Hello2");
+        
+        Arrays.asList("Hello1", "Hello2");
     }
 }


### PR DESCRIPTION
Fixes #3195 .
It is not certain that this correction corrects all the cases but it makes the resolution of the generic type a little more reliable.
