### PR TITLE
Fix: issue 3919 An array of primitive type cannot be assigned to an array of object

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
@@ -107,10 +107,6 @@ public class ResolvedArrayType implements ResolvedType {
 		return false;
 	}
 
-    private boolean isJavaLangObject(ResolvedType type) {
-    	return type.isReferenceType() && type.asReferenceType().isJavaLangObject();
-    }
-
     @Override
     public ResolvedType replaceTypeVariables(ResolvedTypeParameterDeclaration tpToReplace, ResolvedType replaced, Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes) {
         ResolvedType baseTypeReplaced = baseType.replaceTypeVariables(tpToReplace, replaced, inferredTypes);

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
@@ -94,11 +94,10 @@ public class ResolvedArrayType implements ResolvedType {
 			if (baseType.isPrimitive() && other.asArrayType().getComponentType().isPrimitive()) {
 				return baseType.equals(other.asArrayType().getComponentType());
 			}
-			// an array of Object is assignable by any array of primitive type
-			// but an array of primitive type is not assignable by an array of boxed type nor the reverse
-			if (!isJavaLangObject(baseType)
-					&& ((baseType.isPrimitive() && other.asArrayType().getComponentType().isReferenceType())
-							|| (baseType.isReferenceType() && other.asArrayType().getComponentType().isPrimitive()))) {
+			// An array of primitive type is not assignable by an array of boxed type nor the reverse
+			// An array of primitive type cannot be assigned to an array of Object
+			if ((baseType.isPrimitive() && other.asArrayType().getComponentType().isReferenceType())
+							|| (baseType.isReferenceType() && other.asArrayType().getComponentType().isPrimitive())) {
 				return false;
 			}
 			// An array can be assigned only to a variable of a compatible array type, or to

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/types/ResolvedArrayTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/types/ResolvedArrayTypeTest.java
@@ -164,6 +164,18 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 		// An array of primitive type cannot be assigned to a Boxed type variable,
 		// because Boxed type is a class type other than Object
 		assertFalse(array(ResolvedPrimitiveType.LONG).isAssignableBy(rLong));
+		assertTrue(array(rObject).isAssignableBy(array(rLong)));
+		assertFalse(array(rObject).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
+	}
+
+	@Test
+	void ArrayOfObjectIsAssignableByArrayOfReference() {
+		assertTrue(array(rObject).isAssignableBy(array(rLong)));
+	}
+
+	@Test
+	void ArrayOfObjectIsNotAssignableByArrayOfPrimitiveType() {
+		assertFalse(array(rObject).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
 	}
 
 	private boolean isAssignableBy(ResolvedType type, ResolvedType... types) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/types/ResolvedArrayTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/types/ResolvedArrayTypeTest.java
@@ -58,7 +58,7 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	@Test
 	// An array of primitive type can be assigned another array of primitive type
 	// if primitive type are the same.
-	void isAssignablePrimitiveType() {
+	void arrayOfPrimitiveIsAssignableByArrayOfSamePrimitiveType() {
 		assertTrue(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
 		assertTrue(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
 		assertTrue(array(ResolvedPrimitiveType.LONG).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
@@ -69,7 +69,7 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	}
 
 	@Test
-	void isNotAssignablePrimitiveType() {
+	void arrayOfPrimitiveIsNotAssignableByArrayOfDifferentPrimitiveType() {
 		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.DOUBLE),
 				arrays(ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG, ResolvedPrimitiveType.INT,
 						ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
@@ -94,7 +94,9 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	}
 
 	@Test
-	void isNotAssignablePrimitiveTypeAndBoxedType() {
+	// An array of primitive type cannot be assigned to a Boxed type variable,
+	// because Boxed type is a class type other than Object
+	void arrayOfPrimitiveIsNotAssignableByArrayOfBoxedType() {
 		assertFalse(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(array(rDouble)));
 		assertFalse(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(array(rFloat)));
 		assertFalse(array(ResolvedPrimitiveType.LONG).isAssignableBy(array(rLong)));
@@ -105,7 +107,7 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	}
 
 	@Test
-	void isAssignableWithNullType() {
+	void arrayOfPrimitiveIsAssignableByNullType() {
 		assertTrue(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(NullType.INSTANCE));
 		assertTrue(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(NullType.INSTANCE));
 		assertTrue(array(ResolvedPrimitiveType.LONG).isAssignableBy(NullType.INSTANCE));
@@ -118,7 +120,7 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	@Test
 	// An array can be assigned only to a variable of a compatible array type, or to
 	// a variable of type Object, Cloneable or java.io.Serializable.
-	void isAssignableWithObject() {
+	void objectIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
 		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
 		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
 		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
@@ -130,7 +132,7 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	}
 
 	@Test
-	void isAssignableWithCloneable() {
+	void cloneableIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
 		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
 		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
 		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
@@ -142,7 +144,7 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	}
 
 	@Test
-	void isAssignableWithSerializable() {
+	void serializableIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
 		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
 		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
 		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
@@ -154,27 +156,22 @@ class ResolvedArrayTypeTest extends AbstractResolutionTest {
 	}
 
 	@Test
-	void isAssignableWithReference() {
+	void arrayOfSubTypeIsAssignableByArrayOfSuperType() {
 		assertTrue(array(rCharSequence).isAssignableBy(array(rString)));
 	}
 
 	@Test
-	void isNotAssignableWithreference() {
+	void arrayOfReferenceIsNotAssignableByArrayOfOtherReference() {
 		assertFalse(array(rString).isAssignableBy(array(rCharSequence)));
-		// An array of primitive type cannot be assigned to a Boxed type variable,
-		// because Boxed type is a class type other than Object
-		assertFalse(array(ResolvedPrimitiveType.LONG).isAssignableBy(rLong));
-		assertTrue(array(rObject).isAssignableBy(array(rLong)));
-		assertFalse(array(rObject).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
 	}
 
 	@Test
-	void ArrayOfObjectIsAssignableByArrayOfReference() {
+	void arrayOfObjectIsAssignableByArrayOfReference() {
 		assertTrue(array(rObject).isAssignableBy(array(rLong)));
 	}
 
 	@Test
-	void ArrayOfObjectIsNotAssignableByArrayOfPrimitiveType() {
+	void arrayOfObjectIsNotAssignableByArrayOfPrimitiveType() {
 		assertFalse(array(rObject).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
 	}
 


### PR DESCRIPTION
Fixes #3919 .
