### PR TITLE
Fix missing permits clause in DefaultPrettyPrinterVisitor

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Modifier.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Modifier.java
@@ -86,14 +86,6 @@ public class Modifier extends Node {
         return new Modifier(Keyword.TRANSITIVE);
     }
 
-    public static Modifier sealedModifier() {
-        return new Modifier(Keyword.SEALED);
-    }
-
-    public static Modifier nonSealedModifier() {
-        return new Modifier(Keyword.NON_SEALED);
-    }
-
     /**
      * The Java modifier keywords.
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Modifier.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Modifier.java
@@ -86,6 +86,14 @@ public class Modifier extends Node {
         return new Modifier(Keyword.TRANSITIVE);
     }
 
+    public static Modifier sealedModifier() {
+        return new Modifier(Keyword.SEALED);
+    }
+
+    public static Modifier nonSealedModifier() {
+        return new Modifier(Keyword.NON_SEALED);
+    }
+
     /**
      * The Java modifier keywords.
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -297,6 +297,17 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
                 }
             }
         }
+        if(!n.getPermittedTypes().isEmpty()){
+            printer.print(" permits ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getPermittedTypes().iterator(); i.hasNext(); ) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+
         printer.println(" {");
         printer.indent();
         if (!isNullOrEmpty(n.getMembers())) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -305,6 +305,16 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
                 }
             }
         }
+        if(!n.getPermittedTypes().isEmpty()){
+            printer.print(" permits ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getPermittedTypes().iterator(); i.hasNext(); ) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
         printer.println(" {");
         printer.indent();
         if (!isNullOrEmpty(n.getMembers())) {


### PR DESCRIPTION
Let's take this code snippet:
```
var parser = new JavaParser();
parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
var result = parser.parse("sealed interface A permits B {}");
System.out.println(result );
```
To output:
`sealed interface A permits B {}`
Yet, the actual output is:
`sealed interface A {}`
This is because the permits clause doesn't get printed out by the DefaultPrettyPrinterVisitor.
I've fixed this issue(I've only added the printing for classes/interfaces as records and enums can't be sealed)