### PR TITLE
Code Coverage Enhancement for 'javaparser-core/src/main/java/com/github/javaparser/ast/body' package

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/AnnotationDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/AnnotationDeclarationTest.java
@@ -25,8 +25,8 @@ import com.github.javaparser.ast.stmt.Statement;
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.utils.TestParser.parseStatement;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AnnotationDeclarationTest {
     @Test
@@ -38,5 +38,18 @@ class AnnotationDeclarationTest {
     void issue2216() {
         Statement statement = parseStatement("TT tt = new <String> @TypeAnno @TA2 TT( \"S\" );");
         assertEquals("TT tt = new <String> @TypeAnno @TA2 TT(\"S\");", statement.toString());
+    }
+
+    @Test
+    void testTypeCastingMethods() {
+        AnnotationDeclaration decl = new AnnotationDeclaration();
+        assertTrue(decl.isAnnotationDeclaration());
+        assertEquals(decl, decl.asAnnotationDeclaration());
+
+        decl.ifAnnotationDeclaration(e -> {
+            assertTrue(e instanceof AnnotationDeclaration);
+        });
+
+        assertTrue(decl.toAnnotationDeclaration().isPresent());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/AnnotationMemberDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/AnnotationMemberDeclarationTest.java
@@ -21,9 +21,10 @@
 
 package com.github.javaparser.ast.body;
 
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.IntegerLiteralExpr;
-import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -61,5 +62,121 @@ class AnnotationMemberDeclarationTest {
         decl.removeDefaultValue();
 
         assertFalse(defaultValue.getParentNode().isPresent());
+    }
+
+    @Test
+    void testModifiersSetter() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        NodeList<Modifier> modifiers = new NodeList<>(Modifier.publicModifier(), Modifier.staticModifier());
+        decl.setModifiers(modifiers);
+
+        assertTrue(decl.getModifiers().contains(Modifier.publicModifier()));
+        assertTrue(decl.getModifiers().contains(Modifier.staticModifier()));
+    }
+
+    @Test
+    void testTypeSetter() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        ClassOrInterfaceType type = new ClassOrInterfaceType("String");
+        decl.setType(type);
+
+        assertEquals("String", decl.getType().asString());
+    }
+
+    @Test
+    void testDefaultValueSetter() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        BooleanLiteralExpr defaultValue = new BooleanLiteralExpr(true);
+        decl.setDefaultValue(defaultValue);
+
+        assertTrue(decl.getDefaultValue().isPresent());
+        assertTrue(((BooleanLiteralExpr) decl.getDefaultValue().get()).getValue());
+    }
+
+    @Test
+    void testReplaceMethodForDefaultValue() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        LongLiteralExpr defaultValue = new LongLiteralExpr(123L);
+        decl.setDefaultValue(defaultValue);
+
+        LongLiteralExpr newDefaultValue = new LongLiteralExpr(456L);
+        decl.replace(defaultValue, newDefaultValue);
+
+        assertTrue(decl.getDefaultValue().isPresent());
+        assertEquals(456L, ((LongLiteralExpr) decl.getDefaultValue().get()).asLong());
+    }
+
+    @Test
+    void testReplaceMethodForOtherType() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        ClassOrInterfaceType type = new ClassOrInterfaceType("String");
+        decl.setType(type);
+
+        ClassOrInterfaceType newType = new ClassOrInterfaceType("Integer");
+        assertTrue(decl.replace(type, newType));
+        assertEquals("Integer", decl.getType().asString());
+    }
+
+    @Test
+    void testRemoveMethod() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+
+        Modifier publicMod = Modifier.publicModifier();
+        NodeList<Modifier> modifiers = new NodeList<>(publicMod);
+        decl.setModifiers(modifiers);
+
+        assertTrue(decl.remove(publicMod));
+
+        assertFalse(decl.remove(Modifier.protectedModifier()));
+    }
+
+    @Test
+    void testCloneMethod() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        decl.setName(new SimpleName("foo"));
+        decl.setType(new ClassOrInterfaceType("String"));
+        AnnotationMemberDeclaration clonedDecl = decl.clone();
+
+        assertEquals(decl.getName().asString(), clonedDecl.getName().asString());
+        assertEquals(decl.getType().asString(), clonedDecl.getType().asString());
+    }
+
+    @Test
+    void testIsAnnotationMemberDeclaration() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        assertTrue(decl.isAnnotationMemberDeclaration());
+    }
+
+    @Test
+    void testAsAnnotationMemberDeclaration() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        assertEquals(decl, decl.asAnnotationMemberDeclaration());
+    }
+
+    @Test
+    void testIfAnnotationMemberDeclaration() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        decl.ifAnnotationMemberDeclaration(annotationDecl -> assertEquals(decl, annotationDecl));
+    }
+
+    @Test
+    void testToAnnotationMemberDeclaration() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+        assertTrue(decl.toAnnotationMemberDeclaration().isPresent());
+        assertEquals(decl, decl.toAnnotationMemberDeclaration().get());
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        AnnotationMemberDeclaration decl = new AnnotationMemberDeclaration();
+
+        assertTrue(decl.isAnnotationMemberDeclaration());
+        assertEquals(decl, decl.asAnnotationMemberDeclaration());
+
+        decl.ifAnnotationMemberDeclaration(e -> {
+            assertTrue(e instanceof AnnotationMemberDeclaration);
+        });
+
+        assertTrue(decl.toAnnotationMemberDeclaration().isPresent());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/BodyDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/BodyDeclarationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.body;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.visitor.GenericVisitor;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BodyDeclarationTest {
+
+    // A concrete subclass of BodyDeclaration for testing
+    private static class ConcreteBodyDeclaration extends BodyDeclaration<ConcreteBodyDeclaration> {
+        @Override
+        public ConcreteBodyDeclaration clone() {
+            return (ConcreteBodyDeclaration) super.clone();
+        }
+
+        @Override
+        public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+            return null;
+        }
+
+        @Override
+        public <A> void accept(VoidVisitor<A> v, A arg) {
+
+        }
+    }
+
+    // Mock AnnotationExpr class for testing purposes
+    private static class MockAnnotationExpr extends AnnotationExpr {
+        @Override
+        public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+            return null;
+        }
+
+        @Override
+        public <A> void accept(VoidVisitor<A> v, A arg) {
+
+        }
+    }
+
+    @Test
+    void testSetAnnotations() {
+        ConcreteBodyDeclaration decl = new ConcreteBodyDeclaration();
+
+        assertTrue(decl.getAnnotations().isEmpty());
+
+        NodeList<AnnotationExpr> annotations = new NodeList<>(new MarkerAnnotationExpr("Override"));
+        decl.setAnnotations(annotations);
+
+        assertEquals(1, decl.getAnnotations().size());
+        assertEquals("Override", decl.getAnnotations().get(0).getNameAsString());
+    }
+
+    @Test
+    void testRemoveAnnotation() {
+        ConcreteBodyDeclaration decl = new ConcreteBodyDeclaration();
+        NodeList<AnnotationExpr> annotations = new NodeList<>(new MarkerAnnotationExpr("Override"));
+        decl.setAnnotations(annotations);
+
+        assertTrue(decl.remove(decl.getAnnotations().get(0)));
+        assertTrue(decl.getAnnotations().isEmpty());
+    }
+
+    @Test
+    public void testReplace() {
+        ConcreteBodyDeclaration declaration = new ConcreteBodyDeclaration();
+        AnnotationExpr mockAnnotation = new MockAnnotationExpr();
+        declaration.getAnnotations().add(mockAnnotation);
+        AnnotationExpr newAnnotation = new MockAnnotationExpr();
+        assertTrue(declaration.replace(mockAnnotation, newAnnotation));
+    }
+
+    @Test
+    public void testIsAnnotationDeclaration() {
+        ConcreteBodyDeclaration decl = new ConcreteBodyDeclaration();
+        assertFalse(decl.isAnnotationDeclaration());
+    }
+
+    @Test
+    public void testIfAnnotationDeclaration() {
+        ConcreteBodyDeclaration decl = new ConcreteBodyDeclaration();
+        decl.ifAnnotationDeclaration(annotationDeclaration -> fail("Action should not be executed"));
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        ConcreteBodyDeclaration decl = new ConcreteBodyDeclaration();
+
+        assertFalse(decl.isAnnotationDeclaration());
+        assertThrows(IllegalStateException.class, decl::asAnnotationDeclaration);
+
+        assertFalse(decl.isAnnotationMemberDeclaration());
+        assertThrows(IllegalStateException.class, decl::asAnnotationMemberDeclaration);
+
+        assertFalse(decl.isCallableDeclaration());
+        assertThrows(IllegalStateException.class, decl::asCallableDeclaration);
+
+        assertFalse(decl.isClassOrInterfaceDeclaration());
+        assertThrows(IllegalStateException.class, decl::asClassOrInterfaceDeclaration);
+
+        assertFalse(decl.isConstructorDeclaration());
+        assertThrows(IllegalStateException.class, decl::asConstructorDeclaration);
+
+        assertFalse(decl.isCompactConstructorDeclaration());
+        assertThrows(IllegalStateException.class, decl::asCompactConstructorDeclaration);
+
+        assertFalse(decl.isEnumConstantDeclaration());
+        assertThrows(IllegalStateException.class, decl::asEnumConstantDeclaration);
+
+        assertFalse(decl.isEnumDeclaration());
+        assertThrows(IllegalStateException.class, decl::asEnumDeclaration);
+
+        assertFalse(decl.isFieldDeclaration());
+        assertThrows(IllegalStateException.class, decl::asFieldDeclaration);
+
+        assertFalse(decl.isInitializerDeclaration());
+        assertThrows(IllegalStateException.class, decl::asInitializerDeclaration);
+
+        assertFalse(decl.isMethodDeclaration());
+        assertThrows(IllegalStateException.class, decl::asMethodDeclaration);
+
+        assertFalse(decl.isTypeDeclaration());
+        assertThrows(IllegalStateException.class, decl::asTypeDeclaration);
+
+        assertFalse(decl.isRecordDeclaration());
+        assertThrows(IllegalStateException.class, decl::asRecordDeclaration);
+
+        assertEquals(Optional.empty(), decl.toAnnotationDeclaration());
+        assertEquals(Optional.empty(), decl.toAnnotationMemberDeclaration());
+        assertEquals(Optional.empty(), decl.toCallableDeclaration());
+        assertEquals(Optional.empty(), decl.toClassOrInterfaceDeclaration());
+        assertEquals(Optional.empty(), decl.toConstructorDeclaration());
+        assertEquals(Optional.empty(), decl.toEnumConstantDeclaration());
+        assertEquals(Optional.empty(), decl.toEnumDeclaration());
+        assertEquals(Optional.empty(), decl.toFieldDeclaration());
+        assertEquals(Optional.empty(), decl.toInitializerDeclaration());
+        assertEquals(Optional.empty(), decl.toMethodDeclaration());
+        assertEquals(Optional.empty(), decl.toTypeDeclaration());
+        assertEquals(Optional.empty(), decl.toRecordDeclaration());
+        assertEquals(Optional.empty(), decl.toCompactConstructorDeclaration());
+    }
+    
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/BodyDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/BodyDeclarationTest.java
@@ -165,5 +165,4 @@ class BodyDeclarationTest {
         assertEquals(Optional.empty(), decl.toRecordDeclaration());
         assertEquals(Optional.empty(), decl.toCompactConstructorDeclaration());
     }
