### PR TITLE
Fix: issue 3673 isAssignableBy method StackOverflowError

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -92,7 +92,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
 
     @Override
     public boolean isAssignableBy(ResolvedReferenceTypeDeclaration other) {
-        return isAssignableBy(new ReferenceTypeImpl(other));
+        return javassistTypeDeclarationAdapter.isAssignableBy(other);
     }
 
     @Override
@@ -194,35 +194,34 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
     }
 
     @Override
-    public boolean isAssignableBy(ResolvedType type) {
-        if (type.isNull()) {
-            return true;
-        }
-
-        if (type instanceof LambdaArgumentTypePlaceholder) {
+    public boolean canBeAssignedTo(ResolvedReferenceTypeDeclaration other) {
+        if (other instanceof LambdaArgumentTypePlaceholder) {
             return isFunctionalInterface();
         }
-
-        // TODO look into generics
-        if (type.describe().equals(this.getQualifiedName())) {
+        if (other.getQualifiedName().equals(getQualifiedName())) {
             return true;
         }
+        Optional<ResolvedReferenceType> oSuperClass = javassistTypeDeclarationAdapter.getSuperClass();
+		if (oSuperClass.isPresent()) {
+			ResolvedReferenceType superClass = oSuperClass.get();
+			Optional<ResolvedReferenceTypeDeclaration> oDecl = superClass.getTypeDeclaration();
+			if (oDecl.isPresent() && oDecl.get().canBeAssignedTo(other)) {
+				return true;
+			}
+		}
 
-        Optional<ResolvedReferenceType> superClassOpt = getSuperClass();
-        if (superClassOpt.isPresent()) {
-            ResolvedReferenceType superClass = superClassOpt.get();
-            if (superClass.isAssignableBy(type)) {
-                return true;
-            }
-        }
-
-        for (ResolvedReferenceType interfaceType : getInterfaces()) {
-            if (interfaceType.isAssignableBy(type)) {
+		for (ResolvedReferenceType interfaze : javassistTypeDeclarationAdapter.getInterfaces()) {
+            if (interfaze.getTypeDeclaration().isPresent() && interfaze.getTypeDeclaration().get().canBeAssignedTo(other)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    @Override
+    public boolean isAssignableBy(ResolvedType type) {
+    	return javassistTypeDeclarationAdapter.isAssignableBy(type);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -31,6 +31,7 @@ import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.logic.MethodResolutionCapability;
+import com.github.javaparser.resolution.model.LambdaArgumentTypePlaceholder;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -108,18 +109,49 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
     }
 
     @Override
-    public boolean isAssignableBy(ResolvedType type) {
-        return javassistTypeDeclarationAdapter.isAssignableBy(type);
-    }
-
-    @Override
     public List<ResolvedFieldDeclaration> getAllFields() {
       return javassistTypeDeclarationAdapter.getDeclaredFields();
     }
 
     @Override
+    public boolean isAssignableBy(ResolvedType type) {
+        return javassistTypeDeclarationAdapter.isAssignableBy(type);
+    }
+
+    @Override
     public boolean isAssignableBy(ResolvedReferenceTypeDeclaration other) {
         return javassistTypeDeclarationAdapter.isAssignableBy(other);
+    }
+
+    @Override
+    public boolean canBeAssignedTo(ResolvedReferenceTypeDeclaration other) {
+    	if (other.isJavaLangObject()) {
+            // Everything can be assigned to {@code java.lang.Object}
+            return true;
+        }
+
+        if (other instanceof LambdaArgumentTypePlaceholder) {
+            return isFunctionalInterface();
+        }
+        if (other.getQualifiedName().equals(getQualifiedName())) {
+            return true;
+        }
+        Optional<ResolvedReferenceType> oSuperClass = javassistTypeDeclarationAdapter.getSuperClass();
+		if (oSuperClass.isPresent()) {
+			ResolvedReferenceType superClass = oSuperClass.get();
+			Optional<ResolvedReferenceTypeDeclaration> oDecl = superClass.getTypeDeclaration();
+			if (oDecl.isPresent() && oDecl.get().canBeAssignedTo(other)) {
+				return true;
+			}
+		}
+		for (ResolvedReferenceType interfaze : javassistTypeDeclarationAdapter.getInterfaces()) {
+			if (interfaze.getTypeDeclaration().isPresent()
+					&& interfaze.getTypeDeclaration().get().canBeAssignedTo(other)) {
+				return true;
+			}
+		}
+
+        return false;
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclarationTest.java
@@ -539,7 +539,8 @@ class JavassistClassDeclarationTest extends AbstractClassDeclarationTest {
         void whenSuperClassIsProvided() {
             ResolvedReferenceTypeDeclaration node = newTypeSolver.solveType("com.github.javaparser.ast.Node");
             JavassistClassDeclaration cu = (JavassistClassDeclaration) newTypeSolver.solveType("com.github.javaparser.ast.CompilationUnit");
-            assertTrue(cu.isAssignableBy(node));
+            assertFalse(cu.isAssignableBy(node));
+            assertTrue(node.isAssignableBy(cu));
         }
 
         @Test
@@ -548,7 +549,8 @@ class JavassistClassDeclarationTest extends AbstractClassDeclarationTest {
                     "com.github.javaparser.ast.nodeTypes.NodeWithImplements");
             JavassistClassDeclaration classDeclaration = (JavassistClassDeclaration) newTypeSolver.solveType(
                     "com.github.javaparser.ast.body.ClassOrInterfaceDeclaration");
-            assertTrue(classDeclaration.isAssignableBy(nodeWithImplements));
+            assertFalse(classDeclaration.isAssignableBy(nodeWithImplements));
+            assertTrue(nodeWithImplements.isAssignableBy(classDeclaration));
         }
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclarationTest.java
@@ -225,8 +225,8 @@ class JavassistInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
             memoryTypeSolver.addDeclaration("B", declarationB);
 
             // Knowing that B extends A we expect:
-            assertFalse(declarationA.isAssignableBy(declarationB), "This should not be allowed: B variable = new A()");
-            assertTrue(declarationB.isAssignableBy(declarationA), "This should be allowed: A variable = new B()");
+            assertTrue(declarationA.isAssignableBy(declarationB), "This should not be allowed: A variable = new B()");
+            assertFalse(declarationB.isAssignableBy(declarationA), "This should be allowed: B variable = new A()");
         }
     }
 


### PR DESCRIPTION
Fixes #3673 . The method isAssignableBy provided by Javassist class or interface declaration must preserve the same implementation than others.
