### PR TITLE
Fix: issue on FunctionalInterfaceLogic but waiting for Return-Type-Su…

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
@@ -81,10 +81,18 @@ public interface ResolvedMethodDeclaration extends ResolvedMethodLikeDeclaration
     	// If R1 is a reference type then one of the following is true:
 
     	// R1, adapted to the type parameters of d2 (§8.4.4), is a subtype of R2.
+    	// Below we are trying to compare a reference type for example an Object to a type variable let's say T
+    	// we can certainly simplify by saying that this is always true.
+    	if (otherResolvedType.isTypeVariable()) {
+    		return true;
+    	}
 
     	// R1 can be converted to a subtype of R2 by unchecked conversion (§5.1.9).
 
     	// d1 does not have the same signature as d2 (§8.4.2), and R1 = |R2|.
+    	if (returnType.describe().equals(otherResolvedType.erasure().describe())) {
+    		return true;
+    	}
     	throw new UnsupportedOperationException("Return-Type-Substituable must be implemented on reference type.");
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
@@ -77,9 +77,6 @@ public final class FunctionalInterfaceLogic {
         }
         Iterator<MethodUsage> iterator = methods.iterator();
         MethodUsage methodUsage = iterator.next();
-        if (methods.size() == 1) {
-            return Optional.of(methodUsage);
-        }
         while (iterator.hasNext()) {
         	MethodUsage otherMethodUsage = iterator.next();
         	if (!(methodUsage.isSameSignature(otherMethodUsage)

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
@@ -217,10 +217,12 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 		assertFalse(methodUsage.isPresent());
 	}
 
+	/*
+	 * Functional: signatures are logically "the same"
+	 */
 	@Test
-	void withGenericMethods() {
+	void withGenericMethodsWithSameSignatures() {
 		String code = "interface Action<T> {};\n"
-				+ "interface Exec { <T> T execute(Action<T> a); }\n"
 				+ "interface X { <T> T execute(Action<T> a); }\n"
 				+ "interface Y { <S> S execute(Action<S> a); }\n"
 				+ "interface Exec extends X, Y {}\n";
@@ -234,10 +236,12 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 
 	}
 
+	/*
+	 * Error: different signatures, same erasure
+	 */
 	@Test
-	void withGenericMethods2() {
+	void withGenericMethodsWithDifferentSignaturesAndSameErasure() {
 		String code = "interface Action<T> {};\n"
-				+ "interface Exec { <T> T execute(Action<T> a); }\n"
 				+ "interface X { <T>   T execute(Action<T> a); }\n"
 				+ "interface Y { <S,T> S execute(Action<S> a); }\n"
 				+ "interface Exec extends X, Y {}";
@@ -258,8 +262,7 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 	 * multiple methods that cannot be legally overridden with a single declaration.
 	 */
 	@Test
-	@Disabled("Return-Type-Substituable must be implemented on reference type.")
-	void genericFunctionalInterfaces() {
+	void genericFunctionalInterfacesWithReturnTypeSubstituable() {
 		String code = "interface I    { Object m(Class c); }\r\n"
 				+ "interface J<S> { S m(Class<?> c); }\r\n"
 				+ "interface K<T> { T m(Class<?> c); }\r\n"
@@ -267,6 +270,24 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 
 		CompilationUnit cu = StaticJavaParser.parse(code);
 		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Functional");
+		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+				typeSolver);
+		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+		assertTrue(methodUsage.isPresent());
+
+	}
+
+	@Test
+	@Disabled("Waiting Return-Type-Substituable is fully implemented on reference type.")
+	void genericFunctionalInterfacesWithGenericParameter() {
+		String code =
+				"    public interface Foo<T> extends java.util.function.Function<String, T> {\n" +
+                "        @Override\n" +
+                "        T apply(String c);\n" +
+                "    }\n";
+
+		CompilationUnit cu = StaticJavaParser.parse(code);
+		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Foo");
 		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
 				typeSolver);
 		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);


### PR DESCRIPTION
…bstituable is fully implemented on reference type

Cases are defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.8
