### PR TITLE
Fix: issue 3978 typesolver can't parse in parallel

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/cache/InMemoryCache.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/cache/InMemoryCache.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.symbolsolver.cache;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.WeakHashMap;
@@ -47,7 +48,11 @@ public class InMemoryCache<K, V> implements Cache<K, V>  {
         return new InMemoryCache<>();
     }
 
-    private final Map<K, V> mappedValues = new WeakHashMap<>();
+    private final Map<K, V> mappedValues;
+
+    private InMemoryCache() {
+    	mappedValues = Collections.synchronizedMap(new WeakHashMap<>());
+    }
 
     @Override
     public void put(K key, V value) {


### PR DESCRIPTION
Fixes #3978 .

Using Collections.synchronizedMap should solve this problem of access to the cache in memory which is used by the symbol solver.
