### PR TITLE
Fix: issue 3949 LexicalPreservingPrinter Ignores Changes to LambdaExp…

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3949Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3949Test.java
@@ -1,0 +1,48 @@
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.BreakStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+
+class Issue3949Test extends AbstractLexicalPreservingTest  {
+
+	@Test
+    public void test() {
+    	considerCode(
+    			"class A {\n"
+    					+ "\n"
+    		            + "  void foo() {\n"
+    		            + "    Consumer<Integer> lambda = a -> System.out.println(a);\n"
+    		            + "  }\n"
+    		            + "}");
+
+    	ExpressionStmt estmt = cu.findAll(ExpressionStmt.class).get(1).clone();
+    	LambdaExpr lexpr = cu.findAll(LambdaExpr.class).get(0);
+        LexicalPreservingPrinter.setup(cu);
+
+        BlockStmt block = new BlockStmt();
+        BreakStmt bstmt = new BreakStmt();
+        block.addStatement(new ExpressionStmt(estmt.getExpression()));
+        block.addStatement(bstmt);
+        lexpr.setBody(block);
+
+        String expected =
+        		"class A {\n"
+        		+ "\n"
+        		+ "  void foo() {\n"
+        		+ "    Consumer<Integer> lambda = a -> {\n"
+        		+ "        System.out.println(a);\n"
+        		+ "        break;\n"
+        		+ "    };\n"
+        		+ "  }\n"
+        		+ "}";
+
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
@@ -20,15 +20,15 @@
  */
 package com.github.javaparser.ast.observer;
 
-import com.github.javaparser.ast.Generated;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.utils.Utils;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+
+import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.utils.Utils;
 
 /**
  * Properties considered by the AstObserver
@@ -287,14 +287,7 @@ public enum ObservableProperty {
     }
 
     public boolean isNullOrNotPresent(Node node) {
-        Object result = getRawValue(node);
-        if (result == null) {
-            return true;
-        }
-        if (result instanceof Optional) {
-            return !((Optional) result).isPresent();
-        }
-        return false;
+    	return Utils.valueIsNullOrEmptyStringOrOptional(getRawValue(node));
     }
 
     public boolean isNullOrEmpty(Node node) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
@@ -39,11 +39,69 @@ public interface Change {
             case IS_EMPTY:
                 return Utils.valueIsNullOrEmpty(getValue(csmConditional.getProperty(), node));
             case IS_PRESENT:
-                return !Utils.valueIsNullOrEmptyStringOrOptional(getValue(csmConditional.getProperty(), node));
+                return !Utils.valueIsNullOrEmptyStringOrOptional(getValue(csmConditional.getProperty(), node))
+                		&& !isEvaluatedOnDerivedProperty(csmConditional.getProperty());
             default:
                 throw new UnsupportedOperationException("" + csmConditional.getProperty() + " " + csmConditional.getCondition());
         }
     }
+
+	/*
+	 * Evaluate on derived property.
+	 *
+	 * Currently the evaluation of the conditions is carried out in relation to the
+	 * presence of value in the attributes of a class but this is not quite correct.
+	 *
+	 * Indeed, there are attributes that are derived. The meaning of a derived
+	 * attribute (annotated with the DerivedProperty annotation) is not very clear.
+	 *
+	 * Assuming that it is an existing attribute and accessible by another property,
+	 * for example this is the case for the EXPRESSION_BODY property which allows
+	 * access to a derived field (which is also accessible by the BODY property).
+	 *
+	 * The 2 properties EXPRESSION_BODY and BODY have a different meaning because
+	 * one references a simple expression while the other references a list of
+	 * expressions (this distinction is particularly interesting in the case of
+	 * lambda expressions).
+	 *
+	 * In this particular case, the verification of the condition must not succeed
+	 * if the nature of the property is modified. So if we modify a lamba expression
+	 * composed of a single expression by replacing it with a list of expressions,
+	 * the evaluation of a condition relating to the presence of the EXPRESSION_BODY
+	 * property, which makes it possible to determine the nature of the change,
+	 * cannot not lead to a verified proposition which could be the case if we only
+	 * consider that the field referenced by the EXPRESSION_BODY property has an
+	 * acceptable value before the actual modification.
+	 *
+	 * This is why we also check if it is a derived property whose name coincides
+	 * with the updated property. If this is the case, we admit that the
+	 * verification of the condition must fail so that we can execute the else
+	 * clause of the condition. I'm not sure this issue #3949 is completely resolved by
+	 * this change.
+	 */
+    default boolean isEvaluatedOnDerivedProperty(ObservableProperty property) {
+    	ObservableProperty currentProperty = getProperty();
+		/*
+		 * Assuming that by convention the derived property is suffixed with the name of
+		 * the property it derives from (e.g. EXPRESSION_BODY which matches an
+		 * expression would derive from BODY which matches a list of expressions), we
+		 * could deduce that EXPRESSION_BODY and BODY actually represent the same
+		 * field but the validation condition must not be checked.
+		 * Be careful because NoChange property must not affect this evaluation.
+		 */
+    	return currentProperty != null
+    			&& (property.isDerived()
+    					&& property.name().endsWith(currentProperty.name()));
+    }
+
+	/*
+	 * Assuming that by convention the derived property is suffixed
+	 * with the name of the property it derives from (e.g. EXPRESSION_BODY which
+	 * matches an expression vs a list of expressions would derive from BODY) We
+	 * could deduce that EXPRESSION_BODY and BODY actually represent the same
+	 * property but the validation condition is not checked.
+	 */
+    ObservableProperty getProperty();
 
     Object getValue(ObservableProperty property, Node node);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
@@ -50,11 +50,12 @@ public interface Change {
 	 * Evaluate on derived property.
 	 *
 	 * Currently the evaluation of the conditions is carried out in relation to the
-	 * presence of value in the attributes of a class but this is not quite correct.
+	 * presence of value in the field/attribute of a class referenced by a property
+	 * (for example the BODY property is referenced to the body field in the
+	 * LambdaExpr class) but this is not quite correct.
 	 *
 	 * Indeed, there are attributes that are derived. The meaning of a derived
 	 * attribute (annotated with the DerivedProperty annotation) is not very clear.
-	 *
 	 * Assuming that it is an existing attribute and accessible by another property,
 	 * for example this is the case for the EXPRESSION_BODY property which allows
 	 * access to a derived field (which is also accessible by the BODY property).
@@ -64,27 +65,34 @@ public interface Change {
 	 * expressions (this distinction is particularly interesting in the case of
 	 * lambda expressions).
 	 *
-	 * In this particular case, the verification of the condition must not succeed
-	 * if the nature of the property is modified. So if we modify a lamba expression
-	 * composed of a single expression by replacing it with a list of expressions,
-	 * the evaluation of a condition relating to the presence of the EXPRESSION_BODY
-	 * property, which makes it possible to determine the nature of the change,
-	 * cannot not lead to a verified proposition which could be the case if we only
-	 * consider that the field referenced by the EXPRESSION_BODY property has an
-	 * acceptable value before the actual modification.
+	 * In this particular case, the verification of the condition defined in the
+	 * syntax model used by LPP must not succeed if the nature of the property is
+	 * modified. So if we modify a lamba expression composed of a single expression
+	 * by replacing it with a list of expressions, the evaluation of a condition
+	 * relating to the presence of the EXPRESSION_BODY property, which makes it
+	 * possible to determine the nature of the change, cannot not lead to a verified
+	 * proposition which could be the case if we only consider that the field
+	 * referenced by the EXPRESSION_BODY property has an acceptable value before the
+	 * actual modification.
 	 *
 	 * This is why we also check if it is a derived property whose name coincides
-	 * with the updated property. If this is the case, we admit that the
+	 * (*) with the updated property. If this is the case, we admit that the
 	 * verification of the condition must fail so that we can execute the else
-	 * clause of the condition. I'm not sure this issue #3949 is completely resolved by
-	 * this change.
+	 * clause of the condition. I'm not sure this issue #3949 is completely resolved
+	 * by this change.
+	 *
+	 * (*) Assuming that by convention the derived property is suffixed with the
+	 * name of the property it derives from (e.g.. EXPRESSION_BODY which matches an
+	 * expression would derive from BODY which matches a list of expressions), we
+	 * could deduce that EXPRESSION_BODY and BODY actually represent the same field
+	 * but the validation condition must not be checked.
 	 */
     default boolean isEvaluatedOnDerivedProperty(ObservableProperty property) {
     	ObservableProperty currentProperty = getProperty();
 		/*
-		 * Assuming that by convention the derived property is suffixed with the name of
+		 * By convention we admit that the derived property is suffixed with the name of
 		 * the property it derives from (e.g. EXPRESSION_BODY which matches an
-		 * expression would derive from BODY which matches a list of expressions), we
+		 * expression would derive from BODY which matches a list of expressions), so we
 		 * could deduce that EXPRESSION_BODY and BODY actually represent the same
 		 * field but the validation condition must not be checked.
 		 * Be careful because NoChange property must not affect this evaluation.

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
@@ -20,11 +20,11 @@
  */
 package com.github.javaparser.printer.lexicalpreservation.changes;
 
+import java.util.Optional;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
-import java.util.Optional;
 
 /**
  * The Addition of an element to a list.
@@ -66,4 +66,9 @@ public class ListAdditionChange implements Change {
             return new NoChange().getValue(property, node);
         }
     }
+
+	@Override
+	public ObservableProperty getProperty() {
+		return observableProperty;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListRemovalChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListRemovalChange.java
@@ -20,11 +20,11 @@
  */
 package com.github.javaparser.printer.lexicalpreservation.changes;
 
+import java.util.Optional;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
-import java.util.Optional;
 
 /**
  * The removal of an element from a list.
@@ -64,4 +64,9 @@ public class ListRemovalChange implements Change {
             return new NoChange().getValue(property, node);
         }
     }
+
+    @Override
+	public ObservableProperty getProperty() {
+		return observableProperty;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
@@ -20,11 +20,11 @@
  */
 package com.github.javaparser.printer.lexicalpreservation.changes;
 
+import java.util.Optional;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.observer.ObservableProperty;
-
-import java.util.Optional;
 
 /**
  * The replacement of an element in a list.
@@ -66,4 +66,9 @@ public class ListReplacementChange implements Change {
             return new NoChange().getValue(property, node);
         }
     }
+
+    @Override
+	public ObservableProperty getProperty() {
+		return observableProperty;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/NoChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/NoChange.java
@@ -32,4 +32,9 @@ public class NoChange implements Change {
     public Object getValue(ObservableProperty property, Node node) {
         return property.getRawValue(node);
     }
+
+    @Override
+	public ObservableProperty getProperty() {
+		return null;
+	}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/PropertyChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/PropertyChange.java
@@ -40,7 +40,8 @@ public class PropertyChange implements Change {
         this.newValue = newValue;
     }
 
-    public ObservableProperty getProperty() {
+    @Override
+	public ObservableProperty getProperty() {
         return property;
     }
 
@@ -56,8 +57,7 @@ public class PropertyChange implements Change {
     public Object getValue(ObservableProperty property, Node node) {
         if (property == this.property) {
             return newValue;
-        } else {
-            return property.getRawValue(node);
         }
+        return property.getRawValue(node);
     }
 }


### PR DESCRIPTION
…r Body

Fixes #3949 .

Currently the evaluation of the conditions is carried out in relation to the presence of value in the field/attribute of a class referenced by a property (for example the BODY property is referenced to the body field in the LambdaExpr class) but this is not quite correct.

Indeed, there are attributes that are derived. The meaning of a derived attribute (annotated with the DerivedProperty annotation) is not very clear. Assuming that it is an existing attribute and accessible by another property, for example this is the case for the EXPRESSION_BODY property which allows access to a derived field (which is also accessible by the BODY property).

The 2 properties EXPRESSION_BODY and BODY have a different meaning because one references a simple expression while the other references a list of expressions (this distinction is particularly interesting in the case of lambda expressions).

In this particular case, the verification of the condition defined in the syntax model used by LPP must not succeed if the nature of the property is modified. So if we modify a lamba expression composed of a single expression by replacing it with a list of expressions, the evaluation of a condition relating to the presence of the EXPRESSION_BODY property, which makes it possible to determine the nature of the change, cannot not lead to a verified proposition which could be the case if we only  consider that the field referenced by the EXPRESSION_BODY property has an acceptable value before the actual modification. 

This is why we also check if it is a derived property whose name coincides (*)  with the updated property. If this is the case, we admit that the verification of the condition must fail so that we can execute the else clause of the condition. I'm not sure this issue #3949 is completely resolved by  this change.


(*) Assuming that by convention the derived property is suffixed with the name of the property it derives from (e.g.. EXPRESSION_BODY which matches an expression would derive from BODY which matches a list of expressions), we could deduce that EXPRESSION_BODY and BODY actually represent the same field but the validation condition must not be checked. Be careful because NoChange property must not affect this evaluation.

