### PR TITLE
Fix: issue #2751 new HashSet()" != "new HashSet<>()

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
@@ -247,6 +247,66 @@ class XmlPrinterTest {
                 stringWriter.toString()
         );
     }
+
+    @Test
+    void testAbsentTypeParameterList() throws SAXException, IOException, XMLStreamException {
+        Expression expression = parseExpression("new HashSet()");
+        XmlPrinter xmlOutput = new XmlPrinter(false);
+        String output = xmlOutput.output(expression);
+        assertXMLEquals(""
+                // Expected
+                + "<root>"
+                    + "<type>"
+                        + "<name identifier='HashSet'/>"
+                    + "</type>"
+                + "</root>",
+                // Actual
+                output
+        );
+    }
+
+    @Test
+    void testEmptyTypeParameterList() throws SAXException, IOException, XMLStreamException {
+        Expression expression = parseExpression("new HashSet<>()");
+        XmlPrinter xmlOutput = new XmlPrinter(false);
+        String output = xmlOutput.output(expression);
+        assertXMLEquals(""
+                // Expected
+                + "<root>"
+                    + "<type>"
+                        + "<name identifier='HashSet'/>"
+                        + "<typeArguments/>"
+                    + "</type>"
+                + "</root>",
+                // Actual
+                output
+        );
+    }
+
+    @Test
+    void testNonEmptyTypeParameterList() throws SAXException, IOException, XMLStreamException {
+        Expression expression = parseExpression("new HashSet<Integer,File>()");
+        XmlPrinter xmlOutput = new XmlPrinter(false);
+        String output = xmlOutput.output(expression);
+        assertXMLEquals(""
+                // Expected
+                + "<root>"
+                    + "<type>"
+                        + "<name identifier='HashSet'/>"
+                        + "<typeArguments>"
+                            + "<typeArgument>"
+                                + "<name identifier='Integer'/>"
+                            + "</typeArgument>"
+                            + "<typeArgument>"
+                                + "<name identifier='File'/>"
+                            + "</typeArgument>"
+                        + "</typeArguments>"
+                    + "</type>"
+                + "</root>",
+                // Actual
+                output
+        );
+    }
 }
 
 interface Cleanup {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
@@ -22,6 +22,7 @@ package com.github.javaparser.printer;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.metamodel.NodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
 
@@ -42,6 +43,7 @@ import javax.xml.stream.XMLStreamWriter;
 public class XmlPrinter {
 
     private final boolean outputNodeType;
+    private static final Class<?> TYPE_CLASS = Type.class;
 
     public XmlPrinter(boolean outputNodeType) {
         this.outputNodeType = outputNodeType;
@@ -178,6 +180,8 @@ public class XmlPrinter {
         Predicate<PropertyMetaModel> nonNullNode = propertyMetaModel -> propertyMetaModel.getValue(node) != null;
         Predicate<PropertyMetaModel> nonEmptyList = propertyMetaModel ->
                 ((NodeList) propertyMetaModel.getValue(node)).isNonEmpty();
+        Predicate<PropertyMetaModel> typeList = propertyMetaModel ->
+                TYPE_CLASS == propertyMetaModel.getType();
 
         xmlWriter.writeStartElement(name);
 
@@ -220,7 +224,7 @@ public class XmlPrinter {
             allPropertyMetaModels.stream()
                     .filter(PropertyMetaModel::isNodeList)
                     .filter(nonNullNode)
-                    .filter(nonEmptyList)
+                    .filter(nonEmptyList.or(typeList))
                     .forEach(listMetaModel -> {
                         try {
                             String listName = listMetaModel.getName();


### PR DESCRIPTION
Change XML generator so that an empty type argument list is emmitted as an empty XML element. All other empty lists keep not being emmitted.

Fixes #2751 - Generated XML does not distinguish "new HashSet()" from "new HashSet<>()"