### PR TITLE
Improved search for functional interfaces

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
@@ -200,8 +200,63 @@ public class MethodUsage implements ResolvedTypeParametrized {
         return sb.toString();
     }
 
+    /**
+     * The erased signature of the method.
+     */
+    public String getErasedSignature() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getName());
+        sb.append("(");
+        for (int i = 0; i < getNoParams(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            ResolvedType type = getParamType(i).erasure();
+            if (type.isArray() && getDeclaration().getParam(i).isVariadic()) {
+                sb.append(type.asArrayType().getComponentType().describe()).append("...");
+            } else {
+                sb.append(type.describe());
+            }
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
     public List<ResolvedType> exceptionTypes() {
         return exceptionTypes;
     }
 
+	/*
+	 * Two methods or constructors, M and N, have the same signature if they have
+	 * the same name, the same type parameters (if any) (§8.4.4), and, after
+	 * adapting the formal parameter types of N to the the type parameters of M, the
+	 * same formal parameter types.
+	 * https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html
+	 * This method returns an approximation of this rule.
+	 */
+    public boolean isSameSignature(MethodUsage otherMethodUsage) {
+    	return getSignature().equals(otherMethodUsage.getSignature());
+    }
+
+    /*
+     * The signature of a method m1 is a subsignature of the signature of a method m2 if either:
+     * m2 has the same signature as m1, or
+     * the signature of m1 is the same as the erasure (§4.6) of the signature of m2.
+     */
+    public boolean isSubSignature(MethodUsage otherMethodUsage) {
+    	return getErasedSignature().equals(otherMethodUsage.getErasedSignature());
+    }
+
+    /*
+     * A method declaration d1 with return type R1 is return-type-substitutable for another method d2 with return type R2 iff any of the following is true:
+     * If R1 is void then R2 is void.
+     * If R1 is a primitive type then R2 is identical to R1.
+     * If R1 is a reference type then one of the following is true:
+     * R1, adapted to the type parameters of d2 (§8.4.4), is a subtype of R2.
+     * R1 can be converted to a subtype of R2 by unchecked conversion (§5.1.9).
+     * d1 does not have the same signature as d2 (§8.4.2), and R1 = |R2|.
+     */
+	public boolean isReturnTypeSubstituable(MethodUsage otherMethodUsage) {
+		return getDeclaration().isReturnTypeSubstituable(otherMethodUsage.getDeclaration().getReturnType());
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
@@ -57,4 +57,34 @@ public interface ResolvedMethodDeclaration extends ResolvedMethodLikeDeclaration
      * Note that the internal forms of the binary names of Thread and Object are used.
      */
     String toDescriptor();
+
+    /*
+     * A method declaration d1 with return type R1 is return-type-substitutable
+     * for another method d2 with return type R2 if any of the following is true:
+     * If R1 is void then R2 is void.
+     * If R1 is a primitive type then R2 is identical to R1.
+     * If R1 is a reference type then one of the following is true:
+     * R1, adapted to the type parameters of d2 (§8.4.4), is a subtype of R2.
+     * R1 can be converted to a subtype of R2 by unchecked conversion (§5.1.9).
+     * d1 does not have the same signature as d2 (§8.4.2), and R1 = |R2|.
+     * TODO: Probably this method needs to refer to a method "isTypeSubstituable" implemented in ResolvedType
+     */
+    default boolean isReturnTypeSubstituable(ResolvedType otherResolvedType) {
+    	ResolvedType returnType = getReturnType();
+    	if (returnType.isVoid()) {
+    		return otherResolvedType.isVoid();
+    	}
+    	if (returnType.isPrimitive()) {
+    		return otherResolvedType.isPrimitive()
+    				&& returnType.asPrimitive().equals(otherResolvedType.asPrimitive());
+    	}
+    	// If R1 is a reference type then one of the following is true:
+
+    	// R1, adapted to the type parameters of d2 (§8.4.4), is a subtype of R2.
+
+    	// R1 can be converted to a subtype of R2 by unchecked conversion (§5.1.9).
+
+    	// d1 does not have the same signature as d2 (§8.4.2), and R1 = |R2|.
+    	throw new UnsupportedOperationException("Return-Type-Substituable must be implemented on reference type.");
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
@@ -24,10 +24,7 @@ package com.github.javaparser.resolution.logic;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.github.javaparser.resolution.MethodUsage;
@@ -73,12 +70,30 @@ public final class FunctionalInterfaceLogic {
                 // Consider the case of Comparator which define equals. It would be considered a functional method.
                 .filter(m -> !isPublicMemberOfObject(m))
                 .collect(Collectors.toSet());
-
-        if (methods.size() == 1) {
-            return Optional.of(methods.iterator().next());
-        } else {
-            return Optional.empty();
+        // TODO a functional interface can have multiple subsignature method with a return-type-substitutable
+        // see https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.8
+        if (methods.size() == 0) {
+        	return Optional.empty();
         }
+        Iterator<MethodUsage> iterator = methods.iterator();
+        MethodUsage methodUsage = iterator.next();
+        if (methods.size() == 1) {
+            return Optional.of(methodUsage);
+        }
+        while (iterator.hasNext()) {
+        	MethodUsage otherMethodUsage = iterator.next();
+        	if (!(methodUsage.isSameSignature(otherMethodUsage)
+        			|| methodUsage.isSubSignature(otherMethodUsage)
+        			|| otherMethodUsage.isSubSignature(methodUsage))) {
+        		methodUsage = null;
+        		break;
+        	}
+        	if (!(methodUsage.isReturnTypeSubstituable(otherMethodUsage))) {
+        		methodUsage = null;
+        		break;
+        	}
+        }
+        return Optional.ofNullable(methodUsage);
     }
 
     public static boolean isFunctionalInterfaceType(ResolvedType type) {

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
@@ -21,11 +21,8 @@
 
 package com.github.javaparser.resolution.logic;
 
-import com.github.javaparser.resolution.MethodUsage;
-import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
-import com.github.javaparser.resolution.types.ResolvedType;
-
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
@@ -33,11 +30,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+
 /**
  * @author Federico Tomassetti
  */
 public final class FunctionalInterfaceLogic {
-    
+
     private static String JAVA_LANG_FUNCTIONAL_INTERFACE = FunctionalInterface.class.getCanonicalName();
 
     private FunctionalInterfaceLogic() {
@@ -70,7 +71,7 @@ public final class FunctionalInterfaceLogic {
                 .filter(m -> m.getDeclaration().isAbstract())
                 // Remove methods inherited by Object:
                 // Consider the case of Comparator which define equals. It would be considered a functional method.
-                .filter(m -> !declaredOnObject(m))
+                .filter(m -> !isPublicMemberOfObject(m))
                 .collect(Collectors.toSet());
 
         if (methods.size() == 1) {
@@ -98,11 +99,12 @@ public final class FunctionalInterfaceLogic {
         return p.getType().getCanonicalName();
     }
 
-    private static List<String> OBJECT_METHODS_SIGNATURES = Arrays.stream(Object.class.getDeclaredMethods())
+    private static List<String> OBJECT_PUBLIC_METHODS_SIGNATURES = Arrays.stream(Object.class.getDeclaredMethods())
+    		.filter(m -> Modifier.isPublic(m.getModifiers()))
             .map(method -> getSignature(method))
             .collect(Collectors.toList());
 
-    private static boolean declaredOnObject(MethodUsage m) {
-        return OBJECT_METHODS_SIGNATURES.contains(m.getDeclaration().getSignature());
+    private static boolean isPublicMemberOfObject(MethodUsage m) {
+        return OBJECT_PUBLIC_METHODS_SIGNATURES.contains(m.getDeclaration().getSignature());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -588,7 +588,7 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
     }
 
     private boolean isJavaObject(ResolvedType rt) {
-        return rt.isReferenceType() && rt.asReferenceType().isJavaLangObject();
+        return rt != null && rt.isReferenceType() && rt.asReferenceType().isJavaLangObject();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -28,7 +28,6 @@ import static com.github.javaparser.resolution.Navigator.demandParentNode;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -557,7 +556,7 @@ public class TypeExtractor extends DefaultVisitorAdapter {
                         		  .map(e -> facade.getType(e))
                         		  .orElse(ResolvedVoidType.INSTANCE))
                                   .collect(Collectors.toSet());
-                	actualType = new LeastUpperBoundLogic().lub(resolvedTypes);
+                	actualType = LeastUpperBoundLogic.of().lub(resolvedTypes);
 
                 } else {
                     actualType = ResolvedVoidType.INSTANCE;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -21,6 +21,11 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
+import static com.github.javaparser.resolution.Navigator.demandParentNode;
+import static java.util.Collections.singletonList;
+
+import java.util.*;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
@@ -36,11 +41,6 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserPatternDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 
-import java.util.*;
-
-import static com.github.javaparser.resolution.Navigator.demandParentNode;
-import static java.util.Collections.singletonList;
-
 /**
  * @author Federico Tomassetti
  */
@@ -52,7 +52,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
     ///
     /// Static methods
     ///
-    
+
     protected static boolean isQualifiedName(String name) {
         return name.contains(".");
     }
@@ -121,7 +121,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             }
         }
         Node notMethodNode = parentNode;
-        // to avoid an infinite loop if parent scope is the same as wrapped node 
+        // to avoid an infinite loop if parent scope is the same as wrapped node
         while (notMethodNode instanceof MethodCallExpr || notMethodNode instanceof FieldAccessExpr
                 || (notMethodNode != null && notMethodNode.hasScope() && getScope(notMethodNode).equals(wrappedNode)) ) {
             notMethodNode = notMethodNode.getParentNode().orElse(null);
@@ -132,8 +132,8 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
         Context parentContext = JavaParserFactory.getContext(notMethodNode, typeSolver);
         return Optional.of(parentContext);
     }
-    
-    // before to call this method verify the node has a scope 
+
+    // before to call this method verify the node has a scope
     protected Node getScope(Node node) {
         return (Node) ((NodeWithOptionalScope)node).getScope().get();
     }
@@ -237,13 +237,15 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                 return result;
             } else if (typeOfScope.isConstraint()) {
                 // TODO: Figure out if it is appropriate to remove the orElseThrow() -- if so, how...
-                return singletonList(
-                        typeOfScope.asConstraintType()
-                                .getBound()
-                                .asReferenceType()
-                                .getTypeDeclaration()
-                                .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty."))
-                );
+            	ResolvedType type = typeOfScope.asConstraintType().getBound();
+            	if (type.isReferenceType()) {
+	                return singletonList(
+	                        type.asReferenceType().getTypeDeclaration()
+	                                .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty."))
+	                );
+            	} else {
+            		throw new UnsupportedOperationException("The type declaration cannot be found on constraint "+ type.describe());
+            	}
             } else if (typeOfScope.isUnionType()) {
                 return typeOfScope.asUnionType().getCommonAncestor()
                         .flatMap(ResolvedReferenceType::getTypeDeclaration)
@@ -268,12 +270,13 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                         .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty."))
         );
     }
-    
+
     /**
      * Similar to solveMethod but we return a MethodUsage.
      * A MethodUsage corresponds to a MethodDeclaration plus the resolved type variables.
      */
-    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
+    @Override
+	public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
         SymbolReference<ResolvedMethodDeclaration> methodSolved = solveMethod(name, argumentsTypes, false);
         if (methodSolved.isSolved()) {
             ResolvedMethodDeclaration methodDeclaration = methodSolved.getCorrespondingDeclaration();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
@@ -21,6 +21,10 @@
 
 package com.github.javaparser.symbolsolver.logic;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
@@ -30,10 +34,6 @@ import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.utils.Pair;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 /**
  * Common ancestor for most types.
  *
@@ -41,6 +41,12 @@ import java.util.Set;
  */
 public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDeclaration {
 
+	/*
+	 * Returns all methods which have distinct "enhanced" signature declared in this type and all members.
+	 * An "enhanced" signature include the return type which is used sometimes to identify functional interfaces.
+	 * This is a different implementation from the previous one which returned all methods which have a distinct
+	 * signature (based on method name and qualified parameter types)
+	 */
     @Override
     public final Set<MethodUsage> getAllMethods() {
         Set<MethodUsage> methods = new HashSet<>();
@@ -50,7 +56,10 @@ public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDe
         for (ResolvedMethodDeclaration methodDeclaration : getDeclaredMethods()) {
             MethodUsage methodUsage = new MethodUsage(methodDeclaration);
             methods.add(methodUsage);
-            methodsSignatures.add(methodUsage.getSignature());
+            String signature = methodUsage.getSignature();
+            String returnType = methodUsage.getDeclaration().getReturnType().describe();
+            String enhancedSignature = String.format("%s %s", returnType, signature);
+            methodsSignatures.add(enhancedSignature);
         }
 
         for (ResolvedReferenceType ancestor : getAllAncestors()) {
@@ -62,8 +71,10 @@ public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDe
                     methodUsage = methodUsage.replaceTypeParameter(p.a, p.b);
                 }
                 String signature = methodUsage.getSignature();
-                if (!methodsSignatures.contains(signature)) {
-                    methodsSignatures.add(signature);
+                String returnType = methodUsage.getDeclaration().getReturnType().describe();
+                String enhancedSignature = String.format("%s %s", returnType, signature);
+                if (!methodsSignatures.contains(enhancedSignature)) {
+                    methodsSignatures.add(enhancedSignature);
                     methods.add(mu);
                 }
             }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
@@ -22,6 +22,12 @@ public class LeastUpperBoundLogic {
 
     private Set<Set<ResolvedType>> lubCache = new HashSet<>();
 
+    public static LeastUpperBoundLogic of() {
+    	return new LeastUpperBoundLogic();
+    }
+
+    private LeastUpperBoundLogic() {}
+
     /**
      * See JLS 4.10.4. Least Upper Bound.
      */

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/TypeHelper.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/TypeHelper.java
@@ -206,7 +206,7 @@ public class TypeHelper {
      * any other shared supertype (that is, no other shared supertype is a subtype of the least upper bound).
      */
     public static ResolvedType leastUpperBound(Set<ResolvedType> types) {
-    	LeastUpperBoundLogic logic = new LeastUpperBoundLogic();
+    	LeastUpperBoundLogic logic = LeastUpperBoundLogic.of();
     	return logic.lub(types);
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
@@ -21,6 +21,13 @@
 
 package com.github.javaparser.symbolsolver;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.resolution.SymbolResolver;
@@ -28,15 +35,9 @@ import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.github.javaparser.utils.CodeGenerationUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public abstract class AbstractSymbolResolutionTest {
-    
+
     @AfterEach
     public void reset() {
         // reset configuration to not potentially disturb others tests.
@@ -45,7 +46,7 @@ public abstract class AbstractSymbolResolutionTest {
     }
 
     @AfterAll
-    public static void tearDown() {
+    static public void tearDown() {
         // clear internal caches
         JavaParserFacade.clearInstances();
     }
@@ -146,11 +147,11 @@ public abstract class AbstractSymbolResolutionTest {
     protected static Path adaptPath(String path) {
         return adaptPath(Paths.get(path));
     }
-    
+
     protected SymbolResolver symbolResolver(TypeSolver typeSolver) {
     	return new JavaSymbolSolver(typeSolver);
     }
-    
+
     protected TypeSolver defaultTypeSolver() {
     	return new ReflectionTypeSolver();
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -21,6 +21,19 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import static com.github.javaparser.StaticJavaParser.parse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.AccessSpecifier;
@@ -47,18 +60,6 @@ import com.github.javaparser.symbolsolver.utils.LeanParserConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static com.github.javaparser.StaticJavaParser.parse;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.*;
 
 class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
 
@@ -90,7 +91,7 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
         string = new ReferenceTypeImpl(ts.solveType(String.class.getCanonicalName()));
         ResolvedReferenceType booleanC = new ReferenceTypeImpl(ts.solveType(Boolean.class.getCanonicalName()));
         listOfBoolean = new ReferenceTypeImpl(ts.solveType(List.class.getCanonicalName()), ImmutableList.of(booleanC));
-        
+
         // init parser
         ParserConfiguration configuration = new ParserConfiguration()
                 .setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
@@ -320,9 +321,9 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
     @Test
     void testGetAncestorsWithTypeParameters() {
         JavaParserClassDeclaration constructorDeclaration = (JavaParserClassDeclaration) typeSolverNewCode.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
-        
+
         List<ResolvedReferenceType> ancestors = constructorDeclaration.getAncestors();
-        
+
         assertEquals(8, ancestors.size());
 
         ResolvedReferenceType ancestor;
@@ -373,15 +374,15 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals("java.lang.Object", ancestors.get(1).getQualifiedName());
         assertEquals("java.io.Serializable", ancestors.get(2).getQualifiedName());
         assertEquals("java.lang.Comparable", ancestors.get(3).getQualifiedName());
-    } 
-        
+    }
+
     @Test
     void testGetAllAncestorsWithTypeParametersWithDepthFirstTraversalOrder() {
         JavaParserClassDeclaration constructorDeclaration = (JavaParserClassDeclaration) typeSolverNewCode.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
-        
+
         List<ResolvedReferenceType> ancestors = constructorDeclaration.getAllAncestors();
         assertEquals(12, ancestors.size());
-        
+
         ResolvedReferenceType ancestor;
 
         ancestor = ancestors.get(0);
@@ -393,7 +394,7 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
 
         ancestor = ancestors.get(2);
         assertEquals("java.lang.Object", ancestor.getQualifiedName());
-        
+
         ancestor = ancestors.get(3);
         assertEquals("java.lang.Cloneable", ancestor.getQualifiedName());
 
@@ -755,6 +756,7 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
                 "com.github.javaparser.ast.nodeTypes.NodeWithAnnotations.isAnnotationPresent(java.lang.Class<? extends java.lang.annotation.Annotation>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithAnnotations.isAnnotationPresent(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.createBody()",
+                "com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.setBody(com.github.javaparser.ast.stmt.BlockStmt)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc.setJavaDocComment(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.addModifier(com.github.javaparser.ast.Modifier...)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isAbstract()",
@@ -768,6 +770,8 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isSynchronized()",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isTransient()",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isVolatile()",
+                "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.setModifiers(java.util.EnumSet<com.github.javaparser.ast.Modifier>)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithName.setName(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(com.github.javaparser.ast.body.Parameter)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(com.github.javaparser.ast.type.Type, java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(java.lang.Class<?>, java.lang.String)",
@@ -779,10 +783,13 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByName(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByType(java.lang.Class<?>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByType(java.lang.String)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithParameters.setParameters(java.util.List<com.github.javaparser.ast.body.Parameter>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.addThrows(com.github.javaparser.ast.type.ReferenceType)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.addThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.String)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.setThrows(java.util.List<com.github.javaparser.ast.type.ReferenceType>)",
+                "java.lang.Object.clone()",
                 "java.lang.Object.finalize()",
                 "java.lang.Object.getClass()",
                 "java.lang.Object.notify()",
@@ -797,8 +804,7 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
         if(TestJdk.getCurrentHostJdk().getMajorVersion() >= 14) {
             expected.remove("java.lang.Object.registerNatives()");
         }
-
-        assertTrue(signatures.size() == expected.size());
+        assertEquals(expected.size(), signatures.size());
         assertThat(signatures, containsInAnyOrder(expected.toArray()));
     }
 
@@ -974,7 +980,7 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
         // Assign "independent" -- Assign to a interface with a completely separate/independent hierarchy tree (up to Object, down to other) -- should be rejected
         assertFalse(compilationUnit.canBeAssignedTo(serializableTypeDeclaration), "CompilationUnit should not be reported as assignable to Serializable");
     }
-    
+
     @Test
     // issue #3436 getAncestors()/getAllAncestors() does not work if base class starts with the same name
     public void getAncestors_with_child_name_is_part_of_ancestor_name() {
@@ -986,7 +992,7 @@ class JavaParserClassDeclarationTest extends AbstractSymbolResolutionTest {
         assertTrue(ancestors.size() == 1);
         assertEquals("FooBase", ancestors.get(0).getQualifiedName());
     }
-    
+
     private List<ResolvedType> declaredTypes(String... lines) {
         CompilationUnit tree = treeOf(lines);
         List<ResolvedType> results = Lists.newLinkedList();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -21,6 +21,18 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.*;
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
@@ -46,17 +58,6 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import com.github.javaparser.symbolsolver.utils.LeanParserConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.*;
 
 class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest implements ResolvedEnumDeclarationTest,
         MethodResolutionCapabilityTest, MethodUsageResolutionCapabilityTest {
@@ -351,11 +352,11 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest implemen
     @Test
     void testGetAllAncestorsWithTypeParametersWithDepthFirstTraversalOrder() {
         JavaParserClassDeclaration constructorDeclaration = (JavaParserClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
-        
+
         List<ResolvedReferenceType> ancestors = constructorDeclaration.getAllAncestors();
-        
+
         assertEquals(12, ancestors.size());
-        
+
         ResolvedReferenceType ancestor;
 
         ancestor = ancestors.get(0);
@@ -367,7 +368,7 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest implemen
 
         ancestor = constructorDeclaration.getAllAncestors().get(2);
         assertEquals("java.lang.Object", ancestor.getQualifiedName());
-        
+
         ancestor = ancestors.get(3);
         assertEquals("java.lang.Cloneable", ancestor.getQualifiedName());
 
@@ -639,6 +640,8 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest implemen
 
         List<String> signatures = sortedMethods.stream().map(m -> m.getQualifiedSignature()).collect(Collectors.toList());
 
+        signatures.stream().forEach(m -> System.out.println(m));
+
         List<String> expected = new ArrayList<>(Arrays.asList(
                 "com.github.javaparser.ast.Node.addOrphanComment(com.github.javaparser.ast.comments.Comment)",
                 "com.github.javaparser.ast.Node.clone()",
@@ -705,6 +708,7 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest implemen
                 "com.github.javaparser.ast.nodeTypes.NodeWithAnnotations.isAnnotationPresent(java.lang.Class<? extends java.lang.annotation.Annotation>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithAnnotations.isAnnotationPresent(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.createBody()",
+                "com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.setBody(com.github.javaparser.ast.stmt.BlockStmt)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc.setJavaDocComment(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.addModifier(com.github.javaparser.ast.Modifier...)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isAbstract()",
@@ -718,6 +722,8 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest implemen
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isSynchronized()",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isTransient()",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isVolatile()",
+                "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.setModifiers(java.util.EnumSet<com.github.javaparser.ast.Modifier>)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithName.setName(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(com.github.javaparser.ast.body.Parameter)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(com.github.javaparser.ast.type.Type, java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(java.lang.Class<?>, java.lang.String)",
@@ -729,10 +735,13 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest implemen
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByName(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByType(java.lang.Class<?>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByType(java.lang.String)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithParameters.setParameters(java.util.List<com.github.javaparser.ast.body.Parameter>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.addThrows(com.github.javaparser.ast.type.ReferenceType)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.addThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.String)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.setThrows(java.util.List<com.github.javaparser.ast.type.ReferenceType>)",
+                "java.lang.Object.clone()",
                 "java.lang.Object.finalize()",
                 "java.lang.Object.getClass()",
                 "java.lang.Object.notify()",

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -21,6 +21,19 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.AccessSpecifier;
@@ -46,18 +59,6 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import com.github.javaparser.symbolsolver.utils.LeanParserConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
 
@@ -354,9 +355,9 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
     @Test
     void testGetAllAncestorsWithTypeParametersWithDepthFirstTraversalOrder() {
         JavaParserClassDeclaration constructorDeclaration = (JavaParserClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
-        
+
         List<ResolvedReferenceType> ancestors = constructorDeclaration.getAllAncestors();
-        
+
         assertEquals(12, ancestors.size());
 
         ResolvedReferenceType ancestor;
@@ -370,7 +371,7 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
 
         ancestor = ancestors.get(2);
         assertEquals("java.lang.Object", ancestor.getQualifiedName());
-        
+
         ancestor = ancestors.get(3);
         assertEquals("java.lang.Cloneable", ancestor.getQualifiedName());
 
@@ -708,6 +709,7 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
                 "com.github.javaparser.ast.nodeTypes.NodeWithAnnotations.isAnnotationPresent(java.lang.Class<? extends java.lang.annotation.Annotation>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithAnnotations.isAnnotationPresent(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.createBody()",
+                "com.github.javaparser.ast.nodeTypes.NodeWithBlockStmt.setBody(com.github.javaparser.ast.stmt.BlockStmt)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithJavaDoc.setJavaDocComment(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.addModifier(com.github.javaparser.ast.Modifier...)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isAbstract()",
@@ -721,6 +723,8 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isSynchronized()",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isTransient()",
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isVolatile()",
+                "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.setModifiers(java.util.EnumSet<com.github.javaparser.ast.Modifier>)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithName.setName(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(com.github.javaparser.ast.body.Parameter)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(com.github.javaparser.ast.type.Type, java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.addAndGetParameter(java.lang.Class<?>, java.lang.String)",
@@ -732,10 +736,13 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByName(java.lang.String)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByType(java.lang.Class<?>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithParameters.getParamByType(java.lang.String)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithParameters.setParameters(java.util.List<com.github.javaparser.ast.body.Parameter>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.addThrows(com.github.javaparser.ast.type.ReferenceType)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.addThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.String)",
+                "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.setThrows(java.util.List<com.github.javaparser.ast.type.ReferenceType>)",
+                "java.lang.Object.clone()",
                 "java.lang.Object.finalize()",
                 "java.lang.Object.getClass()",
                 "java.lang.Object.notify()",

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/logic/FunctionInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/logic/FunctionInterfaceLogicTest.java
@@ -21,6 +21,13 @@
 
 package com.github.javaparser.symbolsolver.logic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.logic.FunctionalInterfaceLogic;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
@@ -28,12 +35,6 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionClassDeclaration;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionInterfaceDeclaration;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
-import org.junit.jupiter.api.Test;
-
-import java.util.function.Consumer;
-import java.util.function.Function;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FunctionInterfaceLogicTest {
 
@@ -59,8 +60,12 @@ class FunctionInterfaceLogicTest {
     void testGetFunctionalMethodWith2AbstractMethodsInHierarcy() {
         TypeSolver typeSolver = new ReflectionTypeSolver();
         ResolvedType function = new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Foo.class, typeSolver));
-        assertEquals(true, FunctionalInterfaceLogic.getFunctionalMethod(function).isPresent());
-        assertEquals("foo", FunctionalInterfaceLogic.getFunctionalMethod(function).get().getName());
+        // By default, all methods in interface are public and abstract until we do not declare it
+        // as default and properties are static and final.
+        // This interface is not fonctional because it inherits two abstract methods
+   	 	// which are not members of Object and the default apply method does not override the abstract apply method
+        // defined in the Function interface.
+        assertEquals(false, FunctionalInterfaceLogic.getFunctionalMethod(function).isPresent());
     }
 
     public static interface Foo<S, T> extends Function<S, T> {
@@ -68,7 +73,7 @@ class FunctionInterfaceLogicTest {
         T foo(S str);
 
         @Override
-        default T apply(S str) {
+		default T apply(S str) {
             return foo(str);
         }
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.StaticJavaParser;
@@ -27,24 +28,32 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 
 	@BeforeEach
 	void setup() throws Exception {
-        CombinedTypeSolver combinedtypeSolver = new CombinedTypeSolver();
-        combinedtypeSolver.add(new ReflectionTypeSolver());
-        typeSolver = combinedtypeSolver;
-    }
+		CombinedTypeSolver combinedtypeSolver = new CombinedTypeSolver();
+		combinedtypeSolver.add(new ReflectionTypeSolver());
+		typeSolver = combinedtypeSolver;
+	}
 
+	/*
+	 * A simple example of a functional interface
+	 */
 	@Test
-	void simleExampleOfFunctionnalInterface() {
+	void simpleExampleOfFunctionnalInterface() {
 		String code = "interface Runnable {\n"
 				+ "    void run();\n"
 				+ "}";
 
 		CompilationUnit cu = StaticJavaParser.parse(code);
 		ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
-		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
 		assertTrue(methodUsage.isPresent());
 	}
 
+	/*
+	 * The following interface is not functional because it declares nothing which
+	 * is not already a member of Object
+	 */
 	@Test
 	void notFunctionalBecauseItDeclaresNothingWhichIsNotAlreadyAMemberOfObject() {
 		String code = "interface NonFunc {\n"
@@ -53,43 +62,56 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 
 		CompilationUnit cu = StaticJavaParser.parse(code);
 		ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
-		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
 		assertFalse(methodUsage.isPresent());
 	}
 
+	/*
+	 * its subinterface can be functional by declaring an abstract method which is
+	 * not a member of Object
+	 */
 	@Test
 	void subinterfaceCanBeFunctionalByDclaringAnAbstractMethodWhichIsNotAMemberOfObject() {
 		String code = "interface NonFunc {\n"
-				+ "    boolean equals(Object obj);\n"
-				+ "}\n"
+				+ "    boolean equals(Object obj);\n" + "}\n"
 				+ "interface Func extends NonFunc {\n"
-				+ "    int compare(String o1, String o2);\n"
-				+ "}";
+				+ "    int compare(String o1, String o2);\n" + "}";
 
 		CompilationUnit cu = StaticJavaParser.parse(code);
 		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Func");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
-		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
 		assertTrue(methodUsage.isPresent());
 	}
 
+	/*
+	 * the well known interface java.util.Comparator<T> is functional because it has
+	 * one abstract non-Object method:
+	 */
 	@Test
-	void  isFunctionalBecauseItHasOneAbstractNonObjectMethod() {
+	void isFunctionalBecauseItHasOneAbstractNonObjectMethod() {
 		String code = "interface Comparator<T> {\n"
 				+ "    boolean equals(Object obj);\n"
-				+ "    int compare(T o1, T o2);\n"
-				+ "}";
+				+ "    int compare(T o1, T o2);\n" + "}";
 
 		CompilationUnit cu = StaticJavaParser.parse(code);
 		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Comparator");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
-		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
 		assertTrue(methodUsage.isPresent());
 	}
 
+	/*
+	 * The following interface is not functional because while it only declares one
+	 * abstract method which is not a member of Object, it declares two abstract
+	 * methods which are not public members of Object:
+	 */
 	@Test
-	void  isNotFunctionalBecauseItDeclaresTwoAbstractMethodsWhichAreNotPublicMembersOfObject() {
+	void isNotFunctionalBecauseItDeclaresTwoAbstractMethodsWhichAreNotPublicMembersOfObject() {
 		String code = "interface Foo {\n"
 				+ "    int m();\n"
 				+ "    Object clone();\n"
@@ -97,9 +119,159 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 
 		CompilationUnit cu = StaticJavaParser.parse(code);
 		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Foo");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
-		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
 		assertFalse(methodUsage.isPresent());
+	}
+
+	/*
+	 * Z is a functional interface because while it inherits two abstract methods
+	 * which are not members of Object, they have the same signature, so the
+	 * inherited methods logically represent a single method:
+	 */
+	@Test
+	void isFunctionalInterfaceBecauseInheritedAbstractMethodsHaveTheSameSignature() {
+		String code = "interface X { int m(Iterable<String> arg); }\n"
+				+ "interface Y { int m(Iterable<String> arg); }\n"
+				+ "interface Z extends X, Y {}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+	}
+
+	/*
+	 * Z is a functional interface in the following interface hierarchy because Y.m
+	 * is a subsignature of X.m and is return-type-substitutable for X.m:
+	 */
+	@Test
+	@Disabled("Return-Type-Substituable must be implemented on reference type")
+	void isFunctionalInterfaceBecauseOfSubsignatureAndSubstitutableReturnType() {
+		String code = "interface X { Iterable m(Iterable<String> arg); }\n"
+				+ "interface Y { Iterable<String> m(Iterable arg); }\n"
+				+ "interface Z extends X, Y {}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+	}
+
+	/*
+	 * the definition of "functional interface" respects the fact that an interface
+	 * may only have methods with override-equivalent signatures if one is
+	 * return-type-substitutable for all the others. Thus, in the following
+	 * interface hierarchy where Z causes a compile-time error, Z is not a
+	 * functional interface: (because none of its abstract members are
+	 * return-type-substitutable for all other abstract members)
+	 */
+	@Test
+	void isNotFunctionalInterfaceBecauseNoneOfItsAbstractMembersAreReturnTypeSubstitutableForAllOtherAbstractMembers() {
+		String code = "interface X { long m(); }\n"
+				+ "interface Y { int m(); }\n"
+				+ "interface Z extends X, Y {}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertFalse(methodUsage.isPresent());
+	}
+
+	/*
+	 * In the following example, the declarations of Foo<T,N> and Bar are legal: in
+	 * each, the methods called m are not subsignatures of each other, but do have
+	 * different erasures. Still, the fact that the methods in each are not
+	 * subsignatures means Foo<T,N> and Bar are not functional interfaces. However,
+	 * Baz is a functional interface because the methods it inherits from
+	 * Foo<Integer,Integer> have the same signature and so logically represent a
+	 * single method.
+	 */
+	@Test
+	void bazIsAFunctionalInterfaceBecauseMethodsItInheritsFromFooHaveTheSameSignature() {
+		String code = "interface Foo<T, N extends Number> {\n"
+				+ "    void m(T arg);\n"
+				+ "    void m(N arg);\n"
+				+ "}\n"
+				+ "interface Bar extends Foo<String, Integer> {}\n"
+				+ "interface Baz extends Foo<Integer, Integer> {}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Baz");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+
+		classOrInterfaceDecl = Navigator.demandInterface(cu, "Bar");
+		resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertFalse(methodUsage.isPresent());
+	}
+
+	@Test
+	void withGenericMethods() {
+		String code = "interface Action<T> {};\n"
+				+ "interface Exec { <T> T execute(Action<T> a); }\n"
+				+ "interface X { <T> T execute(Action<T> a); }\n"
+				+ "interface Y { <S> S execute(Action<S> a); }\n"
+				+ "interface Exec extends X, Y {}\n";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Exec");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+
+	}
+
+	@Test
+	void withGenericMethods2() {
+		String code = "interface Action<T> {};\n"
+				+ "interface Exec { <T> T execute(Action<T> a); }\n"
+				+ "interface X { <T>   T execute(Action<T> a); }\n"
+				+ "interface Y { <S,T> S execute(Action<S> a); }\n"
+				+ "interface Exec extends X, Y {}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Exec");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+
+	}
+
+	/*
+	 * Functional interfaces can be generic, such as
+	 * java.util.function.Predicate<T>. Such a functional interface may be
+	 * parameterized in a way that produces distinct abstract methods - that is,
+	 * multiple methods that cannot be legally overridden with a single declaration.
+	 */
+	@Test
+	@Disabled("Return-Type-Substituable must be implemented on reference type.")
+	void genericFunctionalInterfaces() {
+		String code = "interface I    { Object m(Class c); }\r\n"
+				+ "interface J<S> { S m(Class<?> c); }\r\n"
+				+ "interface K<T> { T m(Class<?> c); }\r\n"
+				+ "interface Functional<S,T> extends I, J<S>, K<T> {}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Functional");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+
 	}
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
@@ -1,0 +1,105 @@
+package com.github.javaparser.symbolsolver.resolution.logic;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.Navigator;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedInterfaceDeclaration;
+import com.github.javaparser.resolution.logic.FunctionalInterfaceLogic;
+import com.github.javaparser.symbolsolver.AbstractSymbolResolutionTest;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserInterfaceDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
+
+	private TypeSolver typeSolver;
+
+	@BeforeEach
+	void setup() throws Exception {
+        CombinedTypeSolver combinedtypeSolver = new CombinedTypeSolver();
+        combinedtypeSolver.add(new ReflectionTypeSolver());
+        typeSolver = combinedtypeSolver;
+    }
+
+	@Test
+	void simleExampleOfFunctionnalInterface() {
+		String code = "interface Runnable {\n"
+				+ "    void run();\n"
+				+ "}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
+		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+	}
+
+	@Test
+	void notFunctionalBecauseItDeclaresNothingWhichIsNotAlreadyAMemberOfObject() {
+		String code = "interface NonFunc {\n"
+				+ "    boolean equals(Object obj);\n"
+				+ "}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
+		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertFalse(methodUsage.isPresent());
+	}
+
+	@Test
+	void subinterfaceCanBeFunctionalByDclaringAnAbstractMethodWhichIsNotAMemberOfObject() {
+		String code = "interface NonFunc {\n"
+				+ "    boolean equals(Object obj);\n"
+				+ "}\n"
+				+ "interface Func extends NonFunc {\n"
+				+ "    int compare(String o1, String o2);\n"
+				+ "}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Func");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
+		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+	}
+
+	@Test
+	void  isFunctionalBecauseItHasOneAbstractNonObjectMethod() {
+		String code = "interface Comparator<T> {\n"
+				+ "    boolean equals(Object obj);\n"
+				+ "    int compare(T o1, T o2);\n"
+				+ "}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Comparator");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
+		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+	}
+
+	@Test
+	void  isNotFunctionalBecauseItDeclaresTwoAbstractMethodsWhichAreNotPublicMembersOfObject() {
+		String code = "interface Foo {\n"
+				+ "    int m();\n"
+				+ "    Object clone();\n"
+				+ "}";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Foo");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
+		Optional<MethodUsage>  methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertFalse(methodUsage.isPresent());
+	}
+
+}


### PR DESCRIPTION
From https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.8

A functional interface is an interface that has just one abstract method (aside from the methods of Object), and thus represents a single function contract. This "single" method may take the form of multiple abstract methods with override-equivalent signatures inherited from superinterfaces; in this case, the inherited methods logically represent a single method.

For an interface I, let M be the set of abstract methods that are members of I that do not have the same signature as any public instance method of the class Object. Then, I is a functional interface if there exists a method m in M for which both of the following are true:

The signature of m is a subsignature ([§8.4.2](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2)) of every method's signature in M.

m is return-type-substitutable ([§8.4.5](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.5)) for every method in M.
