### PR TITLE
Fix issue 1883 Finding lambda return type

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/resources/Issue200.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Issue200.java.txt
@@ -1,4 +1,5 @@
 import java.util.List;
+import java.util.stream.Stream;
 
 public class JavaTest {
     class MethodDeclaration {
@@ -16,7 +17,7 @@ public class JavaTest {
             return true;
         }
     }
-    private List<String> foo(MethodDeclaration methodDecl) {
+    private Stream<Solved> foo(MethodDeclaration methodDecl) {
         return methodDecl
                 .getNodesByType(MethodDeclaration.class)
                 .stream()

--- a/javaparser-symbol-solver-testing/src/test/resources/LambdaMulti.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/LambdaMulti.java.txt
@@ -1,32 +1,30 @@
 import java.util.List;
-import java.util.stream.IntStream;
 
 public class Agenda {
 
     private List<String> persons;
 
-    public void lambdaImpliedReturn() {
+    public String lambdaImpliedReturn() {
         return persons.stream().parallel().map(i -> {
             addPerson("");
         }).findFirst().get();
     }
 
-    public void lambdaSingleReturn() {
+    public String lambdaSingleReturn() {
         return persons.stream().parallel().map(i -> {
             return addPerson("");
         }).findFirst().get();
     }
 
-    public void multiLineReturn() {
+    public String multiLineReturn() {
         return persons.stream().parallel().map(i -> {
             int irrelevant;
             return addPerson("");
         }).findFirst().get();
     }
 
-
     String addPerson(String x){
-
+		return x;
     }
 
 }


### PR DESCRIPTION
Fixes #1883 .
When there is multiple return statements in lambda body then the type of the lambda is the smallest type common to all the ancestors of the returned types (least upper bound type).