-    
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CallableDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CallableDeclarationTest.java
@@ -111,7 +111,6 @@ class CallableDeclarationTest {
         assertTrue(decl.getTypeParameters().contains(newTypeParam));
     }
 
-
     @Test
     void testVariableArityMethod() {
         ConcreteCallableDeclaration decl = new ConcreteCallableDeclaration();
@@ -129,5 +128,4 @@ class CallableDeclarationTest {
         assertFalse(decl.isVariableArityMethod());
         assertTrue(decl.isFixedArityMethod());
     }
-
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CallableDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CallableDeclarationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.body;
+
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.type.ArrayType;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.ast.visitor.GenericVisitor;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CallableDeclarationTest {
+
+    // A concrete subclass of CallableDeclaration for testing
+    private static class ConcreteCallableDeclaration extends CallableDeclaration<ConcreteCallableDeclaration> {
+        public ConcreteCallableDeclaration () {
+            super(new NodeList<>(), new NodeList<>(), new NodeList<>(), new SimpleName("Test"), new NodeList<>(), new NodeList<>(), null);
+        }
+
+        @Override
+        public String getDeclarationAsString(boolean includingModifiers, boolean includingThrows, boolean includingParameterName) {
+            return null;
+        }
+
+        @Override
+        public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+            return null;
+        }
+
+        @Override
+        public <A> void accept(VoidVisitor<A> v, A arg) {
+
+        }
+    }
+
+    @Test
+    void testConstructor() {
+        ConcreteCallableDeclaration decl = new ConcreteCallableDeclaration();
+        assertNotNull(decl);
+        assertEquals("Test", decl.getName().getIdentifier());
+    }
+
+    @Test
+    void testRemove() {
+        ConcreteCallableDeclaration decl = new ConcreteCallableDeclaration();
+
+        Modifier modToRemove = new Modifier();
+        decl.getModifiers().add(modToRemove);
+        assertTrue(decl.remove(modToRemove));
+        assertFalse(decl.getModifiers().contains(modToRemove));
+
+        Parameter paramToRemove = new Parameter();
+        decl.getParameters().add(paramToRemove);
+        assertTrue(decl.remove(paramToRemove));
+        assertFalse(decl.getParameters().contains(paramToRemove));
+
+        TypeParameter typeParamToRemove = new TypeParameter();
+        decl.getTypeParameters().add(typeParamToRemove);
+        assertTrue(decl.remove(typeParamToRemove));
+        assertFalse(decl.getTypeParameters().contains(typeParamToRemove));
+    }
+
+    @Test
+    void testReplace() {
+        ConcreteCallableDeclaration decl = new ConcreteCallableDeclaration();
+
+        SimpleName newName = new SimpleName("ReplacedTest");
+        decl.replace(decl.getName(), newName);
+        assertEquals("ReplacedTest", decl.getName().getIdentifier());
+
+        Modifier oldModifier = new Modifier();
+        decl.getModifiers().add(oldModifier);
+        Modifier newModifier = new Modifier();
+        decl.replace(oldModifier, newModifier);
+        assertTrue(decl.getModifiers().contains(newModifier));
+
+        Parameter oldParam = new Parameter();
+        decl.getParameters().add(oldParam);
+        Parameter newParam = new Parameter();
+        decl.replace(oldParam, newParam);
+        assertTrue(decl.getParameters().contains(newParam));
+
+        TypeParameter oldTypeParam = new TypeParameter();
+        decl.getTypeParameters().add(oldTypeParam);
+        TypeParameter newTypeParam = new TypeParameter();
+        decl.replace(oldTypeParam, newTypeParam);
+        assertTrue(decl.getTypeParameters().contains(newTypeParam));
+    }
+
+
+    @Test
+    void testVariableArityMethod() {
+        ConcreteCallableDeclaration decl = new ConcreteCallableDeclaration();
+        Parameter varArgParam = new Parameter(new ArrayType(PrimitiveType.intType()), new SimpleName("args"));
+        varArgParam.setVarArgs(true);
+        decl.addParameter(varArgParam);
+        assertTrue(decl.isVariableArityMethod());
+        assertFalse(decl.isFixedArityMethod());
+    }
+
+    @Test
+    void testFixedArityMethod() {
+        ConcreteCallableDeclaration decl = new ConcreteCallableDeclaration();
+        decl.addParameter(new Parameter(PrimitiveType.intType(), new SimpleName("arg1")));
+        assertFalse(decl.isVariableArityMethod());
+        assertTrue(decl.isFixedArityMethod());
+    }
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
@@ -34,6 +34,9 @@ import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.utils.TestParser;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.TypeParameter;
 
 class ClassOrInterfaceDeclarationTest {
     @Test
@@ -143,4 +146,102 @@ class ClassOrInterfaceDeclarationTest {
         });
     }
 
