### PR TITLE
Fix: \s escape gives lexical error but should be valid since Java 15

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3577Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3577Test.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ParserConfiguration.LanguageLevel;
+
+public class Issue3577Test {
+
+    @Test
+    public void test() {
+        String str = "public class MyClass {\n"
+        		+ "    public static void main(String args[]) {\n"
+        		+ "      System.out.println(\"Hello\\sWorld\");\n"
+        		+ "    }\n"
+        		+ "}";
+
+        ParserConfiguration config = new ParserConfiguration().setLanguageLevel(LanguageLevel.JAVA_15);
+        StaticJavaParser.setConfiguration(config);
+
+        assertDoesNotThrow(() -> StaticJavaParser.parse(str));
+//        unitOpt.getProblems().stream().forEach(p -> System.err.println(p.toString()));
+    }
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/StringEscapeUtils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/StringEscapeUtils.java
@@ -79,6 +79,7 @@ public final class StringEscapeUtils {
         return UNESCAPE_JAVA_TEXT_BLOCK.translate(input);
     }
 
+    // TODO do we need to integrate /s escape sequence because there is a compilation error?
     private static final LookupTranslator JAVA_CTRL_CHARS_UNESCAPE = new LookupTranslator(new String[][] { { "\\b", "\b" }, { "\\n", "\n" }, { "\\t", "\t" }, { "\\f", "\f" }, { "\\r", "\r" } });
 
     private static final LookupTranslator JAVA_CTRL_CHARS_ESCAPE = new LookupTranslator(new String[][] { { "\b", "\\b" }, { "\n", "\\n" }, { "\t", "\\t" }, { "\f", "\\f" }, { "\r", "\\r" } });

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -632,14 +632,14 @@ TOKEN :
           // starts off with unicode backslash
           ("\\u005" ["c", "C"]
               // regular escape sequences
-              (["n","t","b","r","f","\\","'","\""]
+              (["s","n","t","b","r","f","\\","'","\""]
                   // escapes another unicode backslash
                   | ("\\u005" ["c", "C"])))
        |
           ( // TODO: Could these escape sequences be extracted out?
               "\\"
               (
-                  ["n","t","b","r","f","\\","'","\""]
+                  ["s","n","t","b","r","f","\\","'","\""]
                |
                   ["0"-"7"] ( ["0"-"7"] )?
                |
@@ -705,7 +705,7 @@ TOKEN :
           ( // TODO: Could these escape sequences be extracted out?
               "\\"
               (
-                  ["n","t","b","r","f","\\","'","\""]
+                  ["s","n","t","b","r","f","\\","'","\""]
                |
                   ["0"-"7"] ( ["0"-"7"] )?
                |


### PR DESCRIPTION
Fixes #3577 .
