### PR TITLE
Checkstyle configuration tweaks

### DIFF
--- a/dev-files/JavaParser-CheckStyle.xml
+++ b/dev-files/JavaParser-CheckStyle.xml
@@ -28,11 +28,6 @@
 			<property name="severity" value="warning" />
 		</module>
 
-		<!-- Avoid star import -->
-		<module name="AvoidStarImport">
-			<property name="severity" value="warning" />
-		</module>
-
 		<!-- Import order -->
 		<module name="CustomImportOrder">
 			<property name="customImportOrderRules"

--- a/dev-files/JavaParser-CheckStyle.xml
+++ b/dev-files/JavaParser-CheckStyle.xml
@@ -31,8 +31,11 @@
 		<!-- Import order -->
 		<module name="CustomImportOrder">
 			<property name="customImportOrderRules"
-			          value="THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC"/>
-			<property name="sortImportsInGroupAlphabetically" value="true"/>
+			          value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/>
+			<property name="specialImportsRegExp" value="^javax\."/>
+			<property name="standardPackageRegExp" value="^java\."/>
+			<property name="sortImportsInGroupAlphabetically" value="false"/>
+			<property name="separateLineBetweenGroups" value="false"/>
 			<property name="severity" value="warning" />
 		</module>
 


### PR DESCRIPTION
This PR tweaks checkstyle, by removing the warning from star imports and by removing the imposition to order imports alphabetically. 