### PR TITLE
Fix: issue #4036 LeastUpperBoundLogic.lub returns null when matches ConditionalExpr

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
@@ -40,6 +40,10 @@ public class LeastUpperBoundLogic {
         // One way to handle this case is to remove the type null from the list of types.
         Set<ResolvedType> resolvedTypes = types.stream().filter(type -> !(type instanceof NullType)).collect(Collectors.toSet());
 
+		// reduces the set in the presence of enumeration type because members are
+		// not equal and they do not have an explicit super type.
+        // So we only keep one enumeration for all the members of an enumeration
+        filterEnumType(resolvedTypes);
 
         // The least upper bound, or "lub", of a set of reference types is a shared supertype that is more specific
         // than any other shared supertype (that is, no other shared supertype is a subtype of the least upper bound).
@@ -194,6 +198,33 @@ public class LeastUpperBoundLogic {
             }
         }
         return erasedBest;
+    }
+
+    /*
+     * Check the type declaration if it is an enum
+     */
+    private boolean isEnum(ResolvedType type) {
+    	return type.isReferenceType() && type.asReferenceType().getTypeDeclaration().get().isEnum();
+    }
+
+    /*
+     * Keep only one enum reference type per enum declaration
+     */
+    private void filterEnumType(Set<ResolvedType> resolvedTypes) {
+    	Map<String, ResolvedType> enumTypes = new HashMap<>();
+        List<ResolvedType> erasedEnumTypes = new ArrayList<>();
+        for (ResolvedType type : resolvedTypes) {
+        	if (isEnum(type)) {
+        		// enum qualified name i.e. java.math.RoundingMode
+        		String qn = type.asReferenceType().getTypeDeclaration().get().asEnum().getQualifiedName();
+        		// Save the first occurrence and mark the others so they can be deleted
+        		ResolvedType returnedType = enumTypes.putIfAbsent(qn, type);
+        		if (returnedType != null) {
+        			erasedEnumTypes.add(type);
+        		}
+        	}
+        }
+        resolvedTypes.removeAll(erasedEnumTypes);
     }
 
     private List<Set<ResolvedType>> supertypes(Set<ResolvedType> types) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundTest.java
@@ -191,7 +191,7 @@ class LeastUpperBoundTest {
         ResolvedType expected = constanteTypes.get(0);
 
         ResolvedType lub = leastUpperBound(constanteTypes.get(0), constanteTypes.get(1));
-        assertEquals(expected.asReferenceType(), lub.asReferenceType());
+        assertEquals(expected.asReferenceType().describe(), lub.asReferenceType().describe());
     }
 
     @Test


### PR DESCRIPTION

Fixes #4036 .

This PR handles special cases introduced by enumeration types.
Each enum constant resolves to a different resolved type and which has no common super type with others. So we need to reduce the resolved enum types to a single resolved type. In the example the resolution of the return type of the following expression must be RoundingMode
s != null ? RoundingMode.HALF_UP : RoundMode.DOWN
