### PR TITLE
Fix: issue 4163 Calling MethodDeclaration.getDeclarationAsString leads to MethodDelaration.getComment returning no comment

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4163Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4163Test.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.github.javaparser.printer.DefaultPrettyPrinter;
+import com.github.javaparser.printer.Printer;
+import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
+import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration;
+import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption;
+import com.github.javaparser.printer.configuration.PrinterConfiguration;
+
+public class Issue4163Test extends AbstractLexicalPreservingTest {
+
+	@Test
+	void test() {
+		VoidVisitorAdapter<Object> visitor = new VoidVisitorAdapter<Object>() {
+	        @Override
+	        public void visit(MethodDeclaration n, Object arg) {
+	            System.out.println(n.getDeclarationAsString(true, true, true));
+	            System.out.println(n.getComment());
+	        }
+	    };
+	    String code =
+	    	"class Foo {\n"
+	    	+ "		/*\n"
+	    	+ "      * comment\n"
+	    	+ "      */\n"
+	    	+ "		void m() {}\n"
+	    	+ "	}";
+
+	    // setup pretty printer to print comments
+	    PrinterConfiguration config = new DefaultPrinterConfiguration()
+                .addOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
+        Printer printer = new DefaultPrettyPrinter(config);
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        MethodDeclaration md = cu.findFirst(MethodDeclaration.class).get();
+
+        // expected result is
+        String expected = md.getComment().get().asString()+"\n";
+
+        // set the new pretty printer in the compilation unit
+        cu.printer(printer);
+        // visit the MethodDeclaration node
+	    visitor.visit(cu, null);
+	    // checks that the comment is printed after executing the getDeclarationAsString method
+	    assertEqualsStringIgnoringEol(expected, md.getComment().get().toString());
+	}
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -153,8 +153,6 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     // usefull to find if the node is a phantom node
     private static final int LEVELS_TO_EXPLORE = 3;
 
-    protected static final PrinterConfiguration prettyPrinterNoCommentsConfiguration = new DefaultPrinterConfiguration().removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
-
     @InternalProperty
     private Range range;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -153,6 +153,9 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     // usefull to find if the node is a phantom node
     private static final int LEVELS_TO_EXPLORE = 3;
 
+    protected static final PrinterConfiguration prettyPrinterNoCommentsConfiguration = new DefaultPrinterConfiguration()
+			.removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
+
     @InternalProperty
     private Range range;
 
@@ -332,7 +335,13 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      * Formatting can be configured with parameter PrinterConfiguration.
      */
     public final String toString(PrinterConfiguration configuration) {
-        return getPrinter(configuration).print(this);
+    	// save the current configuration
+    	PrinterConfiguration previousConfiguration = getPrinter().getConfiguration();
+    	// print with the new configuration
+    	String result = getPrinter(configuration).print(this);
+    	// restore the previous printer configuration (issue 4163)
+    	getPrinter().setConfiguration(previousConfiguration);
+    	return result;
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
@@ -20,6 +20,14 @@
  */
 package com.github.javaparser.ast.body;
 
+import static com.github.javaparser.utils.Utils.assertNotNull;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -35,14 +43,6 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.CallableDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.OptionalProperty;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
-
-import static com.github.javaparser.utils.Utils.assertNotNull;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Represents a declaration which is callable eg. a method or a constructor.
@@ -88,12 +88,14 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
      * @return modifiers
      * @see Modifier
      */
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<Modifier> getModifiers() {
         return modifiers;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setModifiers(final NodeList<Modifier> modifiers) {
         assertNotNull(modifiers);
@@ -108,12 +110,14 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
         return (T) this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public SimpleName getName() {
         return name;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setName(final SimpleName name) {
         assertNotNull(name);
@@ -128,12 +132,14 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
         return (T) this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<Parameter> getParameters() {
         return parameters;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setParameters(final NodeList<Parameter> parameters) {
         assertNotNull(parameters);
@@ -148,12 +154,14 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
         return (T) this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<ReferenceType> getThrownExceptions() {
         return thrownExceptions;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setThrownExceptions(final NodeList<ReferenceType> thrownExceptions) {
         assertNotNull(thrownExceptions);
@@ -168,12 +176,14 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
         return (T) this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<TypeParameter> getTypeParameters() {
         return typeParameters;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setTypeParameters(final NodeList<TypeParameter> typeParameters) {
         assertNotNull(typeParameters);
@@ -199,7 +209,7 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
                 } else {
                     sb.append(", ");
                 }
-                sb.append(thr.toString(prettyPrinterNoCommentsConfiguration));
+                sb.append(thr);
             }
         }
         return sb.toString();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
@@ -209,7 +209,7 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
                 } else {
                     sb.append(", ");
                 }
-                sb.append(thr);
+                sb.append(thr.toString(prettyPrinterNoCommentsConfiguration));
             }
         }
         return sb.toString();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CompactConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CompactConstructorDeclaration.java
@@ -262,7 +262,7 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
                 } else {
                     sb.append(", ");
                 }
-                sb.append(thr);
+                sb.append(thr.toString(prettyPrinterNoCommentsConfiguration));
             }
         }
         return sb.toString();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CompactConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CompactConstructorDeclaration.java
@@ -20,6 +20,11 @@
  */
 package com.github.javaparser.ast.body;
 
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -37,11 +42,6 @@ import com.github.javaparser.metamodel.CompactConstructorDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
-
-import java.util.Optional;
-import java.util.function.Consumer;
-
-import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * <h1>The record declaration's constructor</h1>
@@ -121,7 +121,8 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
         v.visit(this, arg);
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public BlockStmt getBody() {
         return body;
     }
@@ -132,7 +133,8 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
      * @param body the body, can not be null
      * @return this, the ConstructorDeclaration
      */
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setBody(final BlockStmt body) {
         assertNotNull(body);
         if (body == this.body) {
@@ -146,12 +148,14 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
         return this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<Modifier> getModifiers() {
         return modifiers;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setModifiers(final NodeList<Modifier> modifiers) {
         assertNotNull(modifiers);
         if (modifiers == this.modifiers) {
@@ -165,12 +169,14 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
         return this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public SimpleName getName() {
         return name;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setName(final SimpleName name) {
         assertNotNull(name);
         if (name == this.name) {
@@ -184,12 +190,14 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
         return this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<ReferenceType> getThrownExceptions() {
         return thrownExceptions;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setThrownExceptions(final NodeList<ReferenceType> thrownExceptions) {
         assertNotNull(thrownExceptions);
         if (thrownExceptions == this.thrownExceptions) {
@@ -203,12 +211,14 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
         return this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<TypeParameter> getTypeParameters() {
         return typeParameters;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setTypeParameters(final NodeList<TypeParameter> typeParameters) {
         assertNotNull(typeParameters);
         if (typeParameters == this.typeParameters) {
@@ -252,7 +262,7 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
                 } else {
                     sb.append(", ");
                 }
-                sb.append(thr.toString(prettyPrinterNoCommentsConfiguration));
+                sb.append(thr);
             }
         }
         return sb.toString();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -173,9 +173,9 @@ public class ConstructorDeclaration extends CallableDeclaration<ConstructorDecla
                 sb.append(", ");
             }
             if (includingParameterName) {
-            	sb.append(param);
+            	sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
             } else {
-            	sb.append(param.getType());
+            	sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
             }
         }
         sb.append(")");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -20,6 +20,11 @@
  */
 package com.github.javaparser.ast.body;
 
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -37,11 +42,6 @@ import com.github.javaparser.metamodel.ConstructorDeclarationMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
-
-import java.util.Optional;
-import java.util.function.Consumer;
-
-import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * A constructor declaration: {@code class X { X() { } }} where X(){} is the constructor declaration.
@@ -98,7 +98,8 @@ public class ConstructorDeclaration extends CallableDeclaration<ConstructorDecla
         v.visit(this, arg);
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public BlockStmt getBody() {
         return body;
     }
@@ -109,7 +110,8 @@ public class ConstructorDeclaration extends CallableDeclaration<ConstructorDecla
      * @param body the body, can not be null
      * @return this, the ConstructorDeclaration
      */
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public ConstructorDeclaration setBody(final BlockStmt body) {
         assertNotNull(body);
         if (body == this.body) {
@@ -171,9 +173,9 @@ public class ConstructorDeclaration extends CallableDeclaration<ConstructorDecla
                 sb.append(", ");
             }
             if (includingParameterName) {
-                sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
+            	sb.append(param);
             } else {
-                sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
+            	sb.append(param.getType());
             }
         }
         sb.append(")");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -209,7 +209,7 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
                 sb.append("synchronized ");
             }
         }
-        sb.append(getType());
+        sb.append(getType().toString(prettyPrinterNoCommentsConfiguration));
         sb.append(" ");
         sb.append(getName());
         sb.append("(");
@@ -221,9 +221,9 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
                 sb.append(", ");
             }
             if (includingParameterName) {
-            	sb.append(param);
+            	sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
             } else {
-            	sb.append(param.getType());
+            	sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
                 if (param.isVarArgs()) {
                     sb.append("...");
                 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -211,7 +211,7 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
         }
         sb.append(getType().toString(prettyPrinterNoCommentsConfiguration));
         sb.append(" ");
-        sb.append(getName());
+        sb.append(getName().toString(prettyPrinterNoCommentsConfiguration));
         sb.append("(");
         boolean firstParam = true;
         for (Parameter param : getParameters()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -20,6 +20,11 @@
  */
 package com.github.javaparser.ast.body;
 
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -40,11 +45,6 @@ import com.github.javaparser.metamodel.MethodDeclarationMetaModel;
 import com.github.javaparser.metamodel.OptionalProperty;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
-
-import java.util.Optional;
-import java.util.function.Consumer;
-
-import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
  * A method declaration. "public int abc() {return 1;}" in this example: {@code class X { public int abc() {return 1;}
@@ -106,7 +106,8 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
         v.visit(this, arg);
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public Optional<BlockStmt> getBody() {
         return Optional.ofNullable(body);
     }
@@ -117,7 +118,8 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
      * @param body the body, can be null
      * @return this, the MethodDeclaration
      */
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public MethodDeclaration setBody(final BlockStmt body) {
         if (body == this.body) {
             return this;
@@ -130,12 +132,14 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
         return this;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public Type getType() {
         return type;
     }
 
-    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public MethodDeclaration setType(final Type type) {
         assertNotNull(type);
         if (type == this.type) {
@@ -205,7 +209,7 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
                 sb.append("synchronized ");
             }
         }
-        sb.append(getType().toString(prettyPrinterNoCommentsConfiguration));
+        sb.append(getType());
         sb.append(" ");
         sb.append(getName());
         sb.append("(");
@@ -217,9 +221,9 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
                 sb.append(", ");
             }
             if (includingParameterName) {
-                sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
+            	sb.append(param);
             } else {
-                sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
+            	sb.append(param.getType());
                 if (param.isVarArgs()) {
                     sb.append("...");
                 }
@@ -286,7 +290,8 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
         return super.remove(node);
     }
 
-    @Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")
+    @Override
+	@Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")
     public MethodDeclaration removeBody() {
         return setBody((BlockStmt) null);
     }


### PR DESCRIPTION
Fixes #4163 .

Redefining the printer configuration should not be done during processing because it overwrites a configuration that would have been made globally before processing.
The correct way to set the printer configuration is:

    // setup pretty printer to print comments
    PrinterConfiguration config = new DefaultPrinterConfiguration()
                .addOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
    Printer printer = new DefaultPrettyPrinter(config);
    // set the new pretty printer in the compilation unit
    cu.printer(printer);
