### PR TITLE
MethodResolutionLogic.isMoreSpecific throws exception on overloaded method w/varargs

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -820,7 +820,7 @@ public class MethodResolutionLogic {
 
             // If B is vararg and A is not, A is more specific
             if (tdB.isArray() && tdB.asArrayType().getComponentType().isAssignableBy(tdA)) {
-                oneMoreSpecificFound = true;
+                return true;
             }
         }
         return oneMoreSpecificFound;


### PR DESCRIPTION
The isMoreSpecific() may throw an ArrayIndexOutOfBoundsException if the method being resolved is overloaded, and one or more method signatures contain a vararg parameter.

In this case, the number of parameters varies, and the existing logic does not exit the loop once a vararg is detected. Instead, it continues, which then causes an ArrayIndexOutOfBoundsException when it tries to retrieve the next method parameter after the vararg.

The fix is to exit the loop and return true as soon as a vararg is detected in the parameter list.
