### PR TITLE
fix: issue 4115 ResolvedUnionType should give access to a list of resolved types

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedIntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedIntersectionType.java
@@ -20,10 +20,10 @@
  */
 package com.github.javaparser.resolution.types;
 
-import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
-
 import java.util.*;
 import java.util.stream.Collectors;
+
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 
 /**
  * An intersection type is defined in java as list of types separates by ampersands.
@@ -73,5 +73,12 @@ public class ResolvedIntersectionType implements ResolvedType {
             return this;
         }
         return new ResolvedIntersectionType(elementsReplaced);
+    }
+
+    /*
+     * Returns the list of the resolved types
+     */
+    public List<ResolvedType> getElements() {
+        return elements;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedUnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedUnionType.java
@@ -20,10 +20,10 @@
  */
 package com.github.javaparser.resolution.types;
 
-import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
-
 import java.util.*;
 import java.util.stream.Collectors;
+
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 
 /**
  * A union type is defined in java as list of types separates by pipes.
@@ -86,5 +86,12 @@ public class ResolvedUnionType implements ResolvedType {
     @Override
     public ResolvedUnionType asUnionType() {
         return this;
+    }
+
+    /*
+     * Returns the list of the resolved types
+     */
+    public List<ResolvedType> getElements() {
+        return elements;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
@@ -169,6 +169,7 @@ class JavaParserFacadeResolutionTest extends AbstractResolutionTest {
         Type jpType = catchClause.getParameter().getType();
         ResolvedType jssType = jpType.resolve();
         assertTrue(jssType instanceof ResolvedUnionType);
+        assertTrue(jssType.asUnionType().getElements().size()==2);
     }
 
     @Test


### PR DESCRIPTION
This can be applied to ResolvedIntersectionType too.

Fixes #4115 .
