### PR TITLE
feat: Implement addRecord & getRecordByName for CompilationUnit

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
@@ -22,6 +22,7 @@
 package com.github.javaparser.builders;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -37,6 +38,7 @@ import java.util.Map;
 
 import static com.github.javaparser.StaticJavaParser.parseImport;
 import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
+import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -252,8 +254,9 @@ class CompilationUnitBuildersTest {
   }
 
   @Test
-  void testAddRecord() {
-    RecordDeclaration myRecordDeclaration = cu.addRecord("test");
+  void testAddTypeWithRecordDeclaration() {
+    RecordDeclaration myRecordDeclaration = new RecordDeclaration(Modifier.createModifierList(PUBLIC), "test");
+    cu.addType(myRecordDeclaration);
     assertEquals(1, cu.getTypes().size());
     assertEquals("test", cu.getType(0).getNameAsString());
     assertTrue(myRecordDeclaration.isPublic());
@@ -283,6 +286,7 @@ class CompilationUnitBuildersTest {
 
   @Test
   void testGetRecordByName() {
-    assertEquals(cu.addRecord("test"), cu.getRecordByName("test").get());
+    assertEquals(cu.addType(new RecordDeclaration(Modifier.createModifierList(), "test")).getType(0),
+            cu.getRecordByName("test").get());
   }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.expr.Name;
 import org.junit.jupiter.api.Test;
 
@@ -251,6 +252,16 @@ class CompilationUnitBuildersTest {
   }
 
   @Test
+  void testAddRecord() {
+    RecordDeclaration myRecordDeclaration = cu.addRecord("test");
+    assertEquals(1, cu.getTypes().size());
+    assertEquals("test", cu.getType(0).getNameAsString());
+    assertTrue(myRecordDeclaration.isPublic());
+    assertTrue(myRecordDeclaration.isFinal());
+    assertEquals(RecordDeclaration.class, cu.getType(0).getClass());
+  }
+
+  @Test
   void testGetClassByName() {
     assertEquals(cu.addClass("test"), cu.getClassByName("test").get());
   }
@@ -268,5 +279,10 @@ class CompilationUnitBuildersTest {
   @Test
   void testGetAnnotationDeclarationByName() {
     assertEquals(cu.addAnnotationDeclaration("test"), cu.getAnnotationDeclarationByName("test").get());
+  }
+
+  @Test
+  void testGetRecordByName() {
+    assertEquals(cu.addRecord("test"), cu.getRecordByName("test").get());
   }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -21,10 +21,7 @@
 package com.github.javaparser.ast;
 
 import com.github.javaparser.*;
-import com.github.javaparser.ast.body.AnnotationDeclaration;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.EnumDeclaration;
-import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.Name;
@@ -525,6 +522,29 @@ public class CompilationUnit extends Node {
     }
 
     /**
+     * Add a public record to the types of this compilation unit
+     *
+     * @param name the record name
+     * @return the newly created record
+     */
+    public RecordDeclaration addRecord(String name) {
+        return addRecord(name, Modifier.Keyword.PUBLIC);
+    }
+
+    /**
+     * Add a record to the types of this compilation unit
+     *
+     * @param name the record name
+     * @param modifiers the modifiers (like {@link Modifier.Keyword#PUBLIC})
+     * @return the newly created record
+     */
+    public RecordDeclaration addRecord(String name, Modifier.Keyword... modifiers) {
+        RecordDeclaration recordDeclaration = new RecordDeclaration(createModifierList(modifiers), name);
+        getTypes().add(recordDeclaration);
+        return recordDeclaration;
+    }
+
+    /**
      * Try to get a top level class declaration by its name
      *
      * @param className the class name (case-sensitive)
@@ -584,6 +604,15 @@ public class CompilationUnit extends Node {
      */
     public Optional<AnnotationDeclaration> getAnnotationDeclarationByName(String annotationName) {
         return getTypes().stream().filter(type -> type.getNameAsString().equals(annotationName) && type instanceof AnnotationDeclaration).findFirst().map(t -> (AnnotationDeclaration) t);
+    }
+
+    /**
+     * Try to get a top level record declaration by its name
+     *
+     * @param recordName the enum name (case-sensitive)
+     */
+    public Optional<RecordDeclaration> getRecordByName(String recordName) {
+        return getTypes().stream().filter(type -> type.getNameAsString().equals(recordName) && type instanceof RecordDeclaration).findFirst().map(t -> (RecordDeclaration) t);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -522,29 +522,6 @@ public class CompilationUnit extends Node {
     }
 
     /**
-     * Add a public record to the types of this compilation unit
-     *
-     * @param name the record name
-     * @return the newly created record
-     */
-    public RecordDeclaration addRecord(String name) {
-        return addRecord(name, Modifier.Keyword.PUBLIC);
-    }
-
-    /**
-     * Add a record to the types of this compilation unit
-     *
-     * @param name the record name
-     * @param modifiers the modifiers (like {@link Modifier.Keyword#PUBLIC})
-     * @return the newly created record
-     */
-    public RecordDeclaration addRecord(String name, Modifier.Keyword... modifiers) {
-        RecordDeclaration recordDeclaration = new RecordDeclaration(createModifierList(modifiers), name);
-        getTypes().add(recordDeclaration);
-        return recordDeclaration;
-    }
-
-    /**
      * Try to get a top level class declaration by its name
      *
      * @param className the class name (case-sensitive)


### PR DESCRIPTION
Hi there,

while working on a project, I noticed missing implementations for `getRecordByName` and `addRecord`. I added their implementations and some simple tests for the implementations (similar to the existing ones for enum, etc.).

Let me know if something could be improved or is missing.