### PR TITLE
Support getting more annotation default values using reflection

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationMemberDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationMemberDeclaration.java
@@ -40,14 +40,14 @@ import java.util.function.Function;
  */
 public class ReflectionAnnotationMemberDeclaration implements ResolvedAnnotationMemberDeclaration {
 
-    private static Map<Class<?>, Function<Object, ? extends Expression>> valueAsExressionConverter = new HashMap<>();
+    private static Map<Class<?>, Function<Object, ? extends Expression>> valueAsExpressionConverters = new HashMap<>();
     static {
-        valueAsExressionConverter.put(Boolean.class, (value) -> new BooleanLiteralExpr(Boolean.class.cast(value)));
-        valueAsExressionConverter.put(Character.class, (value) -> new CharLiteralExpr(Character.class.cast(value)));
-        valueAsExressionConverter.put(Double.class, (value) -> new DoubleLiteralExpr(Double.class.cast(value)));
-        valueAsExressionConverter.put(Integer.class, (value) -> new IntegerLiteralExpr(Integer.class.cast(value)));
-        valueAsExressionConverter.put(Long.class, (value) -> new LongLiteralExpr(Long.class.cast(value)));
-        valueAsExressionConverter.put(String.class, (value) -> new StringLiteralExpr(String.class.cast(value)));
+        valueAsExpressionConverters.put(Boolean.class, (value) -> new BooleanLiteralExpr((Boolean) value));
+        valueAsExpressionConverters.put(Character.class, (value) -> new CharLiteralExpr((Character) value));
+        valueAsExpressionConverters.put(Double.class, (value) -> new DoubleLiteralExpr((Double) value));
+        valueAsExpressionConverters.put(Integer.class, (value) -> new IntegerLiteralExpr((Integer) value));
+        valueAsExpressionConverters.put(Long.class, (value) -> new LongLiteralExpr((Long) value));
+        valueAsExpressionConverters.put(String.class, (value) -> new StringLiteralExpr((String) value));
     }
     
     private Method annotationMember;
@@ -61,7 +61,7 @@ public class ReflectionAnnotationMemberDeclaration implements ResolvedAnnotation
     @Override
     public Expression getDefaultValue() {
         Object value = annotationMember.getDefaultValue();
-        Function<Object, ? extends Expression> fn = valueAsExressionConverter.get(value.getClass());
+        Function<Object, ? extends Expression> fn = valueAsExpressionConverters.get(value.getClass());
         if (fn == null) throw new UnsupportedOperationException(String.format("Obtaining the type of the annotation member %s is not supported yet.", annotationMember.getName()));
         return fn.apply(value);
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -23,8 +23,10 @@ package com.github.javaparser.symbolsolver.resolution;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
@@ -57,7 +59,7 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
     void configureSymbolSolver() throws IOException {
         // configure symbol solver before parsing
         CombinedTypeSolver typeSolver = new CombinedTypeSolver();
-        typeSolver.add(new ReflectionTypeSolver());
+        typeSolver.add(new ReflectionTypeSolver(false));
         typeSolver.add(new JarTypeSolver(adaptPath("src/test/resources/junit-4.8.1.jar")));
         StaticJavaParser.getConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
     }
@@ -359,4 +361,48 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
         assertEquals(am.getType().asReferenceType().getQualifiedName(), "foo.bar.MyAnnotationWithInnerClass.MyInnerClass");
     }
 
+    @Test
+    void solveReflectionMarkerAnnotationWithDefaultValues() throws IOException {
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CI");
+
+        MarkerAnnotationExpr annotationExpr = clazz.getAnnotation(0).asMarkerAnnotationExpr();
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
+        // get default values
+        // Class<?>[] - {}
+        Expression arrayExpr = findAnnotationMemberByName(resolved, "packagesOf").getDefaultValue();
+        assertInstanceOf(ArrayInitializerExpr.class, arrayExpr);
+        final NodeList<Expression> values = ((ArrayInitializerExpr) arrayExpr).getValues();
+        assertTrue(values.isNonEmpty());
+        assertTrue(values.get(0).isClassExpr());
+        assertEquals("MethodHandle", values.get(0).asClassExpr().getType().asString());
+
+        // Class<?> - LambdaMetafactory.class
+        ClassExpr classExpr = assertInstanceOf(ClassExpr.class, findAnnotationMemberByName(resolved, "clazz").getDefaultValue());
+        final ClassOrInterfaceType type = assertInstanceOf(ClassOrInterfaceType.class, classExpr.getType());
+        assertEquals("LambdaMetafactory", type.getNameAsString());
+
+        // TimeUnit - TimeUnit.HOURS
+        Expression enumExpr = findAnnotationMemberByName(resolved, "unit").getDefaultValue();
+        final FieldAccessExpr fieldAccessExpr = assertInstanceOf(FieldAccessExpr.class, enumExpr);
+        final NameExpr scopeNameExpr = assertInstanceOf(NameExpr.class, fieldAccessExpr.getScope());
+        assertEquals("TimeUnit", scopeNameExpr.asNameExpr().getNameAsString());
+        assertEquals("HOURS", fieldAccessExpr.getNameAsString());
+
+        // NestedAnnotation - @NestedAnnotation
+        Expression nestedExpr = findAnnotationMemberByName(resolved, "nestedAnnotation").getDefaultValue();
+        assertInstanceOf(NormalAnnotationExpr.class, nestedExpr);
+        assertEquals("NestedAnnotation", nestedExpr.asNormalAnnotationExpr().getNameAsString());
+    }
+
+    private ResolvedAnnotationMemberDeclaration findAnnotationMemberByName(ResolvedAnnotationDeclaration resolved, String memberName) {
+        return resolved.getAnnotationMembers().stream()
+                .filter(a -> memberName.equals(a.getName()))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Could not find annotation member %s in %s",
+                        memberName, resolved.getName())));
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnnotationsResolutionTest.java
@@ -362,7 +362,7 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
     }
 
     @Test
