### PR TITLE
Fix: issue 4037 ArrayIndexOutOfBoundsException throws when method par…

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -21,6 +21,8 @@
 
 package com.github.javaparser.symbolsolver;
 
+import static com.github.javaparser.resolution.Navigator.demandParentNode;
+
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.*;
@@ -38,8 +40,6 @@ import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.*;
-
-import static com.github.javaparser.resolution.Navigator.demandParentNode;
 
 /**
  * This implementation of the SymbolResolver wraps the functionality of the library to make them easily usable
@@ -293,7 +293,7 @@ public class JavaSymbolSolver implements SymbolResolver {
     public ResolvedType calculateType(Expression expression) {
         return JavaParserFacade.get(typeSolver).getType(expression);
     }
-    
+
     @Override
     public ResolvedReferenceTypeDeclaration toTypeDeclaration(Node node) {
         if (node instanceof ClassOrInterfaceDeclaration) {
@@ -312,7 +312,7 @@ public class JavaSymbolSolver implements SymbolResolver {
             return new JavaParserAnnotationDeclaration((AnnotationDeclaration) node, typeSolver);
         }
         if (node instanceof EnumConstantDeclaration) {
-            return new JavaParserEnumDeclaration((EnumDeclaration) demandParentNode((EnumConstantDeclaration) node), typeSolver);
+            return new JavaParserEnumDeclaration((EnumDeclaration) demandParentNode(node), typeSolver);
         }
         throw new IllegalArgumentException("Cannot get a reference type declaration from " + node.getClass().getCanonicalName());
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -635,7 +635,14 @@ public class TypeExtractor extends DefaultVisitorAdapter {
 
                 return result;
             }
-            return refMethod.getCorrespondingDeclaration().getParam(pos).getType();
+			// Since variable parameters are represented by an array, in case we deal with
+			// the variadic parameter we have to take into account the base type of the
+			// array.
+			ResolvedMethodDeclaration rmd = refMethod.getCorrespondingDeclaration();
+			if (rmd.hasVariadicParameter() && pos >= rmd.getNumberOfParams() - 1) {
+				return rmd.getLastParam().getType().asArrayType().getComponentType();
+			}
+            return rmd.getParam(pos).getType();
         }
         throw new UnsupportedOperationException("The type of a method reference expr depends on the position and its return value");
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4037Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4037Test.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+
+public class Issue4037Test extends AbstractResolutionTest {
+
+	@Test
+	void test() {
+
+		String code =
+				"public class Test1 {\n"
+						+ "	    public static Integer getD2() { return null; }\n"
+						+ "	    public static Integer getD1() { return null; }\n"
+						+ "	    public void m(java.util.function.Supplier... rs) { }\n"
+						+ "\n"
+						+ "	    public void test() {\n"
+						+ "	        new Test1().m(Test1::getD1, Test1::getD2);    // exception throws\n"
+						+ "	    }\n"
+						+ "	}";
+
+		JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+		CompilationUnit cu = parser.parse(code);
+
+		List<MethodReferenceExpr > exprs = cu.findAll(MethodReferenceExpr .class);
+
+		exprs.forEach(expr -> {
+			assertDoesNotThrow(() -> expr.resolve());
+		});
+	}
+}


### PR DESCRIPTION
…am is variadic

Fixes #4037 .

Since variable parameters are represented by an array, in case we deal with the variadic parameter we have to take into account the base type of the array.
