### PR TITLE
Refactor: cleanup/refactor code after fixing #3859

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithArgumentsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithArgumentsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.nodeTypes;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+import org.junit.jupiter.api.Test;
+
+import static com.github.javaparser.ast.expr.Expression.EXCLUDE_ENCLOSED_EXPR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NodeWithArgumentsTest extends AbstractLexicalPreservingTest {
+    
+    @Test
+    void testGetArgumentPosition() {
+        considerCode("" +
+                "class Foo {\n" +
+                "    Map<Integer,String> map = new HashMap<>();\n" +
+                "    public String bar(int i) {\n" +
+                "        return map.put(((i)),((\"baz\")));\n" +
+                "    } \n" +
+                "}");
+        MethodCallExpr mce = cu.findFirst(MethodCallExpr.class).get();
+        Expression arg0 = mce.getArgument(0);
+        Expression arg1 = mce.getArgument(1);
+        Expression innerExpr0 = arg0.asEnclosedExpr().getInner()
+                .asEnclosedExpr().getInner();
+        Expression innerExpr1 = arg1.asEnclosedExpr().getInner()
+                .asEnclosedExpr().getInner();
+        
+        assertEquals(0, mce.getArgumentPosition(arg0)); // with no conversion
+        assertEquals(0, mce.getArgumentPosition(innerExpr0, EXCLUDE_ENCLOSED_EXPR)); // with a conversion skipping EnclosedExprs
+        assertEquals(1, mce.getArgumentPosition(arg1)); // with no conversion
+        assertEquals(1, mce.getArgumentPosition(innerExpr1, EXCLUDE_ENCLOSED_EXPR)); // with a conversion skipping EnclosedExprs
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Expression.java
@@ -33,6 +33,8 @@ import com.github.javaparser.resolution.types.ResolvedType;
 
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
 
@@ -42,7 +44,28 @@ import static com.github.javaparser.utils.CodeGenerationUtils.f;
  * @author Julio Vilmar Gesser
  */
 public abstract class Expression extends Node {
+    
+    /**
+     * Returns {@code true} when the Node to be tested is not an
+     * {@link EnclosedExpr}, {@code false} otherwise.
+     */
+    public static final Predicate<Node> IS_NOT_ENCLOSED_EXPR = n -> !(n instanceof EnclosedExpr);
 
+
+    /**
+     * A {@link Function} that returns its argument (an {@link Expression}) when 
+     * the argument is not an {@link EnclosedExpr}, otherwise the first 
+     * {@link Expression} down the argument's 'inner' path that is not an 
+     * {@link EnclosedExpr}.
+     * 
+     */
+    public static final Function<Expression, Expression> EXCLUDE_ENCLOSED_EXPR = expr -> {
+        while (expr.isEnclosedExpr()) {
+            expr = expr.asEnclosedExpr().getInner();
+        }
+        return expr;
+    };
+    
     @AllFieldsConstructor
     public Expression() {
         this(null);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithArguments.java
@@ -24,6 +24,8 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 
+import java.util.function.Function;
+
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 
 /**
@@ -54,5 +56,29 @@ public interface NodeWithArguments<N extends Node> {
     default N setArgument(int i, Expression arg) {
         getArguments().set(i, arg);
         return (N) this;
+    }
+
+    /*
+     * Returns the position of the argument in the object's argument list.
+     */
+    default int getArgumentPosition(Expression argument) {
+        return getArgumentPosition(argument, expr -> expr);
+    }
+
+    /*
+     * Returns the position of the {@code argument} in the object's argument 
+     * list, after converting the argument using the given {@code converter} 
+     * function.
+     */
+    default int getArgumentPosition(Expression argument, Function<Expression, Expression> converter) {
+        if (argument == null) {
+            throw new IllegalStateException();
+        }
+        for (int i = 0; i < getArguments().size(); i++) {
+            Expression expression = getArguments().get(i);
+            expression = converter.apply(expression);
+            if (expression == argument) return i;
+        }
+        throw new IllegalStateException();
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3859Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3859Test.java
@@ -1,13 +1,10 @@
 package com.github.javaparser.symbolsolver;
 
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -30,11 +27,8 @@ public class Issue3859Test extends AbstractResolutionTest {
                 "        foo((s->print(s)));\n" +
                 "    }\n" +
                 "}\n";
-        ParserConfiguration configuration = new ParserConfiguration()
-                .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver())));
-        StaticJavaParser.setConfiguration(configuration);
-
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = JavaParserAdapter.of(
+                createParserWithResolver(defaultTypeSolver())).parse(code);
 
         List<LambdaExpr> lambdas = cu.findAll(LambdaExpr.class);
         assertEquals(2, lambdas.size());


### PR DESCRIPTION
This commit contains various refactorings following the bug fix for https://github.com/javaparser/javaparser/issues/3859, as discussed in https://github.com/javaparser/javaparser/issues/3859#issuecomment-1402781546 etc.

Brief summary:
- introduce local variables to avoid repeated evaluation of expressions.
- move IS_NOT_ENCLOSED_EXPR to Expression, avoiding code duplication
- add NodeWithArguments#getArgumentPosition (two overloads) and Expression#EXCLUDE_ENCLOSED_EXPR, and use them, avoiding code duplication (in TypeExtractor#getParamPos, LambdaExprContext#pos)
- simplify CompilationUnit parsing (in test code)
- add test code

