### PR TITLE
fix #3859: UnsupportedOperationException when trying to resolve a type in an argument

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/EnclosedExpr.java
@@ -159,4 +159,16 @@ public class EnclosedExpr extends Expression {
     public boolean isPolyExpression() {
         return getInner().isPolyExpression();
     }
+
+    /**
+     * Returns {@code expression} when it is not an {@link EnclosedExpr},
+     * otherwise the first non-{@link EnclosedExpr} following the "inner" path
+     * of the {@link EnclosedExpr} {@code expression}.
+     */
+    public static Expression ensureNonEnclosedExpression(Expression expression) {
+        while (expression instanceof EnclosedExpr) {
+            expression = ((EnclosedExpr) expression).getInner();
+        }
+        return expression;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -46,6 +46,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static com.github.javaparser.ast.expr.EnclosedExpr.ensureNonEnclosedExpression;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -337,7 +338,7 @@ public class MethodCallExpr extends Expression implements NodeWithTypeArguments<
     @Override
     public boolean isPolyExpression() {
         // A method invocation expression is a poly expression if all of the following are true:
-        // 
+        //
         // 1. The invocation appears in an assignment context or an invocation context (§5.2, §5.3).
         if (!(appearsInAssignmentContext() || appearsInInvocationContext())) {
             return false;
@@ -382,4 +383,24 @@ public class MethodCallExpr extends Expression implements NodeWithTypeArguments<
     protected boolean isInvocationContext() {
         return true;
     }
+
+    /**
+     * Returns the position(/index) of the {@code node} as an argument in
+     * this {@link MethodCallExpr}.
+     * <p>
+     * Throws an {@link IllegalArgumentException} when the {@code node} is not
+     * an argument in this {@link MethodCallExpr}.
+     */
+    public int argumentPosition(Node argument) {
+        int i = 0;
+        for (Expression p : getArguments()) {
+            p = ensureNonEnclosedExpression(p);
+            if (p == argument) {
+                return i;
+            }
+            i++;
+        }
+        throw new IllegalArgumentException();
+    }
+
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/CommonValidators.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/CommonValidators.java
@@ -31,6 +31,8 @@ import com.github.javaparser.ast.validator.Validators;
 import com.github.javaparser.metamodel.NodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 
+import static com.github.javaparser.ast.expr.EnclosedExpr.ensureNonEnclosedExpression;
+
 /**
  * Contains validations that are valid for every Java version.
  */
@@ -48,9 +50,7 @@ public class CommonValidators extends Validators {
         }), new SingleNodeTypeValidator<>(AssignExpr.class, (n, reporter) -> {
             // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26
             Expression target = n.getTarget();
-            while (target instanceof EnclosedExpr) {
-                target = ((EnclosedExpr) target).getInner();
-            }
+            target = ensureNonEnclosedExpression(target);
             if (target instanceof NameExpr || target instanceof ArrayAccessExpr || target instanceof FieldAccessExpr) {
                 return;
             }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/Navigator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/Navigator.java
@@ -24,6 +24,7 @@ package com.github.javaparser.resolution;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.SimpleName;
@@ -145,6 +146,18 @@ public final class Navigator {
 
     public static Node demandParentNode(Node node) {
         return node.getParentNode().orElseThrow(() -> new IllegalStateException("Parent not found, the node does not appear to be inserted in a correct AST"));
+    }
+
+    /**
+     * Same as {@link #demandParentNode(Node)} but it will skip any
+     * {@link EnclosedExpr} in the parent path.
+     */
+    public static Node demandParentNodeSkipEnclosedExprs(Node node) {
+        Node parent = node;
+        do {
+            parent = demandParentNode(parent);
+        } while (parent instanceof EnclosedExpr);
+        return parent;
     }
 
     public static ReturnStmt demandReturnStmt(MethodDeclaration method) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -50,6 +50,7 @@ import com.github.javaparser.utils.Log;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.github.javaparser.ast.expr.EnclosedExpr.ensureNonEnclosedExpression;
 import static com.github.javaparser.resolution.Navigator.demandParentNode;
 import static com.github.javaparser.resolution.model.SymbolReference.solved;
 import static com.github.javaparser.resolution.model.SymbolReference.unsolved;
@@ -71,7 +72,7 @@ public class JavaParserFacade {
     private static final Map<TypeSolver, JavaParserFacade> instances = new WeakHashMap<>();
 
     private static final String JAVA_LANG_STRING = String.class.getCanonicalName();
-    
+
     /**
      * Note that the addition of the modifier {@code synchronized} is specific and directly in response to issue #2668.
      * <br>This <strong>MUST NOT</strong> be misinterpreted as a signal that JavaParser is safe to use within a multi-threaded environment.
@@ -242,6 +243,7 @@ public class JavaParserFacade {
                                 List<LambdaArgumentTypePlaceholder> placeholders) {
         int i = 0;
         for (Expression parameterValue : args) {
+            parameterValue = ensureNonEnclosedExpression(parameterValue);
             if (parameterValue.isLambdaExpr() || parameterValue.isMethodReferenceExpr()) {
                 LambdaArgumentTypePlaceholder placeholder = new LambdaArgumentTypePlaceholder(i);
                 argumentTypes.add(placeholder);
@@ -704,7 +706,7 @@ public class JavaParserFacade {
      * @param clazz The class to be converted.
      *
      * @return The class resolved.
-     * 
+     *
      * @deprecated instead consider SymbolSolver.classToResolvedType(Class<?> clazz)
      */
     @Deprecated

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3859Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3859Test.java
@@ -1,0 +1,59 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3859Test extends AbstractResolutionTest {
+
+    @Test
+    void test() {
+        String code = "import java.util.function.Consumer;\n" +
+                "\n" +
+                "class Demo {\n" +
+                "    void foo(Consumer<String> arg) {}\n" +
+                "    void print(Object arg) {}\n" +
+                "    public void bar() {\n" +
+                "        foo(s->{s;});\n" +
+                "    }\n" +
+                "    public void baz() {\n" +
+                "        foo((s->{s;}));\n" +
+                "    }\n" +
+                "}\n";
+        ParserConfiguration configuration = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver())));
+        StaticJavaParser.setConfiguration(configuration);
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        List<LambdaExpr> lambdas = cu.findAll(LambdaExpr.class);
+        assertEquals(2, lambdas.size());
+        assertEquals("java.util.function.Consumer<java.lang.String>",
+                lambdas.get(0).calculateResolvedType().describe());
+        // Before the fix the following statement failed with an
+        // `UnsupportedOperationException` because an extra `(...)` around
+        // an argument wasn't handled.
+        assertEquals("java.util.function.Consumer<java.lang.String>",
+                lambdas.get(1).calculateResolvedType().describe());
+
+        List<NameExpr> exprs = cu.findAll(NameExpr.class);
+        assertEquals(2, exprs.size());
+        assertEquals("? super java.lang.String",
+                exprs.get(0).calculateResolvedType().describe());
+        // Before the fix the following statement failed with an
+        // `UnsupportedOperationException` because an extra `(...)` around
+        // an argument wasn't handled.
+        assertEquals("? super java.lang.String",
+                exprs.get(1).calculateResolvedType().describe());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>
-                <version>4.6.1</version>
+                <version>5.0.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION

includes:
- extract and reuse EnclosedExpr#ensureNonEnclosedExpression(Expression)
- add and use Navigator#demandParentNodeSkipEnclosedExprs(Node)
- add MethodCallExpr#argumentPosition(Node), substituting the helper
  method LambdaExprContext#pos(...) and parts of the helper method
  TypeExtractor#getParamPos(Node)

https://github.com/javaparser/javaparser/issues/3859