### PR TITLE
[pom] Switch from hamcrest-library (deprecated) to hamcrest

### DIFF
--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -119,7 +119,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -176,7 +176,7 @@
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
+                <artifactId>hamcrest</artifactId>
                 <version>2.2</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
The content of hamcrest-core and hamcrest-library are simply empty with comment to stop using.  See https://github.com/hamcrest/JavaHamcrest/blob/master/hamcrest-library/src/main/java/org/hamcrest/library/deprecated/HamcrestLibraryIsDeprecated.java

This saves having an extra library present in the build that isn't necessary.  No code changes required.