+    @Test
+    public void testClassOrInterfaceDeclarationDefaultConstructor() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        assertNotNull(decl);
+    }
+
+    @Test
+    public void testClassOrInterfaceDeclarationWithModifiersAndName() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration(new NodeList<>(), false, "TestName");
+        assertEquals("TestName", decl.getNameAsString());
+    }
+
+    @Test
+    public void testCloneMethod() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        ClassOrInterfaceDeclaration cloned = decl.clone();
+        assertNotNull(cloned);
+    }
+
+    @Test
+    public void testRemoveMethodExtendedTypes() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        ClassOrInterfaceType extendedType = new ClassOrInterfaceType("ExtendedType");
+        decl.addExtendedType(extendedType);
+        assertTrue(decl.remove(extendedType));
+        assertFalse(decl.getExtendedTypes().contains(extendedType));
+    }
+
+    @Test
+    public void testRemoveMethodImplementedTypes() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        ClassOrInterfaceType implementedType = new ClassOrInterfaceType("ImplementedType");
+        decl.addImplementedType(implementedType);
+        assertTrue(decl.remove(implementedType));
+        assertFalse(decl.getImplementedTypes().contains(implementedType));
+    }
+
+    @Test
+    public void testRemoveMethodTypeParameters() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        TypeParameter typeParameter = new TypeParameter("TypeParam");
+        decl.addTypeParameter(typeParameter);
+        assertTrue(decl.remove(typeParameter));
+        assertFalse(decl.getTypeParameters().contains(typeParameter));
+    }
+
+    @Test
+    public void testGetFullyQualifiedNameNonLocalClass() {
+        CompilationUnit cu = parse("package com.example; class X{}");
+        ClassOrInterfaceDeclaration y = cu.getClassByName("X").get();
+        assertEquals("com.example.X", y.getFullyQualifiedName().get());
+    }
+
+    @Test
+    public void testReplaceExtendedTypes() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        ClassOrInterfaceType oldType = new ClassOrInterfaceType("OldType");
+        ClassOrInterfaceType newType = new ClassOrInterfaceType("NewType");
+        decl.addExtendedType(oldType);
+        boolean result = decl.replace(oldType, newType);
+        assertTrue(result);
+        assertTrue(decl.getExtendedTypes().contains(newType));
+    }
+
+    @Test
+    public void testReplaceImplementedTypes() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        ClassOrInterfaceType oldType = new ClassOrInterfaceType("OldType");
+        ClassOrInterfaceType newType = new ClassOrInterfaceType("NewType");
+        decl.addImplementedType(oldType);
+        boolean result = decl.replace(oldType, newType);
+        assertTrue(result);
+        assertTrue(decl.getImplementedTypes().contains(newType));
+    }
+
+    @Test
+    public void testReplaceTypeParameters() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        TypeParameter oldType = new TypeParameter("OldType");
+        TypeParameter newType = new TypeParameter("NewType");
+        decl.addTypeParameter(oldType);
+        boolean result = decl.replace(oldType, newType);
+        assertTrue(result);
+        assertTrue(decl.getTypeParameters().contains(newType));
+    }
+
+    @Test
+    void testTypeCastingMethods() {
+        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+        assertTrue(decl.isClassOrInterfaceDeclaration());
+        assertEquals(decl, decl.asClassOrInterfaceDeclaration());
+
+        decl.ifClassOrInterfaceDeclaration(e -> {
+            assertTrue(e instanceof ClassOrInterfaceDeclaration);
+        });
+
+        assertTrue(decl.toClassOrInterfaceDeclaration().isPresent());
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CompactConstructorDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CompactConstructorDeclarationTest.java
@@ -154,14 +154,12 @@ class CompactConstructorDeclarationTest {
         assertTrue(removed);
     }
 
-
     @Test
     void testClone() {
         CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
         CompactConstructorDeclaration clone = decl.clone();
         assertNotSame(decl, clone);
     }
-
 
     @Test
     public void testReplaceName() {
@@ -284,5 +282,4 @@ class CompactConstructorDeclarationTest {
 
         assertTrue(decl.toCompactConstructorDeclaration().isPresent());
     }
-
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CompactConstructorDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CompactConstructorDeclarationTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.body;
+
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.ast.visitor.GenericVisitor;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+import com.github.javaparser.resolution.Context;
+import com.github.javaparser.resolution.types.ResolvedType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompactConstructorDeclarationTest {
+    @Test
+    void testDefaultConstructor() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        assertNotNull(decl.getModifiers());
+        assertNotNull(decl.getTypeParameters());
+        assertNotNull(decl.getThrownExceptions());
+        assertNotNull(decl.getName());
+        assertNotNull(decl.getBody());
+    }
+
+    @Test
+    void testConstructorWithName() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration("MyConstructor");
+        assertEquals("MyConstructor", decl.getNameAsString());
+    }
+
+    @Test
+    void testConstructorWithModifiersAndName() {
+        NodeList<Modifier> modifiers = new NodeList<>(Modifier.publicModifier());
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration(modifiers, "MyConstructor");
+        assertTrue(decl.getModifiers().contains(Modifier.publicModifier()));
+        assertEquals("MyConstructor", decl.getNameAsString());
+    }
+
+    @Test
+    void testSetBody() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        BlockStmt blockStmt = new BlockStmt();
+        decl.setBody(blockStmt);
+        assertSame(blockStmt, decl.getBody());
+    }
+
+    @Test
+    void testSetModifiers() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        NodeList<Modifier> modifiers = new NodeList<>(Modifier.publicModifier());
+        decl.setModifiers(modifiers);
+        assertTrue(decl.getModifiers().contains(Modifier.publicModifier()));
+    }
+
+    @Test
+    void testSetName() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        SimpleName name = new SimpleName("MyConstructor");
+        decl.setName(name);
+        assertSame(name, decl.getName());
+    }
+
+    @Test
+    void testGetDeclarationAsString() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration("MyConstructor");
+        String declarationString = decl.getDeclarationAsString(true, true, true);
+        assertEquals("public MyConstructor()", declarationString);
+    }
+
+    @Test
+    public void testAppendThrowsIfRequested() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        decl.addThrownException(new ClassOrInterfaceType("IOException"));
+        decl.addThrownException(new ClassOrInterfaceType("NullPointerException"));
+        String result = decl.appendThrowsIfRequested(true);
+        assertEquals(" throws IOException, NullPointerException", result);
+    }
+
+    @Test
+    void testRemoveTypeParameter() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        TypeParameter tp = new TypeParameter();
+        decl.getTypeParameters().add(tp);
+
+        boolean removed = decl.remove(tp);
+        assertTrue(removed);
+
+        removed = decl.remove(new TypeParameter());
+        assertFalse(removed);
+    }
+
+    @Test
+    void testRemoveThrownException() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        ReferenceType rt = new ReferenceType() {
+            @Override
+            public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+                return null;
+            }
+
+            @Override
+            public <A> void accept(VoidVisitor<A> v, A arg) {
+
+            }
+
+            @Override
+            public ResolvedType convertToUsage(Context context) {
+                return null;
+            }
+
+            @Override
+            public String toDescriptor() {
+                return null;
+            }
+
+            @Override
+            public String asString() {
+                return null;
+            }
+
+            @Override
+            public ResolvedType resolve() {
+                return null;
+            }
+        };
+        decl.getThrownExceptions().add(rt);
+
+        boolean removed = decl.remove(rt);
+        assertTrue(removed);
+    }
+
+
+    @Test
+    void testClone() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        CompactConstructorDeclaration clone = decl.clone();
+        assertNotSame(decl, clone);
+    }
+
+
+    @Test
+    public void testReplaceName() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+
+        SimpleName newName = new SimpleName("newName");
+        assertTrue(decl.replace(decl.getName(), newName));
+        assertEquals(newName, decl.getName());
+    }
+
+    @Test
+    void testReplaceBody() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        BlockStmt newBody = new BlockStmt();
+        assertTrue(decl.replace(decl.getBody(), newBody));
+        assertEquals(newBody, decl.getBody());
+    }
+
+    @Test
+    void testReplaceTypeParameter() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        TypeParameter oldTp = new TypeParameter();
+        decl.getTypeParameters().add(oldTp);
+
+        TypeParameter newTp = new TypeParameter("NewType");
+        assertTrue(decl.replace(oldTp, newTp));
+        assertEquals(newTp, decl.getTypeParameters().get(0));
+    }
+
+    @Test
+    void testReplaceThrownException() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        ReferenceType oldRt = new ReferenceType() {
+            @Override
+            public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+                return null;
+            }
+
+            @Override
+            public <A> void accept(VoidVisitor<A> v, A arg) {
+
+            }
+
+            @Override
+            public ResolvedType convertToUsage(Context context) {
+                return null;
+            }
+
+            @Override
+            public String toDescriptor() {
+                return null;
+            }
+
+            @Override
+            public String asString() {
+                return null;
+            }
+
+            @Override
+            public ResolvedType resolve() {
+                return null;
+            }
+        };
+        ReferenceType newRt = new ReferenceType() {
+            @Override
+            public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+                return null;
+            }
+
+            @Override
+            public <A> void accept(VoidVisitor<A> v, A arg) {
+
+            }
+
+            @Override
+            public ResolvedType convertToUsage(Context context) {
+                return null;
+            }
+
+            @Override
+            public String toDescriptor() {
+                return null;
+            }
+
+            @Override
+            public String asString() {
+                return null;
+            }
+
+            @Override
+            public ResolvedType resolve() {
+                return null;
+            }
+        };
+        decl.getThrownExceptions().add(oldRt);
+
+        assertTrue(decl.replace(oldRt, newRt));
+        assertEquals(newRt, decl.getThrownExceptions().get(0));
+    }
+
+    @Test
+    void testRemoveAnnotation() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+        AnnotationExpr annotation = new SingleMemberAnnotationExpr(new Name("MyAnnotation"), new StringLiteralExpr("value"));
+        decl.getAnnotations().add(annotation);
+
+        boolean removed = decl.remove(annotation);
+        assertTrue(removed);
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        CompactConstructorDeclaration decl = new CompactConstructorDeclaration();
+
+        assertTrue(decl.isCompactConstructorDeclaration());
+        assertEquals(decl, decl.asCompactConstructorDeclaration());
+        decl.ifCompactConstructorDeclaration(e -> {
+            assertTrue(e instanceof CompactConstructorDeclaration);
+        });
+
+        assertTrue(decl.toCompactConstructorDeclaration().isPresent());
+    }
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConstructorDeclarationTest {
     @Test
@@ -35,5 +36,18 @@ class ConstructorDeclarationTest {
         assertEquals(String.format("public Cons() {%1$s" +
                 "    super();%1$s" +
                 "}", SYSTEM_EOL), cons.toString());
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        ConstructorDeclaration decl = new ConstructorDeclaration();
+
+        assertTrue(decl.isConstructorDeclaration());
+        assertEquals(decl, decl.asConstructorDeclaration());
+        decl.ifConstructorDeclaration(e -> {
+            assertTrue(e instanceof ConstructorDeclaration);
+        });
+
+        assertTrue(decl.toConstructorDeclaration().isPresent());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumConstantDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumConstantDeclarationTest.java
@@ -139,6 +139,4 @@ class EnumConstantDeclarationTest {
 
         assertTrue(enumConstant.toEnumConstantDeclaration().isPresent());
     }
-
-
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumConstantDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumConstantDeclarationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.body;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnumConstantDeclarationTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration();
+        assertNotNull(enumConstant.getName());
+        assertTrue(enumConstant.getArguments().isEmpty());
+        assertTrue(enumConstant.getClassBody().isEmpty());
+    }
+
+    @Test
+    public void testStringConstructor() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration("TEST");
+        assertEquals("TEST", enumConstant.getName().asString());
+        assertTrue(enumConstant.getArguments().isEmpty());
+        assertTrue(enumConstant.getClassBody().isEmpty());
+    }
+
+    @Test
+    public void testAllFieldsConstructor() {
+        SimpleName name = new SimpleName("TEST");
+        NodeList<Expression> arguments = new NodeList<>(new NameExpr("arg1"), new NameExpr("arg2"));
+        NodeList<AnnotationExpr> annotations = new NodeList<>(new MarkerAnnotationExpr("Override"));
+        MethodDeclaration methodDeclaration = new MethodDeclaration();
+        NodeList<BodyDeclaration<?>> classBody = new NodeList<>(methodDeclaration);
+
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration(annotations, name, arguments, classBody);
+
+        assertEquals(name, enumConstant.getName());
+        assertTrue(enumConstant.getAnnotations().containsAll(annotations));
+        assertTrue(enumConstant.getArguments().containsAll(arguments));
+        assertTrue(enumConstant.getClassBody().containsAll(classBody));
+    }
+
+
+    @Test
+    public void testSetArguments() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration();
+        enumConstant.setArguments(new com.github.javaparser.ast.NodeList<>(new NameExpr("arg1")));
+        assertEquals(1, enumConstant.getArguments().size());
+        assertEquals("arg1", enumConstant.getArguments().get(0).toString());
+    }
+
+    @Test
+    public void testSetName() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration();
+        enumConstant.setName(new SimpleName("NEW_ENUM_CONSTANT"));
+        assertEquals("NEW_ENUM_CONSTANT", enumConstant.getName().asString());
+    }
+
+    @Test
+    public void testClone() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration("MY_ENUM_CONSTANT");
+        EnumConstantDeclaration clone = enumConstant.clone();
+        assertNotSame(enumConstant, clone);
+        assertEquals(enumConstant.getName(), clone.getName());
+    }
+
+    @Test
+    public void testRemove() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration();
+        NameExpr arg1 = new NameExpr("arg1");
+        enumConstant.getArguments().add(arg1);
+
+        MethodDeclaration methodDeclaration = new MethodDeclaration();
+        enumConstant.getClassBody().add(methodDeclaration);
+
+        assertTrue(enumConstant.remove(arg1));
+        assertFalse(enumConstant.getArguments().contains(arg1));
+
+        assertTrue(enumConstant.remove(methodDeclaration));
+        assertFalse(enumConstant.getClassBody().contains(methodDeclaration));
+    }
+
+    @Test
+    public void testReplace() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration();
+        SimpleName oldName = new SimpleName("OldName");
+        SimpleName newName = new SimpleName("NewName");
+        enumConstant.setName(oldName);
+
+        NameExpr arg1 = new NameExpr("arg1");
+        NameExpr arg2 = new NameExpr("arg2");
+        enumConstant.getArguments().add(arg1);
+
+        MethodDeclaration methodDeclaration = new MethodDeclaration();
+        enumConstant.getClassBody().add(methodDeclaration);
+
+        assertTrue(enumConstant.replace(oldName, newName));
+        assertEquals(newName, enumConstant.getName());
+
+        assertTrue(enumConstant.replace(arg1, arg2));
+        assertFalse(enumConstant.getArguments().contains(arg1));
+        assertTrue(enumConstant.getArguments().contains(arg2));
+
+        assertTrue(enumConstant.replace(methodDeclaration, null));
+        assertFalse(enumConstant.getClassBody().contains(methodDeclaration));
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        EnumConstantDeclaration enumConstant = new EnumConstantDeclaration();
+
+        assertTrue(enumConstant.isEnumConstantDeclaration());
+        assertEquals(enumConstant, enumConstant.asEnumConstantDeclaration());
+
+        enumConstant.ifEnumConstantDeclaration(e -> {
+            assertTrue(e instanceof EnumConstantDeclaration);
+        });
+
+        assertTrue(enumConstant.toEnumConstantDeclaration().isPresent());
+    }
+
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumDeclarationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.body;
+
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnumDeclarationTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+        assertNotNull(enumDeclaration);
+        assertTrue(enumDeclaration.getEntries().isEmpty());
+        assertTrue(enumDeclaration.getImplementedTypes().isEmpty());
+    }
+
+    @Test
+    public void testEntriesManipulation() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+        EnumConstantDeclaration entry = new EnumConstantDeclaration("TEST");
+        enumDeclaration.addEntry(entry);
+
+        assertEquals(1, enumDeclaration.getEntries().size());
+        assertEquals("TEST", enumDeclaration.getEntry(0).getNameAsString());
+
+        EnumConstantDeclaration newEntry = new EnumConstantDeclaration("NewTEST");
+        enumDeclaration.setEntry(0, newEntry);
+        assertEquals("NewTEST", enumDeclaration.getEntry(0).getNameAsString());
+
+        enumDeclaration.remove(newEntry);
+        assertTrue(enumDeclaration.getEntries().isEmpty());
+    }
+
+    @Test
+    void testAddEnumConstant() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+        enumDeclaration.addEnumConstant("TEST_CONSTANT");
+
+        assertTrue(enumDeclaration.getEntries().isNonEmpty());
+        assertEquals("TEST_CONSTANT", enumDeclaration.getEntry(0).getName().asString());
+    }
+
+    @Test
+    public void testRemove() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+        ClassOrInterfaceType implementedType = new ClassOrInterfaceType("Serializable");
+        enumDeclaration.getImplementedTypes().add(implementedType);
+
+        assertEquals(1, enumDeclaration.getImplementedTypes().size());
+        assertEquals("Serializable", enumDeclaration.getImplementedTypes().get(0).asString());
+
+        enumDeclaration.remove(implementedType);
+        assertTrue(enumDeclaration.getImplementedTypes().isEmpty());
+    }
+
+    @Test
+    void testClone() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+        EnumDeclaration clonedEnumDeclaration = enumDeclaration.clone();
+
+        assertNotNull(clonedEnumDeclaration);
+        assertNotSame(enumDeclaration, clonedEnumDeclaration);
+    }
+
+    @Test
+    void testGetMetaModel() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+
+        assertNotNull(enumDeclaration.getMetaModel());
+    }
+
+    @Test
+    public void testReplace() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+        EnumConstantDeclaration entry1 = new EnumConstantDeclaration("TEST1");
+        EnumConstantDeclaration entry2 = new EnumConstantDeclaration("TEST2");
+        enumDeclaration.addEntry(entry1);
+
+        assertTrue(enumDeclaration.replace(entry1, entry2));
+        assertEquals("TEST2", enumDeclaration.getEntry(0).getNameAsString());
+
+        ClassOrInterfaceType type1 = new ClassOrInterfaceType("Serializable");
+        ClassOrInterfaceType type2 = new ClassOrInterfaceType("Cloneable");
+        enumDeclaration.getImplementedTypes().add(type1);
+
+        assertTrue(enumDeclaration.replace(type1, type2));
+        assertEquals("Cloneable", enumDeclaration.getImplementedTypes().get(0).asString());
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        EnumDeclaration enumDeclaration = new EnumDeclaration();
+
+        assertTrue(enumDeclaration.isEnumDeclaration());
+        assertEquals(enumDeclaration, enumDeclaration.asEnumDeclaration());
+
+        enumDeclaration.ifEnumDeclaration(e -> {
+            assertTrue(e instanceof EnumDeclaration);
+        });
+
+        assertTrue(enumDeclaration.toEnumDeclaration().isPresent());
+    }
+
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/EnumDeclarationTest.java
@@ -122,6 +122,4 @@ class EnumDeclarationTest {
 
         assertTrue(enumDeclaration.toEnumDeclaration().isPresent());
     }