-    void solveReflectionMarkerAnnotationWithDefaultValues() throws IOException {
+    void solveReflectionMarkerAnnotationWithDefaultArrayValue() throws IOException {
         // parse compilation unit and get annotation expression
         CompilationUnit cu = parseSample("Annotations");
         ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CI");
@@ -371,7 +371,7 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
 
         // resolve annotation expression
         ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
-        // get default values
+
         // Class<?>[] - {}
         Expression arrayExpr = findAnnotationMemberByName(resolved, "packagesOf").getDefaultValue();
         assertInstanceOf(ArrayInitializerExpr.class, arrayExpr);
@@ -379,11 +379,35 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
         assertTrue(values.isNonEmpty());
         assertTrue(values.get(0).isClassExpr());
         assertEquals("MethodHandle", values.get(0).asClassExpr().getType().asString());
+    }
+
+    @Test
+    void solveReflectionMarkerAnnotationWithDefaultClassValue() throws IOException {
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CI");
+
+        MarkerAnnotationExpr annotationExpr = clazz.getAnnotation(0).asMarkerAnnotationExpr();
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
 
         // Class<?> - LambdaMetafactory.class
         ClassExpr classExpr = assertInstanceOf(ClassExpr.class, findAnnotationMemberByName(resolved, "clazz").getDefaultValue());
         final ClassOrInterfaceType type = assertInstanceOf(ClassOrInterfaceType.class, classExpr.getType());
         assertEquals("LambdaMetafactory", type.getNameAsString());
+    }
+
+    @Test
+    void solveReflectionMarkerAnnotationWithDefaultEnumValue() throws IOException {
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CI");
+
+        MarkerAnnotationExpr annotationExpr = clazz.getAnnotation(0).asMarkerAnnotationExpr();
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
 
         // TimeUnit - TimeUnit.HOURS
         Expression enumExpr = findAnnotationMemberByName(resolved, "unit").getDefaultValue();
@@ -391,6 +415,18 @@ class AnnotationsResolutionTest extends AbstractResolutionTest {
         final NameExpr scopeNameExpr = assertInstanceOf(NameExpr.class, fieldAccessExpr.getScope());
         assertEquals("TimeUnit", scopeNameExpr.asNameExpr().getNameAsString());
         assertEquals("HOURS", fieldAccessExpr.getNameAsString());
+    }
+
+    @Test
+    void solveReflectionMarkerAnnotationWithDefaultNestedAnnotationValue() throws IOException {
+        // parse compilation unit and get annotation expression
+        CompilationUnit cu = parseSample("Annotations");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "CI");
+
+        MarkerAnnotationExpr annotationExpr = clazz.getAnnotation(0).asMarkerAnnotationExpr();
+
+        // resolve annotation expression
+        ResolvedAnnotationDeclaration resolved = annotationExpr.resolve();
 
         // NestedAnnotation - @NestedAnnotation
         Expression nestedExpr = findAnnotationMemberByName(resolved, "nestedAnnotation").getDefaultValue();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/testingclasses/TargetType.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/testingclasses/TargetType.java
@@ -1,0 +1,25 @@
+package com.github.javaparser.symbolsolver.testingclasses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.util.concurrent.TimeUnit;
+
+@interface NestedAnnotation {
+
+}
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Retention(RetentionPolicy.SOURCE)
+public @interface TargetType {
+    Class<?>[] packagesOf() default {MethodHandle.class};
+
+    Class<?> clazz() default LambdaMetafactory.class;
+
+    TimeUnit unit() default TimeUnit.HOURS;
+
+    NestedAnnotation nestedAnnotation() default @NestedAnnotation;
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Annotations.java.txt
@@ -3,6 +3,7 @@ package foo.bar;
 import java.lang.annotation.*;
 import java.beans.*;
 import org.junit.*;
+import com.github.javaparser.symbolsolver.testingclasses.TargetType;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -74,6 +75,10 @@ class CG {
 
 class CH {
     @Transient public String field;
+}
+
+@TargetType
+class CI {
 }
 
 @Inherited


### PR DESCRIPTION
This PR adds support for `Class`, enums, nested annotations, and array types when getting the default value of a reflectively-resolved annotation

Fixes #4099.
