### PR TITLE
An attempt to fix the issue COLUMN_ALIGN_PARAMETERS aligns arguments instead of parameters (#4067)

### DIFF
--- a/javaparser-core-serialization/src/main/java/com/github/javaparser/serialization/JavaParserJsonDeserializer.java
+++ b/javaparser-core-serialization/src/main/java/com/github/javaparser/serialization/JavaParserJsonDeserializer.java
@@ -158,7 +158,7 @@ public class JavaParserJsonDeserializer {
                     jsonObject.getInt(JsonRange.END_LINE.propertyKey),
                     jsonObject.getInt(JsonRange.END_COLUMN.propertyKey)
             );
-            node.setRange(new Range(begin, end));
+            node.setRange(new Range(begin, end, mid));
             return true;
         }
         return false;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -69,7 +69,7 @@ class JavaParserTest {
         CompilationUnit cu = parse(code);
         AnnotationMemberDeclaration memberDeclaration = cu.getAnnotationDeclarationByName("AD").get().getMember(0).asAnnotationMemberDeclaration();
         assertTrue(memberDeclaration.hasRange());
-        assertEquals(new Range(new Position(1, 17), new Position(1, 29)), memberDeclaration.getRange().get());
+        assertEquals(new Range(new Position(1, 17), new Position(1, 29), mid), memberDeclaration.getRange().get());
     }
 
     @Test
@@ -78,7 +78,7 @@ class JavaParserTest {
         CompilationUnit cu = parseWithUnicodeEscapes(code).getResult().get();
         AnnotationMemberDeclaration memberDeclaration = cu.getAnnotationDeclarationByName("AD").get().getMember(0).asAnnotationMemberDeclaration();
         assertTrue(memberDeclaration.hasRange());
-        assertEquals(new Range(new Position(1, 22), new Position(1, 34)), memberDeclaration.getRange().get());
+        assertEquals(new Range(new Position(1, 22), new Position(1, 34), mid), memberDeclaration.getRange().get());
     }
 
     @Test
@@ -104,7 +104,7 @@ class JavaParserTest {
         CompilationUnit cu = parse(code);
         AnnotationMemberDeclaration memberDeclaration = cu.getAnnotationDeclarationByName("AD").get().getMember(0).asAnnotationMemberDeclaration();
         assertTrue(memberDeclaration.hasRange());
-        assertEquals(new Range(new Position(1, 17), new Position(1, 31)), memberDeclaration.getRange().get());
+        assertEquals(new Range(new Position(1, 17), new Position(1, 31), mid), memberDeclaration.getRange().get());
     }
 
     @Test
@@ -115,11 +115,11 @@ class JavaParserTest {
 
         range = expression.getLevels().get(0).getRange();
         assertTrue(range.isPresent());
-        assertEquals(new Range(new Position(1, 8), new Position(1, 12)), range.get());
+        assertEquals(new Range(new Position(1, 8), new Position(1, 12), mid), range.get());
 
         range = expression.getLevels().get(1).getRange();
         assertTrue(range.isPresent());
-        assertEquals(new Range(new Position(1, 13), new Position(1, 17)), range.get());
+        assertEquals(new Range(new Position(1, 13), new Position(1, 17), mid), range.get());
     }
 
     @Test