-
-
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
@@ -26,6 +26,9 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Modifier.Keyword;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.Type;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -127,5 +130,169 @@ class FieldDeclarationTest {
                 () -> assertFalse(i.isStatic()),
                 () -> assertFalse(i.isFinal())
         );
+    }
+
+    @Test
+    public void testFieldWithModifiers() {
+        NodeList<Modifier> modifiers = new NodeList<>();
+        modifiers.add(Modifier.publicModifier());
+        modifiers.add(Modifier.staticModifier());
+
+        Type type = new ClassOrInterfaceType("String");
+        String name = "fieldName";
+
+        FieldDeclaration field = new FieldDeclaration(modifiers, type, name);
+        assertTrue(field.getModifiers().contains(Modifier.publicModifier()));
+        assertTrue(field.getModifiers().contains(Modifier.staticModifier()));
+    }
+
+    @Test
+    public void testGetModifiers() {
+        FieldDeclaration field = new FieldDeclaration();
+        NodeList<Modifier> modifiers = new NodeList<>();
+        modifiers.add(Modifier.publicModifier());
+        field.setModifiers(modifiers);
+        assertTrue(field.getModifiers().contains(Modifier.publicModifier()));
+    }
+
+    @Test
+    public void testSetVariables() {
+        FieldDeclaration field = new FieldDeclaration();
+        NodeList<VariableDeclarator> variables = new NodeList<>();
+        VariableDeclarator var = new VariableDeclarator(new ClassOrInterfaceType("String"), "testVar");
+        variables.add(var);
+        field.setVariables(variables);
+        assertEquals("testVar", field.getVariables().get(0).getNameAsString());
+    }
+
+    @Test
+    public void testCreateGetter() {
+        ClassOrInterfaceDeclaration mockClass = new ClassOrInterfaceDeclaration();
+        FieldDeclaration field = mockClass.addField(int.class, "sampleField", Modifier.Keyword.PRIVATE);
+
+        MethodDeclaration generatedGetter = field.createGetter();
+
+        assertEquals("getSampleField", generatedGetter.getNameAsString());
+        assertEquals(PrimitiveType.intType(), generatedGetter.getType());
+        assertNotNull(generatedGetter.getBody().get());
+    }
+
+    @Test
+    public void testCreateSetter() {
+        ClassOrInterfaceDeclaration mockClass = new ClassOrInterfaceDeclaration();
+        FieldDeclaration field = mockClass.addField(int.class, "sampleField", Modifier.Keyword.PRIVATE);
+
+        MethodDeclaration generatedSetter = field.createSetter();
+
+        assertEquals("setSampleField", generatedSetter.getNameAsString());
+        assertEquals(1, generatedSetter.getParameters().size());
+        assertEquals("sampleField", generatedSetter.getParameter(0).getNameAsString());
+    }
+
+    @Test
+    public void testIsTransient() {
+        FieldDeclaration field = new FieldDeclaration();
+        assertFalse(field.isTransient());
+
+        NodeList<Modifier> modifiers = new NodeList<>();
+        modifiers.add(Modifier.transientModifier());
+        field.setModifiers(modifiers);
+        assertTrue(field.isTransient());
+    }
+
+    @Test
+    public void testSetTransient() {
+        FieldDeclaration field = new FieldDeclaration();
+        assertFalse(field.isTransient());
+        field.setTransient(true);
+        assertTrue(field.isTransient());
+    }
+
+    @Test
+    public void testIsVolatile() {
+        FieldDeclaration field = new FieldDeclaration();
+        assertFalse(field.isVolatile());
+
+        NodeList<Modifier> modifiers = new NodeList<>();
+        modifiers.add(Modifier.volatileModifier());
+        field.setModifiers(modifiers);
+        assertTrue(field.isVolatile());
+    }
+
+    @Test
+    public void testSetVolatile() {
+        FieldDeclaration field = new FieldDeclaration();
+        assertFalse(field.isVolatile());
+        field.setVolatile(true);
+        assertTrue(field.isVolatile());
+    }
+
+    @Test
+    public void testIsStatic() {
+        FieldDeclaration field = new FieldDeclaration();
+        assertFalse(field.isStatic());
+
+        NodeList<Modifier> modifiers = new NodeList<>();
+        modifiers.add(Modifier.staticModifier());
+        field.setModifiers(modifiers);
+        assertTrue(field.isStatic());
+    }
+
+    @Test
+    public void testIsFinal() {
+        FieldDeclaration field = new FieldDeclaration();
+        assertFalse(field.isFinal());
+
+        NodeList<Modifier> modifiers = new NodeList<>();
+        modifiers.add(Modifier.finalModifier());
+        field.setModifiers(modifiers);
+        assertTrue(field.isFinal());
+    }
+
+    @Test
+    public void testIsPublic() {
+        FieldDeclaration field = new FieldDeclaration();
+        assertFalse(field.isPublic());
+
+        NodeList<Modifier> modifiers = new NodeList<>();
+        modifiers.add(Modifier.publicModifier());
+        field.setModifiers(modifiers);
+        assertTrue(field.isPublic());
+    }
+
+    @Test
+    public void testRemoveVariableNode() {
+        FieldDeclaration field = new FieldDeclaration();
+        VariableDeclarator variable = new VariableDeclarator(PrimitiveType.intType(), "testVar");
+        field.addVariable(variable);
+
+        assertTrue(field.getVariables().contains(variable));
+        assertTrue(field.remove(variable));
+        assertFalse(field.getVariables().contains(variable));
+    }
+
+    @Test
+    public void testReplaceVariableNode() {
+        FieldDeclaration field = new FieldDeclaration();
+        VariableDeclarator originalVariable = new VariableDeclarator(PrimitiveType.intType(), "originalVar");
+        field.addVariable(originalVariable);
+        VariableDeclarator replacementVariable = new VariableDeclarator(PrimitiveType.intType(), "replacementVar");
+
+        assertTrue(field.replace(originalVariable, replacementVariable));
+        assertFalse(field.getVariables().contains(originalVariable));
+        assertTrue(field.getVariables().contains(replacementVariable));
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        FieldDeclaration field = new FieldDeclaration();
+
+        assertTrue(field.isFieldDeclaration());
+        assertEquals(field, field.asFieldDeclaration());
+        field.ifFieldDeclaration(e -> {
+            assertTrue(e instanceof FieldDeclaration);
+        });
+
+        assertTrue(field.toFieldDeclaration().isPresent());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/InitializerDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/InitializerDeclarationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.body;
+
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.metamodel.InitializerDeclarationMetaModel;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InitializerDeclarationTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        InitializerDeclaration initializer = new InitializerDeclaration();
+        assertNotNull(initializer.getBody());
+        assertFalse(initializer.isStatic());
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        BlockStmt blockStmt = new BlockStmt();
+        InitializerDeclaration initializer = new InitializerDeclaration(true, blockStmt);
+        assertEquals(blockStmt, initializer.getBody());
+        assertTrue(initializer.isStatic());
+    }
+
+    @Test
+    public void testSetStatic() {
+        InitializerDeclaration initializer = new InitializerDeclaration();
+        initializer.setStatic(true);
+        assertTrue(initializer.isStatic());
+    }
+
+    @Test
+    public void testSetBody() {
+        InitializerDeclaration initializer = new InitializerDeclaration();
+        BlockStmt blockStmt = new BlockStmt();
+        initializer.setBody(blockStmt);
+        assertEquals(blockStmt, initializer.getBody());
+    }
+
+    @Test
+    public void testClone() {
+        InitializerDeclaration initializer = new InitializerDeclaration(true, new BlockStmt());
+        InitializerDeclaration cloned = initializer.clone();
+        assertNotSame(initializer, cloned);
+        assertEquals(initializer.isStatic(), cloned.isStatic());
+    }
+
+    @Test
+    public void testGetMetaModel() {
+        InitializerDeclaration initializer = new InitializerDeclaration();
+        InitializerDeclarationMetaModel metaModel = initializer.getMetaModel();
+        assertNotNull(metaModel);
+        assertEquals(JavaParserMetaModel.initializerDeclarationMetaModel, metaModel);
+    }
+
+    @Test
+    public void testReplaceBody() {
+        InitializerDeclaration initializer = new InitializerDeclaration();
+        BlockStmt oldBody = initializer.getBody();
+        BlockStmt newBody = new BlockStmt();
+        assertTrue(initializer.replace(oldBody, newBody));
+        assertEquals(newBody, initializer.getBody());
+    }
+
+    @Test
+    public void testReplaceWithNull() {
+        InitializerDeclaration initializer = new InitializerDeclaration();
+        assertFalse(initializer.replace(null, new BlockStmt()));
+    }
+
+    @Test
+    public void testTypeCastingMethods() {
+        InitializerDeclaration initializer = new InitializerDeclaration();
+
+        assertTrue(initializer.isInitializerDeclaration());
+        assertEquals(initializer, initializer.asInitializerDeclaration());
+        initializer.ifInitializerDeclaration(e -> {
+            assertTrue(e instanceof InitializerDeclaration);
+        });
+
+        assertTrue(initializer.toInitializerDeclaration().isPresent());
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
@@ -118,4 +118,17 @@ class MethodDeclarationTest {
         MethodDeclaration method2 = parseBodyDeclaration("int x();").asMethodDeclaration();
         assertTrue(method2.isFixedArityMethod());
     }
+
+    @Test
+    public void testTypeCastingMethods() {
+        MethodDeclaration method1 = parseBodyDeclaration("int x(int z);").asMethodDeclaration();
+
+        assertTrue(method1.isMethodDeclaration());
+        assertEquals(method1, method1.asMethodDeclaration());
+        method1.ifMethodDeclaration(e -> {
+            assertTrue(e instanceof MethodDeclaration);
+        });
+
+        assertTrue(method1.toMethodDeclaration().isPresent());
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/RecordDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/RecordDeclarationTest.java
@@ -25,6 +25,11 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.utils.TestParser;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -761,5 +766,242 @@ public class RecordDeclarationTest {
     private void assertTwoRecordDeclarations(CompilationUnit cu) {
         List<RecordDeclaration> recordDeclarations = cu.findAll(RecordDeclaration.class);
         assertEquals(2, recordDeclarations.size());
+    }
+
+    @Test
+    public void testReceiverParameter() {
+        RecordDeclaration record = new RecordDeclaration();
+        ReceiverParameter receiverParameter = new ReceiverParameter();
+        record.setReceiverParameter(receiverParameter);
+        assertEquals(receiverParameter, record.getReceiverParameter().orElse(null));
+    }
+
+    @Test
+    public void testIsRecordDeclaration() {
+        RecordDeclaration record = new RecordDeclaration(new NodeList<Modifier>(), "testName");
+        assertTrue(record.isRecordDeclaration());
+    }
+
+    @Test
+    public void testAsRecordDeclaration() {
+        RecordDeclaration record = new RecordDeclaration(new NodeList<Modifier>(), "testName");
+        assertTrue(record.asRecordDeclaration() instanceof RecordDeclaration);
+    }
+
+    @Test
+    public void testToRecordDeclaration() {
+        RecordDeclaration record = new RecordDeclaration(new NodeList<Modifier>(), "testName");
+        assertTrue(record.toRecordDeclaration().isPresent());
+    }
+
+    @Test
+    public void testIfRecordDeclaration() {
+        RecordDeclaration record = new RecordDeclaration(new NodeList<Modifier>(), "testName");
+        record.ifRecordDeclaration(r -> assertEquals("testName", r.getName().asString()));
+    }
+
+    @Test
+    public void testRemoveImplementedTypes() {
+        RecordDeclaration record = new RecordDeclaration();
+        ClassOrInterfaceType type = new ClassOrInterfaceType("Type");
+        record.getImplementedTypes().add(type);
+        assertTrue(record.remove(type));
+        assertFalse(record.getImplementedTypes().contains(type));
+    }
+
+    @Test
+    public void testRemoveParameters() {
+        RecordDeclaration record = new RecordDeclaration();
+        Parameter param = new Parameter(new PrimitiveType(PrimitiveType.Primitive.INT), "intParam");
+        record.getParameters().add(param);
+        assertTrue(record.remove(param));
+        assertFalse(record.getParameters().contains(param));
+    }
+
+    @Test
+    public void testRemoveReceiverParameter() {
+        RecordDeclaration record = new RecordDeclaration();
+        ReceiverParameter receiverParameter = new ReceiverParameter();
+        record.setReceiverParameter(receiverParameter);
+        assertTrue(record.remove(receiverParameter));
+        record.removeReceiverParameter();
+        assertNull(record.getReceiverParameter().orElse(null));
+    }
+
+    @Test
+    public void testRemoveTypeParameters() {
+        RecordDeclaration record = new RecordDeclaration();
+        TypeParameter typeParam = new TypeParameter("T");
+        record.getTypeParameters().add(typeParam);
+
+        assertTrue(record.remove(typeParam));
+        assertFalse(record.getTypeParameters().contains(typeParam));
+    }
+
+    @Test
+    public void testReplaceImplementedTypes() {
+        RecordDeclaration record = new RecordDeclaration();
+        ClassOrInterfaceType oldType = new ClassOrInterfaceType("OldType");
+        ClassOrInterfaceType newType = new ClassOrInterfaceType("NewType");
+        record.getImplementedTypes().add(oldType);
+
+        assertTrue(record.replace(oldType, newType));
+        assertFalse(record.getImplementedTypes().contains(oldType));
+        assertTrue(record.getImplementedTypes().contains(newType));
+    }
+
+    @Test
+    public void testReplaceParameters() {
+        RecordDeclaration record = new RecordDeclaration();
+        Parameter oldParam = new Parameter(new PrimitiveType(PrimitiveType.Primitive.INT), "intParam");
+        Parameter newParam = new Parameter(new PrimitiveType(PrimitiveType.Primitive.DOUBLE), "doubleParam");
+        record.getParameters().add(oldParam);
+
+        assertTrue(record.replace(oldParam, newParam));
+        assertFalse(record.getParameters().contains(oldParam));
+        assertTrue(record.getParameters().contains(newParam));
+    }
+
+    @Test
+    public void testReplaceTypeParameters() {
+        RecordDeclaration record = new RecordDeclaration();
+        TypeParameter oldTypeParam = new TypeParameter("OldT");
+        TypeParameter newTypeParam = new TypeParameter("NewT");
+        record.getTypeParameters().add(oldTypeParam);
+
+        assertTrue(record.replace(oldTypeParam, newTypeParam));
+        assertFalse(record.getTypeParameters().contains(oldTypeParam));
+        assertTrue(record.getTypeParameters().contains(newTypeParam));
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        ReceiverParameter rp = new ReceiverParameter();
+        assertNotNull(rp.getType());
+        assertNotNull(rp.getName());
+        assertTrue(rp.getAnnotations().isEmpty());
+    }
+
+    @Test
+    public void testConstructorWithTypeAndName() {
+        Type type = new ClassOrInterfaceType();
+        Name name = new Name("TestName");
+        ReceiverParameter rp = new ReceiverParameter(type, name);
+
+        assertEquals(type, rp.getType());
+        assertEquals(name, rp.getName());
+    }
+
+    @Test
+    public void testConstructorWithTypeAndStringName() {
+        Type type = new ClassOrInterfaceType();
+        String name = "TestName";
+        ReceiverParameter rp = new ReceiverParameter(type, name);
+
+        assertEquals(type, rp.getType());
+        assertEquals(name, rp.getName().asString());
+    }
+
+    @Test
+    public void testSetGetType() {
+        ReceiverParameter rp = new ReceiverParameter();
+        Type newType = new ClassOrInterfaceType("NewType");
+        rp.setType(newType);
+
+        assertEquals(newType, rp.getType());
+    }
+
+    @Test
+    public void testSetGetName() {
+        ReceiverParameter rp = new ReceiverParameter();
+        Name newName = new Name("NewName");
+        rp.setName(newName);
+
+        assertEquals(newName, rp.getName());
+    }
+
+    @Test
+    public void testAddAnnotation() {
+        ReceiverParameter rp = new ReceiverParameter();
+        AnnotationExpr annotation = new SingleMemberAnnotationExpr(new Name("TestAnnotation"), new StringLiteralExpr("Value"));
+        rp.getAnnotations().add(annotation);
+
+        assertEquals(1, rp.getAnnotations().size());
+        assertTrue(rp.getAnnotations().contains(annotation));
+    }
+
+    @Test
+    public void testClone() {
+        ReceiverParameter rp = new ReceiverParameter();
+        ReceiverParameter clonedRp = rp.clone();
+        assertNotSame(rp, clonedRp);
+        assertEquals(rp.getType(), clonedRp.getType());
+        assertEquals(rp.getName(), clonedRp.getName());
+        assertEquals(rp.getAnnotations().size(), clonedRp.getAnnotations().size());
+    }
+
+    @Test
+    public void testRemoveAnnotation() {
+        ReceiverParameter rp = new ReceiverParameter();
+        AnnotationExpr annotation = new SingleMemberAnnotationExpr(new Name("TestAnnotation"), new StringLiteralExpr("Value"));
+        rp.getAnnotations().add(annotation);
+        rp.remove(annotation);
+        assertTrue(rp.getAnnotations().isEmpty());
+    }
+
+    @Test
+    public void testReplaceAnnotation() {
+        ReceiverParameter rp = new ReceiverParameter();
+        AnnotationExpr annotation1 = new SingleMemberAnnotationExpr(new Name("Annotation1"), new StringLiteralExpr("Value1"));
+        AnnotationExpr annotation2 = new SingleMemberAnnotationExpr(new Name("Annotation2"), new StringLiteralExpr("Value2"));
+        rp.getAnnotations().add(annotation1);
+        rp.replace(annotation1, annotation2);
+        assertEquals(1, rp.getAnnotations().size());
+        assertTrue(rp.getAnnotations().contains(annotation2));
+        assertFalse(rp.getAnnotations().contains(annotation1));
+    }
+
+    @Test
+    public void testReplaceWithNullNode() {
+        ReceiverParameter rp = new ReceiverParameter();
+        assertFalse(rp.replace(null, new Name("NewName")));
+    }
+
+    @Test
+    public void testReplaceAnnotationInList() {
+        ReceiverParameter rp = new ReceiverParameter();
+        AnnotationExpr annotation1 = new SingleMemberAnnotationExpr(new Name("Annotation1"), new StringLiteralExpr("Value1"));
+        AnnotationExpr annotation2 = new SingleMemberAnnotationExpr(new Name("Annotation2"), new StringLiteralExpr("Value2"));
+        rp.getAnnotations().add(annotation1);
+        assertTrue(rp.replace(annotation1, annotation2));
+        assertFalse(rp.getAnnotations().contains(annotation1));
+        assertTrue(rp.getAnnotations().contains(annotation2));
+    }
+
+    @Test
+    public void testReplaceName() {
+        ReceiverParameter rp = new ReceiverParameter();
+        Name newName = new Name("NewName");
+
+        assertTrue(rp.replace(rp.getName(), newName));
+        assertEquals(newName, rp.getName());
+    }
+
+    @Test
+    public void testReplaceType() {
+        ReceiverParameter rp = new ReceiverParameter();
+        Type newType = new ClassOrInterfaceType("NewType");
+
+        assertTrue(rp.replace(rp.getType(), newType));
+        assertEquals(newType, rp.getType());
+    }
+
+    @Test
+    public void testReplaceWithNonExistentNode() {
+        ReceiverParameter rp = new ReceiverParameter();
+        Name newName = new Name("NewName");
+        Name nonExistentName = new Name("NonExistentName");
+
+        assertFalse(rp.replace(nonExistentName, newName));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/TypeDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/TypeDeclarationTest.java
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.Test;
 import static com.github.javaparser.utils.TestParser.parseBodyDeclaration;
 import static com.github.javaparser.utils.TestParser.parseCompilationUnit;
 import static java.util.stream.Collectors.joining;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TypeDeclarationTest {
     @Test
@@ -80,5 +81,31 @@ class TypeDeclarationTest {
                 .map(td -> (TypeDeclaration<?>) td)
                 .map(td -> td.getFullyQualifiedName().orElse("?"))
                 .collect(joining(",")));
+    }
+
+    @Test
+    void testRemove() {
+        TypeDeclaration<?> td = parseBodyDeclaration("class X{ void method(){} }");
+        assertEquals(1, td.getMembers().size());
+        assertTrue(td.remove(td.getMember(0)));
+        assertTrue(td.getMembers().isEmpty());
+    }
+
+    @Test
+    void testReplace() {
+        TypeDeclaration<?> td = parseBodyDeclaration("class X{ void method(){} }");
+        MethodDeclaration md = (MethodDeclaration) td.getMember(0);
+        assertTrue(td.getMembers().contains(md));
+
+        MethodDeclaration newMd = new MethodDeclaration().setName("newMethod");
+        assertTrue(td.replace(md, newMd));
+        assertFalse(td.getMembers().contains(md));
+        assertTrue(td.getMembers().contains(newMd));
+    }
+
+    @Test
+    void testToTypeDeclaration() {
+        TypeDeclaration<?> td = parseBodyDeclaration("class X{ }");
+        assertTrue(td.toTypeDeclaration().isPresent());
     }
 }


### PR DESCRIPTION
Fixes #820 .

This is a cleaner version of my previous PR aimed at improving the code coverage for the 'body' package.

**Key Highlights**

- Introduced comprehensive unit tests, especially focusing on classes such as 'AnnotationMemberDeclaration' within the 'body' package.
- Enhanced coverage for functionalities like annotation methods, type casting, and method declaration.
- Addressed edge cases to ensure the robustness of the code.

**Code Coverage Progress**

- Initial code coverage for 'body' package: 54.57%
- Code coverage after these changes: 72.53%

**Notes from Previous PRs**

I am aware of the concerns raised in the past regarding changes made in the pom.xml files. I noticed that these files' changes are due to my old commits. To address this, I made a new branch and ensured this PR strictly focuses on improving code coverage without any unrelated changes.

I value the feedback from the maintainers and apologise for any inconvenience caused by my previous submissions. I appreciate your patience and guidance throughout this process.