### PR TITLE
Fix: update codecov setting to not fail ci on error

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -88,7 +88,7 @@ jobs:
         timeout-minutes: 10
         with:
           files: javaparser-core-testing/target/site/jacoco/jacoco.xml,javaparser-core-testing-bdd/target/site/jacoco/jacoco.xml
-          fail_ci_if_error: true # optional (default = false) -- fail the build if upload to codecov.io fails
+          fail_ci_if_error: false # optional (default = false) -- fail the build if upload to codecov.io fails
           verbose: false # optional (default = false):
           flags: javaparser-core,AlsoSlowTests,${{ matrix.os }},jdk-${{ matrix.jdk }}
           env_vars: OS,JDK
@@ -98,7 +98,7 @@ jobs:
         timeout-minutes: 10
         with:
           file: javaparser-symbol-solver-testing/target/site/jacoco/jacoco.xml
-          fail_ci_if_error: true # optional (default = false) -- fail the build if upload to codecov.io fails
+          fail_ci_if_error: false # optional (default = false) -- fail the build if upload to codecov.io fails
           verbose: false # optional (default = false):
           flags: javaparser-symbol-solver,AlsoSlowTests,${{ matrix.os }},jdk-${{ matrix.jdk }}
           env_vars: OS,JDK


### PR DESCRIPTION
To avoid having errors related to codecov during builds we have disabled the fail_ci_if_error attribute by hearing that the following issue is resolved.
https://github.com/codecov/codecov-action/issues/678
