### PR TITLE
Fix: issue 4077 After building JavaParser (with tests) on MacOS multi…

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -21,14 +21,7 @@
 
 package com.github.javaparser.utils;
 
-import com.github.javaparser.ParseProblemException;
-import com.github.javaparser.ParseResult;
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.ast.CompilationUnit;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,15 +29,30 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.printer.DefaultPrettyPrinter;
+import com.github.javaparser.printer.Printer;
+import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
+import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption;
 
 class SourceRootTest {
     private final Path root = CodeGenerationUtils.mavenModuleRoot(SourceRootTest.class).resolve("src/test/resources/com/github/javaparser/utils/");
     private final SourceRoot sourceRoot = new SourceRoot(root);
+    private Printer printer;
 
     @BeforeEach
     void before() {
         sourceRoot.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
+        printer = new DefaultPrettyPrinter();
+        sourceRoot.setPrinter(printer::print);
     }
 
     @Test
@@ -59,11 +67,13 @@ class SourceRootTest {
 
     @Test
     void saveInCallback() throws IOException {
+    	printer.getConfiguration().addOption(new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER, LineSeparator.LF.asRawString()));
         sourceRoot.parse("", sourceRoot.getParserConfiguration(), (localPath, absolutePath, result) -> SourceRoot.Callback.Result.SAVE);
     }
 
     @Test
     void saveInCallbackParallelized() {
+    	printer.getConfiguration().addOption(new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER, LineSeparator.LF.asRawString()));
         sourceRoot.parseParallelized("", sourceRoot.getParserConfiguration(), ((localPath, absolutePath, result) ->
                 SourceRoot.Callback.Result.SAVE));
     }


### PR DESCRIPTION
…ple committed files are modified

The cause of this problem comes mainly from the SourceRoot class which uses printing configuration parameters with default values. The default end-of-line character is system-specific (on Windows it's CRLF...). This only raises a problem when this class is asked to parse and save the result, which is done in particular by the SourceRootTest test class. In this case, ideally, one should use the end-of-line character used in the parsed file.

Fixes #4077 .
