### PR TITLE
Fix: issue 3918 JavaParserTypeDeclarationAdapter resolving wrong Type via Ancestor

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3866Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3866Test.java
@@ -37,8 +37,8 @@ public class Issue3866Test extends AbstractResolutionTest {
 
 	@Test
 	void test() {
-		
-		String code = 
+
+		String code =
 				"public interface MyActivity {\n"
 				+ "  class MyTimestamps {}\n"
 				+ "    MyTimestamps getTimestamps();\n"
@@ -47,12 +47,13 @@ public class Issue3866Test extends AbstractResolutionTest {
 				+ "  public interface MyRichPresence extends MyActivity { }\n"
 				+ "\n"
 				+ "  class MyActivityImpl implements MyActivity {\n"
+				+ "    MyActivity.MyTimestamps timestamps;\n"
 				+ "    @Override\n"
-				+ "    public MyActivityImpl.MyTimestamps getTimestamps() {\n"
+				+ "    public MyActivity.MyTimestamps getTimestamps() {\n"
 				+ "      return timestamps;\n"
 				+ "  }\n"
 				+ "}";
-		
+
 		final JavaSymbolSolver solver = new JavaSymbolSolver(new ReflectionTypeSolver(false));
 		StaticJavaParser.getParserConfiguration().setSymbolResolver(solver);
         final CompilationUnit compilationUnit = StaticJavaParser.parse(code);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3918Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3918Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue3918Test extends AbstractResolutionTest {
+
+	@Test
+	void test() {
+
+		// class ancestor is defined like this
+		// public class Ancestor {
+	    //   public static class Iterator {}
+		// }
+
+		String code =
+				"import java.util.ArrayList;\n"
+				+ "import java.util.List;\n" + "\n"
+				+ "public class Descendant extends Ancestor {\n"
+				+ "    public void doAThing() {\n"
+				+ "        List<Object> list = new ArrayList<>();\n"
+				+ "        java.util.Iterator<Object> iterator = list.iterator();\n"
+				+ "    }\n"
+				+ "}";
+
+		Path testFile = adaptPath("src/test/resources");
+		CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+		typeSolver.add(new ReflectionTypeSolver());
+		typeSolver.add(new JavaParserTypeSolver(testFile));
+		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(typeSolver)).parse(code);
+
+		Type type = cu
+				.findFirst(Type.class, n -> n.isReferenceType() && n.asReferenceType().asString().startsWith("java.util.Iterator"))
+				.get();
+		ResolvedType resolvedType = type.resolve();
+		assertEquals("java.util.Iterator<java.lang.Object>", resolvedType.describe());
+
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/Ancestor.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/Ancestor.java
@@ -1,0 +1,5 @@
+public class Ancestor {
+    public static class Iterator {
+
+    }
+}


### PR DESCRIPTION
Before looking at extended classes and implemented interfaces we need to ensure that if the type declaration package name is empty, the type is not a composite name or an inner class prefixed by the outer class name

Fixes #3918 .
