### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/prepare_release_changelog.yml
+++ b/.github/workflows/prepare_release_changelog.yml
@@ -39,11 +39,11 @@ jobs:
           RELEASE_TITLE="SNAPSHOT - $SHA_SHORT"
           RELEASE_TAG_NAME="v_snapshot_$SHA_SHORT"
 
-          echo "::set-output name=sha_long::$SHA_LONG"
-          echo "::set-output name=sha_short::$SHA_SHORT"
-          echo "::set-output name=changelog::$CHANGELOG"
-          echo "::set-output name=release_title::$RELEASE_TITLE"
-          echo "::set-output name=release_tag_name::$RELEASE_TAG_NAME"
+          echo "sha_long=$SHA_LONG" >> $GITHUB_OUTPUT
+          echo "sha_short=$SHA_SHORT" >> $GITHUB_OUTPUT
+          echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "release_title=$RELEASE_TITLE" >> $GITHUB_OUTPUT
+          echo "release_tag_name=$RELEASE_TAG_NAME" >> $GITHUB_OUTPUT
 
 
       - name: Output variables


### PR DESCRIPTION
I replace deprecated `set-output` command to `$GITHUB_OUTPUT` environment file to use

reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### AS-IS
```yaml
echo "::set-output name=sha_long::$SHA_LONG"
```

### TO-BE
```yaml
echo "sha_long=$SHA_LONG" >> $GITHUB_OUTPUT
```