### PR TITLE
Do not consider same qualified name in isAncestor function

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -392,8 +392,8 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
         Optional<ResolvedReferenceTypeDeclaration> resolvedReferenceTypeDeclaration = candidateAncestor.getTypeDeclaration();
         if (resolvedReferenceTypeDeclaration.isPresent()) {
             ResolvedTypeDeclaration rtd = resolvedReferenceTypeDeclaration.get().asType();
-            // do not consider an inner or nested class as an ancestor
-            return !rtd.hasInternalType(ownQualifiedName);
+            // do not consider an inner or nested class as an ancestor, do not consider same qualified name
+            return !rtd.hasInternalType(ownQualifiedName) && !ownQualifiedName.equals(rtd.getQualifiedName());
         }
         return false;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -392,7 +392,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
         Optional<ResolvedReferenceTypeDeclaration> resolvedReferenceTypeDeclaration = candidateAncestor.getTypeDeclaration();
         if (resolvedReferenceTypeDeclaration.isPresent()) {
             ResolvedTypeDeclaration rtd = resolvedReferenceTypeDeclaration.get().asType();
-            // do not consider an inner or nested class as an ancestor, do not consider same qualified name
+            // do not consider an inner or nested class as an ancestor, do not consider same qualified name 
             return !rtd.hasInternalType(ownQualifiedName) && !ownQualifiedName.equals(rtd.getQualifiedName());
         }
         return false;


### PR DESCRIPTION
In some cases, it is possible to get the qualified name as same as  wrappedNode when called by`getSuperClass`, which causes the stack to overflow.
so need to check same qualified name in `isAncestor` function

in com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration#getSuperClass `toReferenceType(wrappedNode.getExtendedTypes().getFirst().get())`  In some cases, the toReferenceType method may not be possible to obtain an accurate reference (For example, two simple names are the same but the package name is similar, and one of them cannot be referenced).

```
Exception in thread "main" java.lang.StackOverflowError
	at java.lang.StringCoding$StringEncoder.encode(StringCoding.java:304)
	at java.lang.StringCoding.encode(StringCoding.java:344)
	at java.lang.String.getBytes(String.java:918)
	at java.io.UnixFileSystem.getBooleanAttributes0(Native Method)
	at java.io.UnixFileSystem.getBooleanAttributes(UnixFileSystem.java:242)
	at java.io.File.exists(File.java:828)
	at sun.misc.URLClassPath$FileLoader.getResource(URLClassPath.java:1379)
	at sun.misc.URLClassPath.getResource(URLClassPath.java:249)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:355)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:80)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:98)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:98)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:98)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:98)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:98)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:98)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver.tryToSolveType(ClassLoaderTypeSolver.java:98)
	at com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver.tryToSolveType(CombinedTypeSolver.java:165)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.CompilationUnitContext.solveType(CompilationUnitContext.java:220)
	at com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration.solveType(JavaParserClassDeclaration.java:327)
	at com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration.toReferenceType(JavaParserClassDeclaration.java:472)
	at com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration.getSuperClass(JavaParserClassDeclaration.java:211)
	at com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration.getAncestors(JavaParserClassDeclaration.java:357)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:144)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	at com.github.javaparser.symbolsolver.javaparsermodel.contexts.JavaParserTypeDeclarationAdapter.checkAncestorsForType(JavaParserTypeDeclarationAdapter.java:169)
	......
```
