### PR TITLE
Fix: issue 3866 Symbol solver is unable to resolve inner classes of ancestors when they are prefixed with a subclass

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -129,7 +129,8 @@ public class JavaParserTypeDeclarationAdapter {
         }
 
         // Look into extended classes and implemented interfaces
-        ResolvedTypeDeclaration type = checkAncestorsForType(name, this.typeDeclaration);
+        String typeName = isCompositeName(name) ?  innerMostPartOfName(name) : name;
+        ResolvedTypeDeclaration type = checkAncestorsForType(typeName, this.typeDeclaration);
         if (type != null) {
             return SymbolReference.solved(type);
         }
@@ -138,6 +139,14 @@ public class JavaParserTypeDeclarationAdapter {
         return context.getParent()
                 .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
                 .solveType(name, typeArguments);
+    }
+    
+    private boolean isCompositeName(String name) {
+    	return name.indexOf('.') > -1;
+    }
+    
+    private String innerMostPartOfName(String name) {
+    	return isCompositeName(name) ? name.substring(name.lastIndexOf(".")+1) : name;
     }
 
     private <T extends NodeWithTypeArguments<?>> boolean compareTypes(List<? extends Type> types,

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3866Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3866Test.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue3866Test extends AbstractResolutionTest {
+
+	@Test
+	void test() {
+		
+		String code = 
+				"public interface MyActivity {\n"
+				+ "  class MyTimestamps {}\n"
+				+ "    MyTimestamps getTimestamps();\n"
+				+ "  }\n"
+				+ "\n"
+				+ "  public interface MyRichPresence extends MyActivity { }\n"
+				+ "\n"
+				+ "  class MyActivityImpl implements MyActivity {\n"
+				+ "    @Override\n"
+				+ "    public MyActivityImpl.MyTimestamps getTimestamps() {\n"
+				+ "      return timestamps;\n"
+				+ "  }\n"
+				+ "}";
+		
+		final JavaSymbolSolver solver = new JavaSymbolSolver(new ReflectionTypeSolver(false));
+		StaticJavaParser.getParserConfiguration().setSymbolResolver(solver);
+        final CompilationUnit compilationUnit = StaticJavaParser.parse(code);
+
+        final List<String> returnTypes = compilationUnit.findAll(MethodDeclaration.class)
+                .stream()
+                .map(md -> md.resolve())
+                .map(rmd -> rmd.getReturnType().describe())
+                .collect(Collectors.toList());
+
+        returnTypes.forEach(type -> assertEquals("MyActivity.MyTimestamps", type));
+	}
+}


### PR DESCRIPTION

Fixes #3866 .

When the type name is a composite name we have to resolve the inner most type name from ancestors.
