### PR TITLE
Putting code in the .orElse that has a side effect that can affect performance

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/Generator.java
@@ -107,7 +107,7 @@ public abstract class Generator {
             throw new AssertionError(f("Wanted to regenerate a method with signature %s in %s, but found more than one.", callable.getSignature(), containingClassOrInterface.getNameAsString()));
         }
         final CallableDeclaration<?> existingCallable = existingCallables.get(0);
-        callable.setJavadocComment(callable.getJavadocComment().orElse(existingCallable.getJavadocComment().orElse(null)));
+        callable.setJavadocComment(callable.getJavadocComment().orElseGet(() -> existingCallable.getJavadocComment().orElse(null)));
         annotateGenerated(callable);
         containingClassOrInterface.getMembers().replace(existingCallable, callable);
     }

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/AbstractGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/AbstractGenerator.java
@@ -128,7 +128,7 @@ public abstract class AbstractGenerator {
             Optional<Comment> callableComment = callable.getComment();
             Optional<Comment> existingCallableComment = existingCallable.getComment();
 
-            callable.setComment(callableComment.orElse(existingCallable.getComment().orElse(null)));
+            callable.setComment(callableComment.orElseGet(() -> existingCallable.getComment().orElse(null)));
 //            callable.setJavadocComment(callableJavadocComment.orElse(existingCallableJavadocComment.orElse(null)));
 
             // Mark the method as having been fully/partially generated.

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -753,7 +753,7 @@ public class CompilationUnit extends Node {
          */
         public Path getSourceRoot() {
             final Optional<String> pkgAsString = compilationUnit.getPackageDeclaration().map(NodeWithName::getNameAsString);
-            return pkgAsString.map(p -> Paths.get(CodeGenerationUtils.packageToPath(p))).map(pkg -> subtractPaths(getDirectory(), pkg)).orElse(getDirectory());
+            return pkgAsString.map(p -> Paths.get(CodeGenerationUtils.packageToPath(p))).map(pkg -> subtractPaths(getDirectory(), pkg)).orElseGet(() -> getDirectory());
         }
 
         public String getFileName() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -200,14 +200,14 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      * else create a new DefaultPrettyPrinter with default parameters
      */
     protected Printer getPrinter() {
-        return findCompilationUnit().map(c -> c.getPrinter()).orElse(createDefaultPrinter());
+        return findCompilationUnit().map(c -> c.getPrinter()).orElseGet(() -> createDefaultPrinter());
     }
 
     /*
      * Return the printer initialized with the specified configuration
      */
     protected Printer getPrinter(PrinterConfiguration configuration) {
-        return findCompilationUnit().map(c -> c.getPrinter(configuration)).orElse(createDefaultPrinter(configuration));
+        return findCompilationUnit().map(c -> c.getPrinter(configuration)).orElseGet(() -> createDefaultPrinter(configuration));
     }
 
     protected Printer createDefaultPrinter() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -203,7 +203,7 @@ public abstract class TypeDeclaration<T extends TypeDeclaration<?>> extends Body
      */
     public Optional<String> getFullyQualifiedName() {
         if (isTopLevelType()) {
-            return findCompilationUnit().map(cu -> cu.getPackageDeclaration().map(pd -> pd.getNameAsString()).map(pkg -> pkg + "." + getNameAsString()).orElse(getNameAsString()));
+            return findCompilationUnit().map(cu -> cu.getPackageDeclaration().map(pd -> pd.getNameAsString()).map(pkg -> pkg + "." + getNameAsString()).orElseGet(() -> getNameAsString()));
         }
         return findAncestor(TypeDeclaration.class).map(td -> (TypeDeclaration<?>) td).flatMap(td -> td.getFullyQualifiedName().map(fqn -> fqn + "." + getNameAsString()));
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithParameters.java
@@ -164,6 +164,6 @@ public interface NodeWithParameters<N extends Node> {
     default boolean hasParametersOfType(Class<?>... paramTypes) {
         return getParameters().stream().// if p.getType() is a class or interface type, we want to consider its erasure, i.e., if the parameter
         // is "List<String>", we want to consider it as "List", so we need to call getName()
-        map(p -> p.getType().toClassOrInterfaceType().map(NodeWithSimpleName::getNameAsString).orElse(p.getType().asString())).collect(toList()).equals(Stream.of(paramTypes).map(Class::getSimpleName).collect(toList()));
+        map(p -> p.getType().toClassOrInterfaceType().map(NodeWithSimpleName::getNameAsString).orElseGet(() -> p.getType().asString())).collect(toList()).equals(Stream.of(paramTypes).map(Class::getSimpleName).collect(toList()));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -133,8 +133,7 @@ public class LexicalPreservingPrinter {
             }
             if (property == ObservableProperty.COMMENT) {
                 Optional<Node> parentNode = observedNode.getParentNode();
-                NodeText nodeText = parentNode.map(parent -> getOrCreateNodeText(parentNode.get())).// We're at the root node.
-                orElse(getOrCreateNodeText(observedNode));
+                NodeText nodeText = parentNode.map(parent -> getOrCreateNodeText(parentNode.get())).orElseGet(() -> getOrCreateNodeText(observedNode));
                 if (oldValue == null) { // this case corresponds to the addition of a comment
                     int index = parentNode.isPresent() ? // Find the position of the comment node and put in front of it the [...]
                     nodeText.findChild(observedNode) : //


### PR DESCRIPTION
When using Optionals, whatever code is provided in the .orElse will be executed everytime the Optional is evaluated. Sometimes people make the mistake of putting code in the .orElse that has a side effect that can affect performance or can result in bugs. In these cases .orElseGet should be used as it defers execution until the Optional actually evaluates to empty and the .orElseGet needs to be run.
