### PR TITLE
Fixes resolution of method references that are default methods on interfaces

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -405,12 +405,13 @@ public class JavaParserFacade {
         Set<MethodUsage> allMethods = resolvedTypdeDecl.getAllMethods();
 
         if (scope.isTypeExpr()) {
-            // static methods should match all params
-            List<MethodUsage> staticMethodUsages = allMethods.stream()
-                    .filter(it -> it.getDeclaration().isStatic())
+            // default and static methods should match all params
+            List<MethodUsage> nonInstanceMethodUsages = allMethods.stream()
+                    .filter(it -> it.getDeclaration().isStatic() || it.getDeclaration().isDefaultMethod())
                     .collect(Collectors.toList());
 
-            result = MethodResolutionLogic.findMostApplicableUsage(staticMethodUsages, methodReferenceExpr.getIdentifier(), paramTypes, typeSolver);
+            result = MethodResolutionLogic.findMostApplicableUsage(nonInstanceMethodUsages,
+                    methodReferenceExpr.getIdentifier(), paramTypes, typeSolver);
 
             if (!paramTypes.isEmpty()) {
                 // instance methods are called on the first param and should match all other params
@@ -419,6 +420,7 @@ public class JavaParserFacade {
                         .collect(Collectors.toList());
 
                 List<ResolvedType> instanceMethodParamTypes = new ArrayList<>(paramTypes);
+
                 instanceMethodParamTypes.remove(0); // remove the first one
 
                 Optional<MethodUsage> instanceResult = MethodResolutionLogic.findMostApplicableUsage(


### PR DESCRIPTION
Currently, default methods are treated the same as instance methods. Instead, treat default methods the same as static methods, since they do not have an instance as the first parameter.

Sample code which currently breaks:

public class InterfaceWithDefaultMethod {
    Map<String, String> testMap = new ConcurrentHashMap<>();

    public void invokeDefaultMethod(MyInterface myInterface) {
        Optional<Integer> priority = Optional.of(4);
        priority.map(myInterface::toString).orElse("0");
    }

    public interface MyInterface {
        default String toString(int priority) {
            return Integer.toString(priority);
        }
    }
}