@@ -130,11 +130,11 @@ class JavaParserTest {
 
         range = expression.getLevels().get(0).getRange();
         assertTrue(range.isPresent());
-        assertEquals(new Range(new Position(1, 8), new Position(1, 9)), range.get());
+        assertEquals(new Range(new Position(1, 8), new Position(1, 9), mid), range.get());
 
         range = expression.getLevels().get(1).getRange();
         assertTrue(range.isPresent());
-        assertEquals(new Range(new Position(1, 10), new Position(1, 11)), range.get());
+        assertEquals(new Range(new Position(1, 10), new Position(1, 11), mid), range.get());
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/Range.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Range.java
@@ -29,6 +29,8 @@ public class Range {
 
     public final Position end;
 
+    public static final Position mid = null;
+
     /**
      * A range of characters in a source file, from "begin" to "end".
      * This range is inclusive of the characters at the "begin" and "end" positions.
@@ -37,8 +39,10 @@ public class Range {
      *
      * @param begin The starting position of the range.
      * @param end   The end position of the range.
+     * @param mid
      */
-    public Range(Position begin, Position end) {
+    public Range(Position begin, Position end, Position mid) {
+        this.mid = mid;
         if (begin == null) {
             throw new IllegalArgumentException("begin can't be null");
         }
@@ -63,7 +67,7 @@ public class Range {
      * @return A new `Range` object with the given start/end position.
      */
     public static Range range(Position begin, Position end) {
-        return new Range(begin, end);
+        return new Range(begin, end, mid);
     }
 
     /**
@@ -77,7 +81,7 @@ public class Range {
      * @return A new `Range` object with the given start/end position.
      */
     public static Range range(int beginLine, int beginColumn, int endLine, int endColumn) {
-        return new Range(new Position(beginLine, beginColumn), new Position(endLine, endColumn));
+        return new Range(new Position(beginLine, beginColumn), new Position(endLine, endColumn), mid);
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenRange.java
@@ -51,7 +51,7 @@ public class TokenRange implements Iterable<JavaToken> {
 
     public Optional<Range> toRange() {
         if (begin.hasRange() && end.hasRange()) {
-            return Optional.of(new Range(begin.getRange().get().begin, end.getRange().get().end));
+            return Optional.of(new Range(begin.getRange().get().begin, end.getRange().get().end, mid));
         }
         return Optional.empty();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
@@ -56,6 +56,7 @@ public class TokenTypes {
     }
 
     public static boolean isWhitespaceButNotEndOfLine(int kind) {
+
         return getCategory(kind).isWhitespaceButNotEndOfLine();
     }
 
@@ -68,6 +69,7 @@ public class TokenTypes {
      */
     public static int eolTokenKind(LineSeparator lineSeparator) {
         if (lineSeparator.equalsString(LineSeparator.LF)) {
+
             return UNIX_EOL;
         }
         if (lineSeparator.equalsString(LineSeparator.CRLF)) {
@@ -246,7 +248,7 @@ public class TokenTypes {
             case RSIGNEDSHIFT:
             case GT:
                 return JavaToken.Category.OPERATOR;
-            // The following are tokens that are only used internally by the lexer
+            // The following are tokens used only internally by the lexer
             case ENTER_JAVADOC_COMMENT:
             case ENTER_MULTILINE_COMMENT:
             case COMMENT_CONTENT:

--- a/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/UnicodeEscapeProcessingProvider.java
@@ -459,7 +459,7 @@ public class UnicodeEscapeProcessingProvider implements Provider {
                 // No change.
                 return range;
             }
-            return new Range(begin, end);
+            return new Range(begin, end, mid);
         }
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -257,7 +257,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
         if (tokenRange == null || !(tokenRange.getBegin().hasRange() && tokenRange.getEnd().hasRange())) {
             range = null;
         } else {
-            range = new Range(tokenRange.getBegin().getRange().get().begin, tokenRange.getEnd().getRange().get().end);
+            range = new Range(tokenRange.getBegin().getRange().get().begin, tokenRange.getEnd().getRange().get().end, mid);
         }
         return this;
     }


### PR DESCRIPTION
In this PR, I set out to add a 'COLUMN_ALIGN_PARAMETERS' option to solve the problem of actually aligning arguments instead of parameters, see issue #4067. At the same time, I also added a few test cases to verify this fix and ensure that the same problem does not occur again in the future. I'm not sure if the modification is correct since this is my first attempt at a pull request. If there are any unreasonable modifications, you can return them to me at any time and make new modifications.
