### PR TITLE
CalculateResolvedType Type error

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -96,6 +96,13 @@ public class JavaParserTypeDeclarationAdapter {
             }
         }
 
+        // Check class or interface declared in the compilation unit
+        SymbolReference<ResolvedTypeDeclaration> symbolRef = context.getParent()
+                .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
+                .solveType(name, typeArguments);
+        if (symbolRef.isSolved())
+        	return symbolRef;
+
         // Check if is a type parameter
         if (wrappedNode instanceof NodeWithTypeParameters) {
             NodeWithTypeParameters<?> nodeWithTypeParameters = (NodeWithTypeParameters<?>) wrappedNode;
@@ -147,10 +154,7 @@ public class JavaParserTypeDeclarationAdapter {
 			return SymbolReference.solved(type);
 		}
 
-        // Else check parents
-        return context.getParent()
-                .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
-                .solveType(name, typeArguments);
+        return SymbolReference.unsolved();
     }
 
     private boolean isCompositeName(String name) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
@@ -1,0 +1,56 @@
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.*;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+
+class JavaParserTypeDeclarationAdapterTest extends AbstractResolutionTest {
+
+	@BeforeAll
+	static void setUpBeforeClass() throws Exception {
+	}
+
+	@AfterAll
+	static void tearDownAfterClass() throws Exception {
+	}
+
+	@BeforeEach
+	void setUp() throws Exception {
+	}
+
+	@AfterEach
+	void tearDownAfterEach() throws Exception {
+	}
+
+	@Test
+	void issue3214() {
+		String code =
+				"public interface Foo {\n"
+				+ "	    interface Bar {}\n"
+				+ "	}\n"
+				+ "\n"
+				+ "	public interface Bar {\n"
+				+ "	    void show();\n"
+				+ "	}\n"
+				+ "\n"
+				+ "	public class Test implements Foo.Bar {\n"
+				+ "	    private Bar bar;\n"
+				+ "	    private void m() {\n"
+				+ "	        bar.show();\n"
+				+ "	    }\n"
+				+ "	}";
+
+		JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+		CompilationUnit cu = parser.parse(code);
+
+		MethodCallExpr mce = cu.findAll(MethodCallExpr.class).get(0);
+
+		assertEquals("Bar.show()",mce.resolve().getQualifiedSignature());
+	}
+
+}


### PR DESCRIPTION
Fixes #3214.

When we try to resolve a type we must look if the type is not declared in the CompilationUnit before analyzing the extended classes and implemented interfaces
