### PR TITLE
fix: issue 3184 Unable to get the resolved type of class ResolvedReferenceType from T

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -347,7 +347,10 @@ public class MethodResolutionLogic {
                 	if (actualParam.isWildcard() && !actualParam.asWildcard().isBounded()) {
                 		return true;
                 	}
-                    return isAssignableMatchTypeParameters(expectedParam.asWildcard().getBoundedType(), actual, matchedParameters);
+                	if (actualParam.isTypeVariable()) {
+                        return matchTypeVariable(actualParam.asTypeVariable(), expectedParam.asWildcard().getBoundedType(), matchedParameters);
+                    }
+                    return isAssignableMatchTypeParameters(expectedParam.asWildcard().getBoundedType(), actualParam, matchedParameters);
                 }
                 // TODO verify super bound
                 return true;

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -346,18 +346,19 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
      */
     public abstract Set<ResolvedFieldDeclaration> getDeclaredFields();
 
+	/*
+	 * A class or interface whose declaration has one or more type parameters is a
+	 * generic class or interface [JLS, 8.1.2, 9.1.2]. For example, the List
+	 * interface has a single type parameter, E, representing its element type.
+	 * A raw type, is the name of the generic type used without any accompanying type
+	 * parameters [JLS, 4.8]. For example, the raw type corresponding to List<E> is
+	 * List.
+	 */
     public boolean isRawType() {
         if (!typeDeclaration.getTypeParameters().isEmpty()) {
             if (typeParametersMap().isEmpty()) {
                 return true;
             }
-            for (String name : typeParametersMap().getNames()) {
-                Optional<ResolvedType> value = typeParametersMap().getValueBySignature(name);
-                if (!value.isPresent() || !value.get().isTypeVariable() || !value.get().asTypeVariable().qualifiedName().equals(name)) {
-                    return false;
-                }
-            }
-            return true;
         }
         return false;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -101,17 +101,11 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
     public final Optional<Context> getParent() {
         Node parentNode = wrappedNode.getParentNode().orElse(null);
 
-        // TODO/FiXME: Document why the method call expression is treated differently.
+		// Resolution of the scope of the method call expression is delegated to parent
+		// context.
         if (parentNode instanceof MethodCallExpr) {
             MethodCallExpr parentCall = (MethodCallExpr) parentNode;
-            // TODO: Can this be replaced with: boolean found = parentCall.getArguments().contains(wrappedNode);
-            boolean found = false;
-            for (Expression expression : parentCall.getArguments()) {
-                if (expression == wrappedNode) {
-                    found = true;
-                    break;
-                }
-            }
+            boolean found = parentCall.getArguments().contains(wrappedNode);
             if (found) {
                 Node notMethod = parentNode;
                 while (notMethod instanceof MethodCallExpr) {
@@ -121,7 +115,8 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             }
         }
         Node notMethodNode = parentNode;
-        // to avoid an infinite loop if parent scope is the same as wrapped node
+        // To avoid loops JP must ensure that the scope of the parent context
+		// is not the same as the current node.
         while (notMethodNode instanceof MethodCallExpr || notMethodNode instanceof FieldAccessExpr
                 || (notMethodNode != null && notMethodNode.hasScope() && getScope(notMethodNode).equals(wrappedNode)) ) {
             notMethodNode = notMethodNode.getParentNode().orElse(null);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3184Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3184Test.java
@@ -1,0 +1,50 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.utils.Pair;
+
+public class Issue3184Test extends AbstractResolutionTest {
+
+	@Test
+	void test() {
+		String code = "public class Program {\n" +
+		        "\n" +
+		        "    public static class InnerClass<T> {\n" +
+		        "       void method1() {\n" +
+		        "           new InnerClass<T>();\n" + // Buggy
+		        "       }\n" +
+		        "       <T1> void method2() {\n" +
+		        "           new InnerClass<T1>();\n" + // OK
+		        "           new InnerClass<T>();\n" + // Buggy
+		        "       }\n" +
+		        "    }\n" +
+		        "}";
+
+		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(code);
+		List<ObjectCreationExpr> objCrtExprs = cu.findAll(ObjectCreationExpr.class);
+		objCrtExprs.forEach(expr -> {
+		    ResolvedType resRefType = expr.getType().resolve();
+		    ResolvedReferenceTypeDeclaration resRefTypeDecl = resRefType.asReferenceType().getTypeDeclaration().get();
+		    List<ResolvedTypeParameterDeclaration> resTypeParamsDecl = resRefTypeDecl.getTypeParameters();
+		    List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> resTypeParamsDeclMap = resRefType.asReferenceType().getTypeParametersMap();
+		    assertFalse(resTypeParamsDecl.isEmpty());
+		    assertFalse(resTypeParamsDeclMap.isEmpty());
+		    for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> resTypeParamsDeclPair : resTypeParamsDeclMap) {
+		        assertTrue(resTypeParamsDeclPair.b.isTypeVariable());
+		    }
+		});
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserVariableDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserVariableDeclarationTest.java
@@ -21,8 +21,14 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -30,17 +36,10 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.declarations.AssociableToAST;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclarationTest;
-import com.github.javaparser.symbolsolver.JavaSymbolSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
-import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-class JavaParserVariableDeclarationTest implements ResolvedValueDeclarationTest {
+class JavaParserVariableDeclarationTest  extends AbstractResolutionTest  implements ResolvedValueDeclarationTest {
 
     @Override
     public Optional<Node> getWrappedDeclaration(AssociableToAST associableToAST) {
@@ -52,8 +51,9 @@ class JavaParserVariableDeclarationTest implements ResolvedValueDeclarationTest 
     @Override
     public JavaParserVariableDeclaration createValue() {
         String code = "class A {a() {String s;}}";
-        CompilationUnit compilationUnit = StaticJavaParser.parse(code);
-        VariableDeclarator variableDeclarator = compilationUnit.findFirst(VariableDeclarator.class).get();
+        CompilationUnit cu = JavaParserAdapter.of(
+                createParserWithResolver(defaultTypeSolver())).parse(code);
+        VariableDeclarator variableDeclarator = cu.findFirst(VariableDeclarator.class).get();
         ReflectionTypeSolver reflectionTypeSolver = new ReflectionTypeSolver();
         return new JavaParserVariableDeclaration(variableDeclarator, reflectionTypeSolver);
     }
@@ -80,11 +80,8 @@ class JavaParserVariableDeclarationTest implements ResolvedValueDeclarationTest 
                 + "    }\n"
                 + "}";
 
-        ParserConfiguration configuration = new ParserConfiguration()
-                .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver())));
-        StaticJavaParser.setConfiguration(configuration);
-
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = JavaParserAdapter.of(
+                createParserWithResolver(defaultTypeSolver())).parse(code);
 
         List<NameExpr> names = cu.findAll(NameExpr.class);
         ResolvedValueDeclaration rvd = names.get(3).resolve();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -871,7 +871,7 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
         ResolvedType rt = types.get(0);
         String expected = "A";
         ResolvedType erasedType = rt.erasure();
-        assertTrue(rt.asReferenceType().isRawType());
+        assertFalse(rt.asReferenceType().isRawType());
         assertTrue(erasedType.asReferenceType().typeParametersValues().isEmpty());
         assertEquals(expected, erasedType.describe());
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionLogicTest.java
@@ -21,6 +21,13 @@
 
 package com.github.javaparser.symbolsolver.resolution;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.logic.MethodResolutionLogic;
@@ -32,12 +39,6 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeS
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.github.javaparser.symbolsolver.utils.LeanParserConfiguration;
 import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MethodsResolutionLogicTest extends AbstractResolutionTest {
 
@@ -58,9 +59,9 @@ class MethodsResolutionLogicTest extends AbstractResolutionTest {
         JavaParserClassDeclaration constructorDeclaration = (JavaParserClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
 
         ResolvedReferenceType stringType = (ResolvedReferenceType) ReflectionFactory.typeUsageFor(String.class, typeSolver);
-        ResolvedReferenceType rawClassType = (ResolvedReferenceType) ReflectionFactory.typeUsageFor(Class.class, typeSolver);
-        assertEquals(true, rawClassType.isRawType());
-        ResolvedReferenceType classOfStringType = (ResolvedReferenceType) rawClassType.replaceTypeVariables(rawClassType.getTypeDeclaration().get().getTypeParameters().get(0), stringType);
+        ResolvedReferenceType genericClassType = (ResolvedReferenceType) ReflectionFactory.typeUsageFor(Class.class, typeSolver);
+        assertEquals(false, genericClassType.isRawType());
+        ResolvedReferenceType classOfStringType = (ResolvedReferenceType) genericClassType.replaceTypeVariables(genericClassType.getTypeDeclaration().get().getTypeParameters().get(0), stringType);
         MethodUsage mu = constructorDeclaration.getAllMethods().stream().filter(m -> m.getDeclaration().getSignature().equals("isThrows(java.lang.Class<? extends java.lang.Throwable>)")).findFirst().get();
 
         assertEquals(false, MethodResolutionLogic.isApplicable(mu, "isThrows", ImmutableList.of(classOfStringType), typeSolver));
@@ -70,10 +71,10 @@ class MethodsResolutionLogicTest extends AbstractResolutionTest {
     void compatibilityShouldConsiderAlsoTypeVariablesRaw() {
         JavaParserClassDeclaration constructorDeclaration = (JavaParserClassDeclaration) typeSolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
 
-        ResolvedReferenceType rawClassType = (ResolvedReferenceType) ReflectionFactory.typeUsageFor(Class.class, typeSolver);
+        ResolvedReferenceType genericClassType = (ResolvedReferenceType) ReflectionFactory.typeUsageFor(Class.class, typeSolver);
         MethodUsage mu = constructorDeclaration.getAllMethods().stream().filter(m -> m.getDeclaration().getSignature().equals("isThrows(java.lang.Class<? extends java.lang.Throwable>)")).findFirst().get();
 
-        assertEquals(true, MethodResolutionLogic.isApplicable(mu, "isThrows", ImmutableList.of(rawClassType), typeSolver));
+        assertEquals(true, MethodResolutionLogic.isApplicable(mu, "isThrows", ImmutableList.of(genericClassType.erasure()), typeSolver));
     }
 
     @Test


### PR DESCRIPTION
Fixes #3184 .

The fix considers a raw type to be the name of the generic type used without any associated type parameters.
This fix also fixes erroneous unit tests.
For more information you can read these articles which deal with this subject.
https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html
https://www.informit.com/articles/article.aspx?p=2861454


My understanding is that:
Class<?> is a generic type but not a raw type
List<String> is a generic type but not a raw type
List is a raw type of the genreric type List<E>
