### PR TITLE
Indent with spaces rather than with tabs

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/CompilationUnitGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/CompilationUnitGenerator.java
@@ -29,18 +29,18 @@ import java.util.List;
 
 public abstract class CompilationUnitGenerator extends Generator {
 
-	protected CompilationUnitGenerator(SourceRoot sourceRoot) {
-		super(sourceRoot);
-	}
+    protected CompilationUnitGenerator(SourceRoot sourceRoot) {
+        super(sourceRoot);
+    }
 
-	@Override
-	public void generate() throws Exception {
-		List<ParseResult<CompilationUnit>> parsedCus = sourceRoot.tryToParse();
-		for (ParseResult<CompilationUnit> cu : parsedCus) {
-			cu.ifSuccessful(this::generateCompilationUnit);
-		}
-	}
+    @Override
+    public void generate() throws Exception {
+        List<ParseResult<CompilationUnit>> parsedCus = sourceRoot.tryToParse();
+        for (ParseResult<CompilationUnit> cu : parsedCus) {
+            cu.ifSuccessful(this::generateCompilationUnit);
+        }
+    }
 
-	protected abstract void generateCompilationUnit(CompilationUnit compilationUnit);
+    protected abstract void generateCompilationUnit(CompilationUnit compilationUnit);
 
 }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/quality/NotNullGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/quality/NotNullGenerator.java
@@ -50,159 +50,159 @@ import static com.github.javaparser.utils.CodeGenerationUtils.f;
  */
 public class NotNullGenerator extends CompilationUnitGenerator {
 
-	public NotNullGenerator(SourceRoot sourceRoot) {
-		super(sourceRoot);
-	}
+    public NotNullGenerator(SourceRoot sourceRoot) {
+        super(sourceRoot);
+    }
 
-	@Override
-	public void generateCompilationUnit(CompilationUnit compilationUnit) {
-		compilationUnit.findAll(ConstructorDeclaration.class).forEach(this::generateQualityForConstructor);
-		compilationUnit.findAll(MethodDeclaration.class).forEach(this::generateQualityForMethod);
-	}
+    @Override
+    public void generateCompilationUnit(CompilationUnit compilationUnit) {
+        compilationUnit.findAll(ConstructorDeclaration.class).forEach(this::generateQualityForConstructor);
+        compilationUnit.findAll(MethodDeclaration.class).forEach(this::generateQualityForMethod);
+    }
 
-	/**
-	 * Generate the pre conditions based on the method parameters.
-	 * <br>
-	 * If parameters are annotated with {@link com.github.javaparser.quality.NotNull} and a {@code null} is
-	 * passed, the method should throw an {@link IllegalArgumentException}.
-	 * <br>
-	 * If annotated with {@link com.github.javaparser.quality.Nullable}, other annotation or none, nothing should be
-	 * changed.
-	 *
-	 * @param methodDeclaration The method declaration to generate.
-	 */
-	protected void generateQualityForMethod(MethodDeclaration methodDeclaration) {
-		methodDeclaration.getBody().ifPresent(blockStmt ->
-				generateQualityForParameter(methodDeclaration, methodDeclaration.getParameters(), blockStmt));
-	}
+    /**
+     * Generate the pre conditions based on the method parameters.
+     * <br>
+     * If parameters are annotated with {@link com.github.javaparser.quality.NotNull} and a {@code null} is
+     * passed, the method should throw an {@link IllegalArgumentException}.
+     * <br>
+     * If annotated with {@link com.github.javaparser.quality.Nullable}, other annotation or none, nothing should be
+     * changed.
+     *
+     * @param methodDeclaration The method declaration to generate.
+     */
+    protected void generateQualityForMethod(MethodDeclaration methodDeclaration) {
+        methodDeclaration.getBody().ifPresent(blockStmt ->
+                generateQualityForParameter(methodDeclaration, methodDeclaration.getParameters(), blockStmt));
+    }
 
-	/**
-	 * Generate the pre conditions based on the constructor parameters.
-	 * <br>
-	 * If parameters are annotated with {@link com.github.javaparser.quality.NotNull} and a {@code null} is
-	 * passed, the method should throw an {@link IllegalArgumentException}.
-	 * <br>
-	 * If annotated with {@link com.github.javaparser.quality.Nullable}, other annotation or none, nothing should be
-	 * changed.
-	 *
-	 * @param constructorDeclaration The constructor declaration to generate.
-	 */
-	protected void generateQualityForConstructor(ConstructorDeclaration constructorDeclaration) {
-		generateQualityForParameter(constructorDeclaration, constructorDeclaration.getParameters(), constructorDeclaration.getBody());
-	}
+    /**
+     * Generate the pre conditions based on the constructor parameters.
+     * <br>
+     * If parameters are annotated with {@link com.github.javaparser.quality.NotNull} and a {@code null} is
+     * passed, the method should throw an {@link IllegalArgumentException}.
+     * <br>
+     * If annotated with {@link com.github.javaparser.quality.Nullable}, other annotation or none, nothing should be
+     * changed.
+     *
+     * @param constructorDeclaration The constructor declaration to generate.
+     */
+    protected void generateQualityForConstructor(ConstructorDeclaration constructorDeclaration) {
+        generateQualityForParameter(constructorDeclaration, constructorDeclaration.getParameters(), constructorDeclaration.getBody());
+    }
 
-	/**
-	 * Generate the pre conditions for the parameters.
-	 * <br>
-	 * If parameters are annotated with {@link com.github.javaparser.quality.NotNull} and a {@code null} is
-	 * passed, the method should throw an {@link IllegalArgumentException}.
-	 * <br>
-	 * If annotated with {@link com.github.javaparser.quality.Nullable}, other annotation or none, nothing should be
-	 * changed.
-	 *
-	 * @param callableDeclaration 	The declaration where the parameters belong.
-	 * @param parameters 			The list of parameters.
-	 * @param blockStmt 			The block where the assertions should be added.
-	 *
-	 * @param <N>					The callable declaration type.
-	 */
-	protected <N extends CallableDeclaration<?>>
-		void generateQualityForParameter(N callableDeclaration, NodeList<Parameter> parameters, BlockStmt blockStmt) {
+    /**
+     * Generate the pre conditions for the parameters.
+     * <br>
+     * If parameters are annotated with {@link com.github.javaparser.quality.NotNull} and a {@code null} is
+     * passed, the method should throw an {@link IllegalArgumentException}.
+     * <br>
+     * If annotated with {@link com.github.javaparser.quality.Nullable}, other annotation or none, nothing should be
+     * changed.
+     *
+     * @param callableDeclaration     The declaration where the parameters belong.
+     * @param parameters             The list of parameters.
+     * @param blockStmt             The block where the assertions should be added.
+     *
+     * @param <N>                    The callable declaration type.
+     */
+    protected <N extends CallableDeclaration<?>>
+        void generateQualityForParameter(N callableDeclaration, NodeList<Parameter> parameters, BlockStmt blockStmt) {
 
-		List<Statement> assertions = new ArrayList<>();
+        List<Statement> assertions = new ArrayList<>();
 
-		for (Parameter parameter : parameters) {
-			Optional<AnnotationExpr> nonNullAnnotation = parameter.getAnnotationByClass(NotNull.class);
-			if (nonNullAnnotation.isPresent()) {
-				assertions.add(createAssertion(parameter));
-			}
-		}
+        for (Parameter parameter : parameters) {
+            Optional<AnnotationExpr> nonNullAnnotation = parameter.getAnnotationByClass(NotNull.class);
+            if (nonNullAnnotation.isPresent()) {
+                assertions.add(createAssertion(parameter));
+            }
+        }
 
-		insertAssertionsInBlock(callableDeclaration, blockStmt, assertions);
-	}
+        insertAssertionsInBlock(callableDeclaration, blockStmt, assertions);
+    }
 
-	/**
-	 * Create assertion for the parameters.
-	 *
-	 * @param parameter The parameter to create the assertion.
-	 *
-	 * @return The assertion to be added to the code.
-	 */
-	private Statement createAssertion(Parameter parameter) {
+    /**
+     * Create assertion for the parameters.
+     *
+     * @param parameter The parameter to create the assertion.
+     *
+     * @return The assertion to be added to the code.
+     */
+    private Statement createAssertion(Parameter parameter) {
 
-		parameter.tryAddImportToParentCompilationUnit(Preconditions.class);
-		return StaticJavaParser.parseStatement(
-				f("Preconditions.checkNotNull(%s, \"Parameter %s can't be null.\");", parameter.getNameAsString(),
-						parameter.getNameAsString())
-		);
-	}
+        parameter.tryAddImportToParentCompilationUnit(Preconditions.class);
+        return StaticJavaParser.parseStatement(
+                f("Preconditions.checkNotNull(%s, \"Parameter %s can't be null.\");", parameter.getNameAsString(),
+                        parameter.getNameAsString())
+        );
+    }
 
-	/**
-	 * Insert the assertions into the block.
-	 *
-	 * @param callableDeclaration 	The declaration where the parameters belong.
-	 * @param blockStmt 			The block where the assertions should be added.
-	 * @param assertions 			The list of assertions to be inserted.
-	 *
-	 * @param <N>					The callable declaration type.
-	 */
-	private <N extends CallableDeclaration<?>>
-		void insertAssertionsInBlock(N callableDeclaration, BlockStmt blockStmt, List<Statement> assertions) {
+    /**
+     * Insert the assertions into the block.
+     *
+     * @param callableDeclaration     The declaration where the parameters belong.
+     * @param blockStmt             The block where the assertions should be added.
+     * @param assertions             The list of assertions to be inserted.
+     *
+     * @param <N>                    The callable declaration type.
+     */
+    private <N extends CallableDeclaration<?>>
+        void insertAssertionsInBlock(N callableDeclaration, BlockStmt blockStmt, List<Statement> assertions) {
 
-		// If there's nothing to add, just ignore
-		if (assertions.isEmpty())
-			return;
+        // If there's nothing to add, just ignore
+        if (assertions.isEmpty())
+            return;
 
-		int position = 0;
-		NodeList<Statement> statements = blockStmt.getStatements();
+        int position = 0;
+        NodeList<Statement> statements = blockStmt.getStatements();
 
-		// When the callable is a constructor we must check if is a ExplicitConstructorInvocationStmt.
-		if (callableDeclaration.isConstructorDeclaration()) {
-			Optional<Statement> optionalFirstStatement = statements.getFirst();
-			if (optionalFirstStatement.isPresent()) {
+        // When the callable is a constructor we must check if is a ExplicitConstructorInvocationStmt.
+        if (callableDeclaration.isConstructorDeclaration()) {
+            Optional<Statement> optionalFirstStatement = statements.getFirst();
+            if (optionalFirstStatement.isPresent()) {
 
-				// Check if the first item is a "super" expr. If it's then we add the assertions after it.
-				Statement firstStatement = optionalFirstStatement.get();
-				if (firstStatement instanceof ExplicitConstructorInvocationStmt) {
-					position = 1;
-				}
-			}
-		}
+                // Check if the first item is a "super" expr. If it's then we add the assertions after it.
+                Statement firstStatement = optionalFirstStatement.get();
+                if (firstStatement instanceof ExplicitConstructorInvocationStmt) {
+                    position = 1;
+                }
+            }
+        }
 
-		// Register assertions
-		for (int i = 0 ; i < assertions.size() ; i++) {
-			Statement assertion = assertions.get(i);
+        // Register assertions
+        for (int i = 0 ; i < assertions.size() ; i++) {
+            Statement assertion = assertions.get(i);
 
-			Optional<? extends Statement> optOldStmt = getSimilarAssertionInBlock(assertion, blockStmt);
+            Optional<? extends Statement> optOldStmt = getSimilarAssertionInBlock(assertion, blockStmt);
 
-			if (optOldStmt.isPresent()) {
-				optOldStmt.get().replace(assertion);
-			} else {
-				blockStmt.addStatement(position + i, assertion);
-			}
-		}
-	}
+            if (optOldStmt.isPresent()) {
+                optOldStmt.get().replace(assertion);
+            } else {
+                blockStmt.addStatement(position + i, assertion);
+            }
+        }
+    }
 
-	private Optional<? extends Statement> getSimilarAssertionInBlock(Statement assertion, BlockStmt blockStmt) {
+    private Optional<? extends Statement> getSimilarAssertionInBlock(Statement assertion, BlockStmt blockStmt) {
 
-		MethodCallExpr assertionCall = assertion.asExpressionStmt().getExpression().asMethodCallExpr();
-		List<MethodCallExpr> methodCallExpressions = blockStmt.findAll(MethodCallExpr.class);
+        MethodCallExpr assertionCall = assertion.asExpressionStmt().getExpression().asMethodCallExpr();
+        List<MethodCallExpr> methodCallExpressions = blockStmt.findAll(MethodCallExpr.class);
 
-		for (MethodCallExpr blockMethodCall : methodCallExpressions) {
+        for (MethodCallExpr blockMethodCall : methodCallExpressions) {
 
-			// Check if the method calls name match
-			if (
-				blockMethodCall.getNameAsExpression().equals(assertionCall.getNameAsExpression()) &&
-				blockMethodCall.getScope().equals(assertionCall.getScope()) &&
-				blockMethodCall.getArguments().size() == 2 &&
-				blockMethodCall.getArguments().get(0).equals(assertionCall.getArgument(0))
-			) {
-				return blockMethodCall.findAncestor(ExpressionStmt.class);
-			}
+            // Check if the method calls name match
+            if (
+                blockMethodCall.getNameAsExpression().equals(assertionCall.getNameAsExpression()) &&
+                blockMethodCall.getScope().equals(assertionCall.getScope()) &&
+                blockMethodCall.getArguments().size() == 2 &&
+                blockMethodCall.getArguments().get(0).equals(assertionCall.getArgument(0))
+            ) {
+                return blockMethodCall.findAncestor(ExpressionStmt.class);
+            }
 
-		}
-		// TODO:
-		return Optional.empty();
-	}
+        }
+        // TODO:
+        return Optional.empty();
+    }
 
 }

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/utils/CodeUtils.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/utils/CodeUtils.java
@@ -25,33 +25,33 @@ import com.github.javaparser.ast.type.Type;
 
 public final class CodeUtils {
 
-	private CodeUtils() {
-		// This constructor is used to hide the public one
-	}
+    private CodeUtils() {
+        // This constructor is used to hide the public one
+    }
 
-	/**
-	 * Cast the value if the current type doesn't match the required type.
-	 * <br>
-	 * Given the following example:
-	 * <code>
-	 *     int withoutCast = 1;
-	 *     double withCast = (double) 1;
-	 * </code>
-	 * The variable withoutCast doesn't need to be casted, since we have int as required type and int as value type.
-	 * While in the variable withCast we have double as required type and int as value type.
-	 *
-	 * @param value           The value to be returned.
-	 * @param requiredType    The expected type to be casted if needed.
-	 * @param valueType       The type of the value to be returned.
-	 *
-	 * @return The value casted if needed.
-	 */
-	public static String castValue(String value, Type requiredType, String valueType) {
-		String requiredTypeName = requiredType.asString();
+    /**
+     * Cast the value if the current type doesn't match the required type.
+     * <br>
+     * Given the following example:
+     * <code>
+     *     int withoutCast = 1;
+     *     double withCast = (double) 1;
+     * </code>
+     * The variable withoutCast doesn't need to be casted, since we have int as required type and int as value type.
+     * While in the variable withCast we have double as required type and int as value type.
+     *
+     * @param value           The value to be returned.
+     * @param requiredType    The expected type to be casted if needed.
+     * @param valueType       The type of the value to be returned.
+     *
+     * @return The value casted if needed.
+     */
+    public static String castValue(String value, Type requiredType, String valueType) {
+        String requiredTypeName = requiredType.asString();
 
-		if (requiredTypeName.equals(valueType))
-		    return value;
-		return String.format("(%s) %s", requiredTypeName, value);
-	}
+        if (requiredTypeName.equals(valueType))
+            return value;
+        return String.format("(%s) %s", requiredTypeName, value);
+    }
 
 }

--- a/javaparser-core-generators/src/test/java/com/github/javaparser/generator/core/quality/NotNullGeneratorTest.java
+++ b/javaparser-core-generators/src/test/java/com/github/javaparser/generator/core/quality/NotNullGeneratorTest.java
@@ -36,46 +36,46 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class NotNullGeneratorTest {
 
-	@Test
-	void testExecutionOfGenerator() throws Exception {
+    @Test
+    void testExecutionOfGenerator() throws Exception {
 
-		// Setup the
-		String resourcesFolderPath = getClass().getCanonicalName().replace(".", File.separator);
+        // Setup the
+        String resourcesFolderPath = getClass().getCanonicalName().replace(".", File.separator);
 
-		String basePath = Paths.get("src", "test", "resources").toString();
-		Path originalFile = Paths.get(basePath, resourcesFolderPath, "original");
-		Path expectedFile = Paths.get(basePath, resourcesFolderPath, "expected");
+        String basePath = Paths.get("src", "test", "resources").toString();
+        Path originalFile = Paths.get(basePath, resourcesFolderPath, "original");
+        Path expectedFile = Paths.get(basePath, resourcesFolderPath, "expected");
 
-		SourceRoot originalSources = new SourceRoot(originalFile);
-		SourceRoot expectedSources = new SourceRoot(expectedFile);
-		expectedSources.tryToParse();
+        SourceRoot originalSources = new SourceRoot(originalFile);
+        SourceRoot expectedSources = new SourceRoot(expectedFile);
+        expectedSources.tryToParse();
 
-		// Generate the information
-		new NotNullGenerator(originalSources).generate();
+        // Generate the information
+        new NotNullGenerator(originalSources).generate();
 
-		List<CompilationUnit> editedSourceCus = originalSources.getCompilationUnits();
-		List<CompilationUnit> expectedSourcesCus = expectedSources.getCompilationUnits();
-		assertEquals(expectedSourcesCus.size(), editedSourceCus.size());
+        List<CompilationUnit> editedSourceCus = originalSources.getCompilationUnits();
+        List<CompilationUnit> expectedSourcesCus = expectedSources.getCompilationUnits();
+        assertEquals(expectedSourcesCus.size(), editedSourceCus.size());
 
-		// Check if all the files match the expected result
-		for (int i = 0 ; i < editedSourceCus.size() ; i++) {
+        // Check if all the files match the expected result
+        for (int i = 0 ; i < editedSourceCus.size() ; i++) {
 
-			DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
-			String expectedCode = printer.print(expectedSourcesCus.get(i));
-			String editedCode = printer.print(editedSourceCus.get(i));
+            DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+            String expectedCode = printer.print(expectedSourcesCus.get(i));
+            String editedCode = printer.print(editedSourceCus.get(i));
 
-			if (!expectedCode.equals(editedCode)) {
-				System.out.println("Expected:");
-				System.out.println("####");
-				System.out.println(expectedSourcesCus.get(i));
-				System.out.println("####");
-				System.out.println("Actual:");
-				System.out.println("####");
-				System.out.println(editedSourceCus.get(i));
-				System.out.println("####");
-				fail("Actual code doesn't match with the expected code.");
-			}
-		}
-	}
+            if (!expectedCode.equals(editedCode)) {
+                System.out.println("Expected:");
+                System.out.println("####");
+                System.out.println(expectedSourcesCus.get(i));
+                System.out.println("####");
+                System.out.println("Actual:");
+                System.out.println("####");
+                System.out.println(editedSourceCus.get(i));
+                System.out.println("####");
+                fail("Actual code doesn't match with the expected code.");
+            }
+        }
+    }
 
 }

--- a/javaparser-core-generators/src/test/java/com/github/javaparser/generator/core/utils/CodeUtilsTest.java
+++ b/javaparser-core-generators/src/test/java/com/github/javaparser/generator/core/utils/CodeUtilsTest.java
@@ -31,22 +31,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CodeUtilsTest {
 
-	private static final String RETURN_VALUE = "this";
+    private static final String RETURN_VALUE = "this";
 
-	@Test
-	void castReturnValue_whenAValueMatchesTheExpectedTypeNoCastIsNeeded() {
-		Type returnType = PrimitiveType.booleanType();
-		Type valueType = PrimitiveType.booleanType();
+    @Test
+    void castReturnValue_whenAValueMatchesTheExpectedTypeNoCastIsNeeded() {
+        Type returnType = PrimitiveType.booleanType();
+        Type valueType = PrimitiveType.booleanType();
 
-		assertEquals(RETURN_VALUE, castValue(RETURN_VALUE, returnType, valueType.asString()));
-	}
+        assertEquals(RETURN_VALUE, castValue(RETURN_VALUE, returnType, valueType.asString()));
+    }
 
-	@Test
-	void castReturnValue_whenAValueIsNotAssignedByReturnShouldBeCasted() {
-		Type returnType = StaticJavaParser.parseType("String");
-		Type valueType = StaticJavaParser.parseType("Object");
+    @Test
+    void castReturnValue_whenAValueIsNotAssignedByReturnShouldBeCasted() {
+        Type returnType = StaticJavaParser.parseType("String");
+        Type valueType = StaticJavaParser.parseType("Object");
 
-		assertEquals(String.format("(%s) %s", returnType, RETURN_VALUE), castValue(RETURN_VALUE, returnType, valueType.asString()));
-	}
+        assertEquals(String.format("(%s) %s", returnType, RETURN_VALUE), castValue(RETURN_VALUE, returnType, valueType.asString()));
+    }
 
 }

--- a/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/expected/MethodParameterRerunTest.java
+++ b/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/expected/MethodParameterRerunTest.java
@@ -24,8 +24,8 @@ import com.github.javaparser.quality.Preconditions;
 
 class A {
 
-	public void method(@NotNull String notNull, @NotNull String secondNotNull) {
-		Preconditions.checkNotNull(notNull, "Parameter notNull can't be null.");
-		Preconditions.checkNotNull(secondNotNull, "Parameter secondNotNull can't be null.");
-	}
+    public void method(@NotNull String notNull, @NotNull String secondNotNull) {
+        Preconditions.checkNotNull(notNull, "Parameter notNull can't be null.");
+        Preconditions.checkNotNull(secondNotNull, "Parameter secondNotNull can't be null.");
+    }
 }

--- a/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/expected/MethodParameterTest.java
+++ b/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/expected/MethodParameterTest.java
@@ -24,10 +24,10 @@ import com.github.javaparser.quality.Preconditions;
 
 class A {
 
-	public void method(@NotNull String notNull) {
-		Preconditions.checkNotNull(notNull, "Parameter notNull can't be null.");
-	}
+    public void method(@NotNull String notNull) {
+        Preconditions.checkNotNull(notNull, "Parameter notNull can't be null.");
+    }
 
-	public void method(int age) {
-	}
+    public void method(int age) {
+    }
 }

--- a/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/ConstructorParameterTest.java
+++ b/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/ConstructorParameterTest.java
@@ -26,15 +26,15 @@ import com.github.javaparser.quality.Nullable;
 
 class ConstructorParameterTest {
 
-	private final String a;
-	private final String b;
-	private final String c;
+    private final String a;
+    private final String b;
+    private final String c;
 
-	public ConstructorParameterTest(@NotNull String notNullString, @Nullable String nullableString,
-									String otherString) {
-		this.a = notNullString;
-		this.b = nullableString;
-		this.c = otherString;
-	}
+    public ConstructorParameterTest(@NotNull String notNullString, @Nullable String nullableString,
+                                    String otherString) {
+        this.a = notNullString;
+        this.b = nullableString;
+        this.c = otherString;
+    }
 
 }

--- a/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/ConstructorParameterWithSuperTest.java
+++ b/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/ConstructorParameterWithSuperTest.java
@@ -22,13 +22,13 @@
 import com.github.javaparser.quality.NotNull;
 
 class A {
-	public A(String a) {}
+    public A(String a) {}
 }
 
 class B {
 
-	public B(@NotNull String c) {
-		super("ok");
-	}
+    public B(@NotNull String c) {
+        super("ok");
+    }
 
 }

--- a/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/MethodParameterRerunTest.java
+++ b/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/MethodParameterRerunTest.java
@@ -24,8 +24,8 @@ import com.github.javaparser.quality.Preconditions;
 
 class A {
 
-	public void method(@NotNull String notNull, @NotNull String secondNotNull) {
-		Preconditions.checkNotNull(notNull, "This was aan old message.");
-		Preconditions.checkNotNull(secondNotNull, "Parameter secondNotNull can't be null.");
-	}
+    public void method(@NotNull String notNull, @NotNull String secondNotNull) {
+        Preconditions.checkNotNull(notNull, "This was aan old message.");
+        Preconditions.checkNotNull(secondNotNull, "Parameter secondNotNull can't be null.");
+    }
 }

--- a/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/MethodParameterTest.java
+++ b/javaparser-core-generators/src/test/resources/com/github/javaparser/generator/core/quality/NotNullGeneratorTest/original/MethodParameterTest.java
@@ -24,8 +24,8 @@ import com.github.javaparser.quality.Preconditions;
 
 class A {
 
-	public void method(@NotNull String notNull) {}
+    public void method(@NotNull String notNull) {}
 
-	public void method(int age) {}
+    public void method(int age) {}
 
 }

--- a/javaparser-core-serialization/src/test/java/com/github/javaparser/serialization/JavaParserJsonDeserializerTest.java
+++ b/javaparser-core-serialization/src/test/java/com/github/javaparser/serialization/JavaParserJsonDeserializerTest.java
@@ -201,10 +201,10 @@ class JavaParserJsonDeserializerTest {
                 return null;
             }
 
-			@Override
-			public ResolvedReferenceTypeDeclaration toTypeDeclaration(Node node) {
-				return null;
-			}
+            @Override
+            public ResolvedReferenceTypeDeclaration toTypeDeclaration(Node node) {
+                return null;
+            }
         };
         StaticJavaParser.getConfiguration().setSymbolResolver(stubResolver);
         CompilationUnit cu = parse("public class X{} class Z{}");

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3577Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3577Test.java
@@ -31,10 +31,10 @@ public class Issue3577Test {
     @Test
     public void test() {
         String str = "public class MyClass {\n"
-        		+ "    public static void main(String args[]) {\n"
-        		+ "      System.out.println(\"Hello\\sWorld\");\n"
-        		+ "    }\n"
-        		+ "}";
+                + "    public static void main(String args[]) {\n"
+                + "      System.out.println(\"Hello\\sWorld\");\n"
+                + "    }\n"
+                + "}";
 
         ParserConfiguration config = new ParserConfiguration().setLanguageLevel(LanguageLevel.JAVA_15);
         StaticJavaParser.setConfiguration(config);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -83,20 +83,20 @@ class JavaParserTest {
 
     @Test
     void testSourcePositionsWithBrokenUnicodeEscapes() {
-    	// Source positions
-    	//                      111111111122222222 2 22333 3333
-    	//             123456789012345678901234567 8 90123 4567
-    	String code = "@interface AD { String X = \"\\uABC\"; }";
-    	ParseResult<CompilationUnit> cu = parseWithUnicodeEscapes(code);
-    	assertFalse(cu.getResult().isPresent());
-    	assertEquals("Lexical error at line 1, column 34.  Encountered: \"\\\"\" (34), after : \"\\\"\\\\uABC\"", cu.getProblem(0).getMessage());
+        // Source positions
+        //                      111111111122222222 2 22333 3333
+        //             123456789012345678901234567 8 90123 4567
+        String code = "@interface AD { String X = \"\\uABC\"; }";
+        ParseResult<CompilationUnit> cu = parseWithUnicodeEscapes(code);
+        assertFalse(cu.getResult().isPresent());
+        assertEquals("Lexical error at line 1, column 34.  Encountered: \"\\\"\" (34), after : \"\\\"\\\\uABC\"", cu.getProblem(0).getMessage());
     }
 
-	private static ParseResult<CompilationUnit> parseWithUnicodeEscapes(String code) {
-		ParserConfiguration config = new ParserConfiguration();
+    private static ParseResult<CompilationUnit> parseWithUnicodeEscapes(String code) {
+        ParserConfiguration config = new ParserConfiguration();
         config.setPreprocessUnicodeEscapes(true);
-		return new JavaParser(config).parse(code);
-	}
+        return new JavaParser(config).parse(code);
+    }
 
     @Test
     void rangeOfAnnotationMemberDeclarationWithArrayTypeIsCorrect() {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/PositionMappingTest.java
@@ -40,126 +40,126 @@ import static org.junit.jupiter.api.Assertions.*;
 @SuppressWarnings("javadoc")
 public class PositionMappingTest {
 
-	@Test
-	public void testNoMapping() throws IOException {
-		List<List<String>> input = lines(
-			line("Hello World !\n"), 
-			line("Next Line\r"), 
-			line("Third Line\r\n"), 
-			line("Fourth Line."));
-		String inputText = text(input);
-		UnicodeEscapeProcessingProvider provider = provider(inputText);
-		String outputText = process(provider);
-		assertEquals(inputText, outputText);
-		PositionMapping mapping = provider.getPositionMapping();
-		assertTrue(mapping.isEmpty());
-		assertEquals(4, provider.getInputCounter().getLine());
-		assertEquals(4, provider.getOutputCounter().getLine());
-		assertSame(PositionMapping.PositionUpdate.NONE, mapping.lookup(new Position(10000, 1)));
-	}
+    @Test
+    public void testNoMapping() throws IOException {
+        List<List<String>> input = lines(
+            line("Hello World !\n"), 
+            line("Next Line\r"), 
+            line("Third Line\r\n"), 
+            line("Fourth Line."));
+        String inputText = text(input);
+        UnicodeEscapeProcessingProvider provider = provider(inputText);
+        String outputText = process(provider);
+        assertEquals(inputText, outputText);
+        PositionMapping mapping = provider.getPositionMapping();
+        assertTrue(mapping.isEmpty());
+        assertEquals(4, provider.getInputCounter().getLine());
+        assertEquals(4, provider.getOutputCounter().getLine());
+        assertSame(PositionMapping.PositionUpdate.NONE, mapping.lookup(new Position(10000, 1)));
+    }
 
-	@Test
-	public void testEncodedLineFeed() throws IOException {
-		List<List<String>> input = lines(
-			line("B", "\\u000A", "C"));
-		List<List<String>> output = lines(
-			line("B", "\n"), 
-			line("C"));
-		
-		checkConvert(input, output);
-	}
-	
-	@Test
-	public void testComplexMapping() throws IOException {
-		List<List<String>> input = lines(
-			// Character positions:
-			//                      111    1 11111    1222    2 2222     2
-			//    1    2 34567    89012    3 45678    9012    3 45678    9
-			line("H", "\\u00E4", "llo W", "\\u00F6", "rld!", "\\u000A", "123 N", "\\u00E4", "xt Line", "\\u000D", "Third Line", "\r\n"), 
-			line("Fo", "\\u00FC", "rth Line."));
-		List<List<String>> output = lines(
-			line("H", "ä", "llo W", "ö", "rld!", "\n"), 
-			line("123 N", "ä", "xt Line", "\r"), 
-			line("Third Line", "\r\n"), 
-			line("Fo", "ü", "rth Line."));
+    @Test
+    public void testEncodedLineFeed() throws IOException {
+        List<List<String>> input = lines(
+            line("B", "\\u000A", "C"));
+        List<List<String>> output = lines(
+            line("B", "\n"), 
+            line("C"));
+        
+        checkConvert(input, output);
+    }
+    
+    @Test
+    public void testComplexMapping() throws IOException {
+        List<List<String>> input = lines(
+            // Character positions:
+            //                      111    1 11111    1222    2 2222     2
+            //    1    2 34567    89012    3 45678    9012    3 45678    9
+            line("H", "\\u00E4", "llo W", "\\u00F6", "rld!", "\\u000A", "123 N", "\\u00E4", "xt Line", "\\u000D", "Third Line", "\r\n"), 
+            line("Fo", "\\u00FC", "rth Line."));
+        List<List<String>> output = lines(
+            line("H", "ä", "llo W", "ö", "rld!", "\n"), 
+            line("123 N", "ä", "xt Line", "\r"), 
+            line("Third Line", "\r\n"), 
+            line("Fo", "ü", "rth Line."));
 
-		checkConvert(input, output);
-	}
+        checkConvert(input, output);
+    }
 
-	private void checkConvert(List<List<String>> input,
-			List<List<String>> output) throws IOException {
-		UnicodeEscapeProcessingProvider provider = provider(text(input));
-		String decoded = process(provider);
-		assertEquals(text(output), decoded);
-		
-		PositionMapping mapping = provider.getPositionMapping();
-		
-		// Coarse grained test.
-		assertEquals(input.size(), provider.getInputCounter().getLine());
-		assertEquals(output.size(), provider.getOutputCounter().getLine());
-		
-		// Fine grained test.
-		int inPosLine = 1;
-		int inPosColumn = 1;
-		int outPosLine = 1;
-		int outPosColumn = 1;
-		Iterator<List<String>> outLineIt = output.iterator();
-		List<String> outLine = outLineIt.next();
-		Iterator<String> outPartIt = outLine.iterator();
-		String outPart = outPartIt.next();
-		boolean outFinished = false;
-		for (List<String> inLine : input) {
-			for (String inPart : inLine) {
-				assertFalse(outFinished);
-				
-				Position inPos = new Position(inPosLine, inPosColumn);
-				Position outPos = new Position(outPosLine, outPosColumn);
-				Position transfomedOutPos = mapping.transform(outPos);
+    private void checkConvert(List<List<String>> input,
+            List<List<String>> output) throws IOException {
+        UnicodeEscapeProcessingProvider provider = provider(text(input));
+        String decoded = process(provider);
+        assertEquals(text(output), decoded);
+        
+        PositionMapping mapping = provider.getPositionMapping();
+        
+        // Coarse grained test.
+        assertEquals(input.size(), provider.getInputCounter().getLine());
+        assertEquals(output.size(), provider.getOutputCounter().getLine());
+        
+        // Fine grained test.
+        int inPosLine = 1;
+        int inPosColumn = 1;
+        int outPosLine = 1;
+        int outPosColumn = 1;
+        Iterator<List<String>> outLineIt = output.iterator();
+        List<String> outLine = outLineIt.next();
+        Iterator<String> outPartIt = outLine.iterator();
+        String outPart = outPartIt.next();
+        boolean outFinished = false;
+        for (List<String> inLine : input) {
+            for (String inPart : inLine) {
+                assertFalse(outFinished);
+                
+                Position inPos = new Position(inPosLine, inPosColumn);
+                Position outPos = new Position(outPosLine, outPosColumn);
+                Position transfomedOutPos = mapping.transform(outPos);
 
-				assertEquals(inPos, transfomedOutPos, 
-					"Position mismatch at '" + outPart + "' " + outPos + " -> '" + inPart + "' " + inPos + ".");
+                assertEquals(inPos, transfomedOutPos, 
+                    "Position mismatch at '" + outPart + "' " + outPos + " -> '" + inPart + "' " + inPos + ".");
 
-				outPosColumn += outPart.length();
-				inPosColumn += inPart.length();
-				
-				if (!outPartIt.hasNext()) {
-					if (outLineIt.hasNext()) {
-						outPartIt = outLineIt.next().iterator();
-						outPosLine ++;
-						outPosColumn = 1;
+                outPosColumn += outPart.length();
+                inPosColumn += inPart.length();
+                
+                if (!outPartIt.hasNext()) {
+                    if (outLineIt.hasNext()) {
+                        outPartIt = outLineIt.next().iterator();
+                        outPosLine ++;
+                        outPosColumn = 1;
 
-						outPart = outPartIt.next();
-					} else {
-						outFinished = true;
-					}
-				} else {
-					outPart = outPartIt.next();
-				}
-			}
-			
-			inPosColumn = 1;
-			inPosLine++;
-		}
-	}
-	
-	private static String text(List<List<String>> input) {
-		StringBuilder result = new StringBuilder();
-		for (List<String> line : input) {
-			for (String part : line) {
-				result.append(part);
-			}
-		}
-		return result.toString();
-	}
+                        outPart = outPartIt.next();
+                    } else {
+                        outFinished = true;
+                    }
+                } else {
+                    outPart = outPartIt.next();
+                }
+            }
+            
+            inPosColumn = 1;
+            inPosLine++;
+        }
+    }
+    
+    private static String text(List<List<String>> input) {
+        StringBuilder result = new StringBuilder();
+        for (List<String> line : input) {
+            for (String part : line) {
+                result.append(part);
+            }
+        }
+        return result.toString();
+    }
 
-	@SafeVarargs
-	private static List<String> line(String ...parts) {
-		return Arrays.asList(parts);
-	}
+    @SafeVarargs
+    private static List<String> line(String ...parts) {
+        return Arrays.asList(parts);
+    }
 
-	@SafeVarargs
-	private static List<List<String>> lines(List<String> ...lines) {
-		return Arrays.asList(lines);
-	}
-	
+    @SafeVarargs
+    private static List<List<String>> lines(List<String> ...lines) {
+        return Arrays.asList(lines);
+    }
+    
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/UnicodeEscapeProcessingProviderTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/UnicodeEscapeProcessingProviderTest.java
@@ -31,120 +31,120 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class UnicodeEscapeProcessingProviderTest {
 
-	@Test
-	void testUnicodeEscape() throws IOException {
-		assertEquals("13" + '\u12aA' + "98", new String(read("13\\u12aA98")));
-	}
+    @Test
+    void testUnicodeEscape() throws IOException {
+        assertEquals("13" + '\u12aA' + "98", new String(read("13\\u12aA98")));
+    }
 
-	@Test
-	void testEscapedUnicodeEscape() throws IOException {
-		assertEquals("13\\\\u12aA98", new String(read("13\\\\u12aA98")));
-	}
-	
-	@Test
-	void testUnicodeEscapeWithMultipleUs() throws IOException {
-		assertEquals("13" + '\u12aA' + "98", new String(read("13\\uuuuuu12aA98")));
-	}
-	
-	@Test
-	void testInputEndingInBackslash() throws IOException {
-		assertEquals("foobar\\", new String(read("foobar\\")));
-	}
-	
-	@Test
-	void testInputEndingInBackslashU() throws IOException {
-		assertEquals("foobar\\u", new String(read("foobar\\u")));
-	}
-	
-	@Test
-	void testInputEndingInBackslashUs() throws IOException {
-		assertEquals("foobar\\uuuuuu", new String(read("foobar\\uuuuuu")));
-	}
-	
-	@Test
-	void testInputEndingInBackslashU1() throws IOException {
-		assertEquals("foobar\\uA", new String(read("foobar\\uA")));
-	}
-	
-	@Test
-	void testInputEndingInBackslashU2() throws IOException {
-		assertEquals("foobar\\uAB", new String(read("foobar\\uAB")));
-	}
-	
-	@Test
-	void testInputEndingInBackslashU3() throws IOException {
-		assertEquals("foobar\\uABC", new String(read("foobar\\uABC")));
-	}
-	
-	@Test
-	void testInputEndingUnicodeEscape() throws IOException {
-		assertEquals("foobar\uABCD", new String(read("foobar\\uABCD")));
-	}
-	
-	@Test
-	void testEmptyInput() throws IOException {
-		assertEquals("", new String(read("")));
-	}
+    @Test
+    void testEscapedUnicodeEscape() throws IOException {
+        assertEquals("13\\\\u12aA98", new String(read("13\\\\u12aA98")));
+    }
+    
+    @Test
+    void testUnicodeEscapeWithMultipleUs() throws IOException {
+        assertEquals("13" + '\u12aA' + "98", new String(read("13\\uuuuuu12aA98")));
+    }
+    
+    @Test
+    void testInputEndingInBackslash() throws IOException {
+        assertEquals("foobar\\", new String(read("foobar\\")));
+    }
+    
+    @Test
+    void testInputEndingInBackslashU() throws IOException {
+        assertEquals("foobar\\u", new String(read("foobar\\u")));
+    }
+    
+    @Test
+    void testInputEndingInBackslashUs() throws IOException {
+        assertEquals("foobar\\uuuuuu", new String(read("foobar\\uuuuuu")));
+    }
+    
+    @Test
+    void testInputEndingInBackslashU1() throws IOException {
+        assertEquals("foobar\\uA", new String(read("foobar\\uA")));
+    }
+    
+    @Test
+    void testInputEndingInBackslashU2() throws IOException {
+        assertEquals("foobar\\uAB", new String(read("foobar\\uAB")));
+    }
+    
+    @Test
+    void testInputEndingInBackslashU3() throws IOException {
+        assertEquals("foobar\\uABC", new String(read("foobar\\uABC")));
+    }
+    
+    @Test
+    void testInputEndingUnicodeEscape() throws IOException {
+        assertEquals("foobar\uABCD", new String(read("foobar\\uABCD")));
+    }
+    
+    @Test
+    void testEmptyInput() throws IOException {
+        assertEquals("", new String(read("")));
+    }
 
-	@Test
-	void testBadUnicodeEscape0() throws IOException {
-		assertEquals("13\\ux", new String(read("13\\ux")));
-	}
-	
-	@Test
-	void testBadUnicodeEscape1() throws IOException {
-		assertEquals("13\\u1x", new String(read("13\\u1x")));
-	}
+    @Test
+    void testBadUnicodeEscape0() throws IOException {
+        assertEquals("13\\ux", new String(read("13\\ux")));
+    }
+    
+    @Test
+    void testBadUnicodeEscape1() throws IOException {
+        assertEquals("13\\u1x", new String(read("13\\u1x")));
+    }
 
-	@Test
-	void testBadUnicodeEscape2() throws IOException {
-		assertEquals("13\\u1Ax", new String(read("13\\u1Ax")));
-	}
+    @Test
+    void testBadUnicodeEscape2() throws IOException {
+        assertEquals("13\\u1Ax", new String(read("13\\u1Ax")));
+    }
 
-	@Test
-	void testBadUnicodeEscape3() throws IOException {
-		assertEquals("13\\u1ABx", new String(read("13\\u1ABx")));
-	}
+    @Test
+    void testBadUnicodeEscape3() throws IOException {
+        assertEquals("13\\u1ABx", new String(read("13\\u1ABx")));
+    }
 
-	@Test
-	void testBadUnicodeEscapeMultipleUs() throws IOException {
-		assertEquals("13\\uuuuuu1ABx", new String(read("13\\uuuuuu1ABx")));
-	}
+    @Test
+    void testBadUnicodeEscapeMultipleUs() throws IOException {
+        assertEquals("13\\uuuuuu1ABx", new String(read("13\\uuuuuu1ABx")));
+    }
 
-	@Test
-	void testPushBackWithFullBuffer() throws IOException {
-		assertEquals("12345678\\uuxxxxxxxxxxxxxxxxxxxxxxx", new String(read("12345678\\uuxxxxxxxxxxxxxxxxxxxxxxx")));
-	}
-	
-	@Test
-	void testPushBackWithBufferShift() throws IOException {
-		assertEquals("12345678\\uuxx", new String(read("12345678\\uuxx")));
-	}
-	
-	static String read(String source) throws IOException {
-		return process(provider(source));
-	}
+    @Test
+    void testPushBackWithFullBuffer() throws IOException {
+        assertEquals("12345678\\uuxxxxxxxxxxxxxxxxxxxxxxx", new String(read("12345678\\uuxxxxxxxxxxxxxxxxxxxxxxx")));
+    }
+    
+    @Test
+    void testPushBackWithBufferShift() throws IOException {
+        assertEquals("12345678\\uuxx", new String(read("12345678\\uuxx")));
+    }
+    
+    static String read(String source) throws IOException {
+        return process(provider(source));
+    }
 
-	static UnicodeEscapeProcessingProvider provider(String source) {
-		UnicodeEscapeProcessingProvider provider = new UnicodeEscapeProcessingProvider(10, 
-				new StringProvider(source));
-		return provider;
-	}
+    static UnicodeEscapeProcessingProvider provider(String source) {
+        UnicodeEscapeProcessingProvider provider = new UnicodeEscapeProcessingProvider(10, 
+                new StringProvider(source));
+        return provider;
+    }
 
-	static String process(UnicodeEscapeProcessingProvider provider)
-			throws IOException {
-		StringBuilder result = new StringBuilder();
-		char[] buffer = new char[10];
-		while (true) {
-			int direct = provider.read(buffer, 0, buffer.length);
-			if (direct < 0) {
-				break;
-			}
-			result.append(buffer, 0, direct);
-		}
-		
-		provider.close();
-	
-		return result.toString();
-	}
+    static String process(UnicodeEscapeProcessingProvider provider)
+            throws IOException {
+        StringBuilder result = new StringBuilder();
+        char[] buffer = new char[10];
+        while (true) {
+            int direct = provider.read(buffer, 0, buffer.length);
+            if (direct < 0) {
+                break;
+            }
+            result.append(buffer, 0, direct);
+        }
+        
+        provider.close();
+    
+        return result.toString();
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
@@ -114,32 +114,32 @@ class ClassOrInterfaceDeclarationTest {
     @ParameterizedTest
     @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16"})
     void sealedFieldNamePermitted(ParserConfiguration.LanguageLevel languageLevel) {
-    	assertDoesNotThrow(() -> {
-    		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean sealed");
+        assertDoesNotThrow(() -> {
+            TestParser.parseVariableDeclarationExpr(languageLevel, "boolean sealed");
         });
     }
 
     @ParameterizedTest
     @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_17"})
     void sealedFieldNameNotPermitted(ParserConfiguration.LanguageLevel languageLevel) {
-    	assertThrows(AssertionFailedError.class, () -> {
-    		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean sealed");
+        assertThrows(AssertionFailedError.class, () -> {
+            TestParser.parseVariableDeclarationExpr(languageLevel, "boolean sealed");
         });
     }
 
     @ParameterizedTest
     @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16"})
     void permitsFieldNamePermitted(ParserConfiguration.LanguageLevel languageLevel) {
-    	assertDoesNotThrow(() -> {
-    		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean permits");
+        assertDoesNotThrow(() -> {
+            TestParser.parseVariableDeclarationExpr(languageLevel, "boolean permits");
         });
     }
 
     @ParameterizedTest
     @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_17"})
     void permitsFieldNameNotPermitted(ParserConfiguration.LanguageLevel languageLevel) {
-    	assertThrows(AssertionFailedError.class, () -> {
-    		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean permits");
+        assertThrows(AssertionFailedError.class, () -> {
+            TestParser.parseVariableDeclarationExpr(languageLevel, "boolean permits");
         });
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
@@ -51,32 +51,32 @@ class FieldDeclarationTest {
     
     @Test
     void setModifiersPrimitiveType() {
-    	FieldDeclaration field = parseBodyDeclaration("public static final int var = 1;").asFieldDeclaration();
-    	testChangingModifiers(field);
+        FieldDeclaration field = parseBodyDeclaration("public static final int var = 1;").asFieldDeclaration();
+        testChangingModifiers(field);
     }
     
     @Test
     void setModifiersNonPrimitiveType() {
-    	FieldDeclaration field = parseBodyDeclaration("public static final String var = \"a\";").asFieldDeclaration();
-    	testChangingModifiers(field);
+        FieldDeclaration field = parseBodyDeclaration("public static final String var = \"a\";").asFieldDeclaration();
+        testChangingModifiers(field);
     }
     
     private void testChangingModifiers(FieldDeclaration field) {
-    	NodeList<Modifier> modifiers = field.getModifiers();
-    	assertTrue(modifiers.contains(Modifier.publicModifier()));
-    	assertTrue(modifiers.contains(Modifier.staticModifier()));
-    	assertTrue(modifiers.contains(Modifier.finalModifier()));
-    	assertEquals(3, modifiers.size());
-    	
-    	field.setModifiers(new NodeList<Modifier>());
-    	modifiers = field.getModifiers();
-    	assertEquals(0, modifiers.size());
-    	
-    	field.setModifiers(Keyword.PRIVATE, Keyword.SYNCHRONIZED);
-    	modifiers = field.getModifiers();
-    	assertTrue(modifiers.contains(Modifier.privateModifier()));
-    	assertTrue(modifiers.contains(Modifier.synchronizedModifier()));
-    	assertEquals(2, modifiers.size());
+        NodeList<Modifier> modifiers = field.getModifiers();
+        assertTrue(modifiers.contains(Modifier.publicModifier()));
+        assertTrue(modifiers.contains(Modifier.staticModifier()));
+        assertTrue(modifiers.contains(Modifier.finalModifier()));
+        assertEquals(3, modifiers.size());
+        
+        field.setModifiers(new NodeList<Modifier>());
+        modifiers = field.getModifiers();
+        assertEquals(0, modifiers.size());
+        
+        field.setModifiers(Keyword.PRIVATE, Keyword.SYNCHRONIZED);
+        modifiers = field.getModifiers();
+        assertTrue(modifiers.contains(Modifier.privateModifier()));
+        assertTrue(modifiers.contains(Modifier.synchronizedModifier()));
+        assertEquals(2, modifiers.size());
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
@@ -193,8 +193,8 @@ class ArrayTypeTest {
     }
     
     @Test
-	void range() {
-		Type type = parseType("Long[][]");
-		assertEquals(8, type.getRange().get().end.column);
-	}
+    void range() {
+        Type type = parseType("Long[][]");
+        assertEquals(8, type.getRange().get().end.column);
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
@@ -40,929 +40,929 @@ import static org.mockito.Mockito.*;
 
 class HashCodeVisitorTest {
 
-	@Test
-	void testEquals() {
-		CompilationUnit p1 = parse("class X { }");
-		CompilationUnit p2 = parse("class X { }");
-		assertEquals(p1.hashCode(), p2.hashCode());
-	}
-
-	@Test
-	void testNotEquals() {
-		CompilationUnit p1 = parse("class X { }");
-		CompilationUnit p2 = parse("class Y { }");
-		assertNotEquals(p1.hashCode(), p2.hashCode());
-	}
-
-	@Test
-	void testVisitAnnotationDeclaration() {
-		AnnotationDeclaration node = spy(new AnnotationDeclaration());
-		HashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getMembers();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitAnnotationMemberDeclaration() {
-		AnnotationMemberDeclaration node = spy(new AnnotationMemberDeclaration());
-		HashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getDefaultValue();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitArrayAccessExpr() {
-		ArrayAccessExpr node = spy(new ArrayAccessExpr());
-		HashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getIndex();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitArrayCreationExpr() {
-		ArrayCreationExpr node = spy(new ArrayCreationExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getElementType();
-		verify(node, times(2)).getInitializer();
-		verify(node, times(1)).getLevels();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitArrayCreationLevel() {
-		ArrayCreationLevel node = spy(new ArrayCreationLevel());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getDimension();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitArrayInitializerExpr() {
-		ArrayInitializerExpr node = spy(new ArrayInitializerExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getValues();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitArrayType() {
-		ArrayType node = spy(new ArrayType(intType()));
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getComponentType();
-		verify(node, times(1)).getOrigin();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitAssertStmt() {
-		AssertStmt node = spy(new AssertStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getCheck();
-		verify(node, times(1)).getMessage();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitAssignExpr() {
-		AssignExpr node = spy(new AssignExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getOperator();
-		verify(node, times(1)).getTarget();
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitBinaryExpr() {
-		BinaryExpr node = spy(new BinaryExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getLeft();
-		verify(node, times(1)).getOperator();
-		verify(node, times(1)).getRight();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitBlockComment() {
-		BlockComment node = spy(new BlockComment());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getContent();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitBlockStmt() {
-		BlockStmt node = spy(new BlockStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getStatements();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitBooleanLiteralExpr() {
-		BooleanLiteralExpr node = spy(new BooleanLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).isValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitBreakStmt() {
-		BreakStmt node = spy(new BreakStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getLabel();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitCastExpr() {
-		CastExpr node = spy(new CastExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitCatchClause() {
-		CatchClause node = spy(new CatchClause());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getParameter();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitCharLiteralExpr() {
-		CharLiteralExpr node = spy(new CharLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitClassExpr() {
-		ClassExpr node = spy(new ClassExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitClassOrInterfaceDeclaration() {
-		ClassOrInterfaceDeclaration node = spy(new ClassOrInterfaceDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExtendedTypes();
-		verify(node, times(1)).getImplementedTypes();
-		verify(node, times(1)).isInterface();
-		verify(node, times(1)).getTypeParameters();
-		verify(node, times(1)).getMembers();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitClassOrInterfaceType() {
-		ClassOrInterfaceType node = spy(new ClassOrInterfaceType());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitCompilationUnit() {
-		CompilationUnit node = spy(new CompilationUnit());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getImports();
-		verify(node, times(1)).getModule();
-		verify(node, times(1)).getPackageDeclaration();
-		verify(node, times(1)).getTypes();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitConditionalExpr() {
-		ConditionalExpr node = spy(new ConditionalExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getCondition();
-		verify(node, times(1)).getElseExpr();
-		verify(node, times(1)).getThenExpr();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitConstructorDeclaration() {
-		ConstructorDeclaration node = spy(new ConstructorDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getParameters();
-		verify(node, times(1)).getReceiverParameter();
-		verify(node, times(1)).getThrownExceptions();
-		verify(node, times(1)).getTypeParameters();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitContinueStmt() {
-		ContinueStmt node = spy(new ContinueStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getLabel();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitDoStmt() {
-		DoStmt node = spy(new DoStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getCondition();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitDoubleLiteralExpr() {
-		DoubleLiteralExpr node = spy(new DoubleLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitEmptyStmt() {
-		EmptyStmt node = spy(new EmptyStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitEnclosedExpr() {
-		EnclosedExpr node = spy(new EnclosedExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getInner();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitEnumConstantDeclaration() {
-		EnumConstantDeclaration node = spy(new EnumConstantDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getClassBody();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitEnumDeclaration() {
-		EnumDeclaration node = spy(new EnumDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getEntries();
-		verify(node, times(1)).getImplementedTypes();
-		verify(node, times(1)).getMembers();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitExplicitConstructorInvocationStmt() {
-		ExplicitConstructorInvocationStmt node = spy(new ExplicitConstructorInvocationStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).isThis();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitExpressionStmt() {
-		ExpressionStmt node = spy(new ExpressionStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitFieldAccessExpr() {
-		FieldAccessExpr node = spy(new FieldAccessExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitFieldDeclaration() {
-		FieldDeclaration node = spy(new FieldDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getVariables();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitForEachStmt() {
-		ForEachStmt node = spy(new ForEachStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getIterable();
-		verify(node, times(1)).getVariable();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitForStmt() {
-		ForStmt node = spy(new ForStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(2)).getCompare();
-		verify(node, times(1)).getInitialization();
-		verify(node, times(1)).getUpdate();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitIfStmt() {
-		IfStmt node = spy(new IfStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getCondition();
-		verify(node, times(1)).getElseStmt();
-		verify(node, times(1)).getThenStmt();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitImportDeclaration() {
-		ImportDeclaration node = spy(new ImportDeclaration(new Name(), false, false));
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).isAsterisk();
-		verify(node, times(1)).isStatic();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitInitializerDeclaration() {
-		InitializerDeclaration node = spy(new InitializerDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).isStatic();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitInstanceOfExpr() {
-		InstanceOfExpr node = spy(new InstanceOfExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getPattern();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitIntegerLiteralExpr() {
-		IntegerLiteralExpr node = spy(new IntegerLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitIntersectionType() {
-		NodeList<ReferenceType> elements = new NodeList<>();
-		elements.add(new ClassOrInterfaceType());
-		IntersectionType node = spy(new IntersectionType(elements));
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getElements();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitJavadocComment() {
-		JavadocComment node = spy(new JavadocComment());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getContent();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitLabeledStmt() {
-		LabeledStmt node = spy(new LabeledStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getLabel();
-		verify(node, times(1)).getStatement();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitLambdaExpr() {
-		LambdaExpr node = spy(new LambdaExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).isEnclosingParameters();
-		verify(node, times(1)).getParameters();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitLineComment() {
-		LineComment node = spy(new LineComment());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getContent();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitLocalClassDeclarationStmt() {
-		LocalClassDeclarationStmt node = spy(new LocalClassDeclarationStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getClassDeclaration();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitLocalRecordDeclarationStmt() {
-		LocalRecordDeclarationStmt node = spy(new LocalRecordDeclarationStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getRecordDeclaration();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitLongLiteralExpr() {
-		LongLiteralExpr node = spy(new LongLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitMarkerAnnotationExpr() {
-		MarkerAnnotationExpr node = spy(new MarkerAnnotationExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitMemberValuePair() {
-		MemberValuePair node = spy(new MemberValuePair());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitMethodCallExpr() {
-		MethodCallExpr node = spy(new MethodCallExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitMethodDeclaration() {
-		MethodDeclaration node = spy(new MethodDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(2)).getBody();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getParameters();
-		verify(node, times(1)).getReceiverParameter();
-		verify(node, times(1)).getThrownExceptions();
-		verify(node, times(1)).getTypeParameters();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitMethodReferenceExpr() {
-		MethodReferenceExpr node = spy(new MethodReferenceExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getIdentifier();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitModifier() {
-		Modifier node = spy(new Modifier());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getKeyword();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitModuleDeclaration() {
-		ModuleDeclaration node = spy(new ModuleDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getDirectives();
-		verify(node, times(1)).isOpen();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitModuleExportsDirective() {
-		ModuleExportsDirective node = spy(new ModuleExportsDirective());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getModuleNames();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitModuleOpensDirective() {
-		ModuleOpensDirective node = spy(new ModuleOpensDirective());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getModuleNames();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitModuleProvidesDirective() {
-		ModuleProvidesDirective node = spy(new ModuleProvidesDirective());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getWith();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitModuleRequiresDirective() {
-		ModuleRequiresDirective node = spy(new ModuleRequiresDirective());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitModuleUsesDirective() {
-		ModuleUsesDirective node = spy(new ModuleUsesDirective());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitNameExpr() {
-		NameExpr node = spy(new NameExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitName() {
-		Name node = spy(new Name());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getIdentifier();
-		verify(node, times(1)).getQualifier();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitNormalAnnotationExpr() {
-		NormalAnnotationExpr node = spy(new NormalAnnotationExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getPairs();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitNullLiteralExpr() {
-		NullLiteralExpr node = spy(new NullLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitObjectCreationExpr() {
-		ObjectCreationExpr node = spy(new ObjectCreationExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnonymousClassBody();
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getType();
-		verify(node, times(2)).getTypeArguments();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitPackageDeclaration() {
-		PackageDeclaration node = spy(new PackageDeclaration());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitParameter() {
-		Parameter node = spy(new Parameter());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).isVarArgs();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getVarArgsAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitPatternExpr() {
-		PatternExpr node = spy(new PatternExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitPrimitiveType() {
-		PrimitiveType node = spy(new PrimitiveType());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitReceiverParameter() {
-		ReceiverParameter node = spy(new ReceiverParameter());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitReturnStmt() {
-		ReturnStmt node = spy(new ReturnStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitSimpleName() {
-		SimpleName node = spy(new SimpleName());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getIdentifier();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitSingleMemberAnnotationExpr() {
-		SingleMemberAnnotationExpr node = spy(new SingleMemberAnnotationExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getMemberValue();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitStringLiteralExpr() {
-		StringLiteralExpr node = spy(new StringLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitSuperExpr() {
-		SuperExpr node = spy(new SuperExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getTypeName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitSwitchEntry() {
-		SwitchEntry node = spy(new SwitchEntry());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getLabels();
-		verify(node, times(1)).getStatements();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitSwitchExpr() {
-		SwitchExpr node = spy(new SwitchExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getEntries();
-		verify(node, times(1)).getSelector();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitSwitchStmt() {
-		SwitchStmt node = spy(new SwitchStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getEntries();
-		verify(node, times(1)).getSelector();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitSynchronizedStmt() {
-		SynchronizedStmt node = spy(new SynchronizedStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitTextBlockLiteralExpr() {
-		TextBlockLiteralExpr node = spy(new TextBlockLiteralExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getValue();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitThisExpr() {
-		ThisExpr node = spy(new ThisExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getTypeName();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitThrowStmt() {
-		ThrowStmt node = spy(new ThrowStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitTryStmt() {
-		TryStmt node = spy(new TryStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getCatchClauses();
-		verify(node, times(1)).getFinallyBlock();
-		verify(node, times(1)).getResources();
-		verify(node, times(1)).getTryBlock();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitTypeExpr() {
-		TypeExpr node = spy(new TypeExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitTypeParameter() {
-		TypeParameter node = spy(new TypeParameter());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getTypeBound();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitUnaryExpr() {
-		UnaryExpr node = spy(new UnaryExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getOperator();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitUnionType() {
-		UnionType node = spy(new UnionType());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getElements();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitUnknownType() {
-		UnknownType node = spy(new UnknownType());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitUnparsableStmt() {
-		UnparsableStmt node = spy(new UnparsableStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitVarType() {
-		VarType node = spy(new VarType());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitVariableDeclarationExpr() {
-		VariableDeclarationExpr node = spy(new VariableDeclarationExpr());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getVariables();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitVariableDeclarator() {
-		VariableDeclarator node = spy(new VariableDeclarator());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getInitializer();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitVoidType() {
-		VoidType node = spy(new VoidType());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitWhileStmt() {
-		WhileStmt node = spy(new WhileStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getCondition();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitWildcardType() {
-		WildcardType node = spy(new WildcardType());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExtendedType();
-		verify(node, times(1)).getSuperType();
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getComment();
-	}
-
-	@Test
-	void testVisitYieldStmt() {
-		YieldStmt node = spy(new YieldStmt());
-		HashCodeVisitor.hashCode(node);
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getComment();
-	}
+    @Test
+    void testEquals() {
+        CompilationUnit p1 = parse("class X { }");
+        CompilationUnit p2 = parse("class X { }");
+        assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    void testNotEquals() {
+        CompilationUnit p1 = parse("class X { }");
+        CompilationUnit p2 = parse("class Y { }");
+        assertNotEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    void testVisitAnnotationDeclaration() {
+        AnnotationDeclaration node = spy(new AnnotationDeclaration());
+        HashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getMembers();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitAnnotationMemberDeclaration() {
+        AnnotationMemberDeclaration node = spy(new AnnotationMemberDeclaration());
+        HashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getDefaultValue();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitArrayAccessExpr() {
+        ArrayAccessExpr node = spy(new ArrayAccessExpr());
+        HashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getIndex();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitArrayCreationExpr() {
+        ArrayCreationExpr node = spy(new ArrayCreationExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getElementType();
+        verify(node, times(2)).getInitializer();
+        verify(node, times(1)).getLevels();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitArrayCreationLevel() {
+        ArrayCreationLevel node = spy(new ArrayCreationLevel());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getDimension();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitArrayInitializerExpr() {
+        ArrayInitializerExpr node = spy(new ArrayInitializerExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getValues();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitArrayType() {
+        ArrayType node = spy(new ArrayType(intType()));
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getComponentType();
+        verify(node, times(1)).getOrigin();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitAssertStmt() {
+        AssertStmt node = spy(new AssertStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getCheck();
+        verify(node, times(1)).getMessage();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitAssignExpr() {
+        AssignExpr node = spy(new AssignExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getOperator();
+        verify(node, times(1)).getTarget();
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitBinaryExpr() {
+        BinaryExpr node = spy(new BinaryExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getLeft();
+        verify(node, times(1)).getOperator();
+        verify(node, times(1)).getRight();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitBlockComment() {
+        BlockComment node = spy(new BlockComment());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getContent();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitBlockStmt() {
+        BlockStmt node = spy(new BlockStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getStatements();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitBooleanLiteralExpr() {
+        BooleanLiteralExpr node = spy(new BooleanLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).isValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitBreakStmt() {
+        BreakStmt node = spy(new BreakStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getLabel();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitCastExpr() {
+        CastExpr node = spy(new CastExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitCatchClause() {
+        CatchClause node = spy(new CatchClause());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getParameter();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitCharLiteralExpr() {
+        CharLiteralExpr node = spy(new CharLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitClassExpr() {
+        ClassExpr node = spy(new ClassExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitClassOrInterfaceDeclaration() {
+        ClassOrInterfaceDeclaration node = spy(new ClassOrInterfaceDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExtendedTypes();
+        verify(node, times(1)).getImplementedTypes();
+        verify(node, times(1)).isInterface();
+        verify(node, times(1)).getTypeParameters();
+        verify(node, times(1)).getMembers();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitClassOrInterfaceType() {
+        ClassOrInterfaceType node = spy(new ClassOrInterfaceType());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitCompilationUnit() {
+        CompilationUnit node = spy(new CompilationUnit());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getImports();
+        verify(node, times(1)).getModule();
+        verify(node, times(1)).getPackageDeclaration();
+        verify(node, times(1)).getTypes();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitConditionalExpr() {
+        ConditionalExpr node = spy(new ConditionalExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getCondition();
+        verify(node, times(1)).getElseExpr();
+        verify(node, times(1)).getThenExpr();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitConstructorDeclaration() {
+        ConstructorDeclaration node = spy(new ConstructorDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getParameters();
+        verify(node, times(1)).getReceiverParameter();
+        verify(node, times(1)).getThrownExceptions();
+        verify(node, times(1)).getTypeParameters();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitContinueStmt() {
+        ContinueStmt node = spy(new ContinueStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getLabel();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitDoStmt() {
+        DoStmt node = spy(new DoStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getCondition();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitDoubleLiteralExpr() {
+        DoubleLiteralExpr node = spy(new DoubleLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitEmptyStmt() {
+        EmptyStmt node = spy(new EmptyStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitEnclosedExpr() {
+        EnclosedExpr node = spy(new EnclosedExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getInner();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitEnumConstantDeclaration() {
+        EnumConstantDeclaration node = spy(new EnumConstantDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getClassBody();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitEnumDeclaration() {
+        EnumDeclaration node = spy(new EnumDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getEntries();
+        verify(node, times(1)).getImplementedTypes();
+        verify(node, times(1)).getMembers();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitExplicitConstructorInvocationStmt() {
+        ExplicitConstructorInvocationStmt node = spy(new ExplicitConstructorInvocationStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).isThis();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitExpressionStmt() {
+        ExpressionStmt node = spy(new ExpressionStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitFieldAccessExpr() {
+        FieldAccessExpr node = spy(new FieldAccessExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitFieldDeclaration() {
+        FieldDeclaration node = spy(new FieldDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getVariables();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitForEachStmt() {
+        ForEachStmt node = spy(new ForEachStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getIterable();
+        verify(node, times(1)).getVariable();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitForStmt() {
+        ForStmt node = spy(new ForStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(2)).getCompare();
+        verify(node, times(1)).getInitialization();
+        verify(node, times(1)).getUpdate();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitIfStmt() {
+        IfStmt node = spy(new IfStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getCondition();
+        verify(node, times(1)).getElseStmt();
+        verify(node, times(1)).getThenStmt();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitImportDeclaration() {
+        ImportDeclaration node = spy(new ImportDeclaration(new Name(), false, false));
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).isAsterisk();
+        verify(node, times(1)).isStatic();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitInitializerDeclaration() {
+        InitializerDeclaration node = spy(new InitializerDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).isStatic();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitInstanceOfExpr() {
+        InstanceOfExpr node = spy(new InstanceOfExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getPattern();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitIntegerLiteralExpr() {
+        IntegerLiteralExpr node = spy(new IntegerLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitIntersectionType() {
+        NodeList<ReferenceType> elements = new NodeList<>();
+        elements.add(new ClassOrInterfaceType());
+        IntersectionType node = spy(new IntersectionType(elements));
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getElements();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitJavadocComment() {
+        JavadocComment node = spy(new JavadocComment());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getContent();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitLabeledStmt() {
+        LabeledStmt node = spy(new LabeledStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getLabel();
+        verify(node, times(1)).getStatement();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitLambdaExpr() {
+        LambdaExpr node = spy(new LambdaExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).isEnclosingParameters();
+        verify(node, times(1)).getParameters();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitLineComment() {
+        LineComment node = spy(new LineComment());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getContent();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitLocalClassDeclarationStmt() {
+        LocalClassDeclarationStmt node = spy(new LocalClassDeclarationStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getClassDeclaration();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitLocalRecordDeclarationStmt() {
+        LocalRecordDeclarationStmt node = spy(new LocalRecordDeclarationStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getRecordDeclaration();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitLongLiteralExpr() {
+        LongLiteralExpr node = spy(new LongLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitMarkerAnnotationExpr() {
+        MarkerAnnotationExpr node = spy(new MarkerAnnotationExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitMemberValuePair() {
+        MemberValuePair node = spy(new MemberValuePair());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitMethodCallExpr() {
+        MethodCallExpr node = spy(new MethodCallExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitMethodDeclaration() {
+        MethodDeclaration node = spy(new MethodDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(2)).getBody();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getParameters();
+        verify(node, times(1)).getReceiverParameter();
+        verify(node, times(1)).getThrownExceptions();
+        verify(node, times(1)).getTypeParameters();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitMethodReferenceExpr() {
+        MethodReferenceExpr node = spy(new MethodReferenceExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getIdentifier();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitModifier() {
+        Modifier node = spy(new Modifier());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getKeyword();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitModuleDeclaration() {
+        ModuleDeclaration node = spy(new ModuleDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getDirectives();
+        verify(node, times(1)).isOpen();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitModuleExportsDirective() {
+        ModuleExportsDirective node = spy(new ModuleExportsDirective());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getModuleNames();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitModuleOpensDirective() {
+        ModuleOpensDirective node = spy(new ModuleOpensDirective());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getModuleNames();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitModuleProvidesDirective() {
+        ModuleProvidesDirective node = spy(new ModuleProvidesDirective());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getWith();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitModuleRequiresDirective() {
+        ModuleRequiresDirective node = spy(new ModuleRequiresDirective());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitModuleUsesDirective() {
+        ModuleUsesDirective node = spy(new ModuleUsesDirective());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitNameExpr() {
+        NameExpr node = spy(new NameExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitName() {
+        Name node = spy(new Name());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getIdentifier();
+        verify(node, times(1)).getQualifier();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitNormalAnnotationExpr() {
+        NormalAnnotationExpr node = spy(new NormalAnnotationExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getPairs();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitNullLiteralExpr() {
+        NullLiteralExpr node = spy(new NullLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitObjectCreationExpr() {
+        ObjectCreationExpr node = spy(new ObjectCreationExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnonymousClassBody();
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getType();
+        verify(node, times(2)).getTypeArguments();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitPackageDeclaration() {
+        PackageDeclaration node = spy(new PackageDeclaration());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitParameter() {
+        Parameter node = spy(new Parameter());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).isVarArgs();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getVarArgsAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitPatternExpr() {
+        PatternExpr node = spy(new PatternExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitPrimitiveType() {
+        PrimitiveType node = spy(new PrimitiveType());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitReceiverParameter() {
+        ReceiverParameter node = spy(new ReceiverParameter());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitReturnStmt() {
+        ReturnStmt node = spy(new ReturnStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitSimpleName() {
+        SimpleName node = spy(new SimpleName());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getIdentifier();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitSingleMemberAnnotationExpr() {
+        SingleMemberAnnotationExpr node = spy(new SingleMemberAnnotationExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getMemberValue();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitStringLiteralExpr() {
+        StringLiteralExpr node = spy(new StringLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitSuperExpr() {
+        SuperExpr node = spy(new SuperExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getTypeName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitSwitchEntry() {
+        SwitchEntry node = spy(new SwitchEntry());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getLabels();
+        verify(node, times(1)).getStatements();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitSwitchExpr() {
+        SwitchExpr node = spy(new SwitchExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getEntries();
+        verify(node, times(1)).getSelector();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitSwitchStmt() {
+        SwitchStmt node = spy(new SwitchStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getEntries();
+        verify(node, times(1)).getSelector();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitSynchronizedStmt() {
+        SynchronizedStmt node = spy(new SynchronizedStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitTextBlockLiteralExpr() {
+        TextBlockLiteralExpr node = spy(new TextBlockLiteralExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getValue();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitThisExpr() {
+        ThisExpr node = spy(new ThisExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getTypeName();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitThrowStmt() {
+        ThrowStmt node = spy(new ThrowStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitTryStmt() {
+        TryStmt node = spy(new TryStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getCatchClauses();
+        verify(node, times(1)).getFinallyBlock();
+        verify(node, times(1)).getResources();
+        verify(node, times(1)).getTryBlock();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitTypeExpr() {
+        TypeExpr node = spy(new TypeExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitTypeParameter() {
+        TypeParameter node = spy(new TypeParameter());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getTypeBound();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitUnaryExpr() {
+        UnaryExpr node = spy(new UnaryExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getOperator();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitUnionType() {
+        UnionType node = spy(new UnionType());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getElements();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitUnknownType() {
+        UnknownType node = spy(new UnknownType());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitUnparsableStmt() {
+        UnparsableStmt node = spy(new UnparsableStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitVarType() {
+        VarType node = spy(new VarType());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitVariableDeclarationExpr() {
+        VariableDeclarationExpr node = spy(new VariableDeclarationExpr());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getVariables();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitVariableDeclarator() {
+        VariableDeclarator node = spy(new VariableDeclarator());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getInitializer();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitVoidType() {
+        VoidType node = spy(new VoidType());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitWhileStmt() {
+        WhileStmt node = spy(new WhileStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getCondition();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitWildcardType() {
+        WildcardType node = spy(new WildcardType());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExtendedType();
+        verify(node, times(1)).getSuperType();
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getComment();
+    }
+
+    @Test
+    void testVisitYieldStmt() {
+        YieldStmt node = spy(new YieldStmt());
+        HashCodeVisitor.hashCode(node);
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getComment();
+    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
@@ -40,1028 +40,1028 @@ import static org.mockito.Mockito.*;
 
 class NoCommentHashCodeVisitorTest {
 
-	@Test
-	void testEquals() {
-		CompilationUnit p1 = parse("class X { }");
-		CompilationUnit p2 = parse("class X { }");
-		assertEquals(p1.hashCode(), p2.hashCode());
-	}
-
-	@Test
-	void testEqualsWithDifferentComments() {
-		CompilationUnit p1 = parse("/* a */ class X { /** b */} //c");
-		CompilationUnit p2 = parse("/* b */ class X { }  //c");
-		assertEquals(p1.hashCode(), p2.hashCode());
-		assertEquals(3, p1.getAllComments().size());
-		assertEquals(2, p2.getAllComments().size());
-	}
-
-	@Test
-	void testNotEquals() {
-		CompilationUnit p1 = parse("class X { }");
-		CompilationUnit p2 = parse("class Y { }");
-		assertNotEquals(p1.hashCode(), p2.hashCode());
-	}
-
-	@Test
-	void testJavadocCommentDoesNotHaveHashCode() {
-		JavadocComment node = spy(new JavadocComment());
-		assertEquals(0, NoCommentHashCodeVisitor.hashCode(node));
-
-		verify(node).accept(isA(NoCommentHashCodeVisitor.class), isNull());
-	}
-
-	@Test
-	void testLineCommentDoesNotHaveHashCode() {
-		LineComment node = spy(new LineComment());
-		assertEquals(0, NoCommentHashCodeVisitor.hashCode(node));
-
-		verify(node).accept(isA(NoCommentHashCodeVisitor.class), isNull());
-	}
-
-	@Test
-	void testBlockCommentDoesNotHaveHashCode() {
-		BlockComment node = spy(new BlockComment());
-		assertEquals(0, NoCommentHashCodeVisitor.hashCode(node));
-
-		verify(node).accept(isA(NoCommentHashCodeVisitor.class), isNull());
-	}
-
-	@Test
-	void testVisitAnnotationDeclaration() {
-		AnnotationDeclaration node = spy(new AnnotationDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getMembers();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitAnnotationMemberDeclaration() {
-		AnnotationMemberDeclaration node = spy(new AnnotationMemberDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getDefaultValue();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitArrayAccessExpr() {
-		ArrayAccessExpr node = spy(new ArrayAccessExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getIndex();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitArrayCreationExpr() {
-		ArrayCreationExpr node = spy(new ArrayCreationExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getElementType();
-		verify(node, times(2)).getInitializer();
-		verify(node, times(1)).getLevels();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitArrayCreationLevel() {
-		ArrayCreationLevel node = spy(new ArrayCreationLevel());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getDimension();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitArrayInitializerExpr() {
-		ArrayInitializerExpr node = spy(new ArrayInitializerExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getValues();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitArrayType() {
-		ArrayType node = spy(new ArrayType(intType()));
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getComponentType();
-		verify(node, times(1)).getOrigin();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitAssertStmt() {
-		AssertStmt node = spy(new AssertStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getCheck();
-		verify(node, times(1)).getMessage();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitAssignExpr() {
-		AssignExpr node = spy(new AssignExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getOperator();
-		verify(node, times(1)).getTarget();
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitBinaryExpr() {
-		BinaryExpr node = spy(new BinaryExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getLeft();
-		verify(node, times(1)).getOperator();
-		verify(node, times(1)).getRight();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitBlockStmt() {
-		BlockStmt node = spy(new BlockStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getStatements();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitBooleanLiteralExpr() {
-		BooleanLiteralExpr node = spy(new BooleanLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).isValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitBreakStmt() {
-		BreakStmt node = spy(new BreakStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getLabel();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitCastExpr() {
-		CastExpr node = spy(new CastExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitCatchClause() {
-		CatchClause node = spy(new CatchClause());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getParameter();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitCharLiteralExpr() {
-		CharLiteralExpr node = spy(new CharLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitClassExpr() {
-		ClassExpr node = spy(new ClassExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitClassOrInterfaceDeclaration() {
-		ClassOrInterfaceDeclaration node = spy(new ClassOrInterfaceDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExtendedTypes();
-		verify(node, times(1)).getImplementedTypes();
-		verify(node, times(1)).isInterface();
-		verify(node, times(1)).getTypeParameters();
-		verify(node, times(1)).getMembers();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitClassOrInterfaceType() {
-		ClassOrInterfaceType node = spy(new ClassOrInterfaceType());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitCompilationUnit() {
-		CompilationUnit node = spy(new CompilationUnit());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getImports();
-		verify(node, times(1)).getModule();
-		verify(node, times(1)).getPackageDeclaration();
-		verify(node, times(1)).getTypes();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitConditionalExpr() {
-		ConditionalExpr node = spy(new ConditionalExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getCondition();
-		verify(node, times(1)).getElseExpr();
-		verify(node, times(1)).getThenExpr();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitConstructorDeclaration() {
-		ConstructorDeclaration node = spy(new ConstructorDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getParameters();
-		verify(node, times(1)).getReceiverParameter();
-		verify(node, times(1)).getThrownExceptions();
-		verify(node, times(1)).getTypeParameters();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitContinueStmt() {
-		ContinueStmt node = spy(new ContinueStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getLabel();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitDoStmt() {
-		DoStmt node = spy(new DoStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getCondition();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitDoubleLiteralExpr() {
-		DoubleLiteralExpr node = spy(new DoubleLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitEmptyStmt() {
-		EmptyStmt node = spy(new EmptyStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitEnclosedExpr() {
-		EnclosedExpr node = spy(new EnclosedExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getInner();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitEnumConstantDeclaration() {
-		EnumConstantDeclaration node = spy(new EnumConstantDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getClassBody();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitEnumDeclaration() {
-		EnumDeclaration node = spy(new EnumDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getEntries();
-		verify(node, times(1)).getImplementedTypes();
-		verify(node, times(1)).getMembers();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitExplicitConstructorInvocationStmt() {
-		ExplicitConstructorInvocationStmt node = spy(new ExplicitConstructorInvocationStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).isThis();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitExpressionStmt() {
-		ExpressionStmt node = spy(new ExpressionStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExpression();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitFieldAccessExpr() {
-		FieldAccessExpr node = spy(new FieldAccessExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitFieldDeclaration() {
-		FieldDeclaration node = spy(new FieldDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getVariables();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitForStmt() {
-		ForStmt node = spy(new ForStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(2)).getCompare();
-		verify(node, times(1)).getInitialization();
-		verify(node, times(1)).getUpdate();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitForEachStmt() {
-		ForEachStmt node = spy(new ForEachStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getIterable();
-		verify(node, times(1)).getVariable();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitIfStmt() {
-		IfStmt node = spy(new IfStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getCondition();
-		verify(node, times(1)).getElseStmt();
-		verify(node, times(1)).getThenStmt();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitImportDeclaration() {
-		ImportDeclaration node = spy(new ImportDeclaration(new Name(), false, false));
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).isAsterisk();
-		verify(node, times(1)).isStatic();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitInitializerDeclaration() {
-		InitializerDeclaration node = spy(new InitializerDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).isStatic();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitInstanceOfExpr() {
-		InstanceOfExpr node = spy(new InstanceOfExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getPattern();
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitIntegerLiteralExpr() {
-		IntegerLiteralExpr node = spy(new IntegerLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitIntersectionType() {
-		NodeList<ReferenceType> elements = new NodeList<>();
-		elements.add(new ClassOrInterfaceType());
-		IntersectionType node = spy(new IntersectionType(elements));
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getElements();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitLabeledStmt() {
-		LabeledStmt node = spy(new LabeledStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getLabel();
-		verify(node, times(1)).getStatement();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitLambdaExpr() {
-		LambdaExpr node = spy(new LambdaExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).isEnclosingParameters();
-		verify(node, times(1)).getParameters();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitLocalClassDeclarationStmt() {
-		LocalClassDeclarationStmt node = spy(new LocalClassDeclarationStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getClassDeclaration();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitLocalRecordDeclarationStmt() {
-		LocalRecordDeclarationStmt node = spy(new LocalRecordDeclarationStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getRecordDeclaration();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitLongLiteralExpr() {
-		LongLiteralExpr node = spy(new LongLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitMarkerAnnotationExpr() {
-		MarkerAnnotationExpr node = spy(new MarkerAnnotationExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitMemberValuePair() {
-		MemberValuePair node = spy(new MemberValuePair());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitMethodCallExpr() {
-		MethodCallExpr node = spy(new MethodCallExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitMethodDeclaration() {
-		MethodDeclaration node = spy(new MethodDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(2)).getBody();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getParameters();
-		verify(node, times(1)).getReceiverParameter();
-		verify(node, times(1)).getThrownExceptions();
-		verify(node, times(1)).getTypeParameters();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitMethodReferenceExpr() {
-		MethodReferenceExpr node = spy(new MethodReferenceExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getIdentifier();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getTypeArguments();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitNameExpr() {
-		NameExpr node = spy(new NameExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitName() {
-		Name node = spy(new Name());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getIdentifier();
-		verify(node, times(1)).getQualifier();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitNormalAnnotationExpr() {
-		NormalAnnotationExpr node = spy(new NormalAnnotationExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getPairs();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitNullLiteralExpr() {
-		NullLiteralExpr node = spy(new NullLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitObjectCreationExpr() {
-		ObjectCreationExpr node = spy(new ObjectCreationExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnonymousClassBody();
-		verify(node, times(1)).getArguments();
-		verify(node, times(1)).getScope();
-		verify(node, times(1)).getType();
-		verify(node, times(2)).getTypeArguments();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitPackageDeclaration() {
-		PackageDeclaration node = spy(new PackageDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitParameter() {
-		Parameter node = spy(new Parameter());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).isVarArgs();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getVarArgsAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitPrimitiveType() {
-		PrimitiveType node = spy(new PrimitiveType());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getType();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitReturnStmt() {
-		ReturnStmt node = spy(new ReturnStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExpression();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitSimpleName() {
-		SimpleName node = spy(new SimpleName());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getIdentifier();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitSingleMemberAnnotationExpr() {
-		SingleMemberAnnotationExpr node = spy(new SingleMemberAnnotationExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getMemberValue();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitStringLiteralExpr() {
-		StringLiteralExpr node = spy(new StringLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitSuperExpr() {
-		SuperExpr node = spy(new SuperExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getTypeName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitSwitchEntry() {
-		SwitchEntry node = spy(new SwitchEntry());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getLabels();
-		verify(node, times(1)).getStatements();
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitSwitchStmt() {
-		SwitchStmt node = spy(new SwitchStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getEntries();
-		verify(node, times(1)).getSelector();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitSynchronizedStmt() {
-		SynchronizedStmt node = spy(new SynchronizedStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getExpression();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitThisExpr() {
-		ThisExpr node = spy(new ThisExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getTypeName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitThrowStmt() {
-		ThrowStmt node = spy(new ThrowStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExpression();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitTryStmt() {
-		TryStmt node = spy(new TryStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getCatchClauses();
-		verify(node, times(1)).getFinallyBlock();
-		verify(node, times(1)).getResources();
-		verify(node, times(1)).getTryBlock();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitTypeExpr() {
-		TypeExpr node = spy(new TypeExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitTypeParameter() {
-		TypeParameter node = spy(new TypeParameter());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getTypeBound();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitUnaryExpr() {
-		UnaryExpr node = spy(new UnaryExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExpression();
-		verify(node, times(1)).getOperator();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitUnionType() {
-		UnionType node = spy(new UnionType());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getElements();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitUnknownType() {
-		UnknownType node = spy(new UnknownType());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitVariableDeclarationExpr() {
-		VariableDeclarationExpr node = spy(new VariableDeclarationExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getVariables();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitVariableDeclarator() {
-		VariableDeclarator node = spy(new VariableDeclarator());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getInitializer();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitVoidType() {
-		VoidType node = spy(new VoidType());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitWhileStmt() {
-		WhileStmt node = spy(new WhileStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getBody();
-		verify(node, times(1)).getCondition();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitWildcardType() {
-		WildcardType node = spy(new WildcardType());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExtendedType();
-		verify(node, times(1)).getSuperType();
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitModuleDeclaration() {
-		ModuleDeclaration node = spy(new ModuleDeclaration());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getDirectives();
-		verify(node, times(1)).isOpen();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitModuleRequiresDirective() {
-		ModuleRequiresDirective node = spy(new ModuleRequiresDirective());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getModifiers();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitModuleExportsDirective() {
-		ModuleExportsDirective node = spy(new ModuleExportsDirective());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getModuleNames();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitModuleProvidesDirective() {
-		ModuleProvidesDirective node = spy(new ModuleProvidesDirective());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getWith();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitModuleUsesDirective() {
-		ModuleUsesDirective node = spy(new ModuleUsesDirective());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitModuleOpensDirective() {
-		ModuleOpensDirective node = spy(new ModuleOpensDirective());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getModuleNames();
-		verify(node, times(1)).getName();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitUnparsableStmt() {
-		UnparsableStmt node = spy(new UnparsableStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitReceiverParameter() {
-		ReceiverParameter node = spy(new ReceiverParameter());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitVarType() {
-		VarType node = spy(new VarType());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getAnnotations();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitModifier() {
-		Modifier node = spy(new Modifier());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getKeyword();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitSwitchExpr() {
-		SwitchExpr node = spy(new SwitchExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getEntries();
-		verify(node, times(1)).getSelector();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitYieldStmt() {
-		YieldStmt node = spy(new YieldStmt());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getExpression();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitTextBlockLiteralExpr() {
-		TextBlockLiteralExpr node = spy(new TextBlockLiteralExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getValue();
-		verify(node, never()).getComment();
-	}
-
-	@Test
-	void testVisitPatternExpr() {
-		PatternExpr node = spy(new PatternExpr());
-		NoCommentHashCodeVisitor.hashCode(node);
-
-		verify(node, times(1)).getName();
-		verify(node, times(1)).getType();
-		verify(node, never()).getComment();
-	}
+    @Test
+    void testEquals() {
+        CompilationUnit p1 = parse("class X { }");
+        CompilationUnit p2 = parse("class X { }");
+        assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    void testEqualsWithDifferentComments() {
+        CompilationUnit p1 = parse("/* a */ class X { /** b */} //c");
+        CompilationUnit p2 = parse("/* b */ class X { }  //c");
+        assertEquals(p1.hashCode(), p2.hashCode());
+        assertEquals(3, p1.getAllComments().size());
+        assertEquals(2, p2.getAllComments().size());
+    }
+
+    @Test
+    void testNotEquals() {
+        CompilationUnit p1 = parse("class X { }");
+        CompilationUnit p2 = parse("class Y { }");
+        assertNotEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    void testJavadocCommentDoesNotHaveHashCode() {
+        JavadocComment node = spy(new JavadocComment());
+        assertEquals(0, NoCommentHashCodeVisitor.hashCode(node));
+
+        verify(node).accept(isA(NoCommentHashCodeVisitor.class), isNull());
+    }
+
+    @Test
+    void testLineCommentDoesNotHaveHashCode() {
+        LineComment node = spy(new LineComment());
+        assertEquals(0, NoCommentHashCodeVisitor.hashCode(node));
+
+        verify(node).accept(isA(NoCommentHashCodeVisitor.class), isNull());
+    }
+
+    @Test
+    void testBlockCommentDoesNotHaveHashCode() {
+        BlockComment node = spy(new BlockComment());
+        assertEquals(0, NoCommentHashCodeVisitor.hashCode(node));
+
+        verify(node).accept(isA(NoCommentHashCodeVisitor.class), isNull());
+    }
+
+    @Test
+    void testVisitAnnotationDeclaration() {
+        AnnotationDeclaration node = spy(new AnnotationDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getMembers();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitAnnotationMemberDeclaration() {
+        AnnotationMemberDeclaration node = spy(new AnnotationMemberDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getDefaultValue();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitArrayAccessExpr() {
+        ArrayAccessExpr node = spy(new ArrayAccessExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getIndex();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitArrayCreationExpr() {
+        ArrayCreationExpr node = spy(new ArrayCreationExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getElementType();
+        verify(node, times(2)).getInitializer();
+        verify(node, times(1)).getLevels();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitArrayCreationLevel() {
+        ArrayCreationLevel node = spy(new ArrayCreationLevel());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getDimension();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitArrayInitializerExpr() {
+        ArrayInitializerExpr node = spy(new ArrayInitializerExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getValues();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitArrayType() {
+        ArrayType node = spy(new ArrayType(intType()));
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getComponentType();
+        verify(node, times(1)).getOrigin();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitAssertStmt() {
+        AssertStmt node = spy(new AssertStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getCheck();
+        verify(node, times(1)).getMessage();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitAssignExpr() {
+        AssignExpr node = spy(new AssignExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getOperator();
+        verify(node, times(1)).getTarget();
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitBinaryExpr() {
+        BinaryExpr node = spy(new BinaryExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getLeft();
+        verify(node, times(1)).getOperator();
+        verify(node, times(1)).getRight();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitBlockStmt() {
+        BlockStmt node = spy(new BlockStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getStatements();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitBooleanLiteralExpr() {
+        BooleanLiteralExpr node = spy(new BooleanLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).isValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitBreakStmt() {
+        BreakStmt node = spy(new BreakStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getLabel();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitCastExpr() {
+        CastExpr node = spy(new CastExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitCatchClause() {
+        CatchClause node = spy(new CatchClause());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getParameter();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitCharLiteralExpr() {
+        CharLiteralExpr node = spy(new CharLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitClassExpr() {
+        ClassExpr node = spy(new ClassExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitClassOrInterfaceDeclaration() {
+        ClassOrInterfaceDeclaration node = spy(new ClassOrInterfaceDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExtendedTypes();
+        verify(node, times(1)).getImplementedTypes();
+        verify(node, times(1)).isInterface();
+        verify(node, times(1)).getTypeParameters();
+        verify(node, times(1)).getMembers();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitClassOrInterfaceType() {
+        ClassOrInterfaceType node = spy(new ClassOrInterfaceType());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitCompilationUnit() {
+        CompilationUnit node = spy(new CompilationUnit());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getImports();
+        verify(node, times(1)).getModule();
+        verify(node, times(1)).getPackageDeclaration();
+        verify(node, times(1)).getTypes();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitConditionalExpr() {
+        ConditionalExpr node = spy(new ConditionalExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getCondition();
+        verify(node, times(1)).getElseExpr();
+        verify(node, times(1)).getThenExpr();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitConstructorDeclaration() {
+        ConstructorDeclaration node = spy(new ConstructorDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getParameters();
+        verify(node, times(1)).getReceiverParameter();
+        verify(node, times(1)).getThrownExceptions();
+        verify(node, times(1)).getTypeParameters();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitContinueStmt() {
+        ContinueStmt node = spy(new ContinueStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getLabel();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitDoStmt() {
+        DoStmt node = spy(new DoStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getCondition();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitDoubleLiteralExpr() {
+        DoubleLiteralExpr node = spy(new DoubleLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitEmptyStmt() {
+        EmptyStmt node = spy(new EmptyStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitEnclosedExpr() {
+        EnclosedExpr node = spy(new EnclosedExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getInner();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitEnumConstantDeclaration() {
+        EnumConstantDeclaration node = spy(new EnumConstantDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getClassBody();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitEnumDeclaration() {
+        EnumDeclaration node = spy(new EnumDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getEntries();
+        verify(node, times(1)).getImplementedTypes();
+        verify(node, times(1)).getMembers();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitExplicitConstructorInvocationStmt() {
+        ExplicitConstructorInvocationStmt node = spy(new ExplicitConstructorInvocationStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).isThis();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitExpressionStmt() {
+        ExpressionStmt node = spy(new ExpressionStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExpression();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitFieldAccessExpr() {
+        FieldAccessExpr node = spy(new FieldAccessExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitFieldDeclaration() {
+        FieldDeclaration node = spy(new FieldDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getVariables();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitForStmt() {
+        ForStmt node = spy(new ForStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(2)).getCompare();
+        verify(node, times(1)).getInitialization();
+        verify(node, times(1)).getUpdate();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitForEachStmt() {
+        ForEachStmt node = spy(new ForEachStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getIterable();
+        verify(node, times(1)).getVariable();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitIfStmt() {
+        IfStmt node = spy(new IfStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getCondition();
+        verify(node, times(1)).getElseStmt();
+        verify(node, times(1)).getThenStmt();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitImportDeclaration() {
+        ImportDeclaration node = spy(new ImportDeclaration(new Name(), false, false));
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).isAsterisk();
+        verify(node, times(1)).isStatic();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitInitializerDeclaration() {
+        InitializerDeclaration node = spy(new InitializerDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).isStatic();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitInstanceOfExpr() {
+        InstanceOfExpr node = spy(new InstanceOfExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getPattern();
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitIntegerLiteralExpr() {
+        IntegerLiteralExpr node = spy(new IntegerLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitIntersectionType() {
+        NodeList<ReferenceType> elements = new NodeList<>();
+        elements.add(new ClassOrInterfaceType());
+        IntersectionType node = spy(new IntersectionType(elements));
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getElements();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitLabeledStmt() {
+        LabeledStmt node = spy(new LabeledStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getLabel();
+        verify(node, times(1)).getStatement();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitLambdaExpr() {
+        LambdaExpr node = spy(new LambdaExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).isEnclosingParameters();
+        verify(node, times(1)).getParameters();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitLocalClassDeclarationStmt() {
+        LocalClassDeclarationStmt node = spy(new LocalClassDeclarationStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getClassDeclaration();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitLocalRecordDeclarationStmt() {
+        LocalRecordDeclarationStmt node = spy(new LocalRecordDeclarationStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getRecordDeclaration();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitLongLiteralExpr() {
+        LongLiteralExpr node = spy(new LongLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitMarkerAnnotationExpr() {
+        MarkerAnnotationExpr node = spy(new MarkerAnnotationExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitMemberValuePair() {
+        MemberValuePair node = spy(new MemberValuePair());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitMethodCallExpr() {
+        MethodCallExpr node = spy(new MethodCallExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitMethodDeclaration() {
+        MethodDeclaration node = spy(new MethodDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(2)).getBody();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getParameters();
+        verify(node, times(1)).getReceiverParameter();
+        verify(node, times(1)).getThrownExceptions();
+        verify(node, times(1)).getTypeParameters();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitMethodReferenceExpr() {
+        MethodReferenceExpr node = spy(new MethodReferenceExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getIdentifier();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getTypeArguments();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitNameExpr() {
+        NameExpr node = spy(new NameExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitName() {
+        Name node = spy(new Name());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getIdentifier();
+        verify(node, times(1)).getQualifier();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitNormalAnnotationExpr() {
+        NormalAnnotationExpr node = spy(new NormalAnnotationExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getPairs();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitNullLiteralExpr() {
+        NullLiteralExpr node = spy(new NullLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitObjectCreationExpr() {
+        ObjectCreationExpr node = spy(new ObjectCreationExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnonymousClassBody();
+        verify(node, times(1)).getArguments();
+        verify(node, times(1)).getScope();
+        verify(node, times(1)).getType();
+        verify(node, times(2)).getTypeArguments();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitPackageDeclaration() {
+        PackageDeclaration node = spy(new PackageDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitParameter() {
+        Parameter node = spy(new Parameter());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).isVarArgs();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getVarArgsAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitPrimitiveType() {
+        PrimitiveType node = spy(new PrimitiveType());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getType();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitReturnStmt() {
+        ReturnStmt node = spy(new ReturnStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExpression();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitSimpleName() {
+        SimpleName node = spy(new SimpleName());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getIdentifier();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitSingleMemberAnnotationExpr() {
+        SingleMemberAnnotationExpr node = spy(new SingleMemberAnnotationExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getMemberValue();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitStringLiteralExpr() {
+        StringLiteralExpr node = spy(new StringLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitSuperExpr() {
+        SuperExpr node = spy(new SuperExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getTypeName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitSwitchEntry() {
+        SwitchEntry node = spy(new SwitchEntry());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getLabels();
+        verify(node, times(1)).getStatements();
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitSwitchStmt() {
+        SwitchStmt node = spy(new SwitchStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getEntries();
+        verify(node, times(1)).getSelector();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitSynchronizedStmt() {
+        SynchronizedStmt node = spy(new SynchronizedStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getExpression();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitThisExpr() {
+        ThisExpr node = spy(new ThisExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getTypeName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitThrowStmt() {
+        ThrowStmt node = spy(new ThrowStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExpression();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitTryStmt() {
+        TryStmt node = spy(new TryStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getCatchClauses();
+        verify(node, times(1)).getFinallyBlock();
+        verify(node, times(1)).getResources();
+        verify(node, times(1)).getTryBlock();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitTypeExpr() {
+        TypeExpr node = spy(new TypeExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitTypeParameter() {
+        TypeParameter node = spy(new TypeParameter());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getTypeBound();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitUnaryExpr() {
+        UnaryExpr node = spy(new UnaryExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExpression();
+        verify(node, times(1)).getOperator();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitUnionType() {
+        UnionType node = spy(new UnionType());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getElements();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitUnknownType() {
+        UnknownType node = spy(new UnknownType());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitVariableDeclarationExpr() {
+        VariableDeclarationExpr node = spy(new VariableDeclarationExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getVariables();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitVariableDeclarator() {
+        VariableDeclarator node = spy(new VariableDeclarator());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getInitializer();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitVoidType() {
+        VoidType node = spy(new VoidType());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitWhileStmt() {
+        WhileStmt node = spy(new WhileStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getBody();
+        verify(node, times(1)).getCondition();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitWildcardType() {
+        WildcardType node = spy(new WildcardType());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExtendedType();
+        verify(node, times(1)).getSuperType();
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitModuleDeclaration() {
+        ModuleDeclaration node = spy(new ModuleDeclaration());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getDirectives();
+        verify(node, times(1)).isOpen();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitModuleRequiresDirective() {
+        ModuleRequiresDirective node = spy(new ModuleRequiresDirective());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getModifiers();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitModuleExportsDirective() {
+        ModuleExportsDirective node = spy(new ModuleExportsDirective());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getModuleNames();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitModuleProvidesDirective() {
+        ModuleProvidesDirective node = spy(new ModuleProvidesDirective());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getWith();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitModuleUsesDirective() {
+        ModuleUsesDirective node = spy(new ModuleUsesDirective());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitModuleOpensDirective() {
+        ModuleOpensDirective node = spy(new ModuleOpensDirective());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getModuleNames();
+        verify(node, times(1)).getName();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitUnparsableStmt() {
+        UnparsableStmt node = spy(new UnparsableStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitReceiverParameter() {
+        ReceiverParameter node = spy(new ReceiverParameter());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitVarType() {
+        VarType node = spy(new VarType());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getAnnotations();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitModifier() {
+        Modifier node = spy(new Modifier());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getKeyword();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitSwitchExpr() {
+        SwitchExpr node = spy(new SwitchExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getEntries();
+        verify(node, times(1)).getSelector();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitYieldStmt() {
+        YieldStmt node = spy(new YieldStmt());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getExpression();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitTextBlockLiteralExpr() {
+        TextBlockLiteralExpr node = spy(new TextBlockLiteralExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getValue();
+        verify(node, never()).getComment();
+    }
+
+    @Test
+    void testVisitPatternExpr() {
+        PatternExpr node = spy(new PatternExpr());
+        NoCommentHashCodeVisitor.hashCode(node);
+
+        verify(node, times(1)).getName();
+        verify(node, times(1)).getType();
+        verify(node, never()).getComment();
+    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitorTest.java
@@ -38,588 +38,588 @@ import static org.mockito.Mockito.spy;
 
 class ObjectIdentityHashCodeVisitorTest {
 
-	@Test
-	void testVisitAnnotationDeclaration() {
-		AnnotationDeclaration node = spy(new AnnotationDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitAnnotationMemberDeclaration() {
-		AnnotationMemberDeclaration node = spy(new AnnotationMemberDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitArrayAccessExpr() {
-		ArrayAccessExpr node = spy(new ArrayAccessExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitArrayCreationExpr() {
-		ArrayCreationExpr node = spy(new ArrayCreationExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitArrayCreationLevel() {
-		ArrayCreationLevel node = spy(new ArrayCreationLevel());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitArrayInitializerExpr() {
-		ArrayInitializerExpr node = spy(new ArrayInitializerExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitArrayType() {
-		ArrayType node = spy(new ArrayType(intType()));
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitAssertStmt() {
-		AssertStmt node = spy(new AssertStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitAssignExpr() {
-		AssignExpr node = spy(new AssignExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitBinaryExpr() {
-		BinaryExpr node = spy(new BinaryExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitBlockComment() {
-		BlockComment node = spy(new BlockComment());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitBlockStmt() {
-		BlockStmt node = spy(new BlockStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitBooleanLiteralExpr() {
-		BooleanLiteralExpr node = spy(new BooleanLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitBreakStmt() {
-		BreakStmt node = spy(new BreakStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitCastExpr() {
-		CastExpr node = spy(new CastExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitCatchClause() {
-		CatchClause node = spy(new CatchClause());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitCharLiteralExpr() {
-		CharLiteralExpr node = spy(new CharLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitClassExpr() {
-		ClassExpr node = spy(new ClassExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitClassOrInterfaceDeclaration() {
-		ClassOrInterfaceDeclaration node = spy(new ClassOrInterfaceDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitClassOrInterfaceType() {
-		ClassOrInterfaceType node = spy(new ClassOrInterfaceType());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitCompilationUnit() {
-		CompilationUnit node = spy(new CompilationUnit());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitConditionalExpr() {
-		ConditionalExpr node = spy(new ConditionalExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitConstructorDeclaration() {
-		ConstructorDeclaration node = spy(new ConstructorDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitContinueStmt() {
-		ContinueStmt node = spy(new ContinueStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitDoStmt() {
-		DoStmt node = spy(new DoStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitDoubleLiteralExpr() {
-		DoubleLiteralExpr node = spy(new DoubleLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitEmptyStmt() {
-		EmptyStmt node = spy(new EmptyStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitEnclosedExpr() {
-		EnclosedExpr node = spy(new EnclosedExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitEnumConstantDeclaration() {
-		EnumConstantDeclaration node = spy(new EnumConstantDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitEnumDeclaration() {
-		EnumDeclaration node = spy(new EnumDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitExplicitConstructorInvocationStmt() {
-		ExplicitConstructorInvocationStmt node = spy(new ExplicitConstructorInvocationStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitExpressionStmt() {
-		ExpressionStmt node = spy(new ExpressionStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitFieldAccessExpr() {
-		FieldAccessExpr node = spy(new FieldAccessExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitFieldDeclaration() {
-		FieldDeclaration node = spy(new FieldDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitForEachStmt() {
-		ForEachStmt node = spy(new ForEachStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitForStmt() {
-		ForStmt node = spy(new ForStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitIfStmt() {
-		IfStmt node = spy(new IfStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitImportDeclaration() {
-		ImportDeclaration node = spy(new ImportDeclaration(new Name(), false, false));
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitInitializerDeclaration() {
-		InitializerDeclaration node = spy(new InitializerDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitInstanceOfExpr() {
-		InstanceOfExpr node = spy(new InstanceOfExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitIntegerLiteralExpr() {
-		IntegerLiteralExpr node = spy(new IntegerLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitIntersectionType() {
-		NodeList<ReferenceType> elements = new NodeList<>();
-		elements.add(new ClassOrInterfaceType());
-		IntersectionType node = spy(new IntersectionType(elements));
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitJavadocComment() {
-		JavadocComment node = spy(new JavadocComment());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitLabeledStmt() {
-		LabeledStmt node = spy(new LabeledStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitLambdaExpr() {
-		LambdaExpr node = spy(new LambdaExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitLineComment() {
-		LineComment node = spy(new LineComment());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitLocalClassDeclarationStmt() {
-		LocalClassDeclarationStmt node = spy(new LocalClassDeclarationStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitLocalRecordDeclarationStmt() {
-		LocalRecordDeclarationStmt node = spy(new LocalRecordDeclarationStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitLongLiteralExpr() {
-		LongLiteralExpr node = spy(new LongLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitMarkerAnnotationExpr() {
-		MarkerAnnotationExpr node = spy(new MarkerAnnotationExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitMemberValuePair() {
-		MemberValuePair node = spy(new MemberValuePair());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitMethodCallExpr() {
-		MethodCallExpr node = spy(new MethodCallExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitMethodDeclaration() {
-		MethodDeclaration node = spy(new MethodDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitMethodReferenceExpr() {
-		MethodReferenceExpr node = spy(new MethodReferenceExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitModifier() {
-		Modifier node = spy(new Modifier());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitModuleDeclaration() {
-		ModuleDeclaration node = spy(new ModuleDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitModuleExportsDirective() {
-		ModuleExportsDirective node = spy(new ModuleExportsDirective());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitModuleOpensDirective() {
-		ModuleOpensDirective node = spy(new ModuleOpensDirective());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitModuleProvidesDirective() {
-		ModuleProvidesDirective node = spy(new ModuleProvidesDirective());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitModuleRequiresDirective() {
-		ModuleRequiresDirective node = spy(new ModuleRequiresDirective());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitModuleUsesDirective() {
-		ModuleUsesDirective node = spy(new ModuleUsesDirective());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitNameExpr() {
-		NameExpr node = spy(new NameExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitName() {
-		Name node = spy(new Name());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitNormalAnnotationExpr() {
-		NormalAnnotationExpr node = spy(new NormalAnnotationExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitNullLiteralExpr() {
-		NullLiteralExpr node = spy(new NullLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitObjectCreationExpr() {
-		ObjectCreationExpr node = spy(new ObjectCreationExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitPackageDeclaration() {
-		PackageDeclaration node = spy(new PackageDeclaration());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitParameter() {
-		Parameter node = spy(new Parameter());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitPatternExpr() {
-		PatternExpr node = spy(new PatternExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitPrimitiveType() {
-		PrimitiveType node = spy(new PrimitiveType());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitReceiverParameter() {
-		ReceiverParameter node = spy(new ReceiverParameter());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitReturnStmt() {
-		ReturnStmt node = spy(new ReturnStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitSimpleName() {
-		SimpleName node = spy(new SimpleName());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitSingleMemberAnnotationExpr() {
-		SingleMemberAnnotationExpr node = spy(new SingleMemberAnnotationExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitStringLiteralExpr() {
-		StringLiteralExpr node = spy(new StringLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitSuperExpr() {
-		SuperExpr node = spy(new SuperExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitSwitchEntry() {
-		SwitchEntry node = spy(new SwitchEntry());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitSwitchExpr() {
-		SwitchExpr node = spy(new SwitchExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitSwitchStmt() {
-		SwitchStmt node = spy(new SwitchStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitSynchronizedStmt() {
-		SynchronizedStmt node = spy(new SynchronizedStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitTextBlockLiteralExpr() {
-		TextBlockLiteralExpr node = spy(new TextBlockLiteralExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitThisExpr() {
-		ThisExpr node = spy(new ThisExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitThrowStmt() {
-		ThrowStmt node = spy(new ThrowStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitTryStmt() {
-		TryStmt node = spy(new TryStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitTypeExpr() {
-		TypeExpr node = spy(new TypeExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitTypeParameter() {
-		TypeParameter node = spy(new TypeParameter());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitUnaryExpr() {
-		UnaryExpr node = spy(new UnaryExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitUnionType() {
-		UnionType node = spy(new UnionType());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitUnknownType() {
-		UnknownType node = spy(new UnknownType());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitUnparsableStmt() {
-		UnparsableStmt node = spy(new UnparsableStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitVarType() {
-		VarType node = spy(new VarType());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitVariableDeclarationExpr() {
-		VariableDeclarationExpr node = spy(new VariableDeclarationExpr());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitVariableDeclarator() {
-		VariableDeclarator node = spy(new VariableDeclarator());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitVoidType() {
-		VoidType node = spy(new VoidType());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitWhileStmt() {
-		WhileStmt node = spy(new WhileStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitWildcardType() {
-		WildcardType node = spy(new WildcardType());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
-
-	@Test
-	void testVisitYieldStmt() {
-		YieldStmt node = spy(new YieldStmt());
-		assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
-	}
+    @Test
+    void testVisitAnnotationDeclaration() {
+        AnnotationDeclaration node = spy(new AnnotationDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitAnnotationMemberDeclaration() {
+        AnnotationMemberDeclaration node = spy(new AnnotationMemberDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitArrayAccessExpr() {
+        ArrayAccessExpr node = spy(new ArrayAccessExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitArrayCreationExpr() {
+        ArrayCreationExpr node = spy(new ArrayCreationExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitArrayCreationLevel() {
+        ArrayCreationLevel node = spy(new ArrayCreationLevel());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitArrayInitializerExpr() {
+        ArrayInitializerExpr node = spy(new ArrayInitializerExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitArrayType() {
+        ArrayType node = spy(new ArrayType(intType()));
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitAssertStmt() {
+        AssertStmt node = spy(new AssertStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitAssignExpr() {
+        AssignExpr node = spy(new AssignExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitBinaryExpr() {
+        BinaryExpr node = spy(new BinaryExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitBlockComment() {
+        BlockComment node = spy(new BlockComment());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitBlockStmt() {
+        BlockStmt node = spy(new BlockStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitBooleanLiteralExpr() {
+        BooleanLiteralExpr node = spy(new BooleanLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitBreakStmt() {
+        BreakStmt node = spy(new BreakStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitCastExpr() {
+        CastExpr node = spy(new CastExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitCatchClause() {
+        CatchClause node = spy(new CatchClause());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitCharLiteralExpr() {
+        CharLiteralExpr node = spy(new CharLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitClassExpr() {
+        ClassExpr node = spy(new ClassExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitClassOrInterfaceDeclaration() {
+        ClassOrInterfaceDeclaration node = spy(new ClassOrInterfaceDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitClassOrInterfaceType() {
+        ClassOrInterfaceType node = spy(new ClassOrInterfaceType());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitCompilationUnit() {
+        CompilationUnit node = spy(new CompilationUnit());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitConditionalExpr() {
+        ConditionalExpr node = spy(new ConditionalExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitConstructorDeclaration() {
+        ConstructorDeclaration node = spy(new ConstructorDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitContinueStmt() {
+        ContinueStmt node = spy(new ContinueStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitDoStmt() {
+        DoStmt node = spy(new DoStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitDoubleLiteralExpr() {
+        DoubleLiteralExpr node = spy(new DoubleLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitEmptyStmt() {
+        EmptyStmt node = spy(new EmptyStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitEnclosedExpr() {
+        EnclosedExpr node = spy(new EnclosedExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitEnumConstantDeclaration() {
+        EnumConstantDeclaration node = spy(new EnumConstantDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitEnumDeclaration() {
+        EnumDeclaration node = spy(new EnumDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitExplicitConstructorInvocationStmt() {
+        ExplicitConstructorInvocationStmt node = spy(new ExplicitConstructorInvocationStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitExpressionStmt() {
+        ExpressionStmt node = spy(new ExpressionStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitFieldAccessExpr() {
+        FieldAccessExpr node = spy(new FieldAccessExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitFieldDeclaration() {
+        FieldDeclaration node = spy(new FieldDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitForEachStmt() {
+        ForEachStmt node = spy(new ForEachStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitForStmt() {
+        ForStmt node = spy(new ForStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitIfStmt() {
+        IfStmt node = spy(new IfStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitImportDeclaration() {
+        ImportDeclaration node = spy(new ImportDeclaration(new Name(), false, false));
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitInitializerDeclaration() {
+        InitializerDeclaration node = spy(new InitializerDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitInstanceOfExpr() {
+        InstanceOfExpr node = spy(new InstanceOfExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitIntegerLiteralExpr() {
+        IntegerLiteralExpr node = spy(new IntegerLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitIntersectionType() {
+        NodeList<ReferenceType> elements = new NodeList<>();
+        elements.add(new ClassOrInterfaceType());
+        IntersectionType node = spy(new IntersectionType(elements));
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitJavadocComment() {
+        JavadocComment node = spy(new JavadocComment());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitLabeledStmt() {
+        LabeledStmt node = spy(new LabeledStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitLambdaExpr() {
+        LambdaExpr node = spy(new LambdaExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitLineComment() {
+        LineComment node = spy(new LineComment());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitLocalClassDeclarationStmt() {
+        LocalClassDeclarationStmt node = spy(new LocalClassDeclarationStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitLocalRecordDeclarationStmt() {
+        LocalRecordDeclarationStmt node = spy(new LocalRecordDeclarationStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitLongLiteralExpr() {
+        LongLiteralExpr node = spy(new LongLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitMarkerAnnotationExpr() {
+        MarkerAnnotationExpr node = spy(new MarkerAnnotationExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitMemberValuePair() {
+        MemberValuePair node = spy(new MemberValuePair());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitMethodCallExpr() {
+        MethodCallExpr node = spy(new MethodCallExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitMethodDeclaration() {
+        MethodDeclaration node = spy(new MethodDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitMethodReferenceExpr() {
+        MethodReferenceExpr node = spy(new MethodReferenceExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitModifier() {
+        Modifier node = spy(new Modifier());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitModuleDeclaration() {
+        ModuleDeclaration node = spy(new ModuleDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitModuleExportsDirective() {
+        ModuleExportsDirective node = spy(new ModuleExportsDirective());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitModuleOpensDirective() {
+        ModuleOpensDirective node = spy(new ModuleOpensDirective());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitModuleProvidesDirective() {
+        ModuleProvidesDirective node = spy(new ModuleProvidesDirective());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitModuleRequiresDirective() {
+        ModuleRequiresDirective node = spy(new ModuleRequiresDirective());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitModuleUsesDirective() {
+        ModuleUsesDirective node = spy(new ModuleUsesDirective());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitNameExpr() {
+        NameExpr node = spy(new NameExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitName() {
+        Name node = spy(new Name());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitNormalAnnotationExpr() {
+        NormalAnnotationExpr node = spy(new NormalAnnotationExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitNullLiteralExpr() {
+        NullLiteralExpr node = spy(new NullLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitObjectCreationExpr() {
+        ObjectCreationExpr node = spy(new ObjectCreationExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitPackageDeclaration() {
+        PackageDeclaration node = spy(new PackageDeclaration());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitParameter() {
+        Parameter node = spy(new Parameter());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitPatternExpr() {
+        PatternExpr node = spy(new PatternExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitPrimitiveType() {
+        PrimitiveType node = spy(new PrimitiveType());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitReceiverParameter() {
+        ReceiverParameter node = spy(new ReceiverParameter());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitReturnStmt() {
+        ReturnStmt node = spy(new ReturnStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitSimpleName() {
+        SimpleName node = spy(new SimpleName());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitSingleMemberAnnotationExpr() {
+        SingleMemberAnnotationExpr node = spy(new SingleMemberAnnotationExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitStringLiteralExpr() {
+        StringLiteralExpr node = spy(new StringLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitSuperExpr() {
+        SuperExpr node = spy(new SuperExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitSwitchEntry() {
+        SwitchEntry node = spy(new SwitchEntry());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitSwitchExpr() {
+        SwitchExpr node = spy(new SwitchExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitSwitchStmt() {
+        SwitchStmt node = spy(new SwitchStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitSynchronizedStmt() {
+        SynchronizedStmt node = spy(new SynchronizedStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitTextBlockLiteralExpr() {
+        TextBlockLiteralExpr node = spy(new TextBlockLiteralExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitThisExpr() {
+        ThisExpr node = spy(new ThisExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitThrowStmt() {
+        ThrowStmt node = spy(new ThrowStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitTryStmt() {
+        TryStmt node = spy(new TryStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitTypeExpr() {
+        TypeExpr node = spy(new TypeExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitTypeParameter() {
+        TypeParameter node = spy(new TypeParameter());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitUnaryExpr() {
+        UnaryExpr node = spy(new UnaryExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitUnionType() {
+        UnionType node = spy(new UnionType());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitUnknownType() {
+        UnknownType node = spy(new UnknownType());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitUnparsableStmt() {
+        UnparsableStmt node = spy(new UnparsableStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitVarType() {
+        VarType node = spy(new VarType());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitVariableDeclarationExpr() {
+        VariableDeclarationExpr node = spy(new VariableDeclarationExpr());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitVariableDeclarator() {
+        VariableDeclarator node = spy(new VariableDeclarator());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitVoidType() {
+        VoidType node = spy(new VoidType());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitWhileStmt() {
+        WhileStmt node = spy(new WhileStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitWildcardType() {
+        WildcardType node = spy(new WildcardType());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
+
+    @Test
+    void testVisitYieldStmt() {
+        YieldStmt node = spy(new YieldStmt());
+        assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
+    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/VoidVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/VoidVisitorTest.java
@@ -32,43 +32,43 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class VoidVisitorTest {
-	@Test()
+    @Test()
     void compareFindAllSizeWithVoidVisitorAdapterSize() throws IOException {
         CompilationUnit unit = createUnit();
         
         List<ObjectCreationExpr> oce = unit.findAll(ObjectCreationExpr.class);
         
         AtomicInteger foundObjs = new AtomicInteger(0);
-		unit.accept(new VoidVisitorAdapter<Object>() {
+        unit.accept(new VoidVisitorAdapter<Object>() {
             @Override
             public void visit(ObjectCreationExpr exp, Object arg) {
-            	super.visit(exp, arg);
+                super.visit(exp, arg);
                 ((AtomicInteger)arg).incrementAndGet();
             }            
         }, foundObjs);
         
-		Assertions.assertEquals(oce.size(), foundObjs.get());
+        Assertions.assertEquals(oce.size(), foundObjs.get());
     }
 
-	private CompilationUnit createUnit() {
-		JavaParser javaParser = new JavaParser();
+    private CompilationUnit createUnit() {
+        JavaParser javaParser = new JavaParser();
 
         CompilationUnit unit = javaParser.parse("public class Test\n" + 
-        		"{\n" + 
-        		"   public class InnerTest\n" + 
-        		"   {\n" + 
-        		"       public InnerTest() {}\n" + 
-        		"   }\n" + 
-        		"    \n" + 
-        		"   public Test() {\n" + 
-        		"   }\n" + 
-        		"\n" + 
-        		"   public static void main( String[] args ) { \n" + 
-        		"       new Test().new InnerTest();\n" + 
-        		"   }\n" + 
-        		"}").getResult().get();
-		return unit;
-	}
+                "{\n" + 
+                "   public class InnerTest\n" + 
+                "   {\n" + 
+                "       public InnerTest() {}\n" + 
+                "   }\n" + 
+                "    \n" + 
+                "   public Test() {\n" + 
+                "   }\n" + 
+                "\n" + 
+                "   public static void main( String[] args ) { \n" + 
+                "       new Test().new InnerTest();\n" + 
+                "   }\n" + 
+                "}").getResult().get();
+        return unit;
+    }
     
     @Test()
     void testFindAllSize() throws IOException {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -530,8 +530,8 @@ class PrettyPrintVisitorTest extends TestParser {
                 "public sealed interface I1 permits I2, C, D {}"
         );
         String expected =
-        		"public sealed interface I1 permits I2, C, D {\n"
-        		+ "}\n";
+                "public sealed interface I1 permits I2, C, D {\n"
+                + "}\n";
 
 
         assertEqualsStringIgnoringEol(expected, cu.toString());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2137Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2137Test.java
@@ -30,29 +30,29 @@ import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEo
 
 public class Issue2137Test extends AbstractLexicalPreservingTest {
 
-	@Test
-	void test2137() {
-	    considerCode( 
-	            "public class Foo {\n" +
-	            "  void mymethod1() {}\n" +
-	            "  void mymethod2() {}\n" +
-	            "}");
-	    String expected = 
-	            "public class Foo {\n" +
-	            "  void mymethod1() {}\n" +
-	            "  void mymethod3() {\n"+
-	            "  }\n" +
-	            "  \n" +
-	            "  void mymethod2() {}\n" +
-	            "}";
-	    ClassOrInterfaceDeclaration cid = cu.getClassByName("Foo").get();
-	    MethodDeclaration methodDeclaration = new MethodDeclaration();
-	    methodDeclaration.setName("mymethod3");
-	    methodDeclaration.setType(new VoidType());
-	    cid.getMembers().add(1, methodDeclaration);
+    @Test
+    void test2137() {
+        considerCode( 
+                "public class Foo {\n" +
+                "  void mymethod1() {}\n" +
+                "  void mymethod2() {}\n" +
+                "}");
+        String expected = 
+                "public class Foo {\n" +
+                "  void mymethod1() {}\n" +
+                "  void mymethod3() {\n"+
+                "  }\n" +
+                "  \n" +
+                "  void mymethod2() {}\n" +
+                "}";
+        ClassOrInterfaceDeclaration cid = cu.getClassByName("Foo").get();
+        MethodDeclaration methodDeclaration = new MethodDeclaration();
+        methodDeclaration.setName("mymethod3");
+        methodDeclaration.setType(new VoidType());
+        cid.getMembers().add(1, methodDeclaration);
 
-	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
-	}
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
 
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2374Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2374Test.java
@@ -44,13 +44,13 @@ public class Issue2374Test extends AbstractLexicalPreservingTest {
                 "}"
                 );
         String expected =
-        		"public class Bar {\n"
-        		+ "    public void foo() {\n"
-        		+ "        System.out.print(\"Hello\");\n"
-        		+ "        //Example comment\n"
-        		+ "        System.out.println(\"World!\");\n"
-        		+ "    }\n"
-        		+ "}";
+                "public class Bar {\n"
+                + "    public void foo() {\n"
+                + "        System.out.print(\"Hello\");\n"
+                + "        //Example comment\n"
+                + "        System.out.println(\"World!\");\n"
+                + "    }\n"
+                + "}";
         // contruct a statement with a comment
         Statement stmt = StaticJavaParser.parseStatement("System.out.println(\"World!\");");
         stmt.setLineComment(lineComment);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2517Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2517Test.java
@@ -30,33 +30,33 @@ import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEo
 
 public class Issue2517Test extends AbstractLexicalPreservingTest {
 
-	@Test
-	public void test() {
+    @Test
+    public void test() {
 
-		considerCode("public class A {\n" +
-	            "    public A(String a , String b) {\n" +
-	            "    }\n" +
-	            "    public static A m() {\n" +
-	            "      return new A(\"a\",\"b\");\n" +
-	            "    }\n" +
-	            "}");
-		
-		String expected =
-				"public class A {\n" +
-			    "    public A(String a , String b) {\n" +
-			    "    }\n" +
-			    "    public static A m() {\n" +
-			    "      return new A(\"b\", \"a\");\n" +
-			    "    }\n" +
-			    "}";
+        considerCode("public class A {\n" +
+                "    public A(String a , String b) {\n" +
+                "    }\n" +
+                "    public static A m() {\n" +
+                "      return new A(\"a\",\"b\");\n" +
+                "    }\n" +
+                "}");
+        
+        String expected =
+                "public class A {\n" +
+                "    public A(String a , String b) {\n" +
+                "    }\n" +
+                "    public static A m() {\n" +
+                "      return new A(\"b\", \"a\");\n" +
+                "    }\n" +
+                "}";
 
-	    ObjectCreationExpr cd = cu.findFirst(ObjectCreationExpr.class).get();
-	    NodeList<Expression> args = cd.getArguments();
-	    Expression a1 = args.get(0);
-	    Expression a2 = args.get(1);
-	    NodeList<Expression> newArgs = new NodeList<>(a2, a1);
-	    cd.setArguments(newArgs);
+        ObjectCreationExpr cd = cu.findFirst(ObjectCreationExpr.class).get();
+        NodeList<Expression> args = cd.getArguments();
+        Expression a1 = args.get(0);
+        Expression a2 = args.get(1);
+        NodeList<Expression> newArgs = new NodeList<>(a2, a1);
+        cd.setArguments(newArgs);
 
-	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
-	}
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3441Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3441Test.java
@@ -29,28 +29,28 @@ import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEo
 
 public class Issue3441Test extends AbstractLexicalPreservingTest {
 
-	@Test
-	void test() {
-		    considerCode( 
-		    		"public class Foo {\n" +
-		    	     "    void bar() {\n" +
-		    	     "        stmt1(); // comment 1\n" +
-		    	     "        stmt2(); // comment 2\n" +
-		    	     "    }\n" +
-		    	     "}");
-		    String expected = 
-		    		"public class Foo {\n" +
-		   	    	"    void bar() {\n" +
-		   	    	"        stmt2(); // comment 2\n" +
-		   	    	"    }\n" +
-		   	    	"}";
-		    
-		BlockStmt block = cu.findFirst(BlockStmt.class).get();
-	    Statement stmt = block.getStatements().get(0);
-	    
-	    block.remove(stmt);
-	    
-	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
-	}
+    @Test
+    void test() {
+            considerCode( 
+                    "public class Foo {\n" +
+                     "    void bar() {\n" +
+                     "        stmt1(); // comment 1\n" +
+                     "        stmt2(); // comment 2\n" +
+                     "    }\n" +
+                     "}");
+            String expected = 
+                    "public class Foo {\n" +
+                       "    void bar() {\n" +
+                       "        stmt2(); // comment 2\n" +
+                       "    }\n" +
+                       "}";
+            
+        BlockStmt block = cu.findFirst(BlockStmt.class).get();
+        Statement stmt = block.getStatements().get(0);
+        
+        block.remove(stmt);
+        
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
     
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3746Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3746Test.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue3746Test extends AbstractLexicalPreservingTest {
 
-	@Test
+    @Test
     void test() {
         considerCode(
                 "public class MyClass {\n"
@@ -40,24 +40,24 @@ public class Issue3746Test extends AbstractLexicalPreservingTest {
                         + "}");
 
         considerCode("class A {\n"
-				+ "  void foo() {\n"
-				+ "    int first = 1;\n"
-				+ "    int second = 2;\n"
-				+ "  }\n"
-				+ "}"
-				);
-    	
-    	String expected = 
-    			"class A {\n"
-    			+ "  void foo() {\n"
-    			+ "    foo();\n"
-    			+ "    int second = 2;\n"
-    			+ "  }\n"
-    			+ "}";
-    	BlockStmt block = cu.findAll(BlockStmt.class).get(0);
-    	ExpressionStmt newStmt = new ExpressionStmt(new MethodCallExpr("foo"));
-		block.addStatement(1,newStmt);
-		block.getStatement(0).remove();
-		assertEquals(expected, LexicalPreservingPrinter.print(cu));
+                + "  void foo() {\n"
+                + "    int first = 1;\n"
+                + "    int second = 2;\n"
+                + "  }\n"
+                + "}"
+                );
+        
+        String expected = 
+                "class A {\n"
+                + "  void foo() {\n"
+                + "    foo();\n"
+                + "    int second = 2;\n"
+                + "  }\n"
+                + "}";
+        BlockStmt block = cu.findAll(BlockStmt.class).get(0);
+        ExpressionStmt newStmt = new ExpressionStmt(new MethodCallExpr("foo"));
+        block.addStatement(1,newStmt);
+        block.getStatement(0).remove();
+        assertEquals(expected, LexicalPreservingPrinter.print(cu));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3750Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3750Test.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue3750Test extends AbstractLexicalPreservingTest {
 
-	@Test
+    @Test
     void test() {
         considerCode(
                 "public class MyClass {\n"
@@ -43,7 +43,7 @@ public class Issue3750Test extends AbstractLexicalPreservingTest {
         FieldDeclaration field = fields.get(0);
         
         String expected = 
-        		"public class MyClass {\n"
+                "public class MyClass {\n"
                         + " // Comment\n"
                         + " String s1;\n"
                         + "}";

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3761Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3761Test.java
@@ -34,21 +34,21 @@ public class Issue3761Test extends AbstractLexicalPreservingTest {
 
     @Test
     public void test() {
-    	considerCode(
-        		"class C { \n"
-        		+ "    static String S = \"s\";\n"
-        		+ "}");
+        considerCode(
+                "class C { \n"
+                + "    static String S = \"s\";\n"
+                + "}");
 
         FieldDeclaration field = cu.findAll(FieldDeclaration.class).get(0);
 
-		List<Modifier.Keyword> kws = field.getModifiers().stream().map(Modifier::getKeyword).collect(Collectors.toList());
-		kws.add(0, Modifier.Keyword.PROTECTED);
-		field.setModifiers(kws.toArray(new Modifier.Keyword[] {}));
+        List<Modifier.Keyword> kws = field.getModifiers().stream().map(Modifier::getKeyword).collect(Collectors.toList());
+        kws.add(0, Modifier.Keyword.PROTECTED);
+        field.setModifiers(kws.toArray(new Modifier.Keyword[] {}));
         
         String expected = 
-        		"class C { \r\n"
-        		+ "    protected static String S = \"s\";\r\n"
-        		+ "}";
+                "class C { \r\n"
+                + "    protected static String S = \"s\";\r\n"
+                + "}";
 
         assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3773Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3773Test.java
@@ -37,112 +37,112 @@ import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEo
 
 class Issue3773Test extends AbstractLexicalPreservingTest {
 
-	@Test
+    @Test
     void test3773() {
-		considerCode(
+        considerCode(
                 "class A {\r\n"
-                + "	public String output = \"Contents of \";\r\n"
-                + "	\r\n"
-                + "	public String debug(String output) {\r\n"
+                + "    public String output = \"Contents of \";\r\n"
+                + "    \r\n"
+                + "    public String debug(String output) {\r\n"
                 + "\r\n"
-                + "		Log.d(\"Debug\", output1);   \r\n"
-                + "		Log.d(\"Debug\", output2);   \r\n"
-                + "		Log.d(\"Debug\", output3);   			\r\n"
-                + "		Log.d(\"Debug\", output4); \r\n"
-                + "		\r\n"
-                + "		output = \"1\";\r\n"
-                + "		Log.d(\"Debug\", output1);\r\n"
-                + "		\r\n"
-                + "		output = \"2\";\r\n"
-                + "		Log.d(\"Debug\", output2);\r\n"
-                + "		\r\n"
-                + "		output = \"3\";\r\n"
-                + "		Log.d(\"Debug\", output3);\r\n"
-                + "		\r\n"
-                + "		Log.d(\"Debug\", \"\");   \r\n"
-                + "		Log.d(\"Debug\", \"\");  \r\n"
-                + "		Log.d(\"Debug\", \"3\");   \r\n"
-                + "		Log.d(\"Debug\", \"4\");   \r\n"
-                + "		\r\n"
-                + "		return \"\";\r\n"
-                + "	}\r\n"
+                + "        Log.d(\"Debug\", output1);   \r\n"
+                + "        Log.d(\"Debug\", output2);   \r\n"
+                + "        Log.d(\"Debug\", output3);               \r\n"
+                + "        Log.d(\"Debug\", output4); \r\n"
+                + "        \r\n"
+                + "        output = \"1\";\r\n"
+                + "        Log.d(\"Debug\", output1);\r\n"
+                + "        \r\n"
+                + "        output = \"2\";\r\n"
+                + "        Log.d(\"Debug\", output2);\r\n"
+                + "        \r\n"
+                + "        output = \"3\";\r\n"
+                + "        Log.d(\"Debug\", output3);\r\n"
+                + "        \r\n"
+                + "        Log.d(\"Debug\", \"\");   \r\n"
+                + "        Log.d(\"Debug\", \"\");  \r\n"
+                + "        Log.d(\"Debug\", \"3\");   \r\n"
+                + "        Log.d(\"Debug\", \"4\");   \r\n"
+                + "        \r\n"
+                + "        return \"\";\r\n"
+                + "    }\r\n"
                 + "}");
-		String expected = 
-        		"class A {\r\n"
-        		+ "	public String output = \"Contents of \";\r\n"
-        		+ "	\r\n"
-        		+ "	public String debug(String output) {\r\n"
-        		+ "\r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", output1);   \r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", output2);   \r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", output3);   			\r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", output4); \r\n"
-        		+ "		\r\n"
-        		+ "		output = \"1\";\r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", output1);\r\n"
-        		+ "		\r\n"
-        		+ "		output = \"2\";\r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", output2);\r\n"
-        		+ "		\r\n"
-        		+ "		output = \"3\";\r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", output3);\r\n"
-        		+ "		\r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", \"\");   \r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", \"\");  \r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", \"3\");   \r\n"
-        		+ "		if (Log.Level >= 3)\r\n"
-        		+ "		    Log.d(\"Debug\", \"4\");   \r\n"
-        		+ "		\r\n"
-        		+ "		return \"\";\r\n"
-        		+ "	}\r\n"
-        		+ "}";
-		
-		// here the logic
-		FunctionVisitor funVisitor = new FunctionVisitor();
+        String expected = 
+                "class A {\r\n"
+                + "    public String output = \"Contents of \";\r\n"
+                + "    \r\n"
+                + "    public String debug(String output) {\r\n"
+                + "\r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", output1);   \r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", output2);   \r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", output3);               \r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", output4); \r\n"
+                + "        \r\n"
+                + "        output = \"1\";\r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", output1);\r\n"
+                + "        \r\n"
+                + "        output = \"2\";\r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", output2);\r\n"
+                + "        \r\n"
+                + "        output = \"3\";\r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", output3);\r\n"
+                + "        \r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", \"\");   \r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", \"\");  \r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", \"3\");   \r\n"
+                + "        if (Log.Level >= 3)\r\n"
+                + "            Log.d(\"Debug\", \"4\");   \r\n"
+                + "        \r\n"
+                + "        return \"\";\r\n"
+                + "    }\r\n"
+                + "}";
+        
+        // here the logic
+        FunctionVisitor funVisitor = new FunctionVisitor();
         funVisitor.visit(cu, null);
-		
-		
-		assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
-	}
-	
-	public class FunctionVisitor extends ModifierVisitor<Object> {
+        
+        
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
+    
+    public class FunctionVisitor extends ModifierVisitor<Object> {
 
-		@Override
-		public Visitable visit(ExpressionStmt node, Object arg) {
-			List<MethodCallExpr> mces = node.getChildNodesByType(MethodCallExpr.class);
-			if (mces.isEmpty())
-				return node;
-			MethodCallExpr mce = mces.get(0);
-			if (mce.getScope().isPresent() && mce.getName() != null) {
-				String nodeScope = mce.getScope().get().toString();
-				String nodeName = mce.getName().toString();
-				if (nodeScope.equals("Log")) {
-					if (nodeName.equals("d")) {
-						IfStmt ifStmt = makeIfStmt(node);
-						return ifStmt;
-					}
-				}
-			}
-			return node;
-		}
-	}
-	
-	private IfStmt makeIfStmt(Statement thenStmt) {
-		Expression left = new FieldAccessExpr(new NameExpr("Log"), "Level");
-		Expression right = new IntegerLiteralExpr("3");
-		BinaryExpr condition = new BinaryExpr(left, right, Operator.GREATER_EQUALS);
-		IfStmt ifStmt = new IfStmt(condition, thenStmt, null);
-		return ifStmt;
-	}
+        @Override
+        public Visitable visit(ExpressionStmt node, Object arg) {
+            List<MethodCallExpr> mces = node.getChildNodesByType(MethodCallExpr.class);
+            if (mces.isEmpty())
+                return node;
+            MethodCallExpr mce = mces.get(0);
+            if (mce.getScope().isPresent() && mce.getName() != null) {
+                String nodeScope = mce.getScope().get().toString();
+                String nodeName = mce.getName().toString();
+                if (nodeScope.equals("Log")) {
+                    if (nodeName.equals("d")) {
+                        IfStmt ifStmt = makeIfStmt(node);
+                        return ifStmt;
+                    }
+                }
+            }
+            return node;
+        }
+    }
+    
+    private IfStmt makeIfStmt(Statement thenStmt) {
+        Expression left = new FieldAccessExpr(new NameExpr("Log"), "Level");
+        Expression right = new IntegerLiteralExpr("3");
+        BinaryExpr condition = new BinaryExpr(left, right, Operator.GREATER_EQUALS);
+        IfStmt ifStmt = new IfStmt(condition, thenStmt, null);
+        return ifStmt;
+    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3796Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3796Test.java
@@ -32,23 +32,23 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 
 public class Issue3796Test extends AbstractLexicalPreservingTest {
 
-	@Test
+    @Test
     void test() {
-		considerCode(
-				"public class MyClass {\n"
-				+ "	/** Comment */ \n"
-				+ "	@Rule String s0; \n"
-				+ "}");
-		String expected = 
-				"public class MyClass {\n" +
-				"\n" +
-				"}";
+        considerCode(
+                "public class MyClass {\n"
+                + "    /** Comment */ \n"
+                + "    @Rule String s0; \n"
+                + "}");
+        String expected = 
+                "public class MyClass {\n" +
+                "\n" +
+                "}";
 
-		List<FieldDeclaration> fields = cu.findAll(FieldDeclaration.class);
-		FieldDeclaration field = fields.get(0);
+        List<FieldDeclaration> fields = cu.findAll(FieldDeclaration.class);
+        FieldDeclaration field = fields.get(0);
 
-		field.remove();
+        field.remove();
 
-		assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3818Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3818Test.java
@@ -36,22 +36,22 @@ public class Issue3818Test extends AbstractLexicalPreservingTest {
     @Test
     void test() {
         String src = "public class Foo {\n"
-        		+ "\n"
-				+ "    public Long[][] m(int[] a){}\n"
-				+ "}";
+                + "\n"
+                + "    public Long[][] m(int[] a){}\n"
+                + "}";
         
         String expected = "public class Foo {\n"
-        		+ "\n"
-				+ "    public Long[][] m(int[] b){}\n"
-				+ "}";
+                + "\n"
+                + "    public Long[][] m(int[] b){}\n"
+                + "}";
 
-		BodyDeclaration<?> cu = StaticJavaParser.parseBodyDeclaration(src);
-		MethodDeclaration md = cu.findAll(MethodDeclaration.class).get(0);
-		LexicalPreservingPrinter.setup(md);
-		Parameter p = md.getParameter(0);
-		Parameter paramExpr = new Parameter(p.getModifiers(), p.getAnnotations(), p.getType(),
-				p.isVarArgs(), p.getVarArgsAnnotations(), new SimpleName("b"));
-		md.replace(p, paramExpr);
-		assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        BodyDeclaration<?> cu = StaticJavaParser.parseBodyDeclaration(src);
+        MethodDeclaration md = cu.findAll(MethodDeclaration.class).get(0);
+        LexicalPreservingPrinter.setup(md);
+        Parameter p = md.getParameter(0);
+        Parameter paramExpr = new Parameter(p.getModifiers(), p.getAnnotations(), p.getType(),
+                p.isVarArgs(), p.getVarArgsAnnotations(), new SimpleName("b"));
+        md.replace(p, paramExpr);
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3924Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3924Test.java
@@ -27,50 +27,50 @@ import org.junit.jupiter.api.Test;
 
 public class Issue3924Test extends AbstractLexicalPreservingTest {
 
-	@Test
+    @Test
     void test() {
-		considerCode(
-				"/*\n" + " * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-						+ " * you may not use this file except in compliance with the License.\n"
-						+ " * You may obtain a copy of the License at\n"
-						+ " */\n"
-						+ "\n"
-						+ "@XmlSchema(\n"
-						+ "		xmlns = {\n"
-						+ "				@XmlNs(prefix = \"order\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/order/1\"),\n"
-						+ "				@XmlNs(prefix = \"address\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/address/1\")\n"
-						+ "		}\n"
-						+ ")\n"
-						+ "package net.revelc.code.imp;\n"
-						+ "\n"
-						+ "import net.revelc.code.imp.Something;\n"
-						+ "\n"
-						+ "@Component\n"
-						+ "public class UnusedImports {\n"
-						+ "}\n"
-						+ "");
+        considerCode(
+                "/*\n" + " * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+                        + " * you may not use this file except in compliance with the License.\n"
+                        + " * You may obtain a copy of the License at\n"
+                        + " */\n"
+                        + "\n"
+                        + "@XmlSchema(\n"
+                        + "        xmlns = {\n"
+                        + "                @XmlNs(prefix = \"order\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/order/1\"),\n"
+                        + "                @XmlNs(prefix = \"address\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/address/1\")\n"
+                        + "        }\n"
+                        + ")\n"
+                        + "package net.revelc.code.imp;\n"
+                        + "\n"
+                        + "import net.revelc.code.imp.Something;\n"
+                        + "\n"
+                        + "@Component\n"
+                        + "public class UnusedImports {\n"
+                        + "}\n"
+                        + "");
 
-		LexicalPreservingPrinter.setup(cu);
-		cu.getImport(0).remove();
-		String actual = LexicalPreservingPrinter.print(cu);
-		String expected =
-				"/*\r\n"
-				+ " * Licensed under the Apache License, Version 2.0 (the \"License\");\r\n"
-				+ " * you may not use this file except in compliance with the License.\r\n"
-				+ " * You may obtain a copy of the License at\r\n"
-				+ " */\r\n"
-				+ "\r\n"
-				+ "@XmlSchema(\r\n"
-				+ "		xmlns = {\r\n"
-				+ "				@XmlNs(prefix = \"order\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/order/1\"),\r\n"
-				+ "				@XmlNs(prefix = \"address\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/address/1\")\r\n"
-				+ "		}\r\n"
-				+ ")\r\n"
-				+ "package net.revelc.code.imp;\r\n"
-				+ "\r\n"
-				+ "@Component\r\n"
-				+ "public class UnusedImports {\r\n"
-				+ "}\n";
-		assertEqualsStringIgnoringEol(expected, actual);
+        LexicalPreservingPrinter.setup(cu);
+        cu.getImport(0).remove();
+        String actual = LexicalPreservingPrinter.print(cu);
+        String expected =
+                "/*\r\n"
+                + " * Licensed under the Apache License, Version 2.0 (the \"License\");\r\n"
+                + " * you may not use this file except in compliance with the License.\r\n"
+                + " * You may obtain a copy of the License at\r\n"
+                + " */\r\n"
+                + "\r\n"
+                + "@XmlSchema(\r\n"
+                + "        xmlns = {\r\n"
+                + "                @XmlNs(prefix = \"order\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/order/1\"),\r\n"
+                + "                @XmlNs(prefix = \"address\", namespaceURI = \"http://www.camel.apache.org/jaxb/example/address/1\")\r\n"
+                + "        }\r\n"
+                + ")\r\n"
+                + "package net.revelc.code.imp;\r\n"
+                + "\r\n"
+                + "@Component\r\n"
+                + "public class UnusedImports {\r\n"
+                + "}\n";
+        assertEqualsStringIgnoringEol(expected, actual);
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3936Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3936Test.java
@@ -28,45 +28,45 @@ import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
 import org.junit.jupiter.api.Test;
 
 public class Issue3936Test extends AbstractLexicalPreservingTest {
-	static final String given = "package some.project;\n"
-			+ "\n"
-			+ "import java.util.Optional;\n"
-			+ "\n"
-			+ "public class SomeClass {\n"
-			+ "\n"
-			+ "	String html = \"\" + \"<html>\\n\"\n"
-			+ "			+ \"\\t<head>\\n\"\n"
-			+ "			+ \"\\t\\t<meta charset=\\\"utf-8\\\">\\n\"\n"
-			+ "			+ \"\\t</head>\\n\"\n"
-			+ "			+ \"\\t<body class=\\\"default-view\\\" style=\\\"word-wrap: break-word;\\\">\\n\"\n"
-			+ "			+ \"\\t\\t<p>Hello, world</p>\\n\"\n"
-			+ "			+ \"\\t</body>\\n\"\n"
-			+ "			+ \"</html>\\n\";\n"
-			+ "}";
+    static final String given = "package some.project;\n"
+            + "\n"
+            + "import java.util.Optional;\n"
+            + "\n"
+            + "public class SomeClass {\n"
+            + "\n"
+            + "    String html = \"\" + \"<html>\\n\"\n"
+            + "            + \"\\t<head>\\n\"\n"
+            + "            + \"\\t\\t<meta charset=\\\"utf-8\\\">\\n\"\n"
+            + "            + \"\\t</head>\\n\"\n"
+            + "            + \"\\t<body class=\\\"default-view\\\" style=\\\"word-wrap: break-word;\\\">\\n\"\n"
+            + "            + \"\\t\\t<p>Hello, world</p>\\n\"\n"
+            + "            + \"\\t</body>\\n\"\n"
+            + "            + \"</html>\\n\";\n"
+            + "}";
 
-	@Test
+    @Test
     void test() {
-		considerCode(given);
+        considerCode(given);
 
-		String newText = "\tfirstRow\n\tsecondRow\n\tthirdRow";
+        String newText = "\tfirstRow\n\tsecondRow\n\tthirdRow";
 
-		LexicalPreservingPrinter.setup(cu);
+        LexicalPreservingPrinter.setup(cu);
 
-		VariableDeclarator expr = cu.findFirst(VariableDeclarator.class).get();
-		expr.setInitializer(new TextBlockLiteralExpr(newText));
+        VariableDeclarator expr = cu.findFirst(VariableDeclarator.class).get();
+        expr.setInitializer(new TextBlockLiteralExpr(newText));
 
-		String actual = LexicalPreservingPrinter.print(cu);
-		String expected ="package some.project;\n"
-				+ "\n"
-				+ "import java.util.Optional;\n"
-				+ "\n"
-				+ "public class SomeClass {\n"
-				+ "\n"
-				+ "	String html = \"\"\"\n"
-				+ "\tfirstRow\n"
-				+ "\tsecondRow\n"
-				+ "\tthirdRow\"\"\";\n"
-				+ "}";
-		assertEqualsStringIgnoringEol(expected, actual);
+        String actual = LexicalPreservingPrinter.print(cu);
+        String expected ="package some.project;\n"
+                + "\n"
+                + "import java.util.Optional;\n"
+                + "\n"
+                + "public class SomeClass {\n"
+                + "\n"
+                + "    String html = \"\"\"\n"
+                + "\tfirstRow\n"
+                + "\tsecondRow\n"
+                + "\tthirdRow\"\"\";\n"
+                + "}";
+        assertEqualsStringIgnoringEol(expected, actual);
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3937Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3937Test.java
@@ -31,40 +31,40 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 
 public class Issue3937Test extends AbstractLexicalPreservingTest {
-	static final String given = "package custom.project;\n" + "\n"
-			+ "import java.util.stream.Stream;\n"
-			+ "\n"
-			+ "class TestFileSystemCodeProvider {\n"
-			+ "	void testInMemoryFileSystem() {\n"
-			+ "\n"
-			+ "		Stream.of(\"\").listFilesForContent(file -> {\n"
-			+ "			System.out.println(s);\n"
-			+ "		});\n"
-			+ "	}\n"
-			+ "}\n"
-			+ "";
+    static final String given = "package custom.project;\n" + "\n"
+            + "import java.util.stream.Stream;\n"
+            + "\n"
+            + "class TestFileSystemCodeProvider {\n"
+            + "    void testInMemoryFileSystem() {\n"
+            + "\n"
+            + "        Stream.of(\"\").listFilesForContent(file -> {\n"
+            + "            System.out.println(s);\n"
+            + "        });\n"
+            + "    }\n"
+            + "}\n"
+            + "";
 
-	@Test
-	void test() {
-		considerCode(given);
+    @Test
+    void test() {
+        considerCode(given);
 
-		LexicalPreservingPrinter.setup(cu);
+        LexicalPreservingPrinter.setup(cu);
 
-		LambdaExpr lambdaExpr = cu.findFirst(LambdaExpr.class).get();
-		lambdaExpr.setBody(new ExpressionStmt(new MethodCallExpr(new NameExpr("SomeClass"), "someMethod")));
+        LambdaExpr lambdaExpr = cu.findFirst(LambdaExpr.class).get();
+        lambdaExpr.setBody(new ExpressionStmt(new MethodCallExpr(new NameExpr("SomeClass"), "someMethod")));
 
-		String actual = LexicalPreservingPrinter.print(cu);
-		String expected = "package custom.project;\n"
-				+ "\n"
-				+ "import java.util.stream.Stream;\n"
-				+ "\n"
-				+ "class TestFileSystemCodeProvider {\n"
-				+ "	void testInMemoryFileSystem() {\n"
-				+ "\n"
-				+ "		Stream.of(\"\").listFilesForContent(file -> SomeClass.someMethod());\n"
-				+ "	}\n"
-				+ "}\n"
-				+ "";
-		assertEqualsStringIgnoringEol(expected, actual);
-	}
+        String actual = LexicalPreservingPrinter.print(cu);
+        String expected = "package custom.project;\n"
+                + "\n"
+                + "import java.util.stream.Stream;\n"
+                + "\n"
+                + "class TestFileSystemCodeProvider {\n"
+                + "    void testInMemoryFileSystem() {\n"
+                + "\n"
+                + "        Stream.of(\"\").listFilesForContent(file -> SomeClass.someMethod());\n"
+                + "    }\n"
+                + "}\n"
+                + "";
+        assertEqualsStringIgnoringEol(expected, actual);
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3949Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3949Test.java
@@ -11,18 +11,18 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 
 class Issue3949Test extends AbstractLexicalPreservingTest  {
 
-	@Test
+    @Test
     public void test() {
-    	considerCode(
-    			"class A {\n"
-    					+ "\n"
-    		            + "  void foo() {\n"
-    		            + "    Consumer<Integer> lambda = a -> System.out.println(a);\n"
-    		            + "  }\n"
-    		            + "}");
+        considerCode(
+                "class A {\n"
+                        + "\n"
+                        + "  void foo() {\n"
+                        + "    Consumer<Integer> lambda = a -> System.out.println(a);\n"
+                        + "  }\n"
+                        + "}");
 
-    	ExpressionStmt estmt = cu.findAll(ExpressionStmt.class).get(1).clone();
-    	LambdaExpr lexpr = cu.findAll(LambdaExpr.class).get(0);
+        ExpressionStmt estmt = cu.findAll(ExpressionStmt.class).get(1).clone();
+        LambdaExpr lexpr = cu.findAll(LambdaExpr.class).get(0);
         LexicalPreservingPrinter.setup(cu);
 
         BlockStmt block = new BlockStmt();
@@ -32,15 +32,15 @@ class Issue3949Test extends AbstractLexicalPreservingTest  {
         lexpr.setBody(block);
 
         String expected =
-        		"class A {\n"
-        		+ "\n"
-        		+ "  void foo() {\n"
-        		+ "    Consumer<Integer> lambda = a -> {\n"
-        		+ "        System.out.println(a);\n"
-        		+ "        break;\n"
-        		+ "    };\n"
-        		+ "  }\n"
-        		+ "}";
+                "class A {\n"
+                + "\n"
+                + "  void foo() {\n"
+                + "    Consumer<Integer> lambda = a -> {\n"
+                + "        System.out.println(a);\n"
+                + "        break;\n"
+                + "    };\n"
+                + "  }\n"
+                + "}";
 
         assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4104Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4104Test.java
@@ -33,49 +33,49 @@ import com.github.javaparser.ast.stmt.SwitchStmt;
 
 public class Issue4104Test extends AbstractLexicalPreservingTest {
 
-	@Test
+    @Test
     void test() {
-		considerCode(
-				"class Foo {\n"
-				+ "  void foo() {\n"
-				+ "    switch(bar) {\n"
-				+ "      default:\n"
-				+ "        break;\n"
-				+ "    }\n"
-				+ "  }\n"
-				+ "}");
-		// should be this
-//		String expected =
-//				"class Foo {\n"
-//				+ "  void foo() {\n"
-//				+ "    switch(bar) {\n"
-//				+ "      default:\n"
-//				+ "        break;\n"
-//				+ "      case 0:\n"
-//				+ "          break;\n"
-//				+ "    }\n"
-//				+ "  }\n"
-//				+ "}";
+        considerCode(
+                "class Foo {\n"
+                + "  void foo() {\n"
+                + "    switch(bar) {\n"
+                + "      default:\n"
+                + "        break;\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+        // should be this
+//        String expected =
+//                "class Foo {\n"
+//                + "  void foo() {\n"
+//                + "    switch(bar) {\n"
+//                + "      default:\n"
+//                + "        break;\n"
+//                + "      case 0:\n"
+//                + "          break;\n"
+//                + "    }\n"
+//                + "  }\n"
+//                + "}";
 
-		String expected =
-				"class Foo {\n"
-				+ "  void foo() {\n"
-				+ "    switch(bar) {\n"
-				+ "      default:\n"
-				+ "        break;\n"
-				+ "      case 0:\n"
-				+ "          break;\n"
-				+ "      }\n"
-				+ "  }\n"
-				+ "}";
+        String expected =
+                "class Foo {\n"
+                + "  void foo() {\n"
+                + "    switch(bar) {\n"
+                + "      default:\n"
+                + "        break;\n"
+                + "      case 0:\n"
+                + "          break;\n"
+                + "      }\n"
+                + "  }\n"
+                + "}";
 
-		SwitchStmt switchStmt = cu.findAll(SwitchStmt.class).stream().findFirst().get();
+        SwitchStmt switchStmt = cu.findAll(SwitchStmt.class).stream().findFirst().get();
 
         SwitchEntry newEntry = new SwitchEntry();
         newEntry.setLabels(NodeList.nodeList(new IntegerLiteralExpr(0)));
         newEntry.setStatements(NodeList.nodeList(new BreakStmt()));
         switchStmt.getEntries().addLast(newEntry);
 
-		assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4163Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4163Test.java
@@ -38,25 +38,25 @@ import com.github.javaparser.printer.configuration.PrinterConfiguration;
 
 public class Issue4163Test extends AbstractLexicalPreservingTest {
 
-	@Test
-	void test() {
-		VoidVisitorAdapter<Object> visitor = new VoidVisitorAdapter<Object>() {
-	        @Override
-	        public void visit(MethodDeclaration n, Object arg) {
-	            System.out.println(n.getDeclarationAsString(true, true, true));
-	            System.out.println(n.getComment());
-	        }
-	    };
-	    String code =
-	    	"class Foo {\n"
-	    	+ "		/*\n"
-	    	+ "      * comment\n"
-	    	+ "      */\n"
-	    	+ "		void m() {}\n"
-	    	+ "	}";
+    @Test
+    void test() {
+        VoidVisitorAdapter<Object> visitor = new VoidVisitorAdapter<Object>() {
+            @Override
+            public void visit(MethodDeclaration n, Object arg) {
+                System.out.println(n.getDeclarationAsString(true, true, true));
+                System.out.println(n.getComment());
+            }
+        };
+        String code =
+            "class Foo {\n"
+            + "        /*\n"
+            + "      * comment\n"
+            + "      */\n"
+            + "        void m() {}\n"
+            + "    }";
 
-	    // setup pretty printer to print comments
-	    PrinterConfiguration config = new DefaultPrinterConfiguration()
+        // setup pretty printer to print comments
+        PrinterConfiguration config = new DefaultPrinterConfiguration()
                 .addOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
         Printer printer = new DefaultPrettyPrinter(config);
         CompilationUnit cu = StaticJavaParser.parse(code);
@@ -68,8 +68,8 @@ public class Issue4163Test extends AbstractLexicalPreservingTest {
         // set the new pretty printer in the compilation unit
         cu.printer(printer);
         // visit the MethodDeclaration node
-	    visitor.visit(cu, null);
-	    // checks that the comment is printed after executing the getDeclarationAsString method
-	    assertEqualsStringIgnoringEol(expected, md.getComment().get().toString());
-	}
+        visitor.visit(cu, null);
+        // checks that the comment is printed after executing the getDeclarationAsString method
+        assertEqualsStringIgnoringEol(expected, md.getComment().get().toString());
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -342,7 +342,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         c.getMembers().remove(0);
         // This rendering is probably caused by the concret syntax model
         assertEquals("class /*a comment*/ A {\t\t" + SYSTEM_EOL +
-        		SYSTEM_EOL +
+                SYSTEM_EOL +
                 "         void foo(int p  ) { return  'z'  \t; }}", LexicalPreservingPrinter.print(c));
     }
 
@@ -1044,7 +1044,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void handleDeprecatedAnnotationAbstractClass() {
-    	considerCode("public abstract class A {}");
+        considerCode("public abstract class A {}");
 
         cu.getTypes().forEach(type -> type.addAndGetAnnotation(Deprecated.class));
 
@@ -1054,7 +1054,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void issue1244() {
-    	considerCode("public class Foo {" + SYSTEM_EOL + SYSTEM_EOL
+        considerCode("public class Foo {" + SYSTEM_EOL + SYSTEM_EOL
                 + "// Some comment" + SYSTEM_EOL + SYSTEM_EOL // does work with only one \n
                 + "public void writeExternal() {}" + SYSTEM_EOL + "}");
 
@@ -1080,7 +1080,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     // See issue 1277
     @Test
     void testInvokeModifierVisitor() {
-    	considerCode("class A {" + SYSTEM_EOL +
+        considerCode("class A {" + SYSTEM_EOL +
                 "  public String message = \"hello\";" + SYSTEM_EOL +
                 "   void bar() {" + SYSTEM_EOL +
                 "     System.out.println(\"hello\");" + SYSTEM_EOL +
@@ -1100,7 +1100,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void invokeModifierVisitorIssue1297() {
-    	considerCode("class A {" + SYSTEM_EOL +
+        considerCode("class A {" + SYSTEM_EOL +
                 "   public void bar() {" + SYSTEM_EOL +
                 "     System.out.println(\"hello\");" + SYSTEM_EOL +
                 "     System.out.println(\"hello\");" + SYSTEM_EOL +
@@ -1113,7 +1113,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void addedBlockCommentsPrinted() {
-    	considerCode("public class Foo { }");
+        considerCode("public class Foo { }");
 
         cu.getClassByName("Foo").get()
                 .addMethod("mymethod")
@@ -1127,7 +1127,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void addedLineCommentsPrinted() {
-    	considerCode("public class Foo { }");
+        considerCode("public class Foo { }");
 
         cu.getClassByName("Foo").get()
                 .addMethod("mymethod")
@@ -1141,7 +1141,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void removedLineCommentsPrinted() {
-    	considerCode("public class Foo {" + SYSTEM_EOL +
+        considerCode("public class Foo {" + SYSTEM_EOL +
                 "//line" + SYSTEM_EOL +
                 "void mymethod() {" + SYSTEM_EOL +
                 "}" + SYSTEM_EOL +
@@ -1157,7 +1157,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     // Checks if comments get removed properly with Unix style line endings
     @Test
     void removedLineCommentsPrintedUnix() {
-    	considerCode("public class Foo {" + "\n" +
+        considerCode("public class Foo {" + "\n" +
                 "//line" + "\n" +
                 "void mymethod() {" + "\n" +
                 "}" + "\n" +
@@ -1172,7 +1172,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void removedBlockCommentsPrinted() {
-    	considerCode("public class Foo {" + SYSTEM_EOL +
+        considerCode("public class Foo {" + SYSTEM_EOL +
                 "/*" + SYSTEM_EOL +
                 "Block comment coming through" + SYSTEM_EOL +
                 "*/" + SYSTEM_EOL +
@@ -1190,7 +1190,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     @Test
     void testFixIndentOfMovedNode() {
         try {
-        	considerExample("FixIndentOfMovedNode");
+            considerExample("FixIndentOfMovedNode");
 
             cu.getClassByName("ThisIsASampleClass").get()
                     .getMethodsByName("longerMethod")
@@ -1211,7 +1211,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void issue1321() {
-    	considerCode("class X { X() {} private void testme() {} }");
+        considerCode("class X { X() {} private void testme() {} }");
 
         ClassOrInterfaceDeclaration type = cu.getClassByName("X").get();
         type.getConstructors().get(0).setBody(new BlockStmt().addStatement("testme();"));
@@ -1222,7 +1222,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void issue2001() {
-    	considerCode("class X {void blubb(){X.p(\"blaubb04\");}}");
+        considerCode("class X {void blubb(){X.p(\"blaubb04\");}}");
 
         cu.findAll(MethodCallExpr.class).forEach(Node::removeForced);
 
@@ -1292,7 +1292,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     public void testReplaceClassName() {
-    	considerCode("class A {}");
+        considerCode("class A {}");
 
         assertEquals(1, cu.findAll(ClassOrInterfaceDeclaration.class).size());
         cu.findAll(ClassOrInterfaceDeclaration.class).forEach(coid -> coid.setName("B"));
@@ -1403,32 +1403,32 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     }
 
     @Test
-	void testTextBlockSupport() {
-		String code =
-				"String html = \"\"\"\n" +
+    void testTextBlockSupport() {
+        String code =
+                "String html = \"\"\"\n" +
                 "  <html>\n" +
                 "    <body>\n" +
                 "      <p>Hello, world</p>\n" +
                 "    </body>\n" +
                 "  </html>\n" +
                 "\"\"\";";
-		String expected =
-				"String html = \"\"\"\r\n"
-				+ "  <html>\r\n"
-				+ "    <body>\r\n"
-				+ "      <p>Hello, world</p>\r\n"
-				+ "    </body>\r\n"
-				+ "  </html>\r\n"
-				+ "\"\"\";";
-		final JavaParser javaParser = new JavaParser(
+        String expected =
+                "String html = \"\"\"\r\n"
+                + "  <html>\r\n"
+                + "    <body>\r\n"
+                + "      <p>Hello, world</p>\r\n"
+                + "    </body>\r\n"
+                + "  </html>\r\n"
+                + "\"\"\";";
+        final JavaParser javaParser = new JavaParser(
                 new ParserConfiguration()
                         .setLexicalPreservationEnabled(true)
                         .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_15)
         );
-		Statement stmt = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
-		LexicalPreservingPrinter.setup(stmt);
-		assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(stmt));
-	}
+        Statement stmt = javaParser.parseStatement(code).getResult().orElseThrow(AssertionError::new);
+        LexicalPreservingPrinter.setup(stmt);
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(stmt));
+    }
 
     @Test
     void testArrayPreservation_WithSingleLanguageStyle() {
@@ -1688,38 +1688,38 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     // issue 3216 LexicalPreservingPrinter add Wrong indentation when removing comments
     @Test
     void removedIndentationLineCommentsPrinted() {
-		considerCode("public class Foo {\n" +
-    			"  //line \n" +
-    			"  void mymethod() {\n" +
-    			"  }\n" +
-    			"}");
-		String expected =
-				"public class Foo {\n" +
-		    	"  void mymethod() {\n" +
-		    	"  }\n" +
-		    	"}";
-    	cu.getAllContainedComments().get(0).remove();
-    	assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        considerCode("public class Foo {\n" +
+                "  //line \n" +
+                "  void mymethod() {\n" +
+                "  }\n" +
+                "}");
+        String expected =
+                "public class Foo {\n" +
+                "  void mymethod() {\n" +
+                "  }\n" +
+                "}";
+        cu.getAllContainedComments().get(0).remove();
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 
     // issue 3216 LexicalPreservingPrinter add Wrong indentation when removing comments
     @Test
     void removedIndentationBlockCommentsPrinted() {
-    	considerCode("public class Foo {\n" +
-    			"  /*\n" +
-    			"  *Block comment coming through\n" +
-    			"  */\n" +
-    			"  void mymethod() {\n" +
-    			"  }\n" +
-    			"}");
-    	String expected =
-    			"public class Foo {\n" +
-    	    	"  void mymethod() {\n" +
-    	    	"  }\n" +
-    	    	"}";
-    	cu.getAllContainedComments().get(0).remove();
+        considerCode("public class Foo {\n" +
+                "  /*\n" +
+                "  *Block comment coming through\n" +
+                "  */\n" +
+                "  void mymethod() {\n" +
+                "  }\n" +
+                "}");
+        String expected =
+                "public class Foo {\n" +
+                "  void mymethod() {\n" +
+                "  }\n" +
+                "}";
+        cu.getAllContainedComments().get(0).remove();
 
-    	assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 
  // issue 3216 LexicalPreservingPrinter add Wrong indentation when removing comments
@@ -1733,7 +1733,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                 "  }\n" +
                 "}");
         String expected =
-        		"public class Foo {\n" +
+                "public class Foo {\n" +
                 "  void mymethod() {\n" +
                 "  }\n" +
                 "}";
@@ -1744,82 +1744,82 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void addingOrphanCommentToType() {
-    	String actual =
-	            "public class Foo {\n"
-	            + "}" ;
+        String actual =
+                "public class Foo {\n"
+                + "}" ;
 
-	    String expected =
-	    		"//added comment\n"
-	    		+ "public class Foo {\n"
-	    		+ "}";
+        String expected =
+                "//added comment\n"
+                + "public class Foo {\n"
+                + "}";
 
         considerCode(actual);
-	    cu.getTypes().get(0).addOrphanComment(new LineComment("added comment"));
-	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        cu.getTypes().get(0).addOrphanComment(new LineComment("added comment"));
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 
     @Test
     void addingOrphanCommentToBlock() {
-    	String actual =
-	            "public class Foo {\n"
-	            + "}" ;
+        String actual =
+                "public class Foo {\n"
+                + "}" ;
 
-	    String expected =
-	    		"//added comment\n"
-	    		+ "public class Foo {\n"
-	    		+ "}";
+        String expected =
+                "//added comment\n"
+                + "public class Foo {\n"
+                + "}";
 
         considerCode(actual);
-	    cu.getTypes().get(0).getChildNodes().get(0).addOrphanComment(new LineComment("added comment"));
-	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        cu.getTypes().get(0).getChildNodes().get(0).addOrphanComment(new LineComment("added comment"));
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 
     @Test
     void addingOrphanCommentToBlockInMethodDeclaration() {
-    	String actual =
-	            "public class Foo {\n"
-    			+ "  boolean m() {\n"
-	            + "    return true;\n"
-    			+ "  }\n"
-	            + "}" ;
+        String actual =
+                "public class Foo {\n"
+                + "  boolean m() {\n"
+                + "    return true;\n"
+                + "  }\n"
+                + "}" ;
 
-    	// that's probably not what we want,
-    	// but this is what is implemented in LexicalPreservingPrinter.Observer.concretePropertyChange(..)
-	    String expected =
-	    		"public class Foo {\n"
-	    		+ "  boolean m() //added comment\n"
-	    		+ "{\n"
-	    		+ "    return true;\n"
-	    		+ "  }\n"
-	    		+ "}";
+        // that's probably not what we want,
+        // but this is what is implemented in LexicalPreservingPrinter.Observer.concretePropertyChange(..)
+        String expected =
+                "public class Foo {\n"
+                + "  boolean m() //added comment\n"
+                + "{\n"
+                + "    return true;\n"
+                + "  }\n"
+                + "}";
 
         considerCode(actual);
-	    cu.findAll(BlockStmt.class).get(0).addOrphanComment(new LineComment("added comment"));
-	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        cu.findAll(BlockStmt.class).get(0).addOrphanComment(new LineComment("added comment"));
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 
     @Test
     void addingOrphanCommentToBlockInMethodDeclaration2() {
-    	String actual =
-	            "public class Foo {\n"
-    			+ "  boolean m() \n"
-	            + "  {\n"
-	            + "    return true;\n"
-    			+ "  }\n"
-	            + "}" ;
+        String actual =
+                "public class Foo {\n"
+                + "  boolean m() \n"
+                + "  {\n"
+                + "    return true;\n"
+                + "  }\n"
+                + "}" ;
 
-	    String expected =
-	    		"public class Foo {\n"
-	    		+ "  boolean m() \n"
-	    		+ "  //added comment\n"
-	    		+ "  {\n"
-	    		+ "    return true;\n"
-	    		+ "  }\n"
-	    		+ "}";
+        String expected =
+                "public class Foo {\n"
+                + "  boolean m() \n"
+                + "  //added comment\n"
+                + "  {\n"
+                + "    return true;\n"
+                + "  }\n"
+                + "}";
 
         considerCode(actual);
-	    cu.findAll(BlockStmt.class).get(0).addOrphanComment(new LineComment("added comment"));
-	    assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+        cu.findAll(BlockStmt.class).get(0).addOrphanComment(new LineComment("added comment"));
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 
     // issue 3800 determine whether active

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/PeekingIteratorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/PeekingIteratorTest.java
@@ -11,116 +11,116 @@ import org.junit.jupiter.api.*;
 
 class PeekingIteratorTest {
 
-	private static final List<String> EMPTY_LIST = new ArrayList();
+    private static final List<String> EMPTY_LIST = new ArrayList();
 
-	private static List<String> NON_EMPTY_LIST ;
+    private static List<String> NON_EMPTY_LIST ;
 
-	private PeekingIterator<String> peekingIterator;
+    private PeekingIterator<String> peekingIterator;
 
-	@BeforeAll
-	static void setUpBeforeClass() throws Exception {
-	}
+    @BeforeAll
+    static void setUpBeforeClass() throws Exception {
+    }
 
-	@AfterAll
-	static void tearDownAfterClass() throws Exception {
-	}
+    @AfterAll
+    static void tearDownAfterClass() throws Exception {
+    }
 
-	@BeforeEach
-	void setUp() throws Exception {
-		NON_EMPTY_LIST = Arrays.asList("A", "B", "C");
-	}
+    @BeforeEach
+    void setUp() throws Exception {
+        NON_EMPTY_LIST = Arrays.asList("A", "B", "C");
+    }
 
-	@AfterEach
-	void tearDown() throws Exception {
-	}
+    @AfterEach
+    void tearDown() throws Exception {
+    }
 
-	@Test
-	void testHasNext() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertFalse(peekingIterator.hasNext());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertTrue(peekingIterator.hasNext());
-	}
+    @Test
+    void testHasNext() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertFalse(peekingIterator.hasNext());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertTrue(peekingIterator.hasNext());
+    }
 
-	@Test
-	void testPeek() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertEquals(null, peekingIterator.peek());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertEquals("A", peekingIterator.peek());
-		assertEquals("A", peekingIterator.next());
-	}
+    @Test
+    void testPeek() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertEquals(null, peekingIterator.peek());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertEquals("A", peekingIterator.peek());
+        assertEquals("A", peekingIterator.next());
+    }
 
-	@Test
-	void testElement() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertEquals(null, peekingIterator.peek());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertEquals("A", peekingIterator.peek());
-		assertEquals(1, peekingIterator.nextIndex());
-	}
+    @Test
+    void testElement() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertEquals(null, peekingIterator.peek());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertEquals("A", peekingIterator.peek());
+        assertEquals(1, peekingIterator.nextIndex());
+    }
 
-	@Test
-	void testNext() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertThrows(NoSuchElementException.class, () -> peekingIterator.next());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertEquals("A", peekingIterator.next());
-	}
+    @Test
+    void testNext() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertThrows(NoSuchElementException.class, () -> peekingIterator.next());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertEquals("A", peekingIterator.next());
+    }
 
-	@Test
-	void testRemove() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertThrows(IllegalStateException.class, () -> peekingIterator.remove());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertThrows(IllegalStateException.class, () -> peekingIterator.remove());
-		String result = peekingIterator.next();
-		assertThrows(UnsupportedOperationException.class, () -> peekingIterator.remove());
-	}
+    @Test
+    void testRemove() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertThrows(IllegalStateException.class, () -> peekingIterator.remove());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertThrows(IllegalStateException.class, () -> peekingIterator.remove());
+        String result = peekingIterator.next();
+        assertThrows(UnsupportedOperationException.class, () -> peekingIterator.remove());
+    }
 
-	@Test
-	void testHasPrevious() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertFalse(peekingIterator.hasPrevious());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertFalse(peekingIterator.hasPrevious());
-		String result = peekingIterator.next();
-		assertTrue(peekingIterator.hasPrevious());
-	}
+    @Test
+    void testHasPrevious() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertFalse(peekingIterator.hasPrevious());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertFalse(peekingIterator.hasPrevious());
+        String result = peekingIterator.next();
+        assertTrue(peekingIterator.hasPrevious());
+    }
 
-	@Test
-	void testPrevious() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertThrows(NoSuchElementException.class, () -> peekingIterator.previous());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertThrows(NoSuchElementException.class, () -> peekingIterator.previous());
-	}
+    @Test
+    void testPrevious() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertThrows(NoSuchElementException.class, () -> peekingIterator.previous());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertThrows(NoSuchElementException.class, () -> peekingIterator.previous());
+    }
 
-	@Test
-	void testNextIndex() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertEquals(0,  peekingIterator.nextIndex());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertEquals(0, peekingIterator.nextIndex());
-	}
+    @Test
+    void testNextIndex() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertEquals(0,  peekingIterator.nextIndex());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertEquals(0, peekingIterator.nextIndex());
+    }
 
-	@Test
-	void testPreviousIndex() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertEquals(-1, peekingIterator.previousIndex());
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertEquals(-1, peekingIterator.previousIndex());
-	}
+    @Test
+    void testPreviousIndex() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertEquals(-1, peekingIterator.previousIndex());
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertEquals(-1, peekingIterator.previousIndex());
+    }
 
-	@Test
-	void testSet() {
-		peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
-		assertThrows(IllegalStateException.class, () -> peekingIterator.set("D"));
-		peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
-		assertThrows(IllegalStateException.class, () -> peekingIterator.set("D"));
-		peekingIterator.next();
-		peekingIterator.set("D");
-		assertEquals(3, NON_EMPTY_LIST.size());
-	}
+    @Test
+    void testSet() {
+        peekingIterator = new PeekingIterator(EMPTY_LIST.listIterator());
+        assertThrows(IllegalStateException.class, () -> peekingIterator.set("D"));
+        peekingIterator = new PeekingIterator(NON_EMPTY_LIST.listIterator());
+        assertThrows(IllegalStateException.class, () -> peekingIterator.set("D"));
+        peekingIterator.next();
+        peekingIterator.set("D");
+        assertEquals(3, NON_EMPTY_LIST.size());
+    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -258,7 +258,7 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
 
         String result = LexicalPreservingPrinter.print(cu.findCompilationUnit().get());
         assertEqualsStringIgnoringEol(
-        		"class X {\n" +
+                "class X {\n" +
                 "  @Test\n" +
                 "  void testCase() {\n" +
                 "  }\n" +

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/quality/PreconditionsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/quality/PreconditionsTest.java
@@ -29,24 +29,24 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PreconditionsTest {
 
-	@Test
-	void checkArgument_withTrueExpression() {
-		checkArgument(true);
-	}
+    @Test
+    void checkArgument_withTrueExpression() {
+        checkArgument(true);
+    }
 
-	@Test
-	void checkArgument_withFalseExpression() {
-		assertThrows(IllegalArgumentException.class, () -> checkArgument(false));
-	}
+    @Test
+    void checkArgument_withFalseExpression() {
+        assertThrows(IllegalArgumentException.class, () -> checkArgument(false));
+    }
 
-	@Test
-	void checkNotNull_withNonNull() {
-		checkNotNull(new Object());
-	}
+    @Test
+    void checkNotNull_withNonNull() {
+        checkNotNull(new Object());
+    }
 
-	@Test
-	void checkNotNull_withNull() {
-		assertThrows(IllegalArgumentException.class, () -> checkNotNull(null));
-	}
+    @Test
+    void checkNotNull_withNull() {
+        assertThrows(IllegalArgumentException.class, () -> checkNotNull(null));
+    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/remove/NodeRemovalTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/remove/NodeRemovalTest.java
@@ -37,61 +37,61 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NodeRemovalTest extends  AbstractLexicalPreservingTest{
-	
-	private final CompilationUnit compilationUnit = new CompilationUnit();
+    
+    private final CompilationUnit compilationUnit = new CompilationUnit();
 
-	@Test
-	void testRemoveClassFromCompilationUnit() {
-		ClassOrInterfaceDeclaration testClass = compilationUnit.addClass("test");
-		assertEquals(1, compilationUnit.getTypes().size());
-		boolean remove = testClass.remove();
-		assertTrue(remove);
-		assertEquals(0, compilationUnit.getTypes().size());
-	}
+    @Test
+    void testRemoveClassFromCompilationUnit() {
+        ClassOrInterfaceDeclaration testClass = compilationUnit.addClass("test");
+        assertEquals(1, compilationUnit.getTypes().size());
+        boolean remove = testClass.remove();
+        assertTrue(remove);
+        assertEquals(0, compilationUnit.getTypes().size());
+    }
 
-	@Test
-	void testRemoveFieldFromClass() {
-		ClassOrInterfaceDeclaration testClass = compilationUnit.addClass("test");
+    @Test
+    void testRemoveFieldFromClass() {
+        ClassOrInterfaceDeclaration testClass = compilationUnit.addClass("test");
 
-		FieldDeclaration addField = testClass.addField(String.class, "test");
-		assertEquals(1, testClass.getMembers().size());
-		boolean remove = addField.remove();
-		assertTrue(remove);
-		assertEquals(0, testClass.getMembers().size());
-	}
+        FieldDeclaration addField = testClass.addField(String.class, "test");
+        assertEquals(1, testClass.getMembers().size());
+        boolean remove = addField.remove();
+        assertTrue(remove);
+        assertEquals(0, testClass.getMembers().size());
+    }
 
-	@Test
-	void testRemoveStatementFromMethodBody() {
-		ClassOrInterfaceDeclaration testClass = compilationUnit.addClass("testC");
+    @Test
+    void testRemoveStatementFromMethodBody() {
+        ClassOrInterfaceDeclaration testClass = compilationUnit.addClass("testC");
 
-		MethodDeclaration addMethod = testClass.addMethod("testM");
-		BlockStmt methodBody = addMethod.createBody();
-		Statement addStatement = methodBody.addAndGetStatement("test");
-		assertEquals(1, methodBody.getStatements().size());
-		boolean remove = addStatement.remove();
-		assertTrue(remove);
-		assertEquals(0, methodBody.getStatements().size());
-	}
+        MethodDeclaration addMethod = testClass.addMethod("testM");
+        BlockStmt methodBody = addMethod.createBody();
+        Statement addStatement = methodBody.addAndGetStatement("test");
+        assertEquals(1, methodBody.getStatements().size());
+        boolean remove = addStatement.remove();
+        assertTrue(remove);
+        assertEquals(0, methodBody.getStatements().size());
+    }
 
-	@Test
-	void testRemoveStatementFromMethodBodyWithLexicalPreservingPrinter() {
-		considerStatement("{\r\n" + "    log.error(\"context\", e);\r\n" +
-				"    log.error(\"context\", e);\r\n" +
-				"    throw new ApplicationException(e);\r\n" + "}\r\n");
-		BlockStmt bstmt = statement.asBlockStmt();
-		List<Node> children = bstmt.getChildNodes();
-		remove(children.get(0));
-		assertTrue(children.size() == 2);
-		remove(children.get(0));
-		assertTrue(children.size() == 1);
-		assertTrue(children.stream().allMatch(n -> n.getParentNode() != null));
-	}
+    @Test
+    void testRemoveStatementFromMethodBodyWithLexicalPreservingPrinter() {
+        considerStatement("{\r\n" + "    log.error(\"context\", e);\r\n" +
+                "    log.error(\"context\", e);\r\n" +
+                "    throw new ApplicationException(e);\r\n" + "}\r\n");
+        BlockStmt bstmt = statement.asBlockStmt();
+        List<Node> children = bstmt.getChildNodes();
+        remove(children.get(0));
+        assertTrue(children.size() == 2);
+        remove(children.get(0));
+        assertTrue(children.size() == 1);
+        assertTrue(children.stream().allMatch(n -> n.getParentNode() != null));
+    }
 
-	// remove the node and parent's node until response is true
-	boolean remove(Node node) {
-		boolean result = node.remove();
-		if (!result && node.getParentNode().isPresent())
-			result = remove(node.getParentNode().get());
-		return result;
-	}
+    // remove the node and parent's node until response is true
+    boolean remove(Node node) {
+        boolean result = node.remove();
+        if (!result && node.getParentNode().isPresent())
+            result = remove(node.getParentNode().get());
+        return result;
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -67,13 +67,13 @@ class SourceRootTest {
 
     @Test
     void saveInCallback() throws IOException {
-    	printer.getConfiguration().addOption(new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER, LineSeparator.LF.asRawString()));
+        printer.getConfiguration().addOption(new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER, LineSeparator.LF.asRawString()));
         sourceRoot.parse("", sourceRoot.getParserConfiguration(), (localPath, absolutePath, result) -> SourceRoot.Callback.Result.SAVE);
     }
 
     @Test
     void saveInCallbackParallelized() {
-    	printer.getConfiguration().addOption(new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER, LineSeparator.LF.asRawString()));
+        printer.getConfiguration().addOption(new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER, LineSeparator.LF.asRawString()));
         sourceRoot.parseParallelized("", sourceRoot.getParserConfiguration(), ((localPath, absolutePath, result) ->
                 SourceRoot.Callback.Result.SAVE));
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
@@ -57,7 +57,7 @@ class VisitorMapTest {
     
     @Test
     void visitorMapGet(){
-    	CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parse("class X{}");
 
         Map<CompilationUnit, Integer> map = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         map.put(x1, 1);
@@ -66,7 +66,7 @@ class VisitorMapTest {
     
     @Test
     void visitorMapContainsKey(){
-    	CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parse("class X{}");
 
         Map<CompilationUnit, Integer> map = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         map.put(x1, 1);
@@ -75,12 +75,12 @@ class VisitorMapTest {
     
     @Test
     void visitorMapPutAll(){
-    	CompilationUnit x1 = parse("class X{}");
-    	CompilationUnit x2 = parse("class Y{}");
-    	Map<CompilationUnit, Integer> map = new HashMap<>();
-    	map.put(x1, 1);
-    	map.put(x2, 2);
-    	Map<CompilationUnit, Integer> visitorMap = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x2 = parse("class Y{}");
+        Map<CompilationUnit, Integer> map = new HashMap<>();
+        map.put(x1, 1);
+        map.put(x2, 2);
+        Map<CompilationUnit, Integer> visitorMap = new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         visitorMap.putAll(map);
         assertEquals(2, visitorMap.size());
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -154,7 +154,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     private static final int LEVELS_TO_EXPLORE = 3;
 
     protected static final PrinterConfiguration prettyPrinterNoCommentsConfiguration = new DefaultPrinterConfiguration()
-			.removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
+            .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
 
     @InternalProperty
     private Range range;
@@ -239,7 +239,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      * @return the range of characters in the source code that this node covers.
      */
     @Override
-	public Optional<Range> getRange() {
+    public Optional<Range> getRange() {
         return Optional.ofNullable(range);
     }
 
@@ -247,12 +247,12 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      * @return the range of tokens that this node covers.
      */
     @Override
-	public Optional<TokenRange> getTokenRange() {
+    public Optional<TokenRange> getTokenRange() {
         return Optional.ofNullable(tokenRange);
     }
 
     @Override
-	public Node setTokenRange(TokenRange tokenRange) {
+    public Node setTokenRange(TokenRange tokenRange) {
         this.tokenRange = tokenRange;
         if (tokenRange == null || !(tokenRange.getBegin().hasRange() && tokenRange.getEnd().hasRange())) {
             range = null;
@@ -267,7 +267,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      *              no range information is known, or that it is not of interest.
      */
     @Override
-	public Node setRange(Range range) {
+    public Node setRange(Range range) {
         if (this.range == range) {
             return this;
         }
@@ -335,13 +335,13 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      * Formatting can be configured with parameter PrinterConfiguration.
      */
     public final String toString(PrinterConfiguration configuration) {
-    	// save the current configuration
-    	PrinterConfiguration previousConfiguration = getPrinter().getConfiguration();
-    	// print with the new configuration
-    	String result = getPrinter(configuration).print(this);
-    	// restore the previous printer configuration (issue 4163)
-    	getPrinter().setConfiguration(previousConfiguration);
-    	return result;
+        // save the current configuration
+        PrinterConfiguration previousConfiguration = getPrinter().getConfiguration();
+        // print with the new configuration
+        String result = getPrinter(configuration).print(this);
+        // restore the previous printer configuration (issue 4163)
+        getPrinter().setConfiguration(previousConfiguration);
+        return result;
     }
 
     @Override
@@ -373,7 +373,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     }
 
     public void addOrphanComment(Comment comment) {
-    	notifyPropertyChange(ObservableProperty.COMMENT, null, comment);
+        notifyPropertyChange(ObservableProperty.COMMENT, null, comment);
         orphanComments.add(comment);
         comment.setParentNode(this);
     }
@@ -1146,7 +1146,7 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
      */
     public boolean hasScope() {
         return (NodeWithOptionalScope.class.isAssignableFrom(this.getClass()) && ((NodeWithOptionalScope) this).getScope().isPresent())
-        		|| (NodeWithScope.class.isAssignableFrom(this.getClass()) && ((NodeWithScope) this).getScope() != null);
+                || (NodeWithScope.class.isAssignableFrom(this.getClass()) && ((NodeWithScope) this).getScope() != null);
     }
 
     /*

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
@@ -89,13 +89,13 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
      * @see Modifier
      */
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<Modifier> getModifiers() {
         return modifiers;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setModifiers(final NodeList<Modifier> modifiers) {
         assertNotNull(modifiers);
@@ -111,13 +111,13 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public SimpleName getName() {
         return name;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setName(final SimpleName name) {
         assertNotNull(name);
@@ -133,13 +133,13 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<Parameter> getParameters() {
         return parameters;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setParameters(final NodeList<Parameter> parameters) {
         assertNotNull(parameters);
@@ -155,13 +155,13 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<ReferenceType> getThrownExceptions() {
         return thrownExceptions;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setThrownExceptions(final NodeList<ReferenceType> thrownExceptions) {
         assertNotNull(thrownExceptions);
@@ -177,13 +177,13 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<TypeParameter> getTypeParameters() {
         return typeParameters;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     @SuppressWarnings("unchecked")
     public T setTypeParameters(final NodeList<TypeParameter> typeParameters) {
         assertNotNull(typeParameters);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CompactConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CompactConstructorDeclaration.java
@@ -122,7 +122,7 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public BlockStmt getBody() {
         return body;
     }
@@ -134,7 +134,7 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
      * @return this, the ConstructorDeclaration
      */
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setBody(final BlockStmt body) {
         assertNotNull(body);
         if (body == this.body) {
@@ -149,13 +149,13 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<Modifier> getModifiers() {
         return modifiers;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setModifiers(final NodeList<Modifier> modifiers) {
         assertNotNull(modifiers);
         if (modifiers == this.modifiers) {
@@ -170,13 +170,13 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public SimpleName getName() {
         return name;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setName(final SimpleName name) {
         assertNotNull(name);
         if (name == this.name) {
@@ -191,13 +191,13 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<ReferenceType> getThrownExceptions() {
         return thrownExceptions;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setThrownExceptions(final NodeList<ReferenceType> thrownExceptions) {
         assertNotNull(thrownExceptions);
         if (thrownExceptions == this.thrownExceptions) {
@@ -212,13 +212,13 @@ public class CompactConstructorDeclaration extends BodyDeclaration<CompactConstr
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<TypeParameter> getTypeParameters() {
         return typeParameters;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public CompactConstructorDeclaration setTypeParameters(final NodeList<TypeParameter> typeParameters) {
         assertNotNull(typeParameters);
         if (typeParameters == this.typeParameters) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/ConstructorDeclaration.java
@@ -99,7 +99,7 @@ public class ConstructorDeclaration extends CallableDeclaration<ConstructorDecla
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public BlockStmt getBody() {
         return body;
     }
@@ -111,7 +111,7 @@ public class ConstructorDeclaration extends CallableDeclaration<ConstructorDecla
      * @return this, the ConstructorDeclaration
      */
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public ConstructorDeclaration setBody(final BlockStmt body) {
         assertNotNull(body);
         if (body == this.body) {
@@ -173,9 +173,9 @@ public class ConstructorDeclaration extends CallableDeclaration<ConstructorDecla
                 sb.append(", ");
             }
             if (includingParameterName) {
-            	sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
+                sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
             } else {
-            	sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
+                sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
             }
         }
         sb.append(")");

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -127,19 +127,19 @@ public class FieldDeclaration extends BodyDeclaration<FieldDeclaration> implemen
      * @see Modifier
      */
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<Modifier> getModifiers() {
         return modifiers;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public NodeList<VariableDeclarator> getVariables() {
         return variables;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public FieldDeclaration setModifiers(final NodeList<Modifier> modifiers) {
         assertNotNull(modifiers);
         if (modifiers == this.modifiers) {
@@ -154,7 +154,7 @@ public class FieldDeclaration extends BodyDeclaration<FieldDeclaration> implemen
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public FieldDeclaration setVariables(final NodeList<VariableDeclarator> variables) {
         assertNotNull(variables);
         if (variables == this.variables) {
@@ -244,7 +244,7 @@ public class FieldDeclaration extends BodyDeclaration<FieldDeclaration> implemen
      */
     @Override
     public boolean isStatic() {
-    	return hasModifier(STATIC) || isDeclaredInInterface();
+        return hasModifier(STATIC) || isDeclaredInInterface();
     }
 
     /*
@@ -252,7 +252,7 @@ public class FieldDeclaration extends BodyDeclaration<FieldDeclaration> implemen
      */
     @Override
     public boolean isFinal() {
-    	return hasModifier(Keyword.FINAL) || isDeclaredInInterface();
+        return hasModifier(Keyword.FINAL) || isDeclaredInInterface();
     }
 
     /*
@@ -260,14 +260,14 @@ public class FieldDeclaration extends BodyDeclaration<FieldDeclaration> implemen
      */
     @Override
     public boolean isPublic() {
-    	return hasModifier(Keyword.PUBLIC) || isDeclaredInInterface();
+        return hasModifier(Keyword.PUBLIC) || isDeclaredInInterface();
     }
 
     /*
      * Returns true if the field is declared in an interface
      */
     private boolean isDeclaredInInterface() {
-    	Optional<TypeDeclaration> parentType = findAncestor(TypeDeclaration.class);
+        Optional<TypeDeclaration> parentType = findAncestor(TypeDeclaration.class);
         return parentType
                 .filter(BodyDeclaration::isClassOrInterfaceDeclaration)
                 .map(BodyDeclaration::asClassOrInterfaceDeclaration)

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -107,7 +107,7 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public Optional<BlockStmt> getBody() {
         return Optional.ofNullable(body);
     }
@@ -119,7 +119,7 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
      * @return this, the MethodDeclaration
      */
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public MethodDeclaration setBody(final BlockStmt body) {
         if (body == this.body) {
             return this;
@@ -133,13 +133,13 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public Type getType() {
         return type;
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public MethodDeclaration setType(final Type type) {
         assertNotNull(type);
         if (type == this.type) {
@@ -221,9 +221,9 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
                 sb.append(", ");
             }
             if (includingParameterName) {
-            	sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
+                sb.append(param.toString(prettyPrinterNoCommentsConfiguration));
             } else {
-            	sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
+                sb.append(param.getType().toString(prettyPrinterNoCommentsConfiguration));
                 if (param.isVarArgs()) {
                     sb.append("...");
                 }
@@ -291,7 +291,7 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
     }
 
     @Override
-	@Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")
+    @Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")
     public MethodDeclaration removeBody() {
         return setBody((BlockStmt) null);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/BlockComment.java
@@ -109,13 +109,13 @@ public class BlockComment extends Comment {
         return Optional.of(this);
     }
 
-	@Override
-	public String getHeader() {
-		return "/*";
-	}
-	
-	@Override
-	public String getFooter() {
-		return "*/";
-	}
+    @Override
+    public String getHeader() {
+        return "/*";
+    }
+    
+    @Override
+    public String getFooter() {
+        return "*/";
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -237,6 +237,6 @@ public abstract class Comment extends Node {
      * Returns the content of the comment with header and footer
      */
     public String asString() {
-    	return getHeader()+getContent()+getFooter();
+        return getHeader()+getContent()+getFooter();
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -113,12 +113,12 @@ public class JavadocComment extends Comment {
     }
     
     @Override
-	public String getHeader() {
-		return "/**";
-	}
-	
-	@Override
-	public String getFooter() {
-		return "*/";
-	}
+    public String getHeader() {
+        return "/**";
+    }
+    
+    @Override
+    public String getFooter() {
+        return "*/";
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/LineComment.java
@@ -109,12 +109,12 @@ public class LineComment extends Comment {
     }
     
     @Override
-	public String getHeader() {
-		return "//";
-	}
-	
-	@Override
-	public String getFooter() {
-		return "";
-	}
+    public String getHeader() {
+        return "//";
+    }
+    
+    @Override
+    public String getFooter() {
+        return "";
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/observer/ObservableProperty.java
@@ -284,7 +284,7 @@ public enum ObservableProperty {
     }
 
     public boolean isNullOrNotPresent(Node node) {
-    	return Utils.valueIsNullOrEmptyStringOrOptional(getRawValue(node));
+        return Utils.valueIsNullOrEmptyStringOrOptional(getRawValue(node));
     }
 
     public boolean isNullOrEmpty(Node node) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ArrayType.java
@@ -134,21 +134,21 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
      */
     @SafeVarargs
     public static Type wrapInArrayTypes(Type type, List<ArrayBracketPair>... arrayBracketPairLists) {
-    	TokenRange outerMostTokenRange = null;
+        TokenRange outerMostTokenRange = null;
         for (int i = arrayBracketPairLists.length - 1; i >= 0; i--) {
             final List<ArrayBracketPair> arrayBracketPairList = arrayBracketPairLists[i];
             if (arrayBracketPairList != null) {
                 for (int j = arrayBracketPairList.size() - 1; j >= 0; j--) {
                     ArrayBracketPair pair = arrayBracketPairList.get(j);
                     if (type.getTokenRange().isPresent() && pair.getTokenRange().isPresent()) {
-                    	TokenRange currentTokenRange = new TokenRange(type.getTokenRange().get().getBegin(), pair.getTokenRange().get().getEnd());
-                    	// The end range must be equals to the last array bracket pair in the list
-                    	// in the example below:
-                    	// Long[][]
-                    	//        ^
-                    	//        |
-                    	// this is the outermost range for the ArrayType
-                    	outerMostTokenRange = getOuterMostTokenRange(currentTokenRange, outerMostTokenRange);
+                        TokenRange currentTokenRange = new TokenRange(type.getTokenRange().get().getBegin(), pair.getTokenRange().get().getEnd());
+                        // The end range must be equals to the last array bracket pair in the list
+                        // in the example below:
+                        // Long[][]
+                        //        ^
+                        //        |
+                        // this is the outermost range for the ArrayType
+                        outerMostTokenRange = getOuterMostTokenRange(currentTokenRange, outerMostTokenRange);
                     }
                     type = new ArrayType(outerMostTokenRange, type, pair.getOrigin(), pair.getAnnotations());
                 }
@@ -161,11 +161,11 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
      * Returns a {@code TokenRange} with the outermost ending token
      */
     private static TokenRange getOuterMostTokenRange(TokenRange tokenRange1, TokenRange tokenRange2) {
-    	if (tokenRange2 == null) return tokenRange1;
-    	if (tokenRange1.getEnd().getRange().get().isAfter(tokenRange2.getEnd().getRange().get())) {
-    		return tokenRange1;
-    	}
-    	return new TokenRange(tokenRange1.getBegin(), tokenRange2.getEnd());
+        if (tokenRange2 == null) return tokenRange1;
+        if (tokenRange1.getEnd().getRange().get().isAfter(tokenRange2.getEnd().getRange().get())) {
+            return tokenRange1;
+        }
+        return new TokenRange(tokenRange1.getBegin(), tokenRange2.getEnd());
     }
     
     /**
@@ -330,8 +330,8 @@ public class ArrayType extends ReferenceType implements NodeWithAnnotations<Arra
         return 1 + this.getComponentType().getArrayLevel();
     }
 
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		return new ResolvedArrayType(getComponentType().convertToUsage(context));
-	}
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        return new ResolvedArrayType(getComponentType().convertToUsage(context));
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -339,9 +339,9 @@ public class ClassOrInterfaceType extends ReferenceType implements NodeWithSimpl
      *
      * @return The type resolved.
      */
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		String name = getNameWithScope();
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        String name = getNameWithScope();
         SymbolReference<ResolvedTypeDeclaration> ref = context.solveType(name);
         if (!ref.isSolved()) {
             throw new UnsolvedSymbolException(name);
@@ -355,5 +355,5 @@ public class ClassOrInterfaceType extends ReferenceType implements NodeWithSimpl
             return new ResolvedTypeVariable(typeDeclaration.asTypeParameter());
         }
         return new ReferenceTypeImpl((ResolvedReferenceTypeDeclaration) typeDeclaration, typeParameters);
-	}
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ConvertibleToUsage.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ConvertibleToUsage.java
@@ -29,5 +29,5 @@ import com.github.javaparser.resolution.types.ResolvedType;
  */
 public interface ConvertibleToUsage {
 
-	ResolvedType convertToUsage(Context context);
+    ResolvedType convertToUsage(Context context);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/IntersectionType.java
@@ -188,8 +188,8 @@ public class IntersectionType extends Type implements NodeWithAnnotations<Inters
         return Optional.of(this);
     }
 
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		throw new UnsupportedOperationException(getClass().getCanonicalName());
-	}
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        throw new UnsupportedOperationException(getClass().getCanonicalName());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -263,8 +263,8 @@ public class PrimitiveType extends Type implements NodeWithAnnotations<Primitive
         return Optional.of(this);
     }
 
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		return ResolvedPrimitiveType.byName(getType().name());
-	}
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        return ResolvedPrimitiveType.byName(getType().name());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/TypeParameter.java
@@ -245,8 +245,8 @@ public class TypeParameter extends ReferenceType implements NodeWithSimpleName<T
         return Optional.of(this);
     }
 
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		throw new UnsupportedOperationException(getClass().getCanonicalName());
-	}
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        throw new UnsupportedOperationException(getClass().getCanonicalName());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnionType.java
@@ -199,11 +199,11 @@ public class UnionType extends Type implements NodeWithAnnotations<UnionType> {
         return Optional.of(this);
     }
 
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		List<ResolvedType> resolvedElements = getElements().stream()
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        List<ResolvedType> resolvedElements = getElements().stream()
                 .map(el -> el.convertToUsage(context))
                 .collect(Collectors.toList());
         return new ResolvedUnionType(resolvedElements);
-	}
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/UnknownType.java
@@ -144,8 +144,8 @@ public class UnknownType extends Type {
      *
      * @return The type resolved.
      */
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		throw new IllegalArgumentException("Inferred lambda parameter type");
-	}
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        throw new IllegalArgumentException("Inferred lambda parameter type");
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VarType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VarType.java
@@ -54,8 +54,8 @@ import java.util.function.Consumer;
  * </ol>
  */
 public class VarType extends Type {
-	
-	private static final String JAVA_LANG_OBJECT = Object.class.getCanonicalName();
+    
+    private static final String JAVA_LANG_OBJECT = Object.class.getCanonicalName();
 
     @AllFieldsConstructor
     public VarType() {
@@ -134,9 +134,9 @@ public class VarType extends Type {
         action.accept(this);
     }
 
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		Node parent = getParentNode().get();
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        Node parent = getParentNode().get();
         if (!(parent instanceof VariableDeclarator)) {
             throw new IllegalStateException("Trying to resolve a `var` which is not in a variable declaration.");
         }
@@ -157,14 +157,14 @@ public class VarType extends Type {
                 if (iterType.isReferenceType()) {
                     // The type of a variable in a for-each loop with an
                     // Iterable with parameter type
-                	List<ResolvedType> parametersType = iterType.asReferenceType().typeParametersMap().getTypes();
-					if (parametersType.isEmpty()) {
-						Optional<ResolvedTypeDeclaration> oObjectDeclaration = context.solveType(JAVA_LANG_OBJECT)
-								.getDeclaration();
-						return oObjectDeclaration
-								.map(decl -> ReferenceTypeImpl.undeterminedParameters(decl.asReferenceType()))
-								.orElseThrow(() -> new UnsupportedOperationException());
-					}
+                    List<ResolvedType> parametersType = iterType.asReferenceType().typeParametersMap().getTypes();
+                    if (parametersType.isEmpty()) {
+                        Optional<ResolvedTypeDeclaration> oObjectDeclaration = context.solveType(JAVA_LANG_OBJECT)
+                                .getDeclaration();
+                        return oObjectDeclaration
+                                .map(decl -> ReferenceTypeImpl.undeterminedParameters(decl.asReferenceType()))
+                                .orElseThrow(() -> new UnsupportedOperationException());
+                    }
                     return parametersType.get(0);
                 }
             }
@@ -172,9 +172,9 @@ public class VarType extends Type {
         return initializer
                 .map(Expression::calculateResolvedType)
                 .orElseThrow(() -> new IllegalStateException("Cannot resolve `var` which has no initializer."));
-	}
-	
-	private Optional<ForEachStmt> forEachStmtWithVariableDeclarator(
+    }
+    
+    private Optional<ForEachStmt> forEachStmtWithVariableDeclarator(
             VariableDeclarator variableDeclarator) {
         Optional<Node> node = variableDeclarator.getParentNode();
         if (!node.isPresent() || !(node.get() instanceof VariableDeclarationExpr)) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/VoidType.java
@@ -129,8 +129,8 @@ public class VoidType extends Type implements NodeWithAnnotations<VoidType> {
         return Optional.of(this);
     }
 
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		return ResolvedVoidType.INSTANCE;
-	}
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        return ResolvedVoidType.INSTANCE;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/WildcardType.java
@@ -266,17 +266,17 @@ public class WildcardType extends Type implements NodeWithAnnotations<WildcardTy
      *
      * @return The type resolved.
      */
-	@Override
-	public ResolvedType convertToUsage(Context context) {
-		if (getExtendedType().isPresent() && !getSuperType().isPresent()) {
-			return ResolvedWildcard.extendsBound(getExtendedType().get().convertToUsage(context)); // removed (ReferenceTypeImpl)
-		}
-		if (!getExtendedType().isPresent() && getSuperType().isPresent()) {
-			return ResolvedWildcard.superBound(getSuperType().get().convertToUsage(context)); // removed (ReferenceTypeImpl)
-		}
-		if (!getExtendedType().isPresent() && !getSuperType().isPresent()) {
-			return ResolvedWildcard.UNBOUNDED;
-		}
-		throw new UnsupportedOperationException(toString());
-	}
+    @Override
+    public ResolvedType convertToUsage(Context context) {
+        if (getExtendedType().isPresent() && !getSuperType().isPresent()) {
+            return ResolvedWildcard.extendsBound(getExtendedType().get().convertToUsage(context)); // removed (ReferenceTypeImpl)
+        }
+        if (!getExtendedType().isPresent() && getSuperType().isPresent()) {
+            return ResolvedWildcard.superBound(getSuperType().get().convertToUsage(context)); // removed (ReferenceTypeImpl)
+        }
+        if (!getExtendedType().isPresent() && !getSuperType().isPresent()) {
+            return ResolvedWildcard.UNBOUNDED;
+        }
+        throw new UnsupportedOperationException(toString());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java17Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java17Validator.java
@@ -30,8 +30,8 @@ import com.github.javaparser.ast.validator.Validator;
  */
 public class Java17Validator extends Java16Validator {
 
-	final Validator sealedNotAllowedAsIdentifier = new ReservedKeywordValidator("sealed");
-	final Validator permitsNotAllowedAsIdentifier = new ReservedKeywordValidator("permits");
+    final Validator sealedNotAllowedAsIdentifier = new ReservedKeywordValidator("sealed");
+    final Validator permitsNotAllowedAsIdentifier = new ReservedKeywordValidator("permits");
 
     public Java17Validator() {
         super();

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -56,7 +56,7 @@ import com.github.javaparser.printer.configuration.imports.DefaultImportOrdering
  */
 public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
 
-	private static Pattern RTRIM = Pattern.compile("\\s+$");
+    private static Pattern RTRIM = Pattern.compile("\\s+$");
 
     protected final PrinterConfiguration configuration;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -57,7 +57,7 @@ import com.github.javaparser.printer.configuration.PrettyPrinterConfiguration;
 @Deprecated
 public class PrettyPrintVisitor implements VoidVisitor<Void> {
 
-	private static Pattern RTRIM = Pattern.compile("\\s+$");
+    private static Pattern RTRIM = Pattern.compile("\\s+$");
 
     protected PrettyPrinterConfiguration configuration;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmComment.java
@@ -28,9 +28,9 @@ public class CsmComment implements CsmElement {
 
     static void process(Comment comment, SourcePrinter printer) {
         String content = printer.normalizeEolInTextBlock(comment.getContent());
-		printer.print(comment.getHeader());
-		printer.print(content);
-		printer.println(comment.getFooter());
+        printer.print(comment.getHeader());
+        printer.print(content);
+        printer.println(comment.getFooter());
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmElement.java
@@ -154,6 +154,6 @@ public interface CsmElement {
      * Verifies if the content of the {@code CsmElement} is the same as the provided {@code TextElement}
      */
     default boolean isCorrespondingElement(TextElement textElement) {
-    	return false;
+        return false;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmIndent.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmIndent.java
@@ -37,8 +37,8 @@ public class CsmIndent implements CsmElement {
      */
     @Override
     public boolean isCorrespondingElement(TextElement textElement) {
-    	return (textElement instanceof TokenTextElement)
-    			&& ((TokenTextElement)textElement).isSpaceOrTab();
+        return (textElement instanceof TokenTextElement)
+                && ((TokenTextElement)textElement).isSpaceOrTab();
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmToken.java
@@ -118,8 +118,8 @@ public class CsmToken implements CsmElement {
      */
     @Override
     public boolean isCorrespondingElement(TextElement textElement) {
-    	return (textElement instanceof TokenTextElement)
-    			&& ((TokenTextElement)textElement).getTokenKind() == getTokenType()
-    			&& ((TokenTextElement)textElement).getText().equals(getContent());
+        return (textElement instanceof TokenTextElement)
+                && ((TokenTextElement)textElement).getTokenKind() == getTokenType()
+                && ((TokenTextElement)textElement).getText().equals(getContent());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ChildTextElement.java
@@ -135,9 +135,9 @@ public class ChildTextElement extends TextElement {
         return child.getRange();
     }
 
-	@Override
-	public void accept(LexicalPreservingVisitor visitor) {
-		NodeText nodeText = getNodeTextForWrappedNode();
-		nodeText.getElements().forEach(element -> element.accept(visitor));
-	}
+    @Override
+    public void accept(LexicalPreservingVisitor visitor) {
+        NodeText nodeText = getNodeTextForWrappedNode();
+        nodeText.getElements().forEach(element -> element.accept(visitor));
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -98,15 +98,15 @@ public class Difference {
      * Meaning that when an element is encountered that does not match the predicate, the rest of the list is discarded.
      */
     List<TextElement> takeWhile(List<TextElement> prevElements, Predicate<TextElement> predicate) {
-    	List<TextElement> spaces = new ArrayList<>();
-    	for (TextElement element : prevElements) {
-    		if (predicate.test(element)) {
-    			spaces.add(element);
+        List<TextElement> spaces = new ArrayList<>();
+        for (TextElement element : prevElements) {
+            if (predicate.test(element)) {
+                spaces.add(element);
                 continue;
             }
             break;
-    	}
-    	return spaces;
+        }
+        return spaces;
     }
 
 
@@ -133,7 +133,7 @@ public class Difference {
                 continue;
             }
             if (element.isComment()) {
-            	return iterator.index();
+                return iterator.index();
             }
             break;
         }
@@ -144,27 +144,27 @@ public class Difference {
      * Returns true if the next element in the list (starting from @{code fromIndex}) is a comment
      */
     private boolean isFollowedByComment(int fromIndex, List<TextElement> elements) {
-    	return posOfNextComment(fromIndex, elements) != -1;
+        return posOfNextComment(fromIndex, elements) != -1;
     }
 
     /*
      * Removes all elements in the list starting from @{code fromIndex}) ending to @{code toIndex})
      */
     private void removeElements(int fromIndex, int toIndex, List<TextElement> elements) {
-    	if (!(isValidIndex(fromIndex, elements) && isValidIndex(toIndex, elements) && fromIndex <= toIndex))
+        if (!(isValidIndex(fromIndex, elements) && isValidIndex(toIndex, elements) && fromIndex <= toIndex))
             return;
         ListIterator<TextElement> iterator = elements.listIterator(fromIndex);
         // removing elements
         int count = fromIndex;
         while (iterator.hasNext() && count <= toIndex) {
-        	iterator.next();
+            iterator.next();
             iterator.remove();
             count++;
         }
     }
 
     private boolean isValidIndex(int index, List<?> elements) {
-    	return index >= 0 && index <= elements.size();
+        return index >= 0 && index <= elements.size();
     }
 
     /*
@@ -230,7 +230,7 @@ public class Difference {
         // the next position in the list (by default the current position)
         int res = nodeTextIndex;
         if (enforcingIndentationContext.extraCharacters > 0) {
-        	int extraCharacters = enforcingIndentationContext.extraCharacters > numberOfCharactersToPreserve ? enforcingIndentationContext.extraCharacters - numberOfCharactersToPreserve : 0;
+            int extraCharacters = enforcingIndentationContext.extraCharacters > numberOfCharactersToPreserve ? enforcingIndentationContext.extraCharacters - numberOfCharactersToPreserve : 0;
             res = removeExtraCharacters(nodeText, enforcingIndentationContext.start, extraCharacters);
             // The next position must take into account the indentation
             res = extraCharacters > 0 ? res + numberOfCharactersToPreserve : res;
@@ -242,23 +242,23 @@ public class Difference {
     }
 
     private boolean isEnforcingIndentationActivable(RemovedGroup removedGroup) {
-		return (isLastElement(diffElements, diffIndex) || !(nextDiffElement(diffElements,diffIndex).isAdded()))
-				&& originalIndex < originalElements.size()
-				&& !removedGroup.isACompleteLine();
-	}
+        return (isLastElement(diffElements, diffIndex) || !(nextDiffElement(diffElements,diffIndex).isAdded()))
+                && originalIndex < originalElements.size()
+                && !removedGroup.isACompleteLine();
+    }
 
     private boolean isRemovingIndentationActivable(RemovedGroup removedGroup) {
-		return (isLastElement(diffElements, diffIndex) || !(nextDiffElement(diffElements,diffIndex).isAdded()))
-				&& originalIndex < originalElements.size()
-				&& removedGroup.isACompleteLine();
-	}
+        return (isLastElement(diffElements, diffIndex) || !(nextDiffElement(diffElements,diffIndex).isAdded()))
+                && originalIndex < originalElements.size()
+                && removedGroup.isACompleteLine();
+    }
 
     private boolean isLastElement(List<?> list, int index) {
-		return index + 1 >= list.size();
-	}
+        return index + 1 >= list.size();
+    }
 
     private DifferenceElement nextDiffElement(List<DifferenceElement> list, int index) {
-    	return list.get(index + 1);
+        return list.get(index + 1);
     }
 
     /*
@@ -266,15 +266,15 @@ public class Difference {
      * and the number of consecutive whitespace (or tab) characters
      */
     private class EnforcingIndentationContext {
-    	int start;
-    	int extraCharacters;
-    	public EnforcingIndentationContext(int start) {
-    		this(start,0);
-    	}
-    	public EnforcingIndentationContext(int start, int extraCharacters) {
-    		this.start=start;
-    		this.extraCharacters=extraCharacters;
-    	}
+        int start;
+        int extraCharacters;
+        public EnforcingIndentationContext(int start) {
+            this(start,0);
+        }
+        public EnforcingIndentationContext(int start, int extraCharacters) {
+            this.start=start;
+            this.extraCharacters=extraCharacters;
+        }
     }
 
     /**
@@ -301,35 +301,35 @@ public class Difference {
      * The number of consecutive whitespace (or tab) characters
      */
     private EnforcingIndentationContext defineEnforcingIndentationContext(NodeText nodeText, int startIndex) {
-    	EnforcingIndentationContext ctx = new EnforcingIndentationContext(startIndex);
-    	// compute space before startIndex value
-		if (startIndex < nodeText.numberOfElements() && startIndex > 0) {
-			// at this stage startIndex points to the first element before the deleted one
-			for (int i = startIndex - 1; i >= 0 && i < nodeText.numberOfElements(); i--) {
-				if (nodeText.getTextElement(i).isNewline()) {
-					break;
-				}
-				if (!isSpaceOrTabElement(nodeText, i)) {
-					ctx = new EnforcingIndentationContext(startIndex);
-					break;
-				}
-				ctx.start = i;
-				ctx.extraCharacters++;
-			}
-		}
-		// compute space after the deleted element
-		if (startIndex < nodeText.numberOfElements() && isSpaceOrTabElement(nodeText, startIndex)) {
-//			int startingFromIndex = startIndex == 0 ? startIndex : startIndex + 1;
-			for (int i = startIndex; i >= 0 && i < nodeText.numberOfElements(); i++) {
-				if (nodeText.getTextElement(i).isNewline()) {
-					break;
-				}
-				if (!isSpaceOrTabElement(nodeText, i)) {
-					break;
-				}
-				ctx.extraCharacters++;
-			}
-		}
+        EnforcingIndentationContext ctx = new EnforcingIndentationContext(startIndex);
+        // compute space before startIndex value
+        if (startIndex < nodeText.numberOfElements() && startIndex > 0) {
+            // at this stage startIndex points to the first element before the deleted one
+            for (int i = startIndex - 1; i >= 0 && i < nodeText.numberOfElements(); i--) {
+                if (nodeText.getTextElement(i).isNewline()) {
+                    break;
+                }
+                if (!isSpaceOrTabElement(nodeText, i)) {
+                    ctx = new EnforcingIndentationContext(startIndex);
+                    break;
+                }
+                ctx.start = i;
+                ctx.extraCharacters++;
+            }
+        }
+        // compute space after the deleted element
+        if (startIndex < nodeText.numberOfElements() && isSpaceOrTabElement(nodeText, startIndex)) {
+//            int startingFromIndex = startIndex == 0 ? startIndex : startIndex + 1;
+            for (int i = startIndex; i >= 0 && i < nodeText.numberOfElements(); i++) {
+                if (nodeText.getTextElement(i).isNewline()) {
+                    break;
+                }
+                if (!isSpaceOrTabElement(nodeText, i)) {
+                    break;
+                }
+                ctx.extraCharacters++;
+            }
+        }
 
         return ctx;
     }
@@ -337,16 +337,16 @@ public class Difference {
     /*
      * Returns true if the indexed element is a space or a tab
      */
-	private boolean isSpaceOrTabElement(NodeText nodeText, int i) {
-		return nodeText.getTextElement(i).isSpaceOrTab();
-	}
+    private boolean isSpaceOrTabElement(NodeText nodeText, int i) {
+        return nodeText.getTextElement(i).isSpaceOrTab();
+    }
 
     /**
      * Node that we have calculate the Difference we can apply to a concrete NodeText, modifying it according
      * to the difference (adding and removing the elements provided).
      */
     void apply() {
-    	ReshuffledDiffElementExtractor.of(nodeText).extract(diffElements);
+        ReshuffledDiffElementExtractor.of(nodeText).extract(diffElements);
         Map<Removed, RemovedGroup> removedGroups = combineRemovedElementsToRemovedGroups();
         do {
             boolean isLeftOverDiffElement = applyLeftOverDiffElements();
@@ -470,7 +470,7 @@ public class Difference {
                 // (in the latter case we keep the indentation)
                 // then we want to enforce the indentation.
                 if (isEnforcingIndentationActivable(removedGroup)) {
-                	// Since the element has been deleted we try to start the analysis from the element following the one that was deleted
+                    // Since the element has been deleted we try to start the analysis from the element following the one that was deleted
                     originalIndex = considerEnforcingIndentation(nodeText, originalIndex);
                 }
                 // If in front we have one space and before also we had space let's drop one space
@@ -488,19 +488,19 @@ public class Difference {
                 // We need to know if, in the original list of elements, the deleted child node is immediately followed by the same comment.
                 // If so, it should also be deleted.
                 if (isFollowedByComment(originalIndex, originalElements) ) {
-                	int indexOfNextComment = posOfNextComment(originalIndex, originalElements);
-                	removeElements(originalIndex, indexOfNextComment, originalElements);
+                    int indexOfNextComment = posOfNextComment(originalIndex, originalElements);
+                    removeElements(originalIndex, indexOfNextComment, originalElements);
                 }
                 if (isRemovingIndentationActivable(removedGroup)) {
-                	// Since the element has been deleted we try to start the analysis from the previous element
+                    // Since the element has been deleted we try to start the analysis from the previous element
                     originalIndex = considerRemovingIndentation(nodeText, originalIndex);
                 }
                 diffIndex++;
             }
         } else if (removed.isChild() && originalElement.isComment()) {
-        	// removing the comment first
-        	nodeText.removeElement(originalIndex);
-        	if (isRemovingIndentationActivable(removedGroup)) {
+            // removing the comment first
+            nodeText.removeElement(originalIndex);
+            if (isRemovingIndentationActivable(removedGroup)) {
                 originalIndex = considerRemovingIndentation(nodeText, originalIndex);
             }
         } else if (removed.isToken() && originalElementIsToken && (removed.getTokenType() == ((TokenTextElement) originalElement).getTokenKind() || // handle EOLs separately as their token kind might not be equal. This is because the 'removed'
@@ -509,14 +509,14 @@ public class Difference {
             nodeText.removeElement(originalIndex);
             diffIndex++;
         } else if ((removed.isWhiteSpaceNotEol() || removed.getElement() instanceof CsmIndent || removed.getElement() instanceof CsmUnindent)
-        		&& originalElement.isSpaceOrTab()){
-        	// remove the current space
-        	nodeText.removeElement(originalIndex);
+                && originalElement.isSpaceOrTab()){
+            // remove the current space
+            nodeText.removeElement(originalIndex);
         }else if (originalElementIsToken && originalElement.isWhiteSpaceOrComment()) {
             originalIndex++;
             // skip the newline token which may be generated unnecessarily by the concrete syntax pattern
             if (removed.isNewLine()) {
-            	diffIndex++;
+                diffIndex++;
             }
         } else if (originalElement.isLiteral()) {
             nodeText.removeElement(originalIndex);
@@ -553,9 +553,9 @@ public class Difference {
         // we dont want to remove the indentation if the last removed element is a newline
         // because in this case we are trying to remove the indentation of the next child element
         if (!removedGroup.isProcessed()
-        		&& removedGroup.isLastElement(removed)
-        		&& removedGroup.isACompleteLine()
-        		&& !removed.isNewLine()) {
+                && removedGroup.isLastElement(removed)
+                && removedGroup.isACompleteLine()
+                && !removed.isNewLine()) {
             Integer lastElementIndex = removedGroup.getLastElementIndex();
             Optional<Integer> indentation = removedGroup.getIndentation();
             if (indentation.isPresent() && !isReplaced(lastElementIndex)) {
@@ -570,8 +570,8 @@ public class Difference {
                     }
                     // Remove remaining newline character if needed
                     if (nodeText.getTextElement(originalIndex).isNewline()) {
-                    	nodeText.removeElement(originalIndex);
-                    	originalIndex = originalIndex > 0 ? originalIndex-- : 0;
+                        nodeText.removeElement(originalIndex);
+                        originalIndex = originalIndex > 0 ? originalIndex-- : 0;
                     }
                 }
             }
@@ -584,8 +584,8 @@ public class Difference {
     // increment originalIndex if we want to keep the original element
     // increment diffIndex if we want to skip the diff element
     private void applyKeptDiffElement(Kept kept, TextElement originalElement, boolean originalElementIsChild, boolean originalElementIsToken) {
-		if (originalElement.isComment()) {
-			originalIndex++;
+        if (originalElement.isComment()) {
+            originalIndex++;
         } else if (kept.isChild() && ((CsmChild) kept.getElement()).getChild() instanceof Comment) {
             diffIndex++;
         } else if (kept.isChild() && originalElementIsChild) {
@@ -899,9 +899,9 @@ public class Difference {
             boolean currentIsNewline = nodeText.getTextElement(originalIndex).isNewline();
             boolean isFirstElement = originalIndex == 0;
             boolean previousIsWhiteSpace = originalIndex > 0 && nodeText.getTextElement(originalIndex - 1).isWhiteSpace();
-			boolean commentIsBeforeAddedElement = currentIsAComment && addedTextElement.getRange().isPresent()
-					&& nodeText.getTextElement(originalIndex).getRange()
-							.map(range -> range.isBefore(addedTextElement.getRange().get())).orElse(false);
+            boolean commentIsBeforeAddedElement = currentIsAComment && addedTextElement.getRange().isPresent()
+                    && nodeText.getTextElement(originalIndex).getRange()
+                            .map(range -> range.isBefore(addedTextElement.getRange().get())).orElse(false);
             if (sufficientTokensRemainToSkip && currentIsAComment && commentIsBeforeAddedElement) {
                 // Need to get behind the comment:
                 // FIXME: Why 2? This comment and the next newline?
@@ -937,9 +937,9 @@ public class Difference {
                 if (!isPreviousElementNewline && !isFirstElement && !previousIsWhiteSpace) {
                     // Insert after the new line
                     originalIndex++;
-					// We want to adjust the indentation while considering the new element that we
-					// added
-					originalIndex = adjustIndentation(indentation, nodeText, originalIndex, false);
+                    // We want to adjust the indentation while considering the new element that we
+                    // added
+                    originalIndex = adjustIndentation(indentation, nodeText, originalIndex, false);
                 }
                 nodeText.addElement(originalIndex, addedTextElement);
                 originalIndex++;
@@ -963,66 +963,66 @@ public class Difference {
      * A list iterator which provides a method to know the current positioning
      */
     public static class ArrayIterator<T> implements ListIterator<T> {
-    	ListIterator<T> iterator;
-    	public ArrayIterator(List<T> elements) {
-    		this(elements, 0);
-    	}
+        ListIterator<T> iterator;
+        public ArrayIterator(List<T> elements) {
+            this(elements, 0);
+        }
 
-    	public ArrayIterator(List<T> elements, int index) {
-    		this.iterator = elements.listIterator(index);
-    	}
+        public ArrayIterator(List<T> elements, int index) {
+            this.iterator = elements.listIterator(index);
+        }
 
-		@Override
-		public boolean hasNext() {
-			return iterator.hasNext();
-		}
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
 
-		@Override
-		public T next() {
-			return iterator.next();
-		}
+        @Override
+        public T next() {
+            return iterator.next();
+        }
 
-		@Override
-		public boolean hasPrevious() {
-			return iterator.hasPrevious();
-		}
+        @Override
+        public boolean hasPrevious() {
+            return iterator.hasPrevious();
+        }
 
-		@Override
-		public T previous() {
-			return iterator.previous();
-		}
+        @Override
+        public T previous() {
+            return iterator.previous();
+        }
 
-		@Override
-		public int nextIndex() {
-			return iterator.nextIndex();
-		}
+        @Override
+        public int nextIndex() {
+            return iterator.nextIndex();
+        }
 
-		@Override
-		public int previousIndex() {
-			return iterator.previousIndex();
-		}
+        @Override
+        public int previousIndex() {
+            return iterator.previousIndex();
+        }
 
-		/*
-		 * Returns the current index in the underlying list
-		 */
-		public int index() {
-			return iterator.nextIndex() - 1;
-		}
+        /*
+         * Returns the current index in the underlying list
+         */
+        public int index() {
+            return iterator.nextIndex() - 1;
+        }
 
-		@Override
-		public void remove() {
-			iterator.remove();;
-		}
+        @Override
+        public void remove() {
+            iterator.remove();;
+        }
 
-		@Override
-		public void set(T e) {
-			iterator.set(e);
-		}
+        @Override
+        public void set(T e) {
+            iterator.set(e);
+        }
 
-		@Override
-		public void add(T e) {
-			iterator.add(e);;
-		}
+        @Override
+        public void add(T e) {
+            iterator.add(e);;
+        }
 
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
@@ -56,10 +56,10 @@ class DifferenceElementCalculator {
             // in this case we consider that nodes are not equals
             // If the nodes have no declared position they are considered equal.
             return this.node.equals(cpi.node) 
-            		&& (this.node.hasRange() == false && cpi.node.hasRange() == false
-            			||	(this.node.hasRange() && cpi.node.hasRange() && this.node.getRange().get().contains(cpi.node.getRange().get())
-            			)
-            		);
+                    && (this.node.hasRange() == false && cpi.node.hasRange() == false
+                        ||    (this.node.hasRange() && cpi.node.hasRange() && this.node.getRange().get().contains(cpi.node.getRange().get())
+                        )
+                    );
         }
 
         @Override
@@ -194,47 +194,47 @@ class DifferenceElementCalculator {
             final int currentPosOfNextChildInOriginal = posOfNextChildInOriginal;
             final int currentPosOfNextChildInAfter = posOfNextChildInAfter;
             posOfNextChildInOriginal = childrenInOriginal.stream()
-            		.filter(i -> i.equals(child))
-            		.map(i -> i.position)
-            		.filter(position -> position > currentPosOfNextChildInOriginal)
-            		.findFirst().orElse(posOfNextChildInOriginal);
+                    .filter(i -> i.equals(child))
+                    .map(i -> i.position)
+                    .filter(position -> position > currentPosOfNextChildInOriginal)
+                    .findFirst().orElse(posOfNextChildInOriginal);
             // search the position of the node "child" in the modified list of cms element
             posOfNextChildInAfter = childrenInAfter.stream()
-            		.filter(i -> i.equals(child))
-            		.map(i -> i.position)
-            		.filter(position -> position > currentPosOfNextChildInAfter)
-            		.findFirst().orElse(posOfNextChildInAfter);
+                    .filter(i -> i.equals(child))
+                    .map(i -> i.position)
+                    .filter(position -> position > currentPosOfNextChildInAfter)
+                    .findFirst().orElse(posOfNextChildInAfter);
             // Imagine that the common elements has been moved, for example in the case where the parameters of a method are reversed
-			// In this case the afterIndex will be greater than the position of the child in
-			// the list
-			// For example : if {@code new Foo(a, b)} become {@code new Foo(b, a)}
-			// Nota: in this example there is 3 child elements Foo, 'a' and 'b', others are tokens
-			// In the orginal list the child element 'a' is at the position 5 and the
-			// element 'b' is at the position 8
-			// After reverting the list of parameters the child element 'a' is at the
-			// position 8 and the element 'b' is at the position 5
-			// When we deal with element 'b', it is in 5th position in the list after the
-			// modification but the previous position in the list was that of element 'a'.
+            // In this case the afterIndex will be greater than the position of the child in
+            // the list
+            // For example : if {@code new Foo(a, b)} become {@code new Foo(b, a)}
+            // Nota: in this example there is 3 child elements Foo, 'a' and 'b', others are tokens
+            // In the orginal list the child element 'a' is at the position 5 and the
+            // element 'b' is at the position 8
+            // After reverting the list of parameters the child element 'a' is at the
+            // position 8 and the element 'b' is at the position 5
+            // When we deal with element 'b', it is in 5th position in the list after the
+            // modification but the previous position in the list was that of element 'a'.
             if (originalIndex < posOfNextChildInOriginal || afterIndex < posOfNextChildInAfter) {
-            	// defines the sublist of elements located before the common element  
-            	CalculatedSyntaxModel originalSub = originalIndex < posOfNextChildInOriginal ? original.sub(originalIndex, posOfNextChildInOriginal) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
-            	CalculatedSyntaxModel afterSub = afterIndex < posOfNextChildInAfter ? after.sub(afterIndex, posOfNextChildInAfter) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
+                // defines the sublist of elements located before the common element  
+                CalculatedSyntaxModel originalSub = originalIndex < posOfNextChildInOriginal ? original.sub(originalIndex, posOfNextChildInOriginal) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
+                CalculatedSyntaxModel afterSub = afterIndex < posOfNextChildInAfter ? after.sub(afterIndex, posOfNextChildInAfter) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
                 elements.addAll(calculateImpl(originalSub, afterSub));
             }
             if (afterIndex <= posOfNextChildInAfter) {
-            	// we need to keep the current common node
-            	elements.add(new Kept(new CsmChild(child.node)));
+                // we need to keep the current common node
+                elements.add(new Kept(new CsmChild(child.node)));
             } else {
-            	// In this case the current node was not found in the list after change
-            	// so we need to remove it.
-            	elements.add(new Removed(new CsmChild(child.node)));
+                // In this case the current node was not found in the list after change
+                // so we need to remove it.
+                elements.add(new Removed(new CsmChild(child.node)));
             }
             originalIndex = originalIndex <= posOfNextChildInOriginal ? posOfNextChildInOriginal + 1 : originalIndex;
             afterIndex = afterIndex <= posOfNextChildInAfter ? posOfNextChildInAfter + 1 : afterIndex;
         }
         if (originalIndex < original.elements.size() || afterIndex < after.elements.size()) {
-        	CalculatedSyntaxModel originalSub = originalIndex < original.elements.size() ? original.sub(originalIndex, original.elements.size()) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
-        	CalculatedSyntaxModel afterSub = afterIndex < after.elements.size() ? after.sub(afterIndex, after.elements.size()) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
+            CalculatedSyntaxModel originalSub = originalIndex < original.elements.size() ? original.sub(originalIndex, original.elements.size()) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
+            CalculatedSyntaxModel afterSub = afterIndex < after.elements.size() ? after.sub(afterIndex, after.elements.size()) : new CalculatedSyntaxModel(Collections.EMPTY_LIST);
             elements.addAll(calculateImpl(originalSub, afterSub));
         }
         return elements;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -93,8 +93,8 @@ class LexicalDifferenceCalculator {
          */
         @Override
         public boolean isCorrespondingElement(TextElement textElement) {
-        	return (textElement instanceof ChildTextElement)
-        			&& ((ChildTextElement)textElement).getChild() == getChild();
+            return (textElement instanceof ChildTextElement)
+                    && ((ChildTextElement)textElement).getChild() == getChild();
         }
 
         @Override
@@ -198,10 +198,10 @@ class LexicalDifferenceCalculator {
             Node child;
             if (change instanceof PropertyChange && ((PropertyChange) change).getProperty() == csmSingleReference.getProperty()) {
                 child = (Node) ((PropertyChange) change).getNewValue();
-            	if (node instanceof LambdaExpr && child instanceof ExpressionStmt) {
+                if (node instanceof LambdaExpr && child instanceof ExpressionStmt) {
                     // Same edge-case as in DefaultPrettyPrinterVisitor.visit(LambdaExpr, Void)
-            	    child = ((ExpressionStmt) child).getExpression();
-            	}
+                    child = ((ExpressionStmt) child).getExpression();
+                }
             } else {
                 child = csmSingleReference.getProperty().getValueAsSingleReference(node);
             }
@@ -304,8 +304,8 @@ class LexicalDifferenceCalculator {
             }
         } else if ((csm instanceof CsmString) && (node instanceof TextBlockLiteralExpr)) {
             // Per https://openjdk.java.net/jeps/378#1--Line-terminators, any 'CRLF' and 'CR' are turned into 'LF' before interpreting the text
-        	String eol = node.getLineEndingStyle().toString();
-        	// FIXME: csm should be CsmTextBlock -- See also #2677
+            String eol = node.getLineEndingStyle().toString();
+            // FIXME: csm should be CsmTextBlock -- See also #2677
             if (change instanceof PropertyChange) {
                 elements.add(new CsmToken(GeneratedJavaParserConstants.TEXT_BLOCK_LITERAL, "\"\"\"" + eol + ((PropertyChange) change).getNewValue() + "\"\"\""));
             } else {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -110,7 +110,7 @@ public class LexicalPreservingPrinter {
      * Returns true if the lexical preserving printer is initialized on the node
      */
     public static boolean isAvailableOn(Node node) {
-    	return node.containsData(NODE_TEXT_DATA);
+        return node.containsData(NODE_TEXT_DATA);
     }
 
     //
@@ -171,9 +171,9 @@ public class LexicalPreservingPrinter {
                         int index = getIndexOfComment((Comment) oldValue, nodeText);
                         nodeText.removeElement(index);
                         if (isCompleteLine(nodeText.getElements(), index)) {
-                        	removeAllExtraCharacters(nodeText.getElements(), index);
+                            removeAllExtraCharacters(nodeText.getElements(), index);
                         } else {
-                        	removeAllExtraCharactersStartingFrom(nodeText.getElements().listIterator(index));
+                            removeAllExtraCharactersStartingFrom(nodeText.getElements().listIterator(index));
                         }
 //                        if (nodeText.getElements().get(index).isNewline()) {
 //                            nodeText.removeElement(index);
@@ -182,7 +182,7 @@ public class LexicalPreservingPrinter {
                         throw new UnsupportedOperationException("Trying to remove something that is not a comment!");
                     }
                 } else {
-                	// this is a replacement of a comment
+                    // this is a replacement of a comment
                     List<TokenTextElement> matchingTokens = findTokenTextElementForComment((Comment) oldValue, nodeText);
                     if (matchingTokens.size() != 1) {
                         throw new IllegalStateException("The matching comment to be replaced could not be found");
@@ -200,65 +200,65 @@ public class LexicalPreservingPrinter {
         }
 
         private boolean isCompleteLine(List<TextElement> elements , int index) {
-        	if (index <= 0 || index >= elements.size()) return false;
-        	boolean isCompleteLine=true;
-        	ListIterator<TextElement> iterator = elements.listIterator(index);
-        	// verify if elements after the index are only spaces or tabs
-        	while(iterator.hasNext()) {
-        		TextElement textElement = iterator.next();
-        		if (textElement.isNewline()) break;
-        		if (textElement.isSpaceOrTab()) continue;
-        		isCompleteLine=false;
-        		break;
-        	}
-        	// verify if elements before the index are only spaces or tabs
-        	iterator = elements.listIterator(index);
-        	while(iterator.hasPrevious() && isCompleteLine) {
-        		TextElement textElement = iterator.previous();
-        		if (textElement.isNewline()) break;
-        		if (textElement.isSpaceOrTab()) continue;
-        		isCompleteLine=false;
-        	}
+            if (index <= 0 || index >= elements.size()) return false;
+            boolean isCompleteLine=true;
+            ListIterator<TextElement> iterator = elements.listIterator(index);
+            // verify if elements after the index are only spaces or tabs
+            while(iterator.hasNext()) {
+                TextElement textElement = iterator.next();
+                if (textElement.isNewline()) break;
+                if (textElement.isSpaceOrTab()) continue;
+                isCompleteLine=false;
+                break;
+            }
+            // verify if elements before the index are only spaces or tabs
+            iterator = elements.listIterator(index);
+            while(iterator.hasPrevious() && isCompleteLine) {
+                TextElement textElement = iterator.previous();
+                if (textElement.isNewline()) break;
+                if (textElement.isSpaceOrTab()) continue;
+                isCompleteLine=false;
+            }
 
-        	return isCompleteLine;
+            return isCompleteLine;
         }
 
         private void removeAllExtraCharacters(List<TextElement> elements , int index) {
-        	if (index < 0 || index >= elements.size()) return;
-        	removeAllExtraCharactersStartingFrom(elements.listIterator(index));
-        	removeAllExtraCharactersBeforePosition(elements.listIterator(index));
+            if (index < 0 || index >= elements.size()) return;
+            removeAllExtraCharactersStartingFrom(elements.listIterator(index));
+            removeAllExtraCharactersBeforePosition(elements.listIterator(index));
         }
 
         /*
          * Removes all spaces,tabs characters before this position
          */
-		private void removeAllExtraCharactersBeforePosition(ListIterator<TextElement> iterator) {
-        	while(iterator.hasPrevious()) {
-        		TextElement textElement = iterator.previous();
-        		if (textElement.isSpaceOrTab()) {
-        			iterator.remove();
-        			continue;
-        		}
-        		break;
-        	}
-		}
+        private void removeAllExtraCharactersBeforePosition(ListIterator<TextElement> iterator) {
+            while(iterator.hasPrevious()) {
+                TextElement textElement = iterator.previous();
+                if (textElement.isSpaceOrTab()) {
+                    iterator.remove();
+                    continue;
+                }
+                break;
+            }
+        }
 
-		/*
-		 * Removes all spaces,tabs or new line characters starting from this position
-		 */
-		private void removeAllExtraCharactersStartingFrom(ListIterator<TextElement> iterator) {
-        	while(iterator.hasNext()) {
-        		TextElement textElement = iterator.next();
-        		if (textElement.isSpaceOrTab()) {
-        			iterator.remove();
-        			continue;
-        		}
-        		if (textElement.isNewline()) {
-        			iterator.remove();
-        		}
-        		break;
-        	}
-		}
+        /*
+         * Removes all spaces,tabs or new line characters starting from this position
+         */
+        private void removeAllExtraCharactersStartingFrom(ListIterator<TextElement> iterator) {
+            while(iterator.hasNext()) {
+                TextElement textElement = iterator.next();
+                if (textElement.isSpaceOrTab()) {
+                    iterator.remove();
+                    continue;
+                }
+                if (textElement.isNewline()) {
+                    iterator.remove();
+                }
+                break;
+            }
+        }
 
         private TokenTextElement makeCommentToken(Comment newComment) {
             if (newComment.isJavadocComment()) {
@@ -287,7 +287,7 @@ public class LexicalPreservingPrinter {
 
         private List<ChildTextElement> findChildTextElementForComment(Comment oldValue, NodeText nodeText) {
             List<ChildTextElement> matchingChildElements;
-			matchingChildElements = selectMatchingChildElements(oldValue, nodeText);
+            matchingChildElements = selectMatchingChildElements(oldValue, nodeText);
             if (matchingChildElements.size() > 1) {
                 // Duplicate child nodes found, refine the result
                 matchingChildElements = matchingChildElements.stream().filter(t -> isEqualRange(t.getChild().getRange(), oldValue.getRange())).collect(toList());
@@ -299,27 +299,27 @@ public class LexicalPreservingPrinter {
         }
 
         private List<ChildTextElement> selectMatchingChildElements(Comment oldValue, NodeText nodeText) {
-        	List<ChildTextElement> result = new ArrayList<>();
-        	List<ChildTextElement> childTextElements = nodeText.getElements().stream().filter(e -> e.isChild())
-					.map(c -> (ChildTextElement) c).collect(toList());
-        	ListIterator<ChildTextElement> iterator = childTextElements.listIterator();
-        	while(iterator.hasNext()) {
-        		ChildTextElement textElement = iterator.next();
-        		if (textElement.isComment() && isSameComment(((Comment) textElement.getChild()), oldValue)) {
-        			result.add(textElement);
-        			continue;
-        		}
-        		Node node = textElement.getChild();
-        		if (node.getComment().isPresent() && isSameComment(node.getComment().get(), oldValue)) {
-        			result.add(textElement);
-        			continue;
-        		}
-        	}
-        	return result;
+            List<ChildTextElement> result = new ArrayList<>();
+            List<ChildTextElement> childTextElements = nodeText.getElements().stream().filter(e -> e.isChild())
+                    .map(c -> (ChildTextElement) c).collect(toList());
+            ListIterator<ChildTextElement> iterator = childTextElements.listIterator();
+            while(iterator.hasNext()) {
+                ChildTextElement textElement = iterator.next();
+                if (textElement.isComment() && isSameComment(((Comment) textElement.getChild()), oldValue)) {
+                    result.add(textElement);
+                    continue;
+                }
+                Node node = textElement.getChild();
+                if (node.getComment().isPresent() && isSameComment(node.getComment().get(), oldValue)) {
+                    result.add(textElement);
+                    continue;
+                }
+            }
+            return result;
         }
 
         private boolean isSameComment(Comment childValue, Comment oldValue) {
-        	return childValue.getContent().equals(oldValue.getContent());
+            return childValue.getContent().equals(oldValue.getContent());
         }
 
         private List<TokenTextElement> findTokenTextElementForComment(Comment oldValue, NodeText nodeText) {
@@ -345,14 +345,14 @@ public class LexicalPreservingPrinter {
             return false;
         }
 
-		/**
-		 * This method inserts new space tokens at the given {@code index}. If a new
-		 * comment is added to the token list at the position following {@code index},
-		 * the new comment and the node will have the same indent.
-		 *
-		 * @param nodeText The text of the node
-		 * @param index    The position at which the analysis should start
-		 */
+        /**
+         * This method inserts new space tokens at the given {@code index}. If a new
+         * comment is added to the token list at the position following {@code index},
+         * the new comment and the node will have the same indent.
+         *
+         * @param nodeText The text of the node
+         * @param index    The position at which the analysis should start
+         */
         private void fixIndentOfAddedNode(NodeText nodeText, int index) {
             if (index <= 0) {
                 return;
@@ -366,7 +366,7 @@ public class LexicalPreservingPrinter {
                 }
                 if (!spaceCandidate.isSpaceOrTab()) {
                     if (spaceCandidate.isNewline() && i != index) {
-                    	int numberOfIndentationCharacters = index - i;
+                        int numberOfIndentationCharacters = index - i;
                         for (int j = 0; j < numberOfIndentationCharacters; j++) {
                             if (currentSpaceCandidate != null) {
                                 // use the current (or last) indentation character
@@ -499,9 +499,9 @@ public class LexicalPreservingPrinter {
      * Print a Node into a String, preserving the lexical information.
      */
     public static String print(Node node) {
-    	LexicalPreservingVisitor visitor = new LexicalPreservingVisitor();
-    	final NodeText nodeText = getOrCreateNodeText(node);
-    	nodeText.getElements().forEach(element -> element.accept(visitor));
+        LexicalPreservingVisitor visitor = new LexicalPreservingVisitor();
+        final NodeText nodeText = getOrCreateNodeText(node);
+        nodeText.getElements().forEach(element -> element.accept(visitor));
         return visitor.toString();
 
     }
@@ -543,17 +543,17 @@ public class LexicalPreservingPrinter {
             return;
         }
         if (node instanceof JavadocComment) {
-        	Comment comment = (JavadocComment) node;
+            Comment comment = (JavadocComment) node;
             nodeText.addToken(JAVADOC_COMMENT, comment.getHeader() + ((JavadocComment) node).getContent() + comment.getFooter());
             return;
         }
         if (node instanceof BlockComment) {
-        	Comment comment = (BlockComment) node;
+            Comment comment = (BlockComment) node;
             nodeText.addToken(MULTI_LINE_COMMENT, comment.getHeader() + ((BlockComment) node).getContent() + comment.getFooter());
             return;
         }
         if (node instanceof LineComment) {
-        	Comment comment = (LineComment) node;
+            Comment comment = (LineComment) node;
             nodeText.addToken(SINGLE_LINE_COMMENT, comment.getHeader() + comment.getContent());
             return;
         }
@@ -574,12 +574,12 @@ public class LexicalPreservingPrinter {
         boolean pendingIndentation = false;
         // Add a comment and line separator if necessary
         node.getComment().ifPresent(comment -> {
-        	// new comment has no range so in this case we want to force the comment before the node
-        	if (!comment.hasRange()) {
-        		LineSeparator lineSeparator = node.getLineEndingStyleOrDefault(LineSeparator.SYSTEM);
-        		calculatedSyntaxModel.elements.add(0,new CsmToken(eolTokenKind(lineSeparator), lineSeparator.asRawString()));
-        		calculatedSyntaxModel.elements.add(0,new CsmChild(comment));
-        	}
+            // new comment has no range so in this case we want to force the comment before the node
+            if (!comment.hasRange()) {
+                LineSeparator lineSeparator = node.getLineEndingStyleOrDefault(LineSeparator.SYSTEM);
+                calculatedSyntaxModel.elements.add(0,new CsmToken(eolTokenKind(lineSeparator), lineSeparator.asRawString()));
+                calculatedSyntaxModel.elements.add(0,new CsmChild(comment));
+            }
         });
         for (CsmElement element : calculatedSyntaxModel.elements) {
             if (element instanceof CsmIndent) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingVisitor.java
@@ -24,26 +24,26 @@ import java.io.StringWriter;
 
 public class LexicalPreservingVisitor {
 
-	private StringWriter writer;
-	
-	public LexicalPreservingVisitor() {
-		this(new StringWriter());
-	}
-	
-	public LexicalPreservingVisitor(StringWriter writer) {
-		this.writer = writer;
-	}
+    private StringWriter writer;
+    
+    public LexicalPreservingVisitor() {
+        this(new StringWriter());
+    }
+    
+    public LexicalPreservingVisitor(StringWriter writer) {
+        this.writer = writer;
+    }
 
-	public void visit(ChildTextElement child) {
-		child.accept(this);
-	}
-	
-	public void visit(TokenTextElement token) {
-		writer.append(token.getText());
-	}
-	
-	@Override
-	public String toString() {
-		return writer.toString();
-	}
+    public void visit(ChildTextElement child) {
+        child.accept(this);
+    }
+    
+    public void visit(TokenTextElement token) {
+        writer.append(token.getText());
+    }
+    
+    @Override
+    public String toString() {
+        return writer.toString();
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LookaheadIterator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LookaheadIterator.java
@@ -4,7 +4,7 @@ import java.util.NoSuchElementException;
 
 public interface LookaheadIterator<E> {
 
-	/**
+    /**
      * Returns the next element in iteration without advancing the underlying iterator.
      * If the iterator is already exhausted, null will be returned.
      * <p>

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/PeekingIterator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/PeekingIterator.java
@@ -121,7 +121,7 @@ public class PeekingIterator<E> implements ListIterator<E>, LookaheadIterator<E>
      * @return the next element from the iterator
      */
     @Override
-	public E peek() {
+    public E peek() {
         fill();
         return exhausted ? null : slot;
     }
@@ -134,7 +134,7 @@ public class PeekingIterator<E> implements ListIterator<E>, LookaheadIterator<E>
      * @throws NoSuchElementException if the iterator is already exhausted according to {@link #hasNext()}
      */
     @Override
-	public E element() {
+    public E element() {
         fill();
         if (exhausted) {
             throw new NoSuchElementException();
@@ -169,55 +169,55 @@ public class PeekingIterator<E> implements ListIterator<E>, LookaheadIterator<E>
     }
 
 
-	@Override
-	public boolean hasPrevious() {
-		return iterator.hasPrevious();
-	}
+    @Override
+    public boolean hasPrevious() {
+        return iterator.hasPrevious();
+    }
 
 
-	@Override
-	public E previous() {
-		return iterator.previous();
-	}
+    @Override
+    public E previous() {
+        return iterator.previous();
+    }
 
 
-	@Override
-	public int nextIndex() {
-		return iterator.nextIndex();
-	}
+    @Override
+    public int nextIndex() {
+        return iterator.nextIndex();
+    }
 
-	/*
-	 * Returns the index of the element that would be returned by the last call to next.
-	 * Returns list size - 1 if the listiterator is at the end of the list.
-	 * Returns -1 if the listiterator is at the beginning of the list.
-	 */
-	public int currentIndex() {
-		if (!hasPrevious()) return previousIndex();
-		return nextIndex() - 1;
-	}
-
-
-	@Override
-	public int previousIndex() {
-		return iterator.previousIndex();
-	}
+    /*
+     * Returns the index of the element that would be returned by the last call to next.
+     * Returns list size - 1 if the listiterator is at the end of the list.
+     * Returns -1 if the listiterator is at the beginning of the list.
+     */
+    public int currentIndex() {
+        if (!hasPrevious()) return previousIndex();
+        return nextIndex() - 1;
+    }
 
 
-	@Override
-	public void set(E e) {
-		if (slotFilled) {
+    @Override
+    public int previousIndex() {
+        return iterator.previousIndex();
+    }
+
+
+    @Override
+    public void set(E e) {
+        if (slotFilled) {
             throw new IllegalStateException("peek() or element() called before set()");
         }
-		iterator.set(e);
-	}
+        iterator.set(e);
+    }
 
 
-	@Override
-	public void add(E e) {
-		if (slotFilled) {
+    @Override
+    public void add(E e) {
+        if (slotFilled) {
             throw new IllegalStateException("peek() or element() called before add()");
         }
-		iterator.add(e);
-	}
+        iterator.add(e);
+    }
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/PrintableTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/PrintableTextElement.java
@@ -22,5 +22,5 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 public interface PrintableTextElement {
 
-	void accept(LexicalPreservingVisitor visitor);
+    void accept(LexicalPreservingVisitor visitor);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ReshuffledDiffElementExtractor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ReshuffledDiffElementExtractor.java
@@ -9,7 +9,7 @@ import com.github.javaparser.printer.lexicalpreservation.Difference.ArrayIterato
 
 public class ReshuffledDiffElementExtractor {
 
-	private final NodeText nodeText;
+    private final NodeText nodeText;
 
     private enum MatchClassification {
 
@@ -27,15 +27,15 @@ public class ReshuffledDiffElementExtractor {
     }
 
     static ReshuffledDiffElementExtractor of(NodeText nodeText) {
-    	return new ReshuffledDiffElementExtractor(nodeText);
+        return new ReshuffledDiffElementExtractor(nodeText);
     }
 
-	private ReshuffledDiffElementExtractor(NodeText nodeText) {
-		this.nodeText = nodeText;
-	}
+    private ReshuffledDiffElementExtractor(NodeText nodeText) {
+        this.nodeText = nodeText;
+    }
 
-	public void extract(List<DifferenceElement> diffElements) {
-    	ArrayIterator<DifferenceElement> iterator = new ArrayIterator<>(diffElements);
+    public void extract(List<DifferenceElement> diffElements) {
+        ArrayIterator<DifferenceElement> iterator = new ArrayIterator<>(diffElements);
         while (iterator.hasNext()) {
             DifferenceElement diffElement = iterator.next();
             if (diffElement instanceof Reshuffled) {
@@ -50,9 +50,9 @@ public class ReshuffledDiffElementExtractor {
                 PeekingIterator<Integer> nodeTextIndexOfPreviousElementsIterator = new PeekingIterator<>(nodeTextIndexOfPreviousElements);
                 Map<Integer, Integer> nodeTextIndexToPreviousCSMIndex = new HashMap<>();
                 while (nodeTextIndexOfPreviousElementsIterator.hasNext()) {
-                	int value = nodeTextIndexOfPreviousElementsIterator.next();
+                    int value = nodeTextIndexOfPreviousElementsIterator.next();
                     if (value != -1) {
-                    	nodeTextIndexToPreviousCSMIndex.put(value, nodeTextIndexOfPreviousElementsIterator.currentIndex());
+                        nodeTextIndexToPreviousCSMIndex.put(value, nodeTextIndexOfPreviousElementsIterator.currentIndex());
                     }
                 }
                 int lastNodeTextIndex = nodeTextIndexOfPreviousElements.stream().max(Integer::compareTo).orElse(-1);
@@ -102,9 +102,9 @@ public class ReshuffledDiffElementExtractor {
                             CsmElement originalCSMElement = elementsFromPreviousOrder.getElements().get(indexOfOriginalCSMElement);
                             boolean toBeKept = correspondanceBetweenNextOrderAndPreviousOrder.containsValue(indexOfOriginalCSMElement);
                             if (toBeKept) {
-                            	iterator.add(new Kept(originalCSMElement));
+                                iterator.add(new Kept(originalCSMElement));
                             } else {
-                            	iterator.add(new Removed(originalCSMElement));
+                                iterator.add(new Removed(originalCSMElement));
                             }
                         }
                         // else we have a simple node text element, without associated csm element, just keep ignore it
@@ -113,64 +113,64 @@ public class ReshuffledDiffElementExtractor {
                 // Finally we look for the remaining new elements that were not yet added and
                 // add all of them
                 for (CsmElement elementToAdd : elementsToBeAddedAtTheEnd) {
-                	iterator.add(new Added(elementToAdd));
+                    iterator.add(new Added(elementToAdd));
                 }
             }
         }
     }
 
-	/*
-	 * Considering that the lists of elements are ordered, We can find the common
-	 * elements by starting with the list before the modifications and, for each
-	 * element, by going through the list of elements containing the modifications.
-	 *
-	 * We can find the common elements by starting with the list before the
-	 * modifications (L1) and, for each element, by going through the list of elements
-	 * containing the modifications (L2).
-	 *
-	 * If element A in list L1 is not found in list L2, it is a deleted element.
-	 * If element A of list L1 is found in list L2, it is a kept element. In this
-	 * case the search for the next element of the list L1 must start from the
-	 * position of the last element kept {@code syncNextIndex}.
-	 */
-	private Map<Integer, Integer> getCorrespondanceBetweenNextOrderAndPreviousOrder(CsmMix elementsFromPreviousOrder,
-			CsmMix elementsFromNextOrder) {
-		Map<Integer, Integer> correspondanceBetweenNextOrderAndPreviousOrder = new HashMap<>();
-		ArrayIterator<CsmElement> previousOrderElementsIterator = new ArrayIterator<>(
-				elementsFromPreviousOrder.getElements());
-		int syncNextIndex = 0;
-		while (previousOrderElementsIterator.hasNext()) {
-			CsmElement pe = previousOrderElementsIterator.next();
-			ArrayIterator<CsmElement> nextOrderElementsIterator = new ArrayIterator<>(
-					elementsFromNextOrder.getElements(), syncNextIndex);
-			while (nextOrderElementsIterator.hasNext()) {
-				CsmElement ne = nextOrderElementsIterator.next();
-				if (!correspondanceBetweenNextOrderAndPreviousOrder.values().contains(previousOrderElementsIterator.index())
-						&& DifferenceElementCalculator.matching(ne, pe)) {
-					correspondanceBetweenNextOrderAndPreviousOrder.put(nextOrderElementsIterator.index(),
-							previousOrderElementsIterator.index());
-					// set the position to start on the next {@code nextOrderElementsIterator} iteration
-					syncNextIndex = nextOrderElementsIterator.index();
-					break;
-				}
-			}
-		}
-		return correspondanceBetweenNextOrderAndPreviousOrder;
-	}
+    /*
+     * Considering that the lists of elements are ordered, We can find the common
+     * elements by starting with the list before the modifications and, for each
+     * element, by going through the list of elements containing the modifications.
+     *
+     * We can find the common elements by starting with the list before the
+     * modifications (L1) and, for each element, by going through the list of elements
+     * containing the modifications (L2).
+     *
+     * If element A in list L1 is not found in list L2, it is a deleted element.
+     * If element A of list L1 is found in list L2, it is a kept element. In this
+     * case the search for the next element of the list L1 must start from the
+     * position of the last element kept {@code syncNextIndex}.
+     */
+    private Map<Integer, Integer> getCorrespondanceBetweenNextOrderAndPreviousOrder(CsmMix elementsFromPreviousOrder,
+            CsmMix elementsFromNextOrder) {
+        Map<Integer, Integer> correspondanceBetweenNextOrderAndPreviousOrder = new HashMap<>();
+        ArrayIterator<CsmElement> previousOrderElementsIterator = new ArrayIterator<>(
+                elementsFromPreviousOrder.getElements());
+        int syncNextIndex = 0;
+        while (previousOrderElementsIterator.hasNext()) {
+            CsmElement pe = previousOrderElementsIterator.next();
+            ArrayIterator<CsmElement> nextOrderElementsIterator = new ArrayIterator<>(
+                    elementsFromNextOrder.getElements(), syncNextIndex);
+            while (nextOrderElementsIterator.hasNext()) {
+                CsmElement ne = nextOrderElementsIterator.next();
+                if (!correspondanceBetweenNextOrderAndPreviousOrder.values().contains(previousOrderElementsIterator.index())
+                        && DifferenceElementCalculator.matching(ne, pe)) {
+                    correspondanceBetweenNextOrderAndPreviousOrder.put(nextOrderElementsIterator.index(),
+                            previousOrderElementsIterator.index());
+                    // set the position to start on the next {@code nextOrderElementsIterator} iteration
+                    syncNextIndex = nextOrderElementsIterator.index();
+                    break;
+                }
+            }
+        }
+        return correspondanceBetweenNextOrderAndPreviousOrder;
+    }
 
-	private List<Integer> findIndexOfCorrespondingNodeTextElement(List<CsmElement> elements, NodeText nodeText) {
+    private List<Integer> findIndexOfCorrespondingNodeTextElement(List<CsmElement> elements, NodeText nodeText) {
         List<Integer> correspondingIndices = new ArrayList<>();
         PeekingIterator<CsmElement> csmElementListIterator = new PeekingIterator<>(elements);
         while ( csmElementListIterator.hasNext() ) {
-        	boolean isFirstIterationOnCsmElements = !csmElementListIterator.hasPrevious();
+            boolean isFirstIterationOnCsmElements = !csmElementListIterator.hasPrevious();
             int previousCsmElementIndex = csmElementListIterator.previousIndex();
             CsmElement csmElement = csmElementListIterator.next();
             Map<MatchClassification, Integer> potentialMatches = new EnumMap<>(MatchClassification.class);
             PeekingIterator<TextElement> nodeTextListIterator = new PeekingIterator<>(nodeText.getElements());
             while (nodeTextListIterator.hasNext()) {
-            	boolean isFirstIterationOnNodeTextElements = !nodeTextListIterator.hasPrevious();
-            	TextElement textElement = nodeTextListIterator.next();
-            	int currentTextElementIndex = nodeTextListIterator.currentIndex();
+                boolean isFirstIterationOnNodeTextElements = !nodeTextListIterator.hasPrevious();
+                TextElement textElement = nodeTextListIterator.next();
+                int currentTextElementIndex = nodeTextListIterator.currentIndex();
                 if (!correspondingIndices.contains(currentTextElementIndex)) {
                     boolean isCorresponding = csmElement.isCorrespondingElement(textElement);
                     if (isCorresponding) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TokenTextElement.java
@@ -146,8 +146,8 @@ public class TokenTextElement extends TextElement {
         return token.getRange();
     }
 
-	@Override
-	public void accept(LexicalPreservingVisitor visitor) {
-		visitor.visit(this);
-	}
+    @Override
+    public void accept(LexicalPreservingVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/Change.java
@@ -40,75 +40,75 @@ public interface Change {
                 return Utils.valueIsNullOrEmpty(getValue(csmConditional.getProperty(), node));
             case IS_PRESENT:
                 return !Utils.valueIsNullOrEmptyStringOrOptional(getValue(csmConditional.getProperty(), node))
-                		&& !isEvaluatedOnDerivedProperty(csmConditional.getProperty());
+                        && !isEvaluatedOnDerivedProperty(csmConditional.getProperty());
             default:
                 throw new UnsupportedOperationException("" + csmConditional.getProperty() + " " + csmConditional.getCondition());
         }
     }
 
-	/*
-	 * Evaluate on derived property.
-	 *
-	 * Currently the evaluation of the conditions is carried out in relation to the
-	 * presence of value in the field/attribute of a class referenced by a property
-	 * (for example the BODY property is referenced to the body field in the
-	 * LambdaExpr class) but this is not quite correct.
-	 *
-	 * Indeed, there are attributes that are derived. The meaning of a derived
-	 * attribute (annotated with the DerivedProperty annotation) is not very clear.
-	 * Assuming that it is an existing attribute and accessible by another property,
-	 * for example this is the case for the EXPRESSION_BODY property which allows
-	 * access to a derived field (which is also accessible by the BODY property).
-	 *
-	 * The 2 properties EXPRESSION_BODY and BODY have a different meaning because
-	 * one references a simple expression while the other references a list of
-	 * expressions (this distinction is particularly interesting in the case of
-	 * lambda expressions).
-	 *
-	 * In this particular case, the verification of the condition defined in the
-	 * syntax model used by LPP must not succeed if the nature of the property is
-	 * modified. So if we modify a lamba expression composed of a single expression
-	 * by replacing it with a list of expressions, the evaluation of a condition
-	 * relating to the presence of the EXPRESSION_BODY property, which makes it
-	 * possible to determine the nature of the change, cannot not lead to a verified
-	 * proposition which could be the case if we only consider that the field
-	 * referenced by the EXPRESSION_BODY property has an acceptable value before the
-	 * actual modification.
-	 *
-	 * This is why we also check if it is a derived property whose name coincides
-	 * (*) with the updated property. If this is the case, we admit that the
-	 * verification of the condition must fail so that we can execute the else
-	 * clause of the condition. I'm not sure this issue #3949 is completely resolved
-	 * by this change.
-	 *
-	 * (*) Assuming that by convention the derived property is suffixed with the
-	 * name of the property it derives from (e.g.. EXPRESSION_BODY which matches an
-	 * expression would derive from BODY which matches a list of expressions), we
-	 * could deduce that EXPRESSION_BODY and BODY actually represent the same field
-	 * but the validation condition must not be checked.
-	 */
+    /*
+     * Evaluate on derived property.
+     *
+     * Currently the evaluation of the conditions is carried out in relation to the
+     * presence of value in the field/attribute of a class referenced by a property
+     * (for example the BODY property is referenced to the body field in the
+     * LambdaExpr class) but this is not quite correct.
+     *
+     * Indeed, there are attributes that are derived. The meaning of a derived
+     * attribute (annotated with the DerivedProperty annotation) is not very clear.
+     * Assuming that it is an existing attribute and accessible by another property,
+     * for example this is the case for the EXPRESSION_BODY property which allows
+     * access to a derived field (which is also accessible by the BODY property).
+     *
+     * The 2 properties EXPRESSION_BODY and BODY have a different meaning because
+     * one references a simple expression while the other references a list of
+     * expressions (this distinction is particularly interesting in the case of
+     * lambda expressions).
+     *
+     * In this particular case, the verification of the condition defined in the
+     * syntax model used by LPP must not succeed if the nature of the property is
+     * modified. So if we modify a lamba expression composed of a single expression
+     * by replacing it with a list of expressions, the evaluation of a condition
+     * relating to the presence of the EXPRESSION_BODY property, which makes it
+     * possible to determine the nature of the change, cannot not lead to a verified
+     * proposition which could be the case if we only consider that the field
+     * referenced by the EXPRESSION_BODY property has an acceptable value before the
+     * actual modification.
+     *
+     * This is why we also check if it is a derived property whose name coincides
+     * (*) with the updated property. If this is the case, we admit that the
+     * verification of the condition must fail so that we can execute the else
+     * clause of the condition. I'm not sure this issue #3949 is completely resolved
+     * by this change.
+     *
+     * (*) Assuming that by convention the derived property is suffixed with the
+     * name of the property it derives from (e.g.. EXPRESSION_BODY which matches an
+     * expression would derive from BODY which matches a list of expressions), we
+     * could deduce that EXPRESSION_BODY and BODY actually represent the same field
+     * but the validation condition must not be checked.
+     */
     default boolean isEvaluatedOnDerivedProperty(ObservableProperty property) {
-    	ObservableProperty currentProperty = getProperty();
-		/*
-		 * By convention we admit that the derived property is suffixed with the name of
-		 * the property it derives from (e.g. EXPRESSION_BODY which matches an
-		 * expression would derive from BODY which matches a list of expressions), so we
-		 * could deduce that EXPRESSION_BODY and BODY actually represent the same
-		 * field but the validation condition must not be checked.
-		 * Be careful because NoChange property must not affect this evaluation.
-		 */
-    	return currentProperty != null
-    			&& (property.isDerived()
-    					&& property.name().endsWith(currentProperty.name()));
+        ObservableProperty currentProperty = getProperty();
+        /*
+         * By convention we admit that the derived property is suffixed with the name of
+         * the property it derives from (e.g. EXPRESSION_BODY which matches an
+         * expression would derive from BODY which matches a list of expressions), so we
+         * could deduce that EXPRESSION_BODY and BODY actually represent the same
+         * field but the validation condition must not be checked.
+         * Be careful because NoChange property must not affect this evaluation.
+         */
+        return currentProperty != null
+                && (property.isDerived()
+                        && property.name().endsWith(currentProperty.name()));
     }
 
-	/*
-	 * Assuming that by convention the derived property is suffixed
-	 * with the name of the property it derives from (e.g. EXPRESSION_BODY which
-	 * matches an expression vs a list of expressions would derive from BODY) We
-	 * could deduce that EXPRESSION_BODY and BODY actually represent the same
-	 * property but the validation condition is not checked.
-	 */
+    /*
+     * Assuming that by convention the derived property is suffixed
+     * with the name of the property it derives from (e.g. EXPRESSION_BODY which
+     * matches an expression vs a list of expressions would derive from BODY) We
+     * could deduce that EXPRESSION_BODY and BODY actually represent the same
+     * property but the validation condition is not checked.
+     */
     ObservableProperty getProperty();
 
     Object getValue(ObservableProperty property, Node node);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListAdditionChange.java
@@ -66,8 +66,8 @@ public class ListAdditionChange implements Change {
         return new NoChange().getValue(property, node);
     }
 
-	@Override
-	public ObservableProperty getProperty() {
-		return observableProperty;
-	}
+    @Override
+    public ObservableProperty getProperty() {
+        return observableProperty;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListRemovalChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListRemovalChange.java
@@ -65,7 +65,7 @@ public class ListRemovalChange implements Change {
     }
 
     @Override
-	public ObservableProperty getProperty() {
-		return observableProperty;
-	}
+    public ObservableProperty getProperty() {
+        return observableProperty;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/ListReplacementChange.java
@@ -67,7 +67,7 @@ public class ListReplacementChange implements Change {
     }
 
     @Override
-	public ObservableProperty getProperty() {
-		return observableProperty;
-	}
+    public ObservableProperty getProperty() {
+        return observableProperty;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/NoChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/NoChange.java
@@ -34,7 +34,7 @@ public class NoChange implements Change {
     }
 
     @Override
-	public ObservableProperty getProperty() {
-		return null;
-	}
+    public ObservableProperty getProperty() {
+        return null;
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/PropertyChange.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/changes/PropertyChange.java
@@ -41,7 +41,7 @@ public class PropertyChange implements Change {
     }
 
     @Override
-	public ObservableProperty getProperty() {
+    public ObservableProperty getProperty() {
         return property;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/quality/Preconditions.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/quality/Preconditions.java
@@ -29,8 +29,8 @@ public final class Preconditions {
     /**
      * Ensures the truth of an expression involving one or more parameters to the calling method.
      *
-     * @param expression 	a boolean expression.
-     * @param message		the exception message to use if the check fails;
+     * @param expression     a boolean expression.
+     * @param message        the exception message to use if the check fails;
      *                      will be converted to a string using String.valueOf(Object)
      *
      * @throws IllegalArgumentException if expression is false.
@@ -44,7 +44,7 @@ public final class Preconditions {
     /**
      * Ensures the truth of an expression involving one or more parameters to the calling method.
      *
-     * @param expression 	a boolean expression.
+     * @param expression     a boolean expression.
      *
      * @throws IllegalArgumentException if expression is false.
      */
@@ -55,8 +55,8 @@ public final class Preconditions {
     /**
      * Ensures that an object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference 	an object reference.
-     * @param message		the exception message to use if the check fails;
+     * @param reference     an object reference.
+     * @param message        the exception message to use if the check fails;
      *                      will be converted to a string using String.valueOf(Object)
      *
      * @throws IllegalArgumentException if reference is {@code null}.
@@ -68,7 +68,7 @@ public final class Preconditions {
     /**
      * Ensures that an object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference 	an object reference.
+     * @param reference     an object reference.
      *
      * @throws IllegalArgumentException if reference is {@code null}.
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/Context.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/Context.java
@@ -42,12 +42,12 @@ import java.util.Optional;
  * @author Federico Tomassetti
  */
 public interface Context {
-	
-	/**
-	 * Returns the node wrapped in the context
-	 * 
-	 */
-	<N extends Node> N getWrappedNode();
+    
+    /**
+     * Returns the node wrapped in the context
+     * 
+     */
+    <N extends Node> N getWrappedNode();
 
     /**
      * @return The parent context, if there is one. For example, a method exists within a compilation unit.

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/MethodUsage.java
@@ -225,16 +225,16 @@ public class MethodUsage implements ResolvedTypeParametrized {
         return exceptionTypes;
     }
 
-	/*
-	 * Two methods or constructors, M and N, have the same signature if they have
-	 * the same name, the same type parameters (if any) (§8.4.4), and, after
-	 * adapting the formal parameter types of N to the the type parameters of M, the
-	 * same formal parameter types.
-	 * https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html
-	 * This method returns an approximation of this rule.
-	 */
+    /*
+     * Two methods or constructors, M and N, have the same signature if they have
+     * the same name, the same type parameters (if any) (§8.4.4), and, after
+     * adapting the formal parameter types of N to the the type parameters of M, the
+     * same formal parameter types.
+     * https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html
+     * This method returns an approximation of this rule.
+     */
     public boolean isSameSignature(MethodUsage otherMethodUsage) {
-    	return getSignature().equals(otherMethodUsage.getSignature());
+        return getSignature().equals(otherMethodUsage.getSignature());
     }
 
     /*
@@ -243,7 +243,7 @@ public class MethodUsage implements ResolvedTypeParametrized {
      * the signature of m1 is the same as the erasure (§4.6) of the signature of m2.
      */
     public boolean isSubSignature(MethodUsage otherMethodUsage) {
-    	return getErasedSignature().equals(otherMethodUsage.getErasedSignature());
+        return getErasedSignature().equals(otherMethodUsage.getErasedSignature());
     }
 
     /*
@@ -255,7 +255,7 @@ public class MethodUsage implements ResolvedTypeParametrized {
      * R1 can be converted to a subtype of R2 by unchecked conversion (§5.1.9).
      * d1 does not have the same signature as d2 (§8.4.2), and R1 = |R2|.
      */
-	public boolean isReturnTypeSubstituable(MethodUsage otherMethodUsage) {
-		return getDeclaration().isReturnTypeSubstituable(otherMethodUsage.getDeclaration().getReturnType());
-	}
+    public boolean isReturnTypeSubstituable(MethodUsage otherMethodUsage) {
+        return getDeclaration().isReturnTypeSubstituable(otherMethodUsage.getDeclaration().getReturnType());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/Solver.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/Solver.java
@@ -33,50 +33,50 @@ import java.util.Optional;
 
 public interface Solver {
 
-	SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Context context);
+    SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Context context);
 
-	SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Node node);
+    SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Node node);
 
-	Optional<Value> solveSymbolAsValue(String name, Context context);
+    Optional<Value> solveSymbolAsValue(String name, Context context);
 
-	Optional<Value> solveSymbolAsValue(String name, Node node);
+    Optional<Value> solveSymbolAsValue(String name, Node node);
 
-	SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Context context);
+    SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Context context);
 
-	SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Node node);
+    SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Node node);
 
-	MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context);
+    MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context);
 
-	MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node);
+    MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node);
 
-	ResolvedTypeDeclaration solveType(Type type);
+    ResolvedTypeDeclaration solveType(Type type);
 
-	ResolvedType solveTypeUsage(String name, Context context);
+    ResolvedType solveTypeUsage(String name, Context context);
 
-	/**
-	 * Solve any possible visible symbols including: fields, internal types, type variables, the type itself or its
-	 * containers.
-	 * <p>
-	 * It should contain its own private fields but not inherited private fields.
-	 */
-	SymbolReference<? extends ResolvedValueDeclaration> solveSymbolInType(ResolvedTypeDeclaration typeDeclaration,
-			String name);
+    /**
+     * Solve any possible visible symbols including: fields, internal types, type variables, the type itself or its
+     * containers.
+     * <p>
+     * It should contain its own private fields but not inherited private fields.
+     */
+    SymbolReference<? extends ResolvedValueDeclaration> solveSymbolInType(ResolvedTypeDeclaration typeDeclaration,
+            String name);
 
-	/**
-	 * Try to solve a symbol just in the declaration, it does not delegate to the container.
-	 *
-	 * @deprecated Similarly to solveType this should eventually disappear as the symbol resolution logic should be more general
-	 * and do not be specific to JavaParser classes like in this case.
-	 */
-	SymbolReference<ResolvedTypeDeclaration> solveTypeInType(ResolvedTypeDeclaration typeDeclaration, String name);
-	
-	/**
+    /**
+     * Try to solve a symbol just in the declaration, it does not delegate to the container.
+     *
+     * @deprecated Similarly to solveType this should eventually disappear as the symbol resolution logic should be more general
+     * and do not be specific to JavaParser classes like in this case.
+     */
+    SymbolReference<ResolvedTypeDeclaration> solveTypeInType(ResolvedTypeDeclaration typeDeclaration, String name);
+    
+    /**
      * Convert a {@link Class} into the corresponding {@link ResolvedType}.
      *
      * @param clazz The class to be converted.
      *
      * @return The class resolved.
      */
-	ResolvedType classToResolvedType(Class<?> clazz);
+    ResolvedType classToResolvedType(Class<?> clazz);
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
@@ -70,29 +70,29 @@ public interface ResolvedMethodDeclaration extends ResolvedMethodLikeDeclaration
      * TODO: Probably this method needs to refer to a method "isTypeSubstituable" implemented in ResolvedType
      */
     default boolean isReturnTypeSubstituable(ResolvedType otherResolvedType) {
-    	ResolvedType returnType = getReturnType();
-    	if (returnType.isVoid()) {
-    		return otherResolvedType.isVoid();
-    	}
-    	if (returnType.isPrimitive()) {
-    		return otherResolvedType.isPrimitive()
-    				&& returnType.asPrimitive().equals(otherResolvedType.asPrimitive());
-    	}
-    	// If R1 is a reference type then one of the following is true:
+        ResolvedType returnType = getReturnType();
+        if (returnType.isVoid()) {
+            return otherResolvedType.isVoid();
+        }
+        if (returnType.isPrimitive()) {
+            return otherResolvedType.isPrimitive()
+                    && returnType.asPrimitive().equals(otherResolvedType.asPrimitive());
+        }
+        // If R1 is a reference type then one of the following is true:
 
-    	// R1, adapted to the type parameters of d2 (§8.4.4), is a subtype of R2.
-    	// Below we are trying to compare a reference type for example an Object to a type variable let's say T
-    	// we can certainly simplify by saying that this is always true.
-    	if (otherResolvedType.isTypeVariable()) {
-    		return true;
-    	}
+        // R1, adapted to the type parameters of d2 (§8.4.4), is a subtype of R2.
+        // Below we are trying to compare a reference type for example an Object to a type variable let's say T
+        // we can certainly simplify by saying that this is always true.
+        if (otherResolvedType.isTypeVariable()) {
+            return true;
+        }
 
-    	// R1 can be converted to a subtype of R2 by unchecked conversion (§5.1.9).
+        // R1 can be converted to a subtype of R2 by unchecked conversion (§5.1.9).
 
-    	// d1 does not have the same signature as d2 (§8.4.2), and R1 = |R2|.
-    	if (returnType.describe().equals(otherResolvedType.erasure().describe())) {
-    		return true;
-    	}
-    	throw new UnsupportedOperationException("Return-Type-Substituable must be implemented on reference type.");
+        // d1 does not have the same signature as d2 (§8.4.2), and R1 = |R2|.
+        if (returnType.describe().equals(otherResolvedType.erasure().describe())) {
+            return true;
+        }
+        throw new UnsupportedOperationException("Return-Type-Substituable must be implemented on reference type.");
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodLikeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodLikeDeclaration.java
@@ -112,7 +112,7 @@ public interface ResolvedMethodLikeDeclaration extends ResolvedDeclaration, Reso
      * Returns the list of formal parameter types
      */
     default List<ResolvedType> formalParameterTypes() {
-    	if (getNumberOfParams() == 0) {
+        if (getNumberOfParams() == 0) {
             return Collections.emptyList();
         }
         List<ResolvedType> types = new ArrayList<>();
@@ -161,10 +161,10 @@ public interface ResolvedMethodLikeDeclaration extends ResolvedDeclaration, Reso
         if (getNumberOfSpecifiedExceptions() == 0) {
             return Collections.emptyList();
         }
-		List<ResolvedType> exceptions = new ArrayList<>();
-		for (int i = 0; i < getNumberOfSpecifiedExceptions(); i++) {
-			exceptions.add(getSpecifiedException(i));
-		}
-		return exceptions;
+        List<ResolvedType> exceptions = new ArrayList<>();
+        for (int i = 0; i < getNumberOfSpecifiedExceptions(); i++) {
+            exceptions.add(getSpecifiedException(i));
+        }
+        return exceptions;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
@@ -38,7 +38,7 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
 
     String JAVA_LANG_ENUM = java.lang.Enum.class.getCanonicalName();
     String JAVA_LANG_COMPARABLE = java.lang.Comparable.class.getCanonicalName();
-	String JAVA_IO_SERIALIZABLE = Serializable.class.getCanonicalName();
+    String JAVA_IO_SERIALIZABLE = Serializable.class.getCanonicalName();
     String JAVA_LANG_OBJECT = java.lang.Object.class.getCanonicalName();
 
     @Override
@@ -138,7 +138,7 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      * In the example above, this method returns B,C,D,E
      */
     Function<ResolvedReferenceTypeDeclaration, List<ResolvedReferenceType>> breadthFirstFunc = (rrtd) -> {
-    	List<ResolvedReferenceType> ancestors = new ArrayList<>();
+        List<ResolvedReferenceType> ancestors = new ArrayList<>();
         // We want to avoid infinite recursion in case of Object having Object as ancestor
         if (!rrtd.isJavaLangObject()) {
             // init direct ancestors
@@ -151,7 +151,7 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
                     queuedAncestors.add(ancestor);
                     // add this ancestor to the list of ancestors
                     if (!ancestors.contains(ancestor)) {
-                    	ancestors.add(ancestor);
+                        ancestors.add(ancestor);
                     }
                 }));
             }
@@ -294,35 +294,35 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
             return true;
         }
         return isClass() && getAllAncestors().stream()
-        		.filter(it -> it.asReferenceType().getTypeDeclaration().isPresent())
-        		.filter(it -> it.asReferenceType().getTypeDeclaration().get().isClass())
-        		.map(it -> it.asReferenceType().getTypeDeclaration().get())
-        		.anyMatch(rrtd -> rrtd.hasDirectlyAnnotation(qualifiedName)
-        				&& rrtd.isInheritedAnnotation(qualifiedName));
+                .filter(it -> it.asReferenceType().getTypeDeclaration().isPresent())
+                .filter(it -> it.asReferenceType().getTypeDeclaration().get().isClass())
+                .map(it -> it.asReferenceType().getTypeDeclaration().get())
+                .anyMatch(rrtd -> rrtd.hasDirectlyAnnotation(qualifiedName)
+                        && rrtd.isInheritedAnnotation(qualifiedName));
     }
 
     /**
      * Returns true if the specified annotation is inheritable.
      */
     default boolean isInheritedAnnotation(String name) {
-    	Optional<ResolvedAnnotationDeclaration> declaration = getDeclaredAnnotation(name);
-    	return declaration.isPresent() && declaration.get().isInheritable();
+        Optional<ResolvedAnnotationDeclaration> declaration = getDeclaredAnnotation(name);
+        return declaration.isPresent() && declaration.get().isInheritable();
     }
 
     /**
      * Returns the resolved annotation corresponding to the specified name and declared in this type declaration.
      */
     default Optional<ResolvedAnnotationDeclaration> getDeclaredAnnotation(String name) {
-    	return getDeclaredAnnotations().stream()
-    			.filter(annotation -> annotation.getQualifiedName().endsWith(name))
-    			.findFirst();
+        return getDeclaredAnnotations().stream()
+                .filter(annotation -> annotation.getQualifiedName().endsWith(name))
+                .findFirst();
     }
 
     /**
      * Return a collection of all annotations declared in this type declaration.
      */
     default Set<ResolvedAnnotationDeclaration> getDeclaredAnnotations() {
-    	throw new UnsupportedOperationException("Getting declared annotation is not supproted on this type " + this.getName());
+        throw new UnsupportedOperationException("Getting declared annotation is not supproted on this type " + this.getName());
     }
 
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeParameterDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypeParameterDeclaration.java
@@ -107,7 +107,7 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
      * Name of the type parameter.
      */
     @Override
-	String getName();
+    String getName();
 
     /**
      * Is the type parameter been defined on a type?
@@ -135,7 +135,7 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
      * This is unsupported because there is no package for a Type Parameter, only for its container.
      */
     @Override
-	default String getPackageName() {
+    default String getPackageName() {
         throw new UnsupportedOperationException();
     }
 
@@ -144,7 +144,7 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
      * This is unsupported because there is no class for a Type Parameter, only for its container.
      */
     @Override
-	default String getClassName() {
+    default String getClassName() {
         throw new UnsupportedOperationException();
     }
 
@@ -154,7 +154,7 @@ public interface ResolvedTypeParameterDeclaration extends ResolvedTypeDeclaratio
      * The qualified name of a method is its qualified signature.
      */
     @Override
-	default String getQualifiedName() {
+    default String getQualifiedName() {
         return String.format("%s.%s", getContainerId(), getName());
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
@@ -72,22 +72,22 @@ public final class FunctionalInterfaceLogic {
         // TODO a functional interface can have multiple subsignature method with a return-type-substitutable
         // see https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.8
         if (methods.size() == 0) {
-        	return Optional.empty();
+            return Optional.empty();
         }
         Iterator<MethodUsage> iterator = methods.iterator();
         MethodUsage methodUsage = iterator.next();
         while (iterator.hasNext()) {
-        	MethodUsage otherMethodUsage = iterator.next();
-        	if (!(methodUsage.isSameSignature(otherMethodUsage)
-        			|| methodUsage.isSubSignature(otherMethodUsage)
-        			|| otherMethodUsage.isSubSignature(methodUsage))) {
-        		methodUsage = null;
-        		break;
-        	}
-        	if (!(methodUsage.isReturnTypeSubstituable(otherMethodUsage))) {
-        		methodUsage = null;
-        		break;
-        	}
+            MethodUsage otherMethodUsage = iterator.next();
+            if (!(methodUsage.isSameSignature(otherMethodUsage)
+                    || methodUsage.isSubSignature(otherMethodUsage)
+                    || otherMethodUsage.isSubSignature(methodUsage))) {
+                methodUsage = null;
+                break;
+            }
+            if (!(methodUsage.isReturnTypeSubstituable(otherMethodUsage))) {
+                methodUsage = null;
+                break;
+            }
         }
         return Optional.ofNullable(methodUsage);
     }
@@ -111,7 +111,7 @@ public final class FunctionalInterfaceLogic {
     }
 
     private static List<String> OBJECT_PUBLIC_METHODS_SIGNATURES = Arrays.stream(Object.class.getDeclaredMethods())
-    		.filter(m -> Modifier.isPublic(m.getModifiers()))
+            .filter(m -> Modifier.isPublic(m.getModifiers()))
             .map(method -> getSignature(method))
             .collect(Collectors.toList());
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/InferenceContext.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/InferenceContext.java
@@ -81,10 +81,10 @@ public class InferenceContext {
                 // which means that if the formal parameter is of type Object,
                 // all types can match including the actual type.
                 List<ResolvedType> correspondingFormalType = "java.lang.Object".equals(formalParamTypeQName) ?
-                		Stream.concat(new ArrayList<ResolvedType>(Arrays.asList(actualType)).stream(),
-                				ancestors.stream().map(ancestor -> ancestor.asReferenceType()).collect(Collectors.toList()).stream())
-                				.collect(Collectors.toList()):
-                		ancestors.stream().filter((a) -> a.getQualifiedName().equals(formalParamTypeQName)).collect(Collectors.toList());
+                        Stream.concat(new ArrayList<ResolvedType>(Arrays.asList(actualType)).stream(),
+                                ancestors.stream().map(ancestor -> ancestor.asReferenceType()).collect(Collectors.toList()).stream())
+                                .collect(Collectors.toList()):
+                        ancestors.stream().filter((a) -> a.getQualifiedName().equals(formalParamTypeQName)).collect(Collectors.toList());
                 if (correspondingFormalType.isEmpty()) {
                     ancestors = formalTypeAsReference.getAllAncestors();
                     final String actualParamTypeQname = actualTypeAsReference.getQualifiedName();
@@ -162,14 +162,14 @@ public class InferenceContext {
             if (formalType.isPrimitive()) {
                 // nothing to do
             } else {
-            	ResolvedReferenceTypeDeclaration resolvedTypedeclaration = typeSolver.solveType(actualType.asPrimitive().getBoxTypeQName());
+                ResolvedReferenceTypeDeclaration resolvedTypedeclaration = typeSolver.solveType(actualType.asPrimitive().getBoxTypeQName());
                 registerCorrespondance(formalType, new ReferenceTypeImpl(resolvedTypedeclaration));
             }
         } else if (actualType.isReferenceType()) {
             if (formalType.isPrimitive()) {
                 if (formalType.asPrimitive().getBoxTypeQName().equals(actualType.describe())) {
-                	ResolvedReferenceTypeDeclaration resolvedTypedeclaration = typeSolver.solveType(formalType.asPrimitive().getBoxTypeQName());
-                	registerCorrespondance(new ReferenceTypeImpl(resolvedTypedeclaration), actualType);
+                    ResolvedReferenceTypeDeclaration resolvedTypedeclaration = typeSolver.solveType(formalType.asPrimitive().getBoxTypeQName());
+                    registerCorrespondance(new ReferenceTypeImpl(resolvedTypedeclaration), actualType);
                 } else {
                     // nothing to do
                 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/InferenceVariableType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/InferenceVariableType.java
@@ -79,7 +79,7 @@ public class InferenceVariableType implements ResolvedType {
     private Set<ResolvedType> superTypes = new HashSet<>();
 
     public InferenceVariableType(int id, TypeSolver typeSolver) {
-    	this.id = id;
+        this.id = id;
         this.typeSolver = typeSolver;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionCapability.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionCapability.java
@@ -28,6 +28,6 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.List;
 
 public interface MethodResolutionCapability {
-	SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> argumentsTypes,
-	                                                       boolean staticOnly);
+    SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> argumentsTypes,
+                                                           boolean staticOnly);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -156,10 +156,10 @@ public class MethodResolutionLogic {
             // must refer to the method String.format(String, Object...)
             // even if an array of primitive type cannot be assigned to an array of Object
             if (methodDeclaration.getParam(i).isVariadic()
-            		&& (i == countOfMethodParametersDeclared - 1)
-            		&& isArrayOfObject(expectedDeclaredType)
-            		&& actualArgumentType.isArray()) {
-            	continue;
+                    && (i == countOfMethodParametersDeclared - 1)
+                    && isArrayOfObject(expectedDeclaredType)
+                    && actualArgumentType.isArray()) {
+                continue;
             }
 
             boolean isAssignableWithoutSubstitution = expectedDeclaredType.isAssignableBy(actualArgumentType) ||
@@ -203,14 +203,14 @@ public class MethodResolutionLogic {
     }
 
     private static boolean isArrayOfObject(ResolvedType type) {
-    	return type.isArray()
-    			&& type.asArrayType().getComponentType().isReferenceType()
-    			&& type.asArrayType().getComponentType().asReferenceType().isJavaLangObject();
+        return type.isArray()
+                && type.asArrayType().getComponentType().isReferenceType()
+                && type.asArrayType().getComponentType().asReferenceType().isJavaLangObject();
     }
 
-	private static ResolvedArrayType convertToVariadicParameter(ResolvedType type) {
-		return type.isArray() ? type.asArrayType() : new ResolvedArrayType(type);
-	}
+    private static ResolvedArrayType convertToVariadicParameter(ResolvedType type) {
+        return type.isArray() ? type.asArrayType() : new ResolvedArrayType(type);
+    }
 
     /*
      * Returns the last parameter index
@@ -265,7 +265,7 @@ public class MethodResolutionLogic {
             return isAssignableMatchTypeParameters(expected.asReferenceType(), actual.asReferenceType(), matchedParameters);
         }
         if (expected.isReferenceType() && ResolvedPrimitiveType.isBoxType(expected) && actual.isPrimitive()) {
-        	ResolvedPrimitiveType expectedType = ResolvedPrimitiveType.byBoxTypeQName(expected.asReferenceType().getQualifiedName()).get().asPrimitive();
+            ResolvedPrimitiveType expectedType = ResolvedPrimitiveType.byBoxTypeQName(expected.asReferenceType().getQualifiedName()).get().asPrimitive();
             return expected.isAssignableBy(actual);
         }
         if (expected.isTypeVariable()) {
@@ -343,11 +343,11 @@ public class MethodResolutionLogic {
             }
             if (expectedParam.isWildcard()) {
                 if (expectedParam.asWildcard().isExtends()) {
-                	// trying to compare with unbounded wildcard type parameter <?>
-                	if (actualParam.isWildcard() && !actualParam.asWildcard().isBounded()) {
-                		return true;
-                	}
-                	if (actualParam.isTypeVariable()) {
+                    // trying to compare with unbounded wildcard type parameter <?>
+                    if (actualParam.isWildcard() && !actualParam.asWildcard().isBounded()) {
+                        return true;
+                    }
+                    if (actualParam.isTypeVariable()) {
                         return matchTypeVariable(actualParam.asTypeVariable(), expectedParam.asWildcard().getBoundedType(), matchedParameters);
                     }
                     return isAssignableMatchTypeParameters(expectedParam.asWildcard().getBoundedType(), actualParam, matchedParameters);
@@ -716,7 +716,7 @@ public class MethodResolutionLogic {
         // If both methods are variadic but the calling method omits any varArgs, bump the omitted args to
         // ensure the varargs type is considered when determining which method is more specific
         if (aVariadic && bVariadic && aNumberOfParams == bNumberOfParams && numberOfArgs == aNumberOfParams - 1) {
-        	omittedArgs++;
+            omittedArgs++;
         }
 
         // Either both methods are variadic or neither is. So we must compare the parameter types.
@@ -726,7 +726,7 @@ public class MethodResolutionLogic {
 
             ResolvedType argType = null;
             if (i < argumentTypes.size()) {
-            	argType = argumentTypes.get(i);
+                argType = argumentTypes.get(i);
             }
 
             // Safety: if a type is null it means a signature with too few parameters managed to get to this point.
@@ -743,14 +743,14 @@ public class MethodResolutionLogic {
             // instead of a boxing conversion from int to Integer. See JLS §15.12.2.
             // This is what we check here.
             if (argType != null &&
-            		paramTypeA.isPrimitive() == argType.isPrimitive() &&
+                    paramTypeA.isPrimitive() == argType.isPrimitive() &&
                     paramTypeB.isPrimitive() != argType.isPrimitive() &&
                     paramTypeA.isAssignableBy(argType)) {
 
                 return true;
             }
             if (argType != null &&
-            		paramTypeB.isPrimitive() == argType.isPrimitive() &&
+                    paramTypeB.isPrimitive() == argType.isPrimitive() &&
                     paramTypeA.isPrimitive() != argType.isPrimitive() &&
                     paramTypeB.isAssignableBy(argType)) {
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/model/typesystem/ReferenceTypeImpl.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/model/typesystem/ReferenceTypeImpl.java
@@ -44,8 +44,8 @@ import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParame
  */
 public class ReferenceTypeImpl extends ResolvedReferenceType {
 
-	private static final String[] ASSIGNABLE_REFERENCE_TYPE = { "java.lang.Object", "java.lang.Cloneable",
-	"java.io.Serializable" };
+    private static final String[] ASSIGNABLE_REFERENCE_TYPE = { "java.lang.Object", "java.lang.Cloneable",
+    "java.io.Serializable" };
 
     public static ResolvedReferenceType undeterminedParameters(ResolvedReferenceTypeDeclaration typeDeclaration) {
         return new ReferenceTypeImpl(typeDeclaration, typeDeclaration.getTypeParameters().stream().map(
@@ -73,7 +73,7 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
 
     @Override
     public ResolvedTypeParameterDeclaration asTypeParameter() {
-    	return this.typeDeclaration.asTypeParameter();
+        return this.typeDeclaration.asTypeParameter();
     }
 
     /**
@@ -138,19 +138,19 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
             return false;
         }
         if (other.isUnionType()) {
-        	Optional<ResolvedReferenceType> common = other.asUnionType().getCommonAncestor();
+            Optional<ResolvedReferenceType> common = other.asUnionType().getCommonAncestor();
             return common.map(ancestor -> isAssignableBy(ancestor)).orElse(false);
         }
         // An array can be assigned only to a variable of a compatible array type,
         // or to a variable of type Object, Cloneable or java.io.Serializable.
         if (other.isArray()) {
-			return isAssignableByReferenceType(getQualifiedName());
-		}
+            return isAssignableByReferenceType(getQualifiedName());
+        }
         return false;
     }
 
     private boolean isAssignableByReferenceType(String qname) {
-    	return Stream.of(ASSIGNABLE_REFERENCE_TYPE).anyMatch(ref -> ref.equals(qname));
+        return Stream.of(ASSIGNABLE_REFERENCE_TYPE).anyMatch(ref -> ref.equals(qname));
     }
 
     @Override
@@ -210,7 +210,7 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
     }
 
     @Override
-	public List<ResolvedReferenceType> getAllAncestors(Function<ResolvedReferenceTypeDeclaration, List<ResolvedReferenceType>> traverser) {
+    public List<ResolvedReferenceType> getAllAncestors(Function<ResolvedReferenceTypeDeclaration, List<ResolvedReferenceType>> traverser) {
         // We need to go through the inheritance line and propagate the type parameters
 
         List<ResolvedReferenceType> ancestors = typeDeclaration.getAllAncestors(traverser);
@@ -223,7 +223,7 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
     }
 
     @Override
-	public List<ResolvedReferenceType> getDirectAncestors() {
+    public List<ResolvedReferenceType> getDirectAncestors() {
         // We need to go through the inheritance line and propagate the type parameters
 
         List<ResolvedReferenceType> ancestors = typeDeclaration.getAncestors();
@@ -241,7 +241,7 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
                 boolean superClassIsJavaLangObject = optionalSuperClass.isPresent() && optionalSuperClass.get().isJavaLangObject();
                 boolean thisIsJavaLangObject = thisTypeDeclaration.asClass().isJavaLangObject();
                 if (superClassIsJavaLangObject && !thisIsJavaLangObject) {
-                	ancestors.add(optionalSuperClass.get());
+                    ancestors.add(optionalSuperClass.get());
                 }
             }
         }
@@ -250,7 +250,7 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
     }
 
     @Override
-	public ResolvedReferenceType deriveTypeParameters(ResolvedTypeParametersMap typeParametersMap) {
+    public ResolvedReferenceType deriveTypeParameters(ResolvedTypeParametersMap typeParametersMap) {
         return create(typeDeclaration, typeParametersMap);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedArrayType.java
@@ -86,26 +86,26 @@ public class ResolvedArrayType implements ResolvedType {
 
     @Override
     // https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.2
-	public boolean isAssignableBy(ResolvedType other) {
-		if (other.isNull()) {
-			return true;
-		}
-		if (other.isArray()) {
-			if (baseType.isPrimitive() && other.asArrayType().getComponentType().isPrimitive()) {
-				return baseType.equals(other.asArrayType().getComponentType());
-			}
-			// An array of primitive type is not assignable by an array of boxed type nor the reverse
-			// An array of primitive type cannot be assigned to an array of Object
-			if ((baseType.isPrimitive() && other.asArrayType().getComponentType().isReferenceType())
-							|| (baseType.isReferenceType() && other.asArrayType().getComponentType().isPrimitive())) {
-				return false;
-			}
-			// An array can be assigned only to a variable of a compatible array type, or to
-			// a variable of type Object, Cloneable or java.io.Serializable.
-			return baseType.isAssignableBy(other.asArrayType().getComponentType());
-		}
-		return false;
-	}
+    public boolean isAssignableBy(ResolvedType other) {
+        if (other.isNull()) {
+            return true;
+        }
+        if (other.isArray()) {
+            if (baseType.isPrimitive() && other.asArrayType().getComponentType().isPrimitive()) {
+                return baseType.equals(other.asArrayType().getComponentType());
+            }
+            // An array of primitive type is not assignable by an array of boxed type nor the reverse
+            // An array of primitive type cannot be assigned to an array of Object
+            if ((baseType.isPrimitive() && other.asArrayType().getComponentType().isReferenceType())
+                            || (baseType.isReferenceType() && other.asArrayType().getComponentType().isPrimitive())) {
+                return false;
+            }
+            // An array can be assigned only to a variable of a compatible array type, or to
+            // a variable of type Object, Cloneable or java.io.Serializable.
+            return baseType.isAssignableBy(other.asArrayType().getComponentType());
+        }
+        return false;
+    }
 
     @Override
     public ResolvedType replaceTypeVariables(ResolvedTypeParameterDeclaration tpToReplace, ResolvedType replaced, Map<ResolvedTypeParameterDeclaration, ResolvedType> inferredTypes) {

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedPrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedPrimitiveType.java
@@ -71,9 +71,9 @@ public enum ResolvedPrimitiveType implements ResolvedType {
      * Returns true if the specified type is a boxed type of a primitive type.
      */
     public static boolean isBoxType(ResolvedType type) {
-    	if (!type.isReferenceType()) {
-    		return false;
-    	}
+        if (!type.isReferenceType()) {
+            return false;
+        }
         String qName = type.asReferenceType().getQualifiedName();
         for (ResolvedPrimitiveType ptu : values()) {
             if (ptu.getBoxTypeQName().equals(qName)) {

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -89,7 +89,7 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
         if (this == o)
             return true;
         if (o == null || (!isLazyType(o) && getClass() != o.getClass())
-        		|| (isLazyType(o) && !this.equals(asResolvedReferenceType(o))))
+                || (isLazyType(o) && !this.equals(asResolvedReferenceType(o))))
             return false;
         ResolvedReferenceType that = asResolvedReferenceType(o);
         if (!typeDeclaration.equals(that.typeDeclaration))
@@ -100,14 +100,14 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
     }
 
     private boolean isLazyType(Object type) {
-    	return type !=null && type instanceof LazyType;
+        return type !=null && type instanceof LazyType;
     }
 
     private ResolvedReferenceType asResolvedReferenceType(Object o) {
-    	if (isLazyType(o)) {
-    		return ((LazyType) o).asReferenceType();
-    	}
-    	return ResolvedReferenceType.class.cast(o);
+        if (isLazyType(o)) {
+            return ((LazyType) o).asReferenceType();
+        }
+        return ResolvedReferenceType.class.cast(o);
     }
 
     @Override
@@ -256,7 +256,7 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
      * It returns Optional.empty unless the type declaration declares a type parameter with the given name.
      */
     @Override
-	public Optional<ResolvedType> getGenericParameterByName(String name) {
+    public Optional<ResolvedType> getGenericParameterByName(String name) {
         for (ResolvedTypeParameterDeclaration tp : typeDeclaration.getTypeParameters()) {
             if (tp.getName().equals(name)) {
                 return Optional.of(this.typeParametersMap().getValue(tp));
@@ -346,14 +346,14 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
      */
     public abstract Set<ResolvedFieldDeclaration> getDeclaredFields();
 
-	/*
-	 * A class or interface whose declaration has one or more type parameters is a
-	 * generic class or interface [JLS, 8.1.2, 9.1.2]. For example, the List
-	 * interface has a single type parameter, E, representing its element type.
-	 * A raw type, is the name of the generic type used without any accompanying type
-	 * parameters [JLS, 4.8]. For example, the raw type corresponding to List<E> is
-	 * List.
-	 */
+    /*
+     * A class or interface whose declaration has one or more type parameters is a
+     * generic class or interface [JLS, 8.1.2, 9.1.2]. For example, the List
+     * interface has a single type parameter, E, representing its element type.
+     * A raw type, is the name of the generic type used without any accompanying type
+     * parameters [JLS, 4.8]. For example, the raw type corresponding to List<E> is
+     * List.
+     */
     public boolean isRawType() {
         if (!typeDeclaration.getTypeParameters().isEmpty()) {
             if (typeParametersMap().isEmpty()) {
@@ -364,7 +364,7 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
     }
 
     @Override
-	public Optional<ResolvedType> typeParamValue(ResolvedTypeParameterDeclaration typeParameterDeclaration) {
+    public Optional<ResolvedType> typeParamValue(ResolvedTypeParameterDeclaration typeParameterDeclaration) {
         if (typeParameterDeclaration.declaredOnMethod()) {
             throw new IllegalArgumentException();
         }
@@ -579,12 +579,12 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
         List<ResolvedType> erasedParameters = new ArrayList<ResolvedType>();
         if (!typeParametersMap.isEmpty()) {
             // add erased type except java.lang.object
-        	List<ResolvedType> parameters = typeParametersMap.getTypes().stream()
-        			.filter(type -> !type.isReferenceType())
-        			.map(type -> type.erasure())
-        			.filter(erasedType -> !(isJavaObject(erasedType)))
-        			.filter(erasedType -> erasedType != null)
-        			.collect(Collectors.toList());
+            List<ResolvedType> parameters = typeParametersMap.getTypes().stream()
+                    .filter(type -> !type.isReferenceType())
+                    .map(type -> type.erasure())
+                    .filter(erasedType -> !(isJavaObject(erasedType)))
+                    .filter(erasedType -> erasedType != null)
+                    .collect(Collectors.toList());
             erasedParameters.addAll(parameters);
         }
         return erasedParameters;

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedType.java
@@ -235,7 +235,7 @@ public interface ResolvedType {
      * Returns the resolved type for a type variable or the bounded resolved type or the type itself.
      */
     default ResolvedType solveGenericTypes(Context context) {
-    	return this;
+        return this;
     }
 
     default String toDescriptor() {

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedTypeVariable.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedTypeVariable.java
@@ -141,7 +141,7 @@ public class ResolvedTypeVariable implements ResolvedType {
      */
     @Override
     public ResolvedType solveGenericTypes(Context context) {
-    	return context.solveGenericType(describe()).orElse(this);
+        return context.solveGenericType(describe()).orElse(this);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedUnionType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedUnionType.java
@@ -43,9 +43,9 @@ public class ResolvedUnionType implements ResolvedType {
 
     public Optional<ResolvedReferenceType> getCommonAncestor() {
         Optional<List<ResolvedReferenceType>> reduce = elements.stream()
-        		.map(ResolvedType::asReferenceType)
-        		.map(rt -> rt. getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc))
-        		.reduce((a, b) -> {
+                .map(ResolvedType::asReferenceType)
+                .map(rt -> rt. getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc))
+                .reduce((a, b) -> {
             ArrayList<ResolvedReferenceType> common = new ArrayList<>(a);
             common.retainAll(b);
             return common;

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedWildcard.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedWildcard.java
@@ -68,12 +68,12 @@ public class ResolvedWildcard implements ResolvedType {
     }
 
     @Override
-	public boolean isWildcard() {
+    public boolean isWildcard() {
         return true;
     }
 
     @Override
-	public ResolvedWildcard asWildcard() {
+    public ResolvedWildcard asWildcard() {
         return this;
     }
 
@@ -187,24 +187,24 @@ public class ResolvedWildcard implements ResolvedType {
      */
     @Override
     public ResolvedType solveGenericTypes(Context context) {
-    	if (isExtends() || isSuper()) {
+        if (isExtends() || isSuper()) {
             ResolvedType boundResolved = getBoundedType().solveGenericTypes(context);
             if (isExtends()) {
                 return ResolvedWildcard.extendsBound(boundResolved);
             }
             return ResolvedWildcard.superBound(boundResolved);
         }
-    	return this;
+        return this;
     }
 
-	//
-	// Erasure
-	//
-	// The erasure of a type variable (§4.4) is the erasure of its leftmost bound.
-	// This method returns null if no bound is declared. This is probably a limitation.
-	//
-	@Override
-	public ResolvedType erasure() {
-		return boundedType;
-	}
+    //
+    // Erasure
+    //
+    // The erasure of a type variable (§4.4) is the erasure of its leftmost bound.
+    // This method returns null if no bound is declared. This is probably a limitation.
+    //
+    @Override
+    public ResolvedType erasure() {
+        return boundedType;
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/cache/InMemoryCache.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/cache/InMemoryCache.java
@@ -51,7 +51,7 @@ public class InMemoryCache<K, V> implements Cache<K, V>  {
     private final Map<K, V> mappedValues;
 
     private InMemoryCache() {
-    	mappedValues = Collections.synchronizedMap(new WeakHashMap<>());
+        mappedValues = Collections.synchronizedMap(new WeakHashMap<>());
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/MethodUsageResolutionCapability.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/MethodUsageResolutionCapability.java
@@ -29,6 +29,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MethodUsageResolutionCapability {
-	Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentTypes, Context invocationContext,
-	                                         List<ResolvedType> typeParameters);
+    Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentTypes, Context invocationContext,
+                                             List<ResolvedType> typeParameters);
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/SymbolResolutionCapability.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/SymbolResolutionCapability.java
@@ -28,10 +28,10 @@ import com.github.javaparser.resolution.model.SymbolReference;
  * Allows for an implementing declaration type to support solving for field <i>(symbol)</i> usage.
  */
 public interface SymbolResolutionCapability {
-	/**
-	 * @param name Field / symbol name.
-	 * @param typeSolver Symbol solver to resolve type usage.
-	 * @return Symbol reference of the resolved value.
-	 */
-	SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, TypeSolver typeSolver);
+    /**
+     * @param name Field / symbol name.
+     * @param typeSolver Symbol solver to resolve type usage.
+     * @return Symbol reference of the resolved value.
+     */
+    SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, TypeSolver typeSolver);
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/TypeVariableResolutionCapability.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/TypeVariableResolutionCapability.java
@@ -28,5 +28,5 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.List;
 
 public interface TypeVariableResolutionCapability {
-	MethodUsage resolveTypeVariables(Context context, List<ResolvedType> parameterTypes);
+    MethodUsage resolveTypeVariables(Context context, List<ResolvedType> parameterTypes);
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -615,7 +615,7 @@ public class JavaParserFacade {
      * @return The type resolved.
      */
     public ResolvedType convertToUsage(Type type) {
-    	return convertToUsage(type, JavaParserFactory.getContext(type, typeSolver));
+        return convertToUsage(type, JavaParserFactory.getContext(type, typeSolver));
     }
 
     private Optional<ForEachStmt> forEachStmtWithVariableDeclarator(
@@ -709,8 +709,8 @@ public class JavaParserFacade {
      */
     @Deprecated
     public ResolvedType classToResolvedType(Class<?> clazz) {
-    	Solver symbolSolver = new SymbolSolver(new ReflectionTypeSolver());
-    	return symbolSolver.classToResolvedType(clazz);
+        Solver symbolSolver = new SymbolSolver(new ReflectionTypeSolver());
+        return symbolSolver.classToResolvedType(clazz);
     }
 
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -550,12 +550,12 @@ public class TypeExtractor extends DefaultVisitorAdapter {
                 List<ReturnStmt> returnStmts = blockStmt.findAll(ReturnStmt.class);
 
                 if (returnStmts.size() > 0) {
-                	Set<ResolvedType> resolvedTypes = returnStmts.stream()
+                    Set<ResolvedType> resolvedTypes = returnStmts.stream()
                           .map(returnStmt -> returnStmt.getExpression()
-                        		  .map(e -> facade.getType(e))
-                        		  .orElse(ResolvedVoidType.INSTANCE))
+                                  .map(e -> facade.getType(e))
+                                  .orElse(ResolvedVoidType.INSTANCE))
                                   .collect(Collectors.toSet());
-                	actualType = LeastUpperBoundLogic.of().lub(resolvedTypes);
+                    actualType = LeastUpperBoundLogic.of().lub(resolvedTypes);
 
                 } else {
                     actualType = ResolvedVoidType.INSTANCE;
@@ -585,9 +585,9 @@ public class TypeExtractor extends DefaultVisitorAdapter {
 
     @Override
     public ResolvedType visit(MethodReferenceExpr node, Boolean solveLambdas) {
-    	if ("new".equals(node.getIdentifier())) {
-			return node.getScope().calculateResolvedType();
-		}
+        if ("new".equals(node.getIdentifier())) {
+            return node.getScope().calculateResolvedType();
+        }
         Node parentNode = demandParentNode(node);
         if (parentNode instanceof MethodCallExpr) {
             MethodCallExpr callExpr = (MethodCallExpr) parentNode;
@@ -634,13 +634,13 @@ public class TypeExtractor extends DefaultVisitorAdapter {
 
                 return result;
             }
-			// Since variable parameters are represented by an array, in case we deal with
-			// the variadic parameter we have to take into account the base type of the
-			// array.
-			ResolvedMethodDeclaration rmd = refMethod.getCorrespondingDeclaration();
-			if (rmd.hasVariadicParameter() && pos >= rmd.getNumberOfParams() - 1) {
-				return rmd.getLastParam().getType().asArrayType().getComponentType();
-			}
+            // Since variable parameters are represented by an array, in case we deal with
+            // the variadic parameter we have to take into account the base type of the
+            // array.
+            ResolvedMethodDeclaration rmd = refMethod.getCorrespondingDeclaration();
+            if (rmd.hasVariadicParameter() && pos >= rmd.getNumberOfParams() - 1) {
+                return rmd.getLastParam().getType().asArrayType().getComponentType();
+            }
             return rmd.getParam(pos).getType();
         }
         throw new UnsupportedOperationException("The type of a method reference expr depends on the position and its return value");

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -101,8 +101,8 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
     public final Optional<Context> getParent() {
         Node parentNode = wrappedNode.getParentNode().orElse(null);
 
-		// Resolution of the scope of the method call expression is delegated to parent
-		// context.
+        // Resolution of the scope of the method call expression is delegated to parent
+        // context.
         if (parentNode instanceof MethodCallExpr) {
             MethodCallExpr parentCall = (MethodCallExpr) parentNode;
             boolean found = parentCall.getArguments().contains(wrappedNode);
@@ -116,7 +116,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
         }
         Node notMethodNode = parentNode;
         // To avoid loops JP must ensure that the scope of the parent context
-		// is not the same as the current node.
+        // is not the same as the current node.
         while (notMethodNode instanceof MethodCallExpr || notMethodNode instanceof FieldAccessExpr
                 || (notMethodNode != null && notMethodNode.hasScope() && getScope(notMethodNode).equals(wrappedNode)) ) {
             notMethodNode = notMethodNode.getParentNode().orElse(null);
@@ -235,14 +235,14 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             }
                     if (typeOfScope.isConstraint()) {
                 // TODO: Figure out if it is appropriate to remove the orElseThrow() -- if so, how...
-            	ResolvedType type = typeOfScope.asConstraintType().getBound();
-            	if (type.isReferenceType()) {
-	                return singletonList(
-	                        type.asReferenceType().getTypeDeclaration()
-	                                .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty."))
-	                );
-            	}
-            	throw new UnsupportedOperationException("The type declaration cannot be found on constraint "+ type.describe());
+                ResolvedType type = typeOfScope.asConstraintType().getBound();
+                if (type.isReferenceType()) {
+                    return singletonList(
+                            type.asReferenceType().getTypeDeclaration()
+                                    .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty."))
+                    );
+                }
+                throw new UnsupportedOperationException("The type declaration cannot be found on constraint "+ type.describe());
             }
             if (typeOfScope.isUnionType()) {
                 return typeOfScope.asUnionType().getCommonAncestor()
@@ -274,7 +274,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
      * A MethodUsage corresponds to a MethodDeclaration plus the resolved type variables.
      */
     @Override
-	public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
+    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
         SymbolReference<ResolvedMethodDeclaration> methodSolved = solveMethod(name, argumentsTypes, false);
         if (methodSolved.isSolved()) {
             ResolvedMethodDeclaration methodDeclaration = methodSolved.getCorrespondingDeclaration();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -101,7 +101,7 @@ public class JavaParserTypeDeclarationAdapter {
                 .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
                 .solveType(name, typeArguments);
         if (symbolRef.isSolved())
-        	return symbolRef;
+            return symbolRef;
 
         // Check if is a type parameter
         if (wrappedNode instanceof NodeWithTypeParameters) {
@@ -137,36 +137,36 @@ public class JavaParserTypeDeclarationAdapter {
             }
         }
 
-		// Looking at extended classes and implemented interfaces
-		String typeName = isCompositeName(name) ? innerMostPartOfName(name) : name;
-		ResolvedTypeDeclaration type = checkAncestorsForType(typeName, this.typeDeclaration);
-		// Before accepting this value we need to ensure that
-		// - the name is not a composite name (this is probably a local class which is discovered
-		//   by the check of ancestors
-		// - or the outer most part of the name is equals to the type declaration name.
-		//   it could be the case when the name is prefixed by the outer class name (eg outerclass.innerClass)
-		// - or the qualified name of the type is the same as the name (in case when the name is
-		//   a fully qualified class name like java.util.Iterator
-		if (type != null
-				&& (!isCompositeName(name)
-						|| outerMostPartOfName(name).equals(this.typeDeclaration.getName())
-						|| type.getQualifiedName().equals(name))) {
-			return SymbolReference.solved(type);
-		}
+        // Looking at extended classes and implemented interfaces
+        String typeName = isCompositeName(name) ? innerMostPartOfName(name) : name;
+        ResolvedTypeDeclaration type = checkAncestorsForType(typeName, this.typeDeclaration);
+        // Before accepting this value we need to ensure that
+        // - the name is not a composite name (this is probably a local class which is discovered
+        //   by the check of ancestors
+        // - or the outer most part of the name is equals to the type declaration name.
+        //   it could be the case when the name is prefixed by the outer class name (eg outerclass.innerClass)
+        // - or the qualified name of the type is the same as the name (in case when the name is
+        //   a fully qualified class name like java.util.Iterator
+        if (type != null
+                && (!isCompositeName(name)
+                        || outerMostPartOfName(name).equals(this.typeDeclaration.getName())
+                        || type.getQualifiedName().equals(name))) {
+            return SymbolReference.solved(type);
+        }
 
         return SymbolReference.unsolved();
     }
 
     private boolean isCompositeName(String name) {
-    	return name.indexOf('.') > -1;
+        return name.indexOf('.') > -1;
     }
 
     private String innerMostPartOfName(String name) {
-    	return isCompositeName(name) ? name.substring(name.lastIndexOf(".")+1) : name;
+        return isCompositeName(name) ? name.substring(name.lastIndexOf(".")+1) : name;
     }
 
     private String outerMostPartOfName(String name) {
-    	return isCompositeName(name) ? name.substring(0, name.lastIndexOf(".")) : name;
+        return isCompositeName(name) ? name.substring(0, name.lastIndexOf(".")) : name;
     }
 
     private <T extends NodeWithTypeArguments<?>> boolean compareTypes(List<? extends Type> types,

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -93,8 +93,8 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                         methodUsage = resolveMethodTypeParameters(methodUsage, argumentsTypes);
                         return Optional.of(methodUsage);
                     }
-					throw new UnsolvedSymbolException(ref.getCorrespondingDeclaration().toString(),
-							"Method '" + name + "' with parameterTypes " + argumentsTypes);
+                    throw new UnsolvedSymbolException(ref.getCorrespondingDeclaration().toString(),
+                            "Method '" + name + "' with parameterTypes " + argumentsTypes);
                 }
             }
 
@@ -231,7 +231,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             }
             return Optional.of(methodUsage);
         }
-		return ref;
+        return ref;
     }
 
     private void inferTypes(ResolvedType source, ResolvedType target, Map<ResolvedTypeParameterDeclaration, ResolvedType> mappings) {
@@ -242,11 +242,11 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             ResolvedReferenceType sourceRefType = source.asReferenceType();
             ResolvedReferenceType targetRefType = target.asReferenceType();
             if (sourceRefType.getQualifiedName().equals(targetRefType.getQualifiedName())) {
-            	if (!sourceRefType.isRawType() && !targetRefType.isRawType()) {
-	                for (int i = 0; i < sourceRefType.typeParametersValues().size(); i++) {
-	                    inferTypes(sourceRefType.typeParametersValues().get(i), targetRefType.typeParametersValues().get(i), mappings);
-	                }
-            	}
+                if (!sourceRefType.isRawType() && !targetRefType.isRawType()) {
+                    for (int i = 0; i < sourceRefType.typeParametersValues().size(); i++) {
+                        inferTypes(sourceRefType.typeParametersValues().get(i), targetRefType.typeParametersValues().get(i), mappings);
+                    }
+                }
             }
             return;
         }
@@ -341,22 +341,22 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                 // Arrays.aslist(int[]{1}) must returns List<int[]>
                 // but Arrays.aslist(String[]{""}) must returns List<String>
                 // Arrays.asList() accept generic type T. Since Java generics work only on
-				// reference types (object types), not on primitives, and int[] is an object
+                // reference types (object types), not on primitives, and int[] is an object
                 // then Arrays.aslist(int[]{1}) returns List<int[]>
                 ResolvedType lastActualParamType =
                         actualParamTypes.get(actualParamTypes.size() - 1);
                 ResolvedType actualType = lastActualParamType;
                 if (lastActualParamType.isArray()) {
-                	ResolvedType componentType = lastActualParamType.asArrayType().getComponentType();
-                	// in cases where, the expected type is a generic type (Arrays.asList(T... a)) and the component type of the array type is a reference type
-                	// or the expected type is not a generic (IntStream.of(int... values)) and the component type is not a reference type
-                	// then the actual type is the component type (in the example above 'int')
-                	if ((componentType.isReferenceType()
-                			&& ResolvedTypeVariable.class.isInstance(expectedType))
-                			|| (!componentType.isReferenceType()
-                        			&& !ResolvedTypeVariable.class.isInstance(expectedType))) {
-                		actualType = lastActualParamType.asArrayType().getComponentType();
-                	}
+                    ResolvedType componentType = lastActualParamType.asArrayType().getComponentType();
+                    // in cases where, the expected type is a generic type (Arrays.asList(T... a)) and the component type of the array type is a reference type
+                    // or the expected type is not a generic (IntStream.of(int... values)) and the component type is not a reference type
+                    // then the actual type is the component type (in the example above 'int')
+                    if ((componentType.isReferenceType()
+                            && ResolvedTypeVariable.class.isInstance(expectedType))
+                            || (!componentType.isReferenceType()
+                                    && !ResolvedTypeVariable.class.isInstance(expectedType))) {
+                        actualType = lastActualParamType.asArrayType().getComponentType();
+                    }
                 }
                 if (!expectedType.isAssignableBy(actualType)) {
                     for (ResolvedTypeParameterDeclaration tp : methodUsage.getDeclaration().getTypeParameters()) {
@@ -375,8 +375,8 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                 // match only the varargs type
                 matchTypeParameters(expectedType, actualType, matchedTypeParameters);
             } else if (methodUsage.getDeclaration().getNumberOfParams() == 1) {
-            	// In this case the method declares only one parameter which is a variadic parameter.
-            	// At this stage we can consider that the actual parameters all have the same type.
+                // In this case the method declares only one parameter which is a variadic parameter.
+                // At this stage we can consider that the actual parameters all have the same type.
                 ResolvedType expectedType =
                     methodUsage.getDeclaration().getLastParam().getType().asArrayType().getComponentType();
                 // the varargs corresponding type can not be an Array<T> because of the assumption
@@ -384,7 +384,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                 ResolvedType actualType = actualParamTypes.get(actualParamTypes.size() - 1);
                 if (!expectedType.isAssignableBy(actualType)) {
                     throw new UnsupportedOperationException(
-                    		String.format("Unable to resolve the type typeParametersValues in a MethodUsage. Expected type: %s, Actual type: %s. Method Declaration: %s. MethodUsage: %s",
+                            String.format("Unable to resolve the type typeParametersValues in a MethodUsage. Expected type: %s, Actual type: %s. Method Declaration: %s. MethodUsage: %s",
                             expectedType,
                             actualType,
                             methodUsage.getDeclaration(),
@@ -415,87 +415,87 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
      * If there is more than one actual type argument for a formal type parameter
      * then the type parameter list is reduced using LUB fonction.
      */
-	private MethodUsage replaceTypeParameter(MethodUsage methodUsage,
-			Map<ResolvedTypeParameterDeclaration, ResolvedType> matchedTypeParameters) {
-		// first group all resolved types by type variable
-		Map<String, Set<ResolvedType>> resolvedTypesByTypeVariable = groupResolvedTypeByTypeVariable(matchedTypeParameters);
-		// then reduce the list of resolved types with the least upper bound logic
-		Map<String, ResolvedType> reducedResolvedTypesByTypeVariable = reduceResolvedTypesByTypeVariable(resolvedTypesByTypeVariable);
-		// then replace resolved type by the reduced type for each type variable
-		convertTypesParameters(matchedTypeParameters, reducedResolvedTypesByTypeVariable);
-		// finally replace type parameters
-		for (ResolvedTypeParameterDeclaration tp : matchedTypeParameters.keySet()) {
+    private MethodUsage replaceTypeParameter(MethodUsage methodUsage,
+            Map<ResolvedTypeParameterDeclaration, ResolvedType> matchedTypeParameters) {
+        // first group all resolved types by type variable
+        Map<String, Set<ResolvedType>> resolvedTypesByTypeVariable = groupResolvedTypeByTypeVariable(matchedTypeParameters);
+        // then reduce the list of resolved types with the least upper bound logic
+        Map<String, ResolvedType> reducedResolvedTypesByTypeVariable = reduceResolvedTypesByTypeVariable(resolvedTypesByTypeVariable);
+        // then replace resolved type by the reduced type for each type variable
+        convertTypesParameters(matchedTypeParameters, reducedResolvedTypesByTypeVariable);
+        // finally replace type parameters
+        for (ResolvedTypeParameterDeclaration tp : matchedTypeParameters.keySet()) {
             methodUsage = methodUsage.replaceTypeParameter(tp, matchedTypeParameters.get(tp));
         }
-		return methodUsage;
-	}
+        return methodUsage;
+    }
 
-	/*
-	 * Update the matchedTypeParameters map from the types in reducedResolvedTypesByTypeVariable map.
-	 */
-	private void convertTypesParameters(
-			Map<ResolvedTypeParameterDeclaration, ResolvedType> matchedTypeParameters,
-			Map<String, ResolvedType> reducedResolvedTypesByTypeVariable) {
-		for (ResolvedTypeParameterDeclaration tp : matchedTypeParameters.keySet()) {
-			String typeParameterName = tp.getName();
-			boolean replacement = reducedResolvedTypesByTypeVariable.keySet().contains(typeParameterName);
-			if (replacement) {
-				matchedTypeParameters.put(tp, reducedResolvedTypesByTypeVariable.get(typeParameterName));
-			}
+    /*
+     * Update the matchedTypeParameters map from the types in reducedResolvedTypesByTypeVariable map.
+     */
+    private void convertTypesParameters(
+            Map<ResolvedTypeParameterDeclaration, ResolvedType> matchedTypeParameters,
+            Map<String, ResolvedType> reducedResolvedTypesByTypeVariable) {
+        for (ResolvedTypeParameterDeclaration tp : matchedTypeParameters.keySet()) {
+            String typeParameterName = tp.getName();
+            boolean replacement = reducedResolvedTypesByTypeVariable.keySet().contains(typeParameterName);
+            if (replacement) {
+                matchedTypeParameters.put(tp, reducedResolvedTypesByTypeVariable.get(typeParameterName));
+            }
         }
-	}
+    }
 
-	/*
-	 * Group resolved type by the variable type. For example in Map.of("k0", 0, "k1",
-	 * 1D) which is solved as static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2)
-	 * the type variable named V that represents the type of the first and fourth parameter
-	 * must reference v1 (Integer type) and v2 (Double type).
-	 */
-	private Map<String, Set<ResolvedType>> groupResolvedTypeByTypeVariable(Map<ResolvedTypeParameterDeclaration, ResolvedType> typeParameters) {
-		Map<String, Set<ResolvedType>> resolvedTypesByTypeVariable = new HashMap<>();
-		for (ResolvedTypeParameterDeclaration tp : typeParameters.keySet()) {
-			String typeParameterName = tp.getName();
-			boolean alreadyCollected = resolvedTypesByTypeVariable.keySet().contains(typeParameterName);
-			if (!alreadyCollected) {
-				Set<ResolvedType> resolvedTypes = findResolvedTypesByTypeVariable(typeParameterName, typeParameters);
-				resolvedTypesByTypeVariable.put(typeParameterName, resolvedTypes);
-			}
+    /*
+     * Group resolved type by the variable type. For example in Map.of("k0", 0, "k1",
+     * 1D) which is solved as static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2)
+     * the type variable named V that represents the type of the first and fourth parameter
+     * must reference v1 (Integer type) and v2 (Double type).
+     */
+    private Map<String, Set<ResolvedType>> groupResolvedTypeByTypeVariable(Map<ResolvedTypeParameterDeclaration, ResolvedType> typeParameters) {
+        Map<String, Set<ResolvedType>> resolvedTypesByTypeVariable = new HashMap<>();
+        for (ResolvedTypeParameterDeclaration tp : typeParameters.keySet()) {
+            String typeParameterName = tp.getName();
+            boolean alreadyCollected = resolvedTypesByTypeVariable.keySet().contains(typeParameterName);
+            if (!alreadyCollected) {
+                Set<ResolvedType> resolvedTypes = findResolvedTypesByTypeVariable(typeParameterName, typeParameters);
+                resolvedTypesByTypeVariable.put(typeParameterName, resolvedTypes);
+            }
         }
-		return resolvedTypesByTypeVariable;
-	}
+        return resolvedTypesByTypeVariable;
+    }
 
-	/*
-	 * Collect all resolved type from a type variable name
-	 */
-	private Set<ResolvedType> findResolvedTypesByTypeVariable(String typeVariableName, Map<ResolvedTypeParameterDeclaration, ResolvedType> typeParameters) {
-		return typeParameters.keySet().stream()
-				.filter(resolvedTypeParameterDeclaration -> resolvedTypeParameterDeclaration.getName().equals(typeVariableName))
-				.map(resolvedTypeParameterDeclaration -> typeParameters.get(resolvedTypeParameterDeclaration))
-				.collect(Collectors.toSet());
-	}
+    /*
+     * Collect all resolved type from a type variable name
+     */
+    private Set<ResolvedType> findResolvedTypesByTypeVariable(String typeVariableName, Map<ResolvedTypeParameterDeclaration, ResolvedType> typeParameters) {
+        return typeParameters.keySet().stream()
+                .filter(resolvedTypeParameterDeclaration -> resolvedTypeParameterDeclaration.getName().equals(typeVariableName))
+                .map(resolvedTypeParameterDeclaration -> typeParameters.get(resolvedTypeParameterDeclaration))
+                .collect(Collectors.toSet());
+    }
 
-	/*
-	 * Reduce all set of resolved type with LUB
-	 */
-	private Map<String, ResolvedType> reduceResolvedTypesByTypeVariable(Map<String, Set<ResolvedType>> typeParameters) {
-		Map<String, ResolvedType> reducedResolvedTypesList = new HashMap<>();
-		for (String typeParameterName : typeParameters.keySet()) {
-			ResolvedType type = reduceResolvedTypesWithLub(typeParameters.get(typeParameterName));
-			reducedResolvedTypesList.put(typeParameterName, type);
+    /*
+     * Reduce all set of resolved type with LUB
+     */
+    private Map<String, ResolvedType> reduceResolvedTypesByTypeVariable(Map<String, Set<ResolvedType>> typeParameters) {
+        Map<String, ResolvedType> reducedResolvedTypesList = new HashMap<>();
+        for (String typeParameterName : typeParameters.keySet()) {
+            ResolvedType type = reduceResolvedTypesWithLub(typeParameters.get(typeParameterName));
+            reducedResolvedTypesList.put(typeParameterName, type);
         }
-		return reducedResolvedTypesList;
-	}
+        return reducedResolvedTypesList;
+    }
 
-	private ResolvedType reduceResolvedTypesWithLub(Set<ResolvedType> resolvedTypes) {
-		return LeastUpperBoundLogic.of().lub(resolvedTypes);
-	}
+    private ResolvedType reduceResolvedTypesWithLub(Set<ResolvedType> resolvedTypes) {
+        return LeastUpperBoundLogic.of().lub(resolvedTypes);
+    }
 
     private void matchTypeParameters(ResolvedType expectedType, ResolvedType actualType, Map<ResolvedTypeParameterDeclaration, ResolvedType> matchedTypeParameters) {
         if (expectedType.isTypeVariable()) {
             ResolvedType type = actualType;
             // in case of primitive type, the expected type must be compared with the boxed type of the actual type
             if (type.isPrimitive()) {
-            	ResolvedReferenceTypeDeclaration resolvedTypedeclaration = typeSolver.solveType(type.asPrimitive().getBoxTypeQName());
+                ResolvedReferenceTypeDeclaration resolvedTypedeclaration = typeSolver.solveType(type.asPrimitive().getBoxTypeQName());
                 type = new ReferenceTypeImpl(resolvedTypedeclaration);
             }
             /*
@@ -511,7 +511,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             }
             matchedTypeParameters.put(expectedType.asTypeParameter(), type);
         } else if (expectedType.isArray()) {
-        	// Issue 2258 : NullType must not fail this search
+            // Issue 2258 : NullType must not fail this search
             if (!(actualType.isArray() || actualType.isNull())) {
                 throw new UnsupportedOperationException(actualType.getClass().getCanonicalName());
             }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
@@ -101,12 +101,12 @@ public class MethodReferenceExprContext extends AbstractJavaParserContext<Method
             MethodUsage methodUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(methodCallExpr);
             int pos = pos(methodCallExpr, wrappedNode);
             ResolvedMethodDeclaration rmd = methodUsage.getDeclaration();
-			// Since variable parameters are represented by an array, in case we deal with
-			// the variadic parameter we have to take into account the base type of the
-			// array.
+            // Since variable parameters are represented by an array, in case we deal with
+            // the variadic parameter we have to take into account the base type of the
+            // array.
             ResolvedType lambdaType = (rmd.hasVariadicParameter() && pos >= rmd.getNumberOfParams() - 1) ?
-            		rmd.getLastParam().getType().asArrayType().getComponentType():
-            			methodUsage.getParamType(pos);
+                    rmd.getLastParam().getType().asArrayType().getComponentType():
+                        methodUsage.getParamType(pos);
 
             // Get the functional method in order for us to resolve it's type arguments properly
             Optional<MethodUsage> functionalMethodOpt = FunctionalInterfaceLogic.getFunctionalMethod(lambdaType);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -376,7 +376,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
         }
 
         @Override
-		public MethodUsage resolveTypeVariables(Context context, List<ResolvedType> parameterTypes) {
+        public MethodUsage resolveTypeVariables(Context context, List<ResolvedType> parameterTypes) {
             return new MethodUsage(this);
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -79,7 +79,7 @@ public class JavaParserMethodDeclaration implements ResolvedMethodDeclaration, T
     }
     
     private SymbolResolver symbolResolver(TypeSolver typeSolver) {
-    	return new JavaSymbolSolver(typeSolver);
+        return new JavaSymbolSolver(typeSolver);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
@@ -181,9 +181,9 @@ public class JavaParserTypeAdapter<T extends Node & NodeWithSimpleName<T> & Node
      * Returns a set of the declared annotation on this type
      */
     public Set<ResolvedAnnotationDeclaration> getDeclaredAnnotations() {
-    	return wrappedNode.getAnnotations().stream()
-    		.map(annotation -> annotation.resolve())
-    		.collect(Collectors.toSet());
+        return wrappedNode.getAnnotations().stream()
+            .map(annotation -> annotation.resolve())
+            .collect(Collectors.toSet());
     }
 
     public Set<ResolvedReferenceTypeDeclaration> internalTypes() {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -130,7 +130,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
     }
 
     @Override
-	@Deprecated
+    @Deprecated
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameterValues) {
         return JavassistUtils.solveMethodAsUsage(name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
@@ -202,15 +202,15 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
             return true;
         }
         Optional<ResolvedReferenceType> oSuperClass = javassistTypeDeclarationAdapter.getSuperClass();
-		if (oSuperClass.isPresent()) {
-			ResolvedReferenceType superClass = oSuperClass.get();
-			Optional<ResolvedReferenceTypeDeclaration> oDecl = superClass.getTypeDeclaration();
-			if (oDecl.isPresent() && oDecl.get().canBeAssignedTo(other)) {
-				return true;
-			}
-		}
+        if (oSuperClass.isPresent()) {
+            ResolvedReferenceType superClass = oSuperClass.get();
+            Optional<ResolvedReferenceTypeDeclaration> oDecl = superClass.getTypeDeclaration();
+            if (oDecl.isPresent() && oDecl.get().canBeAssignedTo(other)) {
+                return true;
+            }
+        }
 
-		for (ResolvedReferenceType interfaze : javassistTypeDeclarationAdapter.getInterfaces()) {
+        for (ResolvedReferenceType interfaze : javassistTypeDeclarationAdapter.getInterfaces()) {
             if (interfaze.getTypeDeclaration().isPresent() && interfaze.getTypeDeclaration().get().canBeAssignedTo(other)) {
                 return true;
             }
@@ -221,7 +221,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
 
     @Override
     public boolean isAssignableBy(ResolvedType type) {
-    	return javassistTypeDeclarationAdapter.isAssignableBy(type);
+        return javassistTypeDeclarationAdapter.isAssignableBy(type);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -145,12 +145,12 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
 
     @Override
     public boolean isAssignableBy(ResolvedType type) {
-    	return javassistTypeDeclarationAdapter.isAssignableBy(type);
+        return javassistTypeDeclarationAdapter.isAssignableBy(type);
     }
 
     @Override
     public boolean isAssignableBy(ResolvedReferenceTypeDeclaration other) {
-    	return javassistTypeDeclarationAdapter.isAssignableBy(other);
+        return javassistTypeDeclarationAdapter.isAssignableBy(other);
     }
 
     @Override
@@ -180,7 +180,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
     }
 
     @Override
-	public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes,
+    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameterValues) {
         return JavassistUtils.solveMethodAsUsage(name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -96,7 +96,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
     }
 
     @Override
-	@Deprecated
+    @Deprecated
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameterValues) {
         return JavassistUtils.solveMethodAsUsage(name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
@@ -125,7 +125,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
 
     @Override
     public boolean canBeAssignedTo(ResolvedReferenceTypeDeclaration other) {
-    	if (other.isJavaLangObject()) {
+        if (other.isJavaLangObject()) {
             // Everything can be assigned to {@code java.lang.Object}
             return true;
         }
@@ -137,19 +137,19 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
             return true;
         }
         Optional<ResolvedReferenceType> oSuperClass = javassistTypeDeclarationAdapter.getSuperClass();
-		if (oSuperClass.isPresent()) {
-			ResolvedReferenceType superClass = oSuperClass.get();
-			Optional<ResolvedReferenceTypeDeclaration> oDecl = superClass.getTypeDeclaration();
-			if (oDecl.isPresent() && oDecl.get().canBeAssignedTo(other)) {
-				return true;
-			}
-		}
-		for (ResolvedReferenceType interfaze : javassistTypeDeclarationAdapter.getInterfaces()) {
-			if (interfaze.getTypeDeclaration().isPresent()
-					&& interfaze.getTypeDeclaration().get().canBeAssignedTo(other)) {
-				return true;
-			}
-		}
+        if (oSuperClass.isPresent()) {
+            ResolvedReferenceType superClass = oSuperClass.get();
+            Optional<ResolvedReferenceTypeDeclaration> oDecl = superClass.getTypeDeclaration();
+            if (oDecl.isPresent() && oDecl.get().canBeAssignedTo(other)) {
+                return true;
+            }
+        }
+        for (ResolvedReferenceType interfaze : javassistTypeDeclarationAdapter.getInterfaces()) {
+            if (interfaze.getTypeDeclaration().isPresent()
+                    && interfaze.getTypeDeclaration().get().canBeAssignedTo(other)) {
+                return true;
+            }
+        }
 
         return false;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
@@ -49,8 +49,8 @@ import javassist.bytecode.SignatureAttribute;
  */
 public class JavassistTypeDeclarationAdapter {
 
-	// this a workaround to get the annotation type (taken from Javassist AnnotationImpl class)
-	private static final String JDK_ANNOTATION_CLASS_NAME = "java.lang.annotation.Annotation";
+    // this a workaround to get the annotation type (taken from Javassist AnnotationImpl class)
+    private static final String JDK_ANNOTATION_CLASS_NAME = "java.lang.annotation.Annotation";
     private static Method JDK_ANNOTATION_TYPE_METHOD = null;
 
     static {
@@ -186,30 +186,30 @@ public class JavassistTypeDeclarationAdapter {
      * Returns a set of the declared annotation on this type
      */
     public Set<ResolvedAnnotationDeclaration> getDeclaredAnnotations() {
-    	try {
-			Object[] annotations = ctClass.getAnnotations();
-			return Stream.of(annotations)
-	    			.map(annotation -> getAnnotationType(annotation))
-	    			.filter(annotationType -> annotationType != null)
-	    			.map(annotationType -> typeSolver.solveType(annotationType))
-	    			.map(rrtd -> rrtd.asAnnotation())
-	    			.collect(Collectors.toSet());
-		} catch (ClassNotFoundException e) {
-			// There is nothing to do except returns an empty set
-		}
-    	return Collections.EMPTY_SET;
+        try {
+            Object[] annotations = ctClass.getAnnotations();
+            return Stream.of(annotations)
+                    .map(annotation -> getAnnotationType(annotation))
+                    .filter(annotationType -> annotationType != null)
+                    .map(annotationType -> typeSolver.solveType(annotationType))
+                    .map(rrtd -> rrtd.asAnnotation())
+                    .collect(Collectors.toSet());
+        } catch (ClassNotFoundException e) {
+            // There is nothing to do except returns an empty set
+        }
+        return Collections.EMPTY_SET;
 
     }
 
     private String getAnnotationType(Object annotation) {
-    	String typeName = null;
-    	try {
-    		Class<?> annotationClass = (Class<?>) Proxy.getInvocationHandler(annotation)
-					.invoke(annotation, JDK_ANNOTATION_TYPE_METHOD, null);
-    		typeName = annotationClass.getTypeName();
-		} catch (Throwable e) {
-		}
-    	return typeName;
+        String typeName = null;
+        try {
+            Class<?> annotationClass = (Class<?>) Proxy.getInvocationHandler(annotation)
+                    .invoke(annotation, JDK_ANNOTATION_TYPE_METHOD, null);
+            typeName = annotationClass.getTypeName();
+        } catch (Throwable e) {
+        }
+        return typeName;
     }
 
     public List<ResolvedTypeParameterDeclaration> getTypeParameters() {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistUtils.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistUtils.java
@@ -242,7 +242,7 @@ class JavassistUtils {
     }
 
     private static Optional<String> getVariableName(LocalVariableAttribute attr, int pos) {
-    	try {
+        try {
             return Optional.of(attr.variableNameByIndex(pos));
         } catch (ArrayIndexOutOfBoundsException e) {
             return Optional.empty();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/logic/AbstractTypeDeclaration.java
@@ -41,12 +41,12 @@ import com.github.javaparser.utils.Pair;
  */
 public abstract class AbstractTypeDeclaration implements ResolvedReferenceTypeDeclaration {
 
-	/*
-	 * Returns all methods which have distinct "enhanced" signature declared in this type and all members.
-	 * An "enhanced" signature include the return type which is used sometimes to identify functional interfaces.
-	 * This is a different implementation from the previous one which returned all methods which have a distinct
-	 * signature (based on method name and qualified parameter types)
-	 */
+    /*
+     * Returns all methods which have distinct "enhanced" signature declared in this type and all members.
+     * An "enhanced" signature include the return type which is used sometimes to identify functional interfaces.
+     * This is a different implementation from the previous one which returned all methods which have a distinct
+     * signature (based on method name and qualified parameter types)
+     */
     @Override
     public final Set<MethodUsage> getAllMethods() {
         Set<MethodUsage> methods = new HashSet<>();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassAdapter.java
@@ -87,17 +87,17 @@ class ReflectionClassAdapter {
 
     public List<ResolvedReferenceType> getAncestors() {
         List<ResolvedReferenceType> ancestors = new LinkedList<>();
-		if (typeDeclaration.isClass() && !Object.class.getCanonicalName().equals(clazz.getCanonicalName())) {
-			if (getSuperClass().isPresent()) {
-				ReferenceTypeImpl superClass = getSuperClass().get();
-				ancestors.add(superClass);
-			} else {
-				// Inject the implicitly added extends java.lang.Object
-				ReferenceTypeImpl object = new ReferenceTypeImpl(
-						new ReflectionClassDeclaration(Object.class, typeSolver));
-				ancestors.add(object);
-			}
-		}
+        if (typeDeclaration.isClass() && !Object.class.getCanonicalName().equals(clazz.getCanonicalName())) {
+            if (getSuperClass().isPresent()) {
+                ReferenceTypeImpl superClass = getSuperClass().get();
+                ancestors.add(superClass);
+            } else {
+                // Inject the implicitly added extends java.lang.Object
+                ReferenceTypeImpl object = new ReferenceTypeImpl(
+                        new ReflectionClassDeclaration(Object.class, typeSolver));
+                ancestors.add(object);
+            }
+        }
         ancestors.addAll(getInterfaces());
         return ancestors;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionFactory.java
@@ -99,7 +99,7 @@ public class ReflectionFactory {
             WildcardType wildcardType = (WildcardType) type;
             if (wildcardType.getLowerBounds().length > 0 && wildcardType.getUpperBounds().length > 0) {
                 if (wildcardType.getUpperBounds().length == 1 && wildcardType.getUpperBounds()[0].getTypeName().equals(JAVA_LANG_OBJECT)) {
-                	// ok, it does not matter
+                    // ok, it does not matter
                 }
             }
             if (wildcardType.getLowerBounds().length > 0) {
@@ -113,7 +113,7 @@ public class ReflectionFactory {
                     throw new UnsupportedOperationException();
                 }
                 if (wildcardType.getUpperBounds().length == 1 && wildcardType.getUpperBounds()[0].getTypeName().equals(JAVA_LANG_OBJECT)) {
-                	return ResolvedWildcard.UNBOUNDED;
+                    return ResolvedWildcard.UNBOUNDED;
                 }
                 return ResolvedWildcard.extendsBound(typeUsageFor(wildcardType.getUpperBounds()[0], typeSolver));
             }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/SymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/SymbolSolver.java
@@ -62,38 +62,38 @@ public class SymbolSolver implements Solver {
     }
 
     @Override
-	public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Context context) {
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Context context) {
         return context.solveSymbol(name);
     }
 
     @Override
-	public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Node node) {
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, Node node) {
         return solveSymbol(name, JavaParserFactory.getContext(node, typeSolver));
     }
 
     @Override
-	public Optional<Value> solveSymbolAsValue(String name, Context context) {
+    public Optional<Value> solveSymbolAsValue(String name, Context context) {
         return context.solveSymbolAsValue(name);
     }
 
     @Override
-	public Optional<Value> solveSymbolAsValue(String name, Node node) {
+    public Optional<Value> solveSymbolAsValue(String name, Node node) {
         Context context = JavaParserFactory.getContext(node, typeSolver);
         return solveSymbolAsValue(name, context);
     }
 
     @Override
-	public SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Context context) {
+    public SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Context context) {
         return context.solveType(name);
     }
 
     @Override
-	public SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Node node) {
+    public SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Node node) {
         return solveType(name, JavaParserFactory.getContext(node, typeSolver));
     }
 
     @Override
-	public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context) {
+    public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context) {
         SymbolReference<ResolvedMethodDeclaration> decl = context.solveMethod(methodName, argumentsTypes, false);
         if (!decl.isSolved()) {
             throw new UnsolvedSymbolException(context.toString(), methodName);
@@ -102,12 +102,12 @@ public class SymbolSolver implements Solver {
     }
 
     @Override
-	public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node) {
+    public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node) {
         return solveMethod(methodName, argumentsTypes, JavaParserFactory.getContext(node, typeSolver));
     }
 
     @Override
-	public ResolvedTypeDeclaration solveType(Type type) {
+    public ResolvedTypeDeclaration solveType(Type type) {
         if (type instanceof ClassOrInterfaceType) {
 
             // FIXME should call typesolver here!
@@ -123,7 +123,7 @@ public class SymbolSolver implements Solver {
     }
 
     @Override
-	public ResolvedType solveTypeUsage(String name, Context context) {
+    public ResolvedType solveTypeUsage(String name, Context context) {
         Optional<ResolvedType> genericType = context.solveGenericType(name);
         if (genericType.isPresent()) {
             return genericType.get();
@@ -139,7 +139,7 @@ public class SymbolSolver implements Solver {
      * It should contain its own private fields but not inherited private fields.
      */
     @Override
-	public SymbolReference<? extends ResolvedValueDeclaration> solveSymbolInType(ResolvedTypeDeclaration typeDeclaration, String name) {
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbolInType(ResolvedTypeDeclaration typeDeclaration, String name) {
         if (typeDeclaration instanceof SymbolResolutionCapability) {
             return ((SymbolResolutionCapability) typeDeclaration).solveSymbol(name, typeSolver);
         }
@@ -153,7 +153,7 @@ public class SymbolSolver implements Solver {
      * and do not be specific to JavaParser classes like in this case.
      */
     @Override
-	@Deprecated
+    @Deprecated
     public SymbolReference<ResolvedTypeDeclaration> solveTypeInType(ResolvedTypeDeclaration typeDeclaration, String name) {
         if (typeDeclaration instanceof JavaParserClassDeclaration) {
             return ((JavaParserClassDeclaration) typeDeclaration).solveType(name);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
@@ -23,7 +23,7 @@ public class LeastUpperBoundLogic {
     private Set<Set<ResolvedType>> lubCache = new HashSet<>();
 
     public static LeastUpperBoundLogic of() {
-    	return new LeastUpperBoundLogic();
+        return new LeastUpperBoundLogic();
     }
 
     private LeastUpperBoundLogic() {}
@@ -40,8 +40,8 @@ public class LeastUpperBoundLogic {
         // One way to handle this case is to remove the type null from the list of types.
         Set<ResolvedType> resolvedTypes = types.stream().filter(type -> !(type instanceof NullType)).collect(Collectors.toSet());
 
-		// reduces the set in the presence of enumeration type because members are
-		// not equal and they do not have an explicit super type.
+        // reduces the set in the presence of enumeration type because members are
+        // not equal and they do not have an explicit super type.
         // So we only keep one enumeration for all the members of an enumeration
         filterEnumType(resolvedTypes);
 
@@ -204,25 +204,25 @@ public class LeastUpperBoundLogic {
      * Check the type declaration if it is an enum
      */
     private boolean isEnum(ResolvedType type) {
-    	return type.isReferenceType() && type.asReferenceType().getTypeDeclaration().get().isEnum();
+        return type.isReferenceType() && type.asReferenceType().getTypeDeclaration().get().isEnum();
     }
 
     /*
      * Keep only one enum reference type per enum declaration
      */
     private void filterEnumType(Set<ResolvedType> resolvedTypes) {
-    	Map<String, ResolvedType> enumTypes = new HashMap<>();
+        Map<String, ResolvedType> enumTypes = new HashMap<>();
         List<ResolvedType> erasedEnumTypes = new ArrayList<>();
         for (ResolvedType type : resolvedTypes) {
-        	if (isEnum(type)) {
-        		// enum qualified name i.e. java.math.RoundingMode
-        		String qn = type.asReferenceType().getTypeDeclaration().get().asEnum().getQualifiedName();
-        		// Save the first occurrence and mark the others so they can be deleted
-        		ResolvedType returnedType = enumTypes.putIfAbsent(qn, type);
-        		if (returnedType != null) {
-        			erasedEnumTypes.add(type);
-        		}
-        	}
+            if (isEnum(type)) {
+                // enum qualified name i.e. java.math.RoundingMode
+                String qn = type.asReferenceType().getTypeDeclaration().get().asEnum().getQualifiedName();
+                // Save the first occurrence and mark the others so they can be deleted
+                ResolvedType returnedType = enumTypes.putIfAbsent(qn, type);
+                if (returnedType != null) {
+                    erasedEnumTypes.add(type);
+                }
+            }
         }
         resolvedTypes.removeAll(erasedEnumTypes);
     }
@@ -234,7 +234,7 @@ public class LeastUpperBoundLogic {
     }
 
     private Set<ResolvedType> supertypes(ResolvedType type) {
-    	// How to deal with other types like for example type variable?
+        // How to deal with other types like for example type variable?
         return type.isReferenceType() ? supertypes(type.asReferenceType())
                 : new LinkedHashSet<>();
     }
@@ -370,12 +370,12 @@ public class LeastUpperBoundLogic {
      * the result of lcta(List<String>, List<T>) should be in List<String>.
      */
     private boolean isSubstituable(ResolvedTypeParameterDeclaration typeDecl, ResolvedType type) {
-    	return type.isTypeVariable() && (!typeDecl.hasBound() || boundedAsObject(typeDecl));
+        return type.isTypeVariable() && (!typeDecl.hasBound() || boundedAsObject(typeDecl));
     }
 
     private boolean boundedAsObject(ResolvedTypeParameterDeclaration typeDecl) {
-    	List<Bound> bounds = typeDecl.getBounds();
-    	return bounds.size() == 1 && bounds.get(0).getType().equals(typeDecl.object());
+        List<Bound> bounds = typeDecl.getBounds();
+        return bounds.size() == 1 && bounds.get(0).getType().equals(typeDecl.object());
     }
 
     private ResolvedType substituteType(ResolvedType type1, TypeSubstitution typeSubstitution) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/TypeHelper.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/TypeHelper.java
@@ -204,8 +204,8 @@ public class TypeHelper {
      * any other shared supertype (that is, no other shared supertype is a subtype of the least upper bound).
      */
     public static ResolvedType leastUpperBound(Set<ResolvedType> types) {
-    	LeastUpperBoundLogic logic = LeastUpperBoundLogic.of();
-    	return logic.lub(types);
+        LeastUpperBoundLogic logic = LeastUpperBoundLogic.of();
+        return logic.lub(types);
     }
 
     /**

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
@@ -149,10 +149,10 @@ public abstract class AbstractSymbolResolutionTest {
     }
 
     protected SymbolResolver symbolResolver(TypeSolver typeSolver) {
-    	return new JavaSymbolSolver(typeSolver);
+        return new JavaSymbolSolver(typeSolver);
     }
 
     protected TypeSolver defaultTypeSolver() {
-    	return new ReflectionTypeSolver();
+        return new ReflectionTypeSolver();
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2044Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2044Test.java
@@ -94,18 +94,18 @@ public class Issue2044Test {
 /*
 java.lang.RuntimeException: Method 'hashCode' cannot be resolved in context key.hashCode() (line: 3) MethodCallExprContext{wrapped=key.hashCode()}. Parameter types: []
 
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.solveMethodAsUsage(JavaParserFacade.java:586)
-	at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:267)
-	at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:44)
-	at com.github.javaparser.ast.expr.MethodCallExpr.accept(MethodCallExpr.java:115)
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getTypeConcrete(JavaParserFacade.java:447)
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:310)
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:292)
-	at com.github.javaparser.symbolsolver.JavaSymbolSolver.calculateType(JavaSymbolSolver.java:250)
-	at com.github.javaparser.ast.expr.Expression.calculateResolvedType(Expression.java:564)
-	at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:81)
-	at java.util.ArrayList.forEach(ArrayList.java:1249)
-	at com.github.javaparser.symbolsolver.Issue2044.lambda$issue2044$1(Issue2044.java:49)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.solveMethodAsUsage(JavaParserFacade.java:586)
+    at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:267)
+    at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:44)
+    at com.github.javaparser.ast.expr.MethodCallExpr.accept(MethodCallExpr.java:115)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getTypeConcrete(JavaParserFacade.java:447)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:310)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:292)
+    at com.github.javaparser.symbolsolver.JavaSymbolSolver.calculateType(JavaSymbolSolver.java:250)
+    at com.github.javaparser.ast.expr.Expression.calculateResolvedType(Expression.java:564)
+    at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:81)
+    at java.util.ArrayList.forEach(ArrayList.java:1249)
+    at com.github.javaparser.symbolsolver.Issue2044.lambda$issue2044$1(Issue2044.java:49)
 */
 
 
@@ -115,9 +115,9 @@ java.lang.RuntimeException: Method 'hashCode' cannot be resolved in context key.
 Unsolved symbol : We are unable to find the method declaration corresponding to key.hashCode()
 UnsolvedSymbolException{context='null', name='We are unable to find the method declaration corresponding to key.hashCode()', cause='null'}
 
-	at com.github.javaparser.symbolsolver.JavaSymbolSolver.resolveDeclaration(JavaSymbolSolver.java:146)
-	at com.github.javaparser.ast.expr.MethodCallExpr.resolve(MethodCallExpr.java:313)
-	at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:101)
+    at com.github.javaparser.symbolsolver.JavaSymbolSolver.resolveDeclaration(JavaSymbolSolver.java:146)
+    at com.github.javaparser.ast.expr.MethodCallExpr.resolve(MethodCallExpr.java:313)
+    at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:101)
 */
 
         });
@@ -181,18 +181,18 @@ UnsolvedSymbolException{context='null', name='We are unable to find the method d
                 /*
 java.lang.RuntimeException: Method 'hashCode' cannot be resolved in context key.hashCode() (line: 3) MethodCallExprContext{wrapped=key.hashCode()}. Parameter types: []
 
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.solveMethodAsUsage(JavaParserFacade.java:586)
-	at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:267)
-	at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:44)
-	at com.github.javaparser.ast.expr.MethodCallExpr.accept(MethodCallExpr.java:115)
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getTypeConcrete(JavaParserFacade.java:447)
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:310)
-	at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:292)
-	at com.github.javaparser.symbolsolver.JavaSymbolSolver.calculateType(JavaSymbolSolver.java:250)
-	at com.github.javaparser.ast.expr.Expression.calculateResolvedType(Expression.java:564)
-	at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:81)
-	at java.util.ArrayList.forEach(ArrayList.java:1249)
-	at com.github.javaparser.symbolsolver.Issue2044.lambda$issue2044$1(Issue2044.java:49)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.solveMethodAsUsage(JavaParserFacade.java:586)
+    at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:267)
+    at com.github.javaparser.symbolsolver.javaparsermodel.TypeExtractor.visit(TypeExtractor.java:44)
+    at com.github.javaparser.ast.expr.MethodCallExpr.accept(MethodCallExpr.java:115)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getTypeConcrete(JavaParserFacade.java:447)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:310)
+    at com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade.getType(JavaParserFacade.java:292)
+    at com.github.javaparser.symbolsolver.JavaSymbolSolver.calculateType(JavaSymbolSolver.java:250)
+    at com.github.javaparser.ast.expr.Expression.calculateResolvedType(Expression.java:564)
+    at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:81)
+    at java.util.ArrayList.forEach(ArrayList.java:1249)
+    at com.github.javaparser.symbolsolver.Issue2044.lambda$issue2044$1(Issue2044.java:49)
                  */
 
 
@@ -202,9 +202,9 @@ java.lang.RuntimeException: Method 'hashCode' cannot be resolved in context key.
 Unsolved symbol : We are unable to find the method declaration corresponding to key.hashCode()
 UnsolvedSymbolException{context='null', name='We are unable to find the method declaration corresponding to key.hashCode()', cause='null'}
 
-	at com.github.javaparser.symbolsolver.JavaSymbolSolver.resolveDeclaration(JavaSymbolSolver.java:146)
-	at com.github.javaparser.ast.expr.MethodCallExpr.resolve(MethodCallExpr.java:313)
-	at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:101)
+    at com.github.javaparser.symbolsolver.JavaSymbolSolver.resolveDeclaration(JavaSymbolSolver.java:146)
+    at com.github.javaparser.ast.expr.MethodCallExpr.resolve(MethodCallExpr.java:313)
+    at com.github.javaparser.symbolsolver.Issue2044.lambda$null$0(Issue2044.java:101)
                  */
 
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2362Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2362Test.java
@@ -46,11 +46,11 @@ class Issue2362Test extends AbstractSymbolResolutionTest {
         Path dir = adaptPath("src/test/resources/issue2362");
         Path file = adaptPath("src/test/resources/issue2362/Test.java");
 
-        CombinedTypeSolver combinedSolver = new CombinedTypeSolver(new ReflectionTypeSolver());	    
+        CombinedTypeSolver combinedSolver = new CombinedTypeSolver(new ReflectionTypeSolver());        
 
         ParserConfiguration pc = new ParserConfiguration()
-            	                        .setSymbolResolver(new JavaSymbolSolver(combinedSolver))
-            	                        .setLanguageLevel(LanguageLevel.JAVA_8);
+                                        .setSymbolResolver(new JavaSymbolSolver(combinedSolver))
+                                        .setLanguageLevel(LanguageLevel.JAVA_8);
 
         JavaParser javaParser = new JavaParser(pc);
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue241Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue241Test.java
@@ -46,7 +46,7 @@ class Issue241Test extends AbstractResolutionTest{
     void testSolveStaticallyImportedMemberType() {
         Path src = adaptPath("src/test/resources");
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JavaParserTypeSolver(src, new LeanParserConfiguration()));
-        		
+                
         JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
         
         CompilationUnit cu = parseSample("Issue241");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue276Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue276Test.java
@@ -47,15 +47,15 @@ class Issue276Test extends AbstractResolutionTest{
         CompilationUnit cu = parse(adaptPath("src/test/resources/issue276/foo/C.java"));
         ClassOrInterfaceDeclaration cls = Navigator.demandClassOrInterface(cu, "C");
         TypeSolver typeSolver = new CombinedTypeSolver(
-        		new ReflectionTypeSolver(), 
-        		new JavaParserTypeSolver(adaptPath("src/test/resources/issue276"), new LeanParserConfiguration()));
+                new ReflectionTypeSolver(), 
+                new JavaParserTypeSolver(adaptPath("src/test/resources/issue276"), new LeanParserConfiguration()));
         List<MethodDeclaration> methods = cls.findAll(MethodDeclaration.class);
         boolean isSolved = false;
         for (MethodDeclaration method: methods) {
-        	if (method.getNameAsString().equals("overrideMe")) {
-        		MethodContext context = new MethodContext(method, typeSolver);
-        		isSolved = context.solveType("FindMeIfYouCan").isSolved();
-        	}
+            if (method.getNameAsString().equals("overrideMe")) {
+                MethodContext context = new MethodContext(method, typeSolver);
+                isSolved = context.solveType("FindMeIfYouCan").isSolved();
+            }
         }
         Assertions.assertTrue(isSolved);
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3028Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3028Test.java
@@ -37,13 +37,13 @@ public class Issue3028Test extends AbstractResolutionTest {
 
     @Test
     void varArgsIssue() {
-    	
-    	TypeSolver typeSolver = new CombinedTypeSolver(
-				new ReflectionTypeSolver());
-		JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
-		
-		StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
-		
+        
+        TypeSolver typeSolver = new CombinedTypeSolver(
+                new ReflectionTypeSolver());
+        JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
+        
+        StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
+        
         CompilationUnit cu = parseSample("Issue3028");
         
         final MethodCallExpr mce = Navigator.findMethodCall(cu, "doSomething").get();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3038Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3038Test.java
@@ -43,64 +43,64 @@ import java.util.concurrent.TimeUnit;
  * Without any fixes applied, this takes multiple hours to run.
  */
 public class Issue3038Test extends AbstractResolutionTest {
-	// The number of declarations to define
-	private static final long MAX_ADJACENT_NODES = 500;
-	// In no way should this take more than 2.5 seconds
-	// Realistically this should take much less.
-	private static final long TIME_LIMIT_MS = 2500;
+    // The number of declarations to define
+    private static final long MAX_ADJACENT_NODES = 500;
+    // In no way should this take more than 2.5 seconds
+    // Realistically this should take much less.
+    private static final long TIME_LIMIT_MS = 2500;
 
-	@RepeatedTest(10)
-	@Timeout(value = TIME_LIMIT_MS, unit = TimeUnit.MILLISECONDS)
-	public void test3038() {
-		run(generate("        new Thread(){\n" +
-				"            @Override\n" +
-				"            public void run() {\n" +
-				"                Foo foo = Foo.getInstance();\n" +
-				"            }\n" +
-				"        }.run();\n"));
-	}
+    @RepeatedTest(10)
+    @Timeout(value = TIME_LIMIT_MS, unit = TimeUnit.MILLISECONDS)
+    public void test3038() {
+        run(generate("        new Thread(){\n" +
+                "            @Override\n" +
+                "            public void run() {\n" +
+                "                Foo foo = Foo.getInstance();\n" +
+                "            }\n" +
+                "        }.run();\n"));
+    }
 
-	@RepeatedTest(10)
-	@Timeout(value = TIME_LIMIT_MS, unit = TimeUnit.MILLISECONDS)
-	public void testAlt3038() {
-		run(generate("        Foo foo = Foo.getInstance();\n"));
-	}
+    @RepeatedTest(10)
+    @Timeout(value = TIME_LIMIT_MS, unit = TimeUnit.MILLISECONDS)
+    public void testAlt3038() {
+        run(generate("        Foo foo = Foo.getInstance();\n"));
+    }
 
-	private void run(String code) {
-		ParserConfiguration config = new ParserConfiguration();
-		config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
-		StaticJavaParser.setConfiguration(config);
+    private void run(String code) {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = StaticJavaParser.parse(code);
 
-		List<NameExpr> exprs = cu.findAll(NameExpr.class);
-		for (NameExpr expr : exprs) {
-			long start = System.currentTimeMillis();
-			try {
-				expr.resolve();
-			} catch (UnsolvedSymbolException ex) {
-				// this is expected since we have no way for the resolver to find "Foo"
-			}
-			long end = System.currentTimeMillis();
-			System.out.printf("Call to resolve '%s' took %dms", expr.toString(), (end - start));
-		}
-	}
+        List<NameExpr> exprs = cu.findAll(NameExpr.class);
+        for (NameExpr expr : exprs) {
+            long start = System.currentTimeMillis();
+            try {
+                expr.resolve();
+            } catch (UnsolvedSymbolException ex) {
+                // this is expected since we have no way for the resolver to find "Foo"
+            }
+            long end = System.currentTimeMillis();
+            System.out.printf("Call to resolve '%s' took %dms", expr.toString(), (end - start));
+        }
+    }
 
-	private String generate(String extra) {
-		StringBuilder code = new StringBuilder(
-				"public class Foo{\n" +
-				"    public static void main(String[] args) {\n");
-		for (int i = 0; i < MAX_ADJACENT_NODES; i++) {
-			code.append(
-				"        String s").append(i).append("   = \"hello\";\n");
-		}
-		code.append(
-				extra  +
-				"    }\n" +
-				"    static Foo getInstance() {\n" +
-				"        return new Foo();\n" +
-				"    }\n" +
-				"}");
-		return code.toString();
-	}
+    private String generate(String extra) {
+        StringBuilder code = new StringBuilder(
+                "public class Foo{\n" +
+                "    public static void main(String[] args) {\n");
+        for (int i = 0; i < MAX_ADJACENT_NODES; i++) {
+            code.append(
+                "        String s").append(i).append("   = \"hello\";\n");
+        }
+        code.append(
+                extra  +
+                "    }\n" +
+                "    static Foo getInstance() {\n" +
+                "        return new Foo();\n" +
+                "    }\n" +
+                "}");
+        return code.toString();
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3045Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3045Test.java
@@ -36,31 +36,31 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 
 class Issue3045Test extends AbstractResolutionTest {
 
-	@Test
-	void createAnonymousClassWithUnsolvableParent() {
-	  String sourceCode =
-			  "import com.google.common.base.Function;\n" +
-	          "public class A {\n" +
-	          "    private static final Function<Object, Object> MAP = new Function<Object, Object>() {\n" +
-	          "        @Override\n" +
-	          "        public Object apply(Object input) {\n" +
-	          "            return null;\n" +
-	          "        }\n" +
-	          "    };\n" +
-	          "}";
+    @Test
+    void createAnonymousClassWithUnsolvableParent() {
+      String sourceCode =
+              "import com.google.common.base.Function;\n" +
+              "public class A {\n" +
+              "    private static final Function<Object, Object> MAP = new Function<Object, Object>() {\n" +
+              "        @Override\n" +
+              "        public Object apply(Object input) {\n" +
+              "            return null;\n" +
+              "        }\n" +
+              "    };\n" +
+              "}";
 
-	  // Create the parser
-	  JavaParser parser = createParserWithResolver(defaultTypeSolver());
+      // Create the parser
+      JavaParser parser = createParserWithResolver(defaultTypeSolver());
 
-	  // Get the method return type that is declared inside of anonymous class
-	  Optional<Type> methodType = parser.parse(sourceCode)
-	          .getResult()
-	          .flatMap(cu -> cu.findFirst(MethodDeclaration.class))
-	          .map(MethodDeclaration::getType);
-	  assertTrue(methodType.isPresent());
+      // Get the method return type that is declared inside of anonymous class
+      Optional<Type> methodType = parser.parse(sourceCode)
+              .getResult()
+              .flatMap(cu -> cu.findFirst(MethodDeclaration.class))
+              .map(MethodDeclaration::getType);
+      assertTrue(methodType.isPresent());
 
-	  // Try to resolve the given type and expect an unsolved exception
-	  assertThrows(UnsolvedSymbolException.class, methodType.get()::resolve);
-	}
+      // Try to resolve the given type and expect an unsolved exception
+      assertThrows(UnsolvedSymbolException.class, methodType.get()::resolve);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3099Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3099Test.java
@@ -45,34 +45,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Issue3099Test extends AbstractResolutionTest {
 
-	@Test
-	void illegalArgumentExceptionWhenSolvingName() throws IOException {
+    @Test
+    void illegalArgumentExceptionWhenSolvingName() throws IOException {
 
-		// Setup symbol solver
-		JavaParserTypeSolver javaParserTypeSolver = new JavaParserTypeSolver(adaptPath("src/test/resources/issue3099/"));
-		StaticJavaParser.getConfiguration()
-				.setSymbolResolver(new JavaSymbolSolver(
-						new CombinedTypeSolver(new ReflectionTypeSolver(), javaParserTypeSolver))
-				);
+        // Setup symbol solver
+        JavaParserTypeSolver javaParserTypeSolver = new JavaParserTypeSolver(adaptPath("src/test/resources/issue3099/"));
+        StaticJavaParser.getConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(
+                        new CombinedTypeSolver(new ReflectionTypeSolver(), javaParserTypeSolver))
+                );
 
-		// Parse the File
-		Path filePath = adaptPath("src/test/resources/issue3099/com/example/Beta.java");
-		CompilationUnit cu = StaticJavaParser.parse(filePath);
+        // Parse the File
+        Path filePath = adaptPath("src/test/resources/issue3099/com/example/Beta.java");
+        CompilationUnit cu = StaticJavaParser.parse(filePath);
 
-		// Get the expected inner class
-		List<ClassOrInterfaceDeclaration> classes = cu.findAll(ClassOrInterfaceDeclaration.class);
-		assertEquals(2, classes.size());
-		ResolvedReferenceTypeDeclaration innerInterface = classes.get(1).resolve();
-		assertTrue(innerInterface.isInterface());
+        // Get the expected inner class
+        List<ClassOrInterfaceDeclaration> classes = cu.findAll(ClassOrInterfaceDeclaration.class);
+        assertEquals(2, classes.size());
+        ResolvedReferenceTypeDeclaration innerInterface = classes.get(1).resolve();
+        assertTrue(innerInterface.isInterface());
 
-		// Check if the value is present
-		Optional<ResolvedReferenceType> resolvedType = cu.findFirst(VariableDeclarator.class)
-				.map(VariableDeclarator::getType)
-				.map(Type::resolve)
-				.filter(ResolvedType::isReferenceType)
-				.map(ResolvedType::asReferenceType);
-		assertTrue(resolvedType.isPresent());
-		assertEquals(innerInterface, resolvedType.get().getTypeDeclaration().orElse(null));
-	}
+        // Check if the value is present
+        Optional<ResolvedReferenceType> resolvedType = cu.findFirst(VariableDeclarator.class)
+                .map(VariableDeclarator::getType)
+                .map(Type::resolve)
+                .filter(ResolvedType::isReferenceType)
+                .map(ResolvedType::asReferenceType);
+        assertTrue(resolvedType.isPresent());
+        assertEquals(innerInterface, resolvedType.get().getTypeDeclaration().orElse(null));
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3184Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3184Test.java
@@ -18,33 +18,33 @@ import com.github.javaparser.utils.Pair;
 
 public class Issue3184Test extends AbstractResolutionTest {
 
-	@Test
-	void test() {
-		String code = "public class Program {\n" +
-		        "\n" +
-		        "    public static class InnerClass<T> {\n" +
-		        "       void method1() {\n" +
-		        "           new InnerClass<T>();\n" + // Buggy
-		        "       }\n" +
-		        "       <T1> void method2() {\n" +
-		        "           new InnerClass<T1>();\n" + // OK
-		        "           new InnerClass<T>();\n" + // Buggy
-		        "       }\n" +
-		        "    }\n" +
-		        "}";
+    @Test
+    void test() {
+        String code = "public class Program {\n" +
+                "\n" +
+                "    public static class InnerClass<T> {\n" +
+                "       void method1() {\n" +
+                "           new InnerClass<T>();\n" + // Buggy
+                "       }\n" +
+                "       <T1> void method2() {\n" +
+                "           new InnerClass<T1>();\n" + // OK
+                "           new InnerClass<T>();\n" + // Buggy
+                "       }\n" +
+                "    }\n" +
+                "}";
 
-		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(code);
-		List<ObjectCreationExpr> objCrtExprs = cu.findAll(ObjectCreationExpr.class);
-		objCrtExprs.forEach(expr -> {
-		    ResolvedType resRefType = expr.getType().resolve();
-		    ResolvedReferenceTypeDeclaration resRefTypeDecl = resRefType.asReferenceType().getTypeDeclaration().get();
-		    List<ResolvedTypeParameterDeclaration> resTypeParamsDecl = resRefTypeDecl.getTypeParameters();
-		    List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> resTypeParamsDeclMap = resRefType.asReferenceType().getTypeParametersMap();
-		    assertFalse(resTypeParamsDecl.isEmpty());
-		    assertFalse(resTypeParamsDeclMap.isEmpty());
-		    for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> resTypeParamsDeclPair : resTypeParamsDeclMap) {
-		        assertTrue(resTypeParamsDeclPair.b.isTypeVariable());
-		    }
-		});
-	}
+        CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(code);
+        List<ObjectCreationExpr> objCrtExprs = cu.findAll(ObjectCreationExpr.class);
+        objCrtExprs.forEach(expr -> {
+            ResolvedType resRefType = expr.getType().resolve();
+            ResolvedReferenceTypeDeclaration resRefTypeDecl = resRefType.asReferenceType().getTypeDeclaration().get();
+            List<ResolvedTypeParameterDeclaration> resTypeParamsDecl = resRefTypeDecl.getTypeParameters();
+            List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> resTypeParamsDeclMap = resRefType.asReferenceType().getTypeParametersMap();
+            assertFalse(resTypeParamsDecl.isEmpty());
+            assertFalse(resTypeParamsDeclMap.isEmpty());
+            for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> resTypeParamsDeclPair : resTypeParamsDeclMap) {
+                assertTrue(resTypeParamsDeclPair.b.isTypeVariable());
+            }
+        });
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
@@ -80,7 +80,7 @@ class Issue343Test extends AbstractResolutionTest {
 
     @Test
     void resolveMethodCallOnStringLiteralOutsideAST() {
-    	assertTrue(symbolSolver.classToResolvedType(int.class).equals(getExpressionType(typeResolver, new MethodCallExpr(new StringLiteralExpr("hello"), "length"))));
+        assertTrue(symbolSolver.classToResolvedType(int.class).equals(getExpressionType(typeResolver, new MethodCallExpr(new StringLiteralExpr("hello"), "length"))));
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3866Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3866Test.java
@@ -35,27 +35,27 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 
 public class Issue3866Test extends AbstractResolutionTest {
 
-	@Test
-	void test() {
+    @Test
+    void test() {
 
-		String code =
-				"public interface MyActivity {\n"
-				+ "  class MyTimestamps {}\n"
-				+ "    MyTimestamps getTimestamps();\n"
-				+ "  }\n"
-				+ "\n"
-				+ "  public interface MyRichPresence extends MyActivity { }\n"
-				+ "\n"
-				+ "  class MyActivityImpl implements MyActivity {\n"
-				+ "    MyActivity.MyTimestamps timestamps;\n"
-				+ "    @Override\n"
-				+ "    public MyActivity.MyTimestamps getTimestamps() {\n"
-				+ "      return timestamps;\n"
-				+ "  }\n"
-				+ "}";
+        String code =
+                "public interface MyActivity {\n"
+                + "  class MyTimestamps {}\n"
+                + "    MyTimestamps getTimestamps();\n"
+                + "  }\n"
+                + "\n"
+                + "  public interface MyRichPresence extends MyActivity { }\n"
+                + "\n"
+                + "  class MyActivityImpl implements MyActivity {\n"
+                + "    MyActivity.MyTimestamps timestamps;\n"
+                + "    @Override\n"
+                + "    public MyActivity.MyTimestamps getTimestamps() {\n"
+                + "      return timestamps;\n"
+                + "  }\n"
+                + "}";
 
-		final JavaSymbolSolver solver = new JavaSymbolSolver(new ReflectionTypeSolver(false));
-		StaticJavaParser.getParserConfiguration().setSymbolResolver(solver);
+        final JavaSymbolSolver solver = new JavaSymbolSolver(new ReflectionTypeSolver(false));
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(solver);
         final CompilationUnit compilationUnit = StaticJavaParser.parse(code);
 
         final List<String> returnTypes = compilationUnit.findAll(MethodDeclaration.class)
@@ -65,5 +65,5 @@ public class Issue3866Test extends AbstractResolutionTest {
                 .collect(Collectors.toList());
 
         returnTypes.forEach(type -> assertEquals("MyActivity.MyTimestamps", type));
-	}
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3918Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3918Test.java
@@ -37,35 +37,35 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 
 public class Issue3918Test extends AbstractResolutionTest {
 
-	@Test
-	void test() {
+    @Test
+    void test() {
 
-		// class ancestor is defined like this
-		// public class Ancestor {
-	    //   public static class Iterator {}
-		// }
+        // class ancestor is defined like this
+        // public class Ancestor {
+        //   public static class Iterator {}
+        // }
 
-		String code =
-				"import java.util.ArrayList;\n"
-				+ "import java.util.List;\n" + "\n"
-				+ "public class Descendant extends Ancestor {\n"
-				+ "    public void doAThing() {\n"
-				+ "        List<Object> list = new ArrayList<>();\n"
-				+ "        java.util.Iterator<Object> iterator = list.iterator();\n"
-				+ "    }\n"
-				+ "}";
+        String code =
+                "import java.util.ArrayList;\n"
+                + "import java.util.List;\n" + "\n"
+                + "public class Descendant extends Ancestor {\n"
+                + "    public void doAThing() {\n"
+                + "        List<Object> list = new ArrayList<>();\n"
+                + "        java.util.Iterator<Object> iterator = list.iterator();\n"
+                + "    }\n"
+                + "}";
 
-		Path testFile = adaptPath("src/test/resources");
-		CombinedTypeSolver typeSolver = new CombinedTypeSolver();
-		typeSolver.add(new ReflectionTypeSolver());
-		typeSolver.add(new JavaParserTypeSolver(testFile));
-		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(typeSolver)).parse(code);
+        Path testFile = adaptPath("src/test/resources");
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver();
+        typeSolver.add(new ReflectionTypeSolver());
+        typeSolver.add(new JavaParserTypeSolver(testFile));
+        CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(typeSolver)).parse(code);
 
-		Type type = cu
-				.findFirst(Type.class, n -> n.isReferenceType() && n.asReferenceType().asString().startsWith("java.util.Iterator"))
-				.get();
-		ResolvedType resolvedType = type.resolve();
-		assertEquals("java.util.Iterator<java.lang.Object>", resolvedType.describe());
+        Type type = cu
+                .findFirst(Type.class, n -> n.isReferenceType() && n.asReferenceType().asString().startsWith("java.util.Iterator"))
+                .get();
+        ResolvedType resolvedType = type.resolve();
+        assertEquals("java.util.Iterator<java.lang.Object>", resolvedType.describe());
 
-	}
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3951Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3951Test.java
@@ -32,36 +32,36 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 
 public class Issue3951Test extends AbstractResolutionTest {
 
-	@Test
-	void test() {
-		final String code = String.join(System.lineSeparator(),
-				"package test;",
-				"import java.util.HashMap;",
-				"import java.util.Map;",
-				"interface Foo {",
-				"    String getFoo();",
-				"    String getBar();",
-				"}",
-				"class FooImpl implements Foo {",
-				"    String getFoo() { return \"foo\"; } ",
-				"    String getBar() { return \"bar\"; } ",
-				"}",
-				"public class Application {",
-				"    public static void main() {",
-				"        Foo f = new FooImpl();",
-				"        Map<Foo, Object> m = new HashMap<>();",
-				"        assertThat(m.containsKey(f));",
-				"    }",
-				"    public static void assertThat(Object m) {",
-				"        assert m != null;",
-				"    }",
-				"}");
+    @Test
+    void test() {
+        final String code = String.join(System.lineSeparator(),
+                "package test;",
+                "import java.util.HashMap;",
+                "import java.util.Map;",
+                "interface Foo {",
+                "    String getFoo();",
+                "    String getBar();",
+                "}",
+                "class FooImpl implements Foo {",
+                "    String getFoo() { return \"foo\"; } ",
+                "    String getBar() { return \"bar\"; } ",
+                "}",
+                "public class Application {",
+                "    public static void main() {",
+                "        Foo f = new FooImpl();",
+                "        Map<Foo, Object> m = new HashMap<>();",
+                "        assertThat(m.containsKey(f));",
+                "    }",
+                "    public static void assertThat(Object m) {",
+                "        assert m != null;",
+                "    }",
+                "}");
 
-		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(new ReflectionTypeSolver())).parse(code);
+        CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(new ReflectionTypeSolver())).parse(code);
 
-		MethodCallExpr getOrDefaultCall = cu.findAll(MethodCallExpr.class).stream()
-				.filter(m -> m.getNameAsString().equals("assertThat")).findFirst().get();
+        MethodCallExpr getOrDefaultCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("assertThat")).findFirst().get();
 
-		assertEquals("test.Application.assertThat", getOrDefaultCall.resolve().getQualifiedName());
-	}
+        assertEquals("test.Application.assertThat", getOrDefaultCall.resolve().getQualifiedName());
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3976Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3976Test.java
@@ -17,19 +17,19 @@ public class Issue3976Test extends AbstractResolutionTest {
     @Test
     @EnabledForJreRange(min = JRE.JAVA_9)
     void test() {
-    	String testCase =
-				"import java.util.Map;\n"
-				+ "public class Foo {\n"
-				+ "		public Object m() {\n"
-				+ "			return Map.of(\"k0\", 0, \"k1\", 1D);\n"
-				+ "		}\n"
-				+ "}";
+        String testCase =
+                "import java.util.Map;\n"
+                + "public class Foo {\n"
+                + "        public Object m() {\n"
+                + "            return Map.of(\"k0\", 0, \"k1\", 1D);\n"
+                + "        }\n"
+                + "}";
 
-		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(testCase);
+        CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(testCase);
 
-		MethodCallExpr methodCallExpr = cu.findFirst(MethodCallExpr.class).get();
+        MethodCallExpr methodCallExpr = cu.findFirst(MethodCallExpr.class).get();
 
-		ResolvedType rt = methodCallExpr.calculateResolvedType();
-		assertEquals("java.util.Map<java.lang.String, java.lang.Number>", rt.describe());
+        ResolvedType rt = methodCallExpr.calculateResolvedType();
+        assertEquals("java.util.Map<java.lang.String, java.lang.Number>", rt.describe());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4037Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4037Test.java
@@ -33,27 +33,27 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 
 public class Issue4037Test extends AbstractResolutionTest {
 
-	@Test
-	void test() {
+    @Test
+    void test() {
 
-		String code =
-				"public class Test1 {\n"
-						+ "	    public static Integer getD2() { return null; }\n"
-						+ "	    public static Integer getD1() { return null; }\n"
-						+ "	    public void m(java.util.function.Supplier... rs) { }\n"
-						+ "\n"
-						+ "	    public void test() {\n"
-						+ "	        new Test1().m(Test1::getD1, Test1::getD2);    // exception throws\n"
-						+ "	    }\n"
-						+ "	}";
+        String code =
+                "public class Test1 {\n"
+                        + "        public static Integer getD2() { return null; }\n"
+                        + "        public static Integer getD1() { return null; }\n"
+                        + "        public void m(java.util.function.Supplier... rs) { }\n"
+                        + "\n"
+                        + "        public void test() {\n"
+                        + "            new Test1().m(Test1::getD1, Test1::getD2);    // exception throws\n"
+                        + "        }\n"
+                        + "    }";
 
-		JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
-		CompilationUnit cu = parser.parse(code);
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+        CompilationUnit cu = parser.parse(code);
 
-		List<MethodReferenceExpr > exprs = cu.findAll(MethodReferenceExpr .class);
+        List<MethodReferenceExpr > exprs = cu.findAll(MethodReferenceExpr .class);
 
-		exprs.forEach(expr -> {
-			assertDoesNotThrow(() -> expr.resolve());
-		});
-	}
+        exprs.forEach(expr -> {
+            assertDoesNotThrow(() -> expr.resolve());
+        });
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4124Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4124Test.java
@@ -32,40 +32,40 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 
 public class Issue4124Test extends AbstractResolutionTest {
 
-	@Test
-	void issue4124_withDifferentTypeParameterName() {
+    @Test
+    void issue4124_withDifferentTypeParameterName() {
 
-		String code =
-				"import java.util.Collections;\n"
-				+ "import java.util.List;\n"
-				+ "public class Foo<E> {\n"
-				+ "    public void test(List<E> ls){\n"
-				+ "        Collections.synchronizedList(ls);\n"
-				+ "    }\n"
-				+ "}\n";
+        String code =
+                "import java.util.Collections;\n"
+                + "import java.util.List;\n"
+                + "public class Foo<E> {\n"
+                + "    public void test(List<E> ls){\n"
+                + "        Collections.synchronizedList(ls);\n"
+                + "    }\n"
+                + "}\n";
 
-		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(code);
+        CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(code);
 
-		MethodCallExpr m = cu.findFirst(MethodCallExpr.class).get();
-		ResolvedMethodDeclaration rmd = m.resolve();
-		assertEquals("java.util.Collections.synchronizedList(java.util.List<T>)", rmd.getQualifiedSignature());
-	}
+        MethodCallExpr m = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rmd = m.resolve();
+        assertEquals("java.util.Collections.synchronizedList(java.util.List<T>)", rmd.getQualifiedSignature());
+    }
 
-	@Test
-	void issue4124_withSameTypeParameterName() {
-		String code =
-				"import java.util.Collections;\n"
-				+ "import java.util.List;\n"
-				+ "public class Foo<T> {\n"
-				+ "    public void test(List<T> ls){\n"
-				+ "        Collections.synchronizedList(ls);\n"
-				+ "    }\n"
-				+ "}\n";
+    @Test
+    void issue4124_withSameTypeParameterName() {
+        String code =
+                "import java.util.Collections;\n"
+                + "import java.util.List;\n"
+                + "public class Foo<T> {\n"
+                + "    public void test(List<T> ls){\n"
+                + "        Collections.synchronizedList(ls);\n"
+                + "    }\n"
+                + "}\n";
 
-		CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(code);
+        CompilationUnit cu = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver())).parse(code);
 
-		MethodCallExpr m = cu.findFirst(MethodCallExpr.class).get();
-		ResolvedMethodDeclaration rmd = m.resolve();
-		assertEquals("java.util.Collections.synchronizedList(java.util.List<T>)", rmd.getQualifiedSignature());
-	}
+        MethodCallExpr m = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rmd = m.resolve();
+        assertEquals("java.util.Collections.synchronizedList(java.util.List<T>)", rmd.getQualifiedSignature());
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
@@ -11,46 +11,46 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 
 class JavaParserTypeDeclarationAdapterTest extends AbstractResolutionTest {
 
-	@BeforeAll
-	static void setUpBeforeClass() throws Exception {
-	}
+    @BeforeAll
+    static void setUpBeforeClass() throws Exception {
+    }
 
-	@AfterAll
-	static void tearDownAfterClass() throws Exception {
-	}
+    @AfterAll
+    static void tearDownAfterClass() throws Exception {
+    }
 
-	@BeforeEach
-	void setUp() throws Exception {
-	}
+    @BeforeEach
+    void setUp() throws Exception {
+    }
 
-	@AfterEach
-	void tearDownAfterEach() throws Exception {
-	}
+    @AfterEach
+    void tearDownAfterEach() throws Exception {
+    }
 
-	@Test
-	void issue3214() {
-		String code =
-				"public interface Foo {\n"
-				+ "	    interface Bar {}\n"
-				+ "	}\n"
-				+ "\n"
-				+ "	public interface Bar {\n"
-				+ "	    void show();\n"
-				+ "	}\n"
-				+ "\n"
-				+ "	public class Test implements Foo.Bar {\n"
-				+ "	    private Bar bar;\n"
-				+ "	    private void m() {\n"
-				+ "	        bar.show();\n"
-				+ "	    }\n"
-				+ "	}";
+    @Test
+    void issue3214() {
+        String code =
+                "public interface Foo {\n"
+                + "        interface Bar {}\n"
+                + "    }\n"
+                + "\n"
+                + "    public interface Bar {\n"
+                + "        void show();\n"
+                + "    }\n"
+                + "\n"
+                + "    public class Test implements Foo.Bar {\n"
+                + "        private Bar bar;\n"
+                + "        private void m() {\n"
+                + "            bar.show();\n"
+                + "        }\n"
+                + "    }";
 
-		JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
-		CompilationUnit cu = parser.parse(code);
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+        CompilationUnit cu = parser.parse(code);
 
-		MethodCallExpr mce = cu.findAll(MethodCallExpr.class).get(0);
+        MethodCallExpr mce = cu.findAll(MethodCallExpr.class).get(0);
 
-		assertEquals("Bar.show()",mce.resolve().getQualifiedSignature());
-	}
+        assertEquals("Bar.show()",mce.resolve().getQualifiedSignature());
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnnotationDeclarationTest.java
@@ -39,68 +39,68 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class JavaParserAnnotationDeclarationTest extends AbstractResolutionTest {
 
-	private final TypeSolver typeSolver = new ReflectionTypeSolver();
-	private final JavaParser javaParser = createParserWithResolver(typeSolver);
+    private final TypeSolver typeSolver = new ReflectionTypeSolver();
+    private final JavaParser javaParser = createParserWithResolver(typeSolver);
 
-	@Test
-	void getAllFields_shouldReturnASingleField() {
-		String sourceCode = "@interface Foo { int a = 0; }";
+    @Test
+    void getAllFields_shouldReturnASingleField() {
+        String sourceCode = "@interface Foo { int a = 0; }";
 
-		ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
-		assertTrue(result.getResult().isPresent());
-		CompilationUnit cu = result.getResult().get();
+        ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
+        assertTrue(result.getResult().isPresent());
+        CompilationUnit cu = result.getResult().get();
 
-		Optional<AnnotationDeclaration> annotation = cu.findFirst(AnnotationDeclaration.class);
-		assertTrue(annotation.isPresent());
+        Optional<AnnotationDeclaration> annotation = cu.findFirst(AnnotationDeclaration.class);
+        assertTrue(annotation.isPresent());
 
-		List<ResolvedFieldDeclaration> fields = annotation.get().resolve().getAllFields();
-		assertEquals(1, fields.size());
-		assertEquals("a", fields.get(0).getName());
-	}
+        List<ResolvedFieldDeclaration> fields = annotation.get().resolve().getAllFields();
+        assertEquals(1, fields.size());
+        assertEquals("a", fields.get(0).getName());
+    }
 
-	@Test
-	void getAllFields_shouldReturnMultipleVariablesDeclaration() {
-		String sourceCode = "@interface Foo { int a = 0, b = 1; }";
+    @Test
+    void getAllFields_shouldReturnMultipleVariablesDeclaration() {
+        String sourceCode = "@interface Foo { int a = 0, b = 1; }";
 
-		ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
-		assertTrue(result.getResult().isPresent());
-		CompilationUnit cu = result.getResult().get();
+        ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
+        assertTrue(result.getResult().isPresent());
+        CompilationUnit cu = result.getResult().get();
 
-		Optional<AnnotationDeclaration> annotation = cu.findFirst(AnnotationDeclaration.class);
-		assertTrue(annotation.isPresent());
+        Optional<AnnotationDeclaration> annotation = cu.findFirst(AnnotationDeclaration.class);
+        assertTrue(annotation.isPresent());
 
-		List<ResolvedFieldDeclaration> fields = annotation.get().resolve().getAllFields();
-		assertEquals(2, fields.size());
-		assertEquals("a", fields.get(0).getName());
-		assertEquals("b", fields.get(1).getName());
-	}
+        List<ResolvedFieldDeclaration> fields = annotation.get().resolve().getAllFields();
+        assertEquals(2, fields.size());
+        assertEquals("a", fields.get(0).getName());
+        assertEquals("b", fields.get(1).getName());
+    }
 
-	@Test
-	void testForIssue3094() {
-		String sourceCode = "@interface Foo { int a = 0; int b = a; }";
-		ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
-		assertTrue(result.getResult().isPresent());
-		CompilationUnit cu = result.getResult().get();
+    @Test
+    void testForIssue3094() {
+        String sourceCode = "@interface Foo { int a = 0; int b = a; }";
+        ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
+        assertTrue(result.getResult().isPresent());
+        CompilationUnit cu = result.getResult().get();
 
-		Optional<NameExpr> nameExpr = cu.findFirst(NameExpr.class);
-		assertTrue(nameExpr.isPresent());
-		assertDoesNotThrow(nameExpr.get()::resolve);
-	}
+        Optional<NameExpr> nameExpr = cu.findFirst(NameExpr.class);
+        assertTrue(nameExpr.isPresent());
+        assertDoesNotThrow(nameExpr.get()::resolve);
+    }
 
-	@Test
-	void internalTypes_shouldFindAllInnerTypeDeclaration() {
-		String sourceCode = "@interface Foo { class A {} interface B {} @interface C {} enum D {} }";
+    @Test
+    void internalTypes_shouldFindAllInnerTypeDeclaration() {
+        String sourceCode = "@interface Foo { class A {} interface B {} @interface C {} enum D {} }";
 
-		ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
-		assertTrue(result.getResult().isPresent());
-		CompilationUnit cu = result.getResult().get();
+        ParseResult<CompilationUnit> result = javaParser.parse(sourceCode);
+        assertTrue(result.getResult().isPresent());
+        CompilationUnit cu = result.getResult().get();
 
-		Optional<AnnotationDeclaration> annotation = cu.findFirst(AnnotationDeclaration.class);
-		assertTrue(annotation.isPresent());
-		assertEquals(4, annotation.get().resolve().internalTypes().size());
-	}
-	
-	@Test
+        Optional<AnnotationDeclaration> annotation = cu.findFirst(AnnotationDeclaration.class);
+        assertTrue(annotation.isPresent());
+        assertEquals(4, annotation.get().resolve().internalTypes().size());
+    }
+    
+    @Test
     void isAnnotationNotInheritable() {
         String sourceCode = "@interface Foo {}";
 
@@ -113,8 +113,8 @@ class JavaParserAnnotationDeclarationTest extends AbstractResolutionTest {
 
         assertFalse(annotation.get().resolve().isInheritable());
     }
-	
-	@Test
+    
+    @Test
     void isAnnotationInheritable() {
         String sourceCode = "import java.lang.annotation.Inherited;\n" + 
                 "    @Inherited\n" + 
@@ -129,5 +129,5 @@ class JavaParserAnnotationDeclarationTest extends AbstractResolutionTest {
 
         assertTrue(annotation.get().resolve().isInheritable());
     }
-	
+    
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -960,24 +960,24 @@ class JavaParserClassDeclarationTest extends AbstractResolutionTest {
 
     // issue #4133
     @Test
-	void testContainerType() {
-		String code =
-	            "public class Foo {\n"
-	            + "    public static class Bar {\n"
-	            + "        public static class Baz {\n"
-	            + "        }\n"
-	            + "    }\n"
-	            + "}\n";
+    void testContainerType() {
+        String code =
+                "public class Foo {\n"
+                + "    public static class Bar {\n"
+                + "        public static class Baz {\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
 
-		JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
-		CompilationUnit cu = parser.parse(code);
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+        CompilationUnit cu = parser.parse(code);
 
-		List<ClassOrInterfaceDeclaration> declarations = cu.findAll(ClassOrInterfaceDeclaration.class);
-		// top level type
-		assertFalse(declarations.get(0).resolve().asReferenceType().containerType().isPresent());
-		assertEquals("Foo", declarations.get(1).resolve().asReferenceType().containerType().get().getQualifiedName());
-		assertEquals("Foo.Bar", declarations.get(2).resolve().asReferenceType().containerType().get().getQualifiedName());
-	}
+        List<ClassOrInterfaceDeclaration> declarations = cu.findAll(ClassOrInterfaceDeclaration.class);
+        // top level type
+        assertFalse(declarations.get(0).resolve().asReferenceType().containerType().isPresent());
+        assertEquals("Foo", declarations.get(1).resolve().asReferenceType().containerType().get().getQualifiedName());
+        assertEquals("Foo.Bar", declarations.get(2).resolve().asReferenceType().containerType().get().getQualifiedName());
+    }
 
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclarationTest.java
@@ -42,7 +42,7 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 
 class JavaParserMethodDeclarationTest extends AbstractResolutionTest
-		implements ResolvedMethodDeclarationTest, TypeVariableResolutionCapabilityTest {
+        implements ResolvedMethodDeclarationTest, TypeVariableResolutionCapabilityTest {
 
     @Override
     public Optional<Node> getWrappedDeclaration(AssociableToAST associableToAST) {
@@ -60,29 +60,29 @@ class JavaParserMethodDeclarationTest extends AbstractResolutionTest
     }
 
     @Test
-	void issue2484() {
-		String code =
-				"public class MyClass {\n"
-						+ "    private Ibaz m_something;\n"
-						+ "\n"
-						+ "    public interface Ibaz {\n"
-						+ "    }\n"
-						+ "    \n"
-						+ "    public void foo(Class<? extends Ibaz> clazz) {\n"
-						+ "    }\n"
-						+ "    \n"
-						+ "    protected void bar() {\n"
-						+ "        foo(null); // this works\n"
-						+ "        foo(m_something.getClass()); // this doesn't work\n"
-						+ "    }\n"
-						+ "}";
+    void issue2484() {
+        String code =
+                "public class MyClass {\n"
+                        + "    private Ibaz m_something;\n"
+                        + "\n"
+                        + "    public interface Ibaz {\n"
+                        + "    }\n"
+                        + "    \n"
+                        + "    public void foo(Class<? extends Ibaz> clazz) {\n"
+                        + "    }\n"
+                        + "    \n"
+                        + "    protected void bar() {\n"
+                        + "        foo(null); // this works\n"
+                        + "        foo(m_something.getClass()); // this doesn't work\n"
+                        + "    }\n"
+                        + "}";
 
-		JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
-		CompilationUnit cu = parser.parse(code);
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+        CompilationUnit cu = parser.parse(code);
 
-		List<MethodCallExpr> mces = cu.findAll(MethodCallExpr.class);
-		assertEquals("MyClass.foo(java.lang.Class<? extends MyClass.Ibaz>)", mces.get(0).resolve().getQualifiedSignature());
-		assertEquals("MyClass.foo(java.lang.Class<? extends MyClass.Ibaz>)", mces.get(1).resolve().getQualifiedSignature());
-	}
+        List<MethodCallExpr> mces = cu.findAll(MethodCallExpr.class);
+        assertEquals("MyClass.foo(java.lang.Class<? extends MyClass.Ibaz>)", mces.get(0).resolve().getQualifiedSignature());
+        assertEquals("MyClass.foo(java.lang.Class<? extends MyClass.Ibaz>)", mces.get(1).resolve().getQualifiedSignature());
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/logic/FunctionInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/logic/FunctionInterfaceLogicTest.java
@@ -63,7 +63,7 @@ class FunctionInterfaceLogicTest {
         // By default, all methods in interface are public and abstract until we do not declare it
         // as default and properties are static and final.
         // This interface is not fonctional because it inherits two abstract methods
-   	 	// which are not members of Object and the default apply method does not override the abstract apply method
+        // which are not members of Object and the default apply method does not override the abstract apply method
         // defined in the Function interface.
         assertEquals(false, FunctionalInterfaceLogic.getFunctionalMethod(function).isPresent());
     }
@@ -73,7 +73,7 @@ class FunctionInterfaceLogicTest {
         T foo(S str);
 
         @Override
-		default T apply(S str) {
+        default T apply(S str) {
             return foo(str);
         }
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/PrimitiveTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/PrimitiveTypeTest.java
@@ -337,14 +337,14 @@ class PrimitiveTypeTest {
     
     @Test
     void testIsNumeric() {
-    	assertFalse(ResolvedPrimitiveType.BOOLEAN.isNumeric());
-    	assertTrue(ResolvedPrimitiveType.CHAR.isNumeric());
-    	assertTrue(ResolvedPrimitiveType.BYTE.isNumeric());
-    	assertTrue(ResolvedPrimitiveType.SHORT.isNumeric());
-    	assertTrue(ResolvedPrimitiveType.INT.isNumeric());
-    	assertTrue(ResolvedPrimitiveType.LONG.isNumeric());
-    	assertTrue(ResolvedPrimitiveType.FLOAT.isNumeric());
-    	assertTrue(ResolvedPrimitiveType.DOUBLE.isNumeric());
+        assertFalse(ResolvedPrimitiveType.BOOLEAN.isNumeric());
+        assertTrue(ResolvedPrimitiveType.CHAR.isNumeric());
+        assertTrue(ResolvedPrimitiveType.BYTE.isNumeric());
+        assertTrue(ResolvedPrimitiveType.SHORT.isNumeric());
+        assertTrue(ResolvedPrimitiveType.INT.isNumeric());
+        assertTrue(ResolvedPrimitiveType.LONG.isNumeric());
+        assertTrue(ResolvedPrimitiveType.FLOAT.isNumeric());
+        assertTrue(ResolvedPrimitiveType.DOUBLE.isNumeric());
     }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -269,7 +269,7 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
             }
 
             @Override
-			public boolean isCorrespondingBoxingType(String name) {
+            public boolean isCorrespondingBoxingType(String name) {
                 return super.isCorrespondingBoxingType(name);
             }
 
@@ -931,16 +931,16 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
     @Test
     void extend_type() {
-    	ResolvedTypeVariable variable = parametrizedType("java.util.List", "java.lang.String");
-    	assertTrue(variable.asTypeParameter().hasUpperBound());
-    	assertFalse(variable.asTypeParameter().hasLowerBound());
+        ResolvedTypeVariable variable = parametrizedType("java.util.List", "java.lang.String");
+        assertTrue(variable.asTypeParameter().hasUpperBound());
+        assertFalse(variable.asTypeParameter().hasLowerBound());
     }
 
     @Test
     void super_type() {
-    	ResolvedTypeVariable variable = parametrizedTypeLowerBounded("java.util.List", "java.lang.String");
-    	assertTrue(variable.asTypeParameter().hasLowerBound());
-    	assertFalse(variable.asTypeParameter().hasUpperBound());
+        ResolvedTypeVariable variable = parametrizedTypeLowerBounded("java.util.List", "java.lang.String");
+        assertTrue(variable.asTypeParameter().hasLowerBound());
+        assertFalse(variable.asTypeParameter().hasUpperBound());
     }
 
     // return a generic type with type arguments (arguments can be bounded)

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/WildcardUsageTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/WildcardUsageTest.java
@@ -431,55 +431,55 @@ class WildcardUsageTest {
     }*/
 
 //    @Test
-//	void testIsAssignableByGenerics() {
-//		ResolvedType listOfSomethingExtendingNumbers = genericType(List.class.getCanonicalName(),
-//				extendsBound(Number.class.getCanonicalName()));
-//		ResolvedType listOfNumbers = genericType(List.class.getCanonicalName(), Number.class.getCanonicalName());
-//		ResolvedType listOfSomethingExtendingIntegers = genericType(List.class.getCanonicalName(),
-//				extendsBound(Integer.class.getCanonicalName()));
+//    void testIsAssignableByGenerics() {
+//        ResolvedType listOfSomethingExtendingNumbers = genericType(List.class.getCanonicalName(),
+//                extendsBound(Number.class.getCanonicalName()));
+//        ResolvedType listOfNumbers = genericType(List.class.getCanonicalName(), Number.class.getCanonicalName());
+//        ResolvedType listOfSomethingExtendingIntegers = genericType(List.class.getCanonicalName(),
+//                extendsBound(Integer.class.getCanonicalName()));
 //
-//		ResolvedType list1 = genericType(List.class.getCanonicalName(), Integer.class.getCanonicalName());
+//        ResolvedType list1 = genericType(List.class.getCanonicalName(), Integer.class.getCanonicalName());
 //
-//		print(listOfSomethingExtendingIntegers.asReferenceType().getAllAncestors());
+//        print(listOfSomethingExtendingIntegers.asReferenceType().getAllAncestors());
 //
-//		Collection<? extends Number> c1;
-//		Collection<Number> c2 = new ArrayList<>();;
-//		List<? extends Number> lnum = new ArrayList<>();
-//		List<? extends Integer> lint = new ArrayList<>();
-//		c1 = lint;
-//		c1 = lnum;
-//		lnum = lint;
-//		c1 = c2;
-//	}
+//        Collection<? extends Number> c1;
+//        Collection<Number> c2 = new ArrayList<>();;
+//        List<? extends Number> lnum = new ArrayList<>();
+//        List<? extends Integer> lint = new ArrayList<>();
+//        c1 = lint;
+//        c1 = lnum;
+//        lnum = lint;
+//        c1 = c2;
+//    }
 
 
     // Utility methods
 
-	private void print(List<ResolvedReferenceType> ancestors) {
-		for (ResolvedReferenceType ancestor : ancestors) {
-			System.out.println(ancestor.describe());
-		}
-	}
+    private void print(List<ResolvedReferenceType> ancestors) {
+        for (ResolvedReferenceType ancestor : ancestors) {
+            System.out.println(ancestor.describe());
+        }
+    }
 
-	private List<ResolvedType> types(String... types) {
-		return Arrays.stream(types).map(type -> type(type)).collect(Collectors.toList());
-	}
+    private List<ResolvedType> types(String... types) {
+        return Arrays.stream(types).map(type -> type(type)).collect(Collectors.toList());
+    }
 
-	private ResolvedType type(String type) {
-		return new ReferenceTypeImpl(typeSolver.solveType(type));
-	}
+    private ResolvedType type(String type) {
+        return new ReferenceTypeImpl(typeSolver.solveType(type));
+    }
 
-	private ResolvedType genericType(String type, String... parameterTypes) {
-		return new ReferenceTypeImpl(typeSolver.solveType(type), types(parameterTypes));
-	}
+    private ResolvedType genericType(String type, String... parameterTypes) {
+        return new ReferenceTypeImpl(typeSolver.solveType(type), types(parameterTypes));
+    }
 
-	private ResolvedType genericType(String type, ResolvedType... parameterTypes) {
-		return new ReferenceTypeImpl(typeSolver.solveType(type), Arrays.asList(parameterTypes));
-	}
+    private ResolvedType genericType(String type, ResolvedType... parameterTypes) {
+        return new ReferenceTypeImpl(typeSolver.solveType(type), Arrays.asList(parameterTypes));
+    }
 
-	private ResolvedType extendsBound(String type) {
-		return ResolvedWildcard.extendsBound(type(type));
-	}
+    private ResolvedType extendsBound(String type) {
+        return ResolvedWildcard.extendsBound(type(type));
+    }
 
 
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclarationTest.java
@@ -89,40 +89,40 @@ class ReflectionInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
         assertEquals(new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Iterable.class, typeResolver), ImmutableList.of(typeVariable)), ancestors.get("java.lang.Iterable"));
     }
     
-	@Test
-	void testAllAncestorsForAnInterfaceWithBreadthFirstFunc() {
-		TypeSolver typeResolver = new ReflectionTypeSolver();
-		ResolvedInterfaceDeclaration list = new ReflectionInterfaceDeclaration(List.class, typeResolver);
-		List<ResolvedReferenceType> ancestors = list.getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc);
-		assertEquals(2, ancestors.size());
+    @Test
+    void testAllAncestorsForAnInterfaceWithBreadthFirstFunc() {
+        TypeSolver typeResolver = new ReflectionTypeSolver();
+        ResolvedInterfaceDeclaration list = new ReflectionInterfaceDeclaration(List.class, typeResolver);
+        List<ResolvedReferenceType> ancestors = list.getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc);
+        assertEquals(2, ancestors.size());
 
-		ResolvedTypeVariable typeVariable = new ResolvedTypeVariable(list.getTypeParameters().get(0));
-		assertEquals(new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Collection.class, typeResolver),
-				ImmutableList.of(typeVariable)), ancestors.get(0));
-		assertEquals(new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Iterable.class, typeResolver),
-				ImmutableList.of(typeVariable)), ancestors.get(1));
-	}
-	
-	@Test
-	void testAllAncestorsForAClassWithBreadthFirstFunc() {
-		TypeSolver typeResolver = new ReflectionTypeSolver();
-		ReflectionClassDeclaration obj = new ReflectionClassDeclaration(CharBuffer.class, typeResolver);
-		List<ResolvedReferenceType> ancestors = obj.getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc);
-		assertEquals(6, ancestors.size());
+        ResolvedTypeVariable typeVariable = new ResolvedTypeVariable(list.getTypeParameters().get(0));
+        assertEquals(new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Collection.class, typeResolver),
+                ImmutableList.of(typeVariable)), ancestors.get(0));
+        assertEquals(new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Iterable.class, typeResolver),
+                ImmutableList.of(typeVariable)), ancestors.get(1));
+    }
+    
+    @Test
+    void testAllAncestorsForAClassWithBreadthFirstFunc() {
+        TypeSolver typeResolver = new ReflectionTypeSolver();
+        ReflectionClassDeclaration obj = new ReflectionClassDeclaration(CharBuffer.class, typeResolver);
+        List<ResolvedReferenceType> ancestors = obj.getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc);
+        assertEquals(6, ancestors.size());
 
-		assertEquals(new ReferenceTypeImpl(new ReflectionClassDeclaration(Buffer.class, typeResolver)),
-				ancestors.get(0));
-		assertEquals(
-				new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Appendable.class, typeResolver)),
-				ancestors.get(2));
-		assertEquals(
-				new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(CharSequence.class, typeResolver)),
-				ancestors.get(3));
-		assertEquals(
-				new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Readable.class, typeResolver)),
-				ancestors.get(4));
-		assertEquals(new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeResolver)),
-				ancestors.get(5));
-	}
+        assertEquals(new ReferenceTypeImpl(new ReflectionClassDeclaration(Buffer.class, typeResolver)),
+                ancestors.get(0));
+        assertEquals(
+                new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Appendable.class, typeResolver)),
+                ancestors.get(2));
+        assertEquals(
+                new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(CharSequence.class, typeResolver)),
+                ancestors.get(3));
+        assertEquals(
+                new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(Readable.class, typeResolver)),
+                ancestors.get(4));
+        assertEquals(new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeResolver)),
+                ancestors.get(5));
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ConditionalExprTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ConditionalExprTest.java
@@ -166,7 +166,7 @@ class ConditionalExprTest extends AbstractResolutionTest {
     @Test
     void test_reference_conditional_expression_with_type_variable() {
         // require that type variable T in the returned type of this method call java.util.Collections.emptyList()
-    	// can be translated into String type
+        // can be translated into String type
         String code = "class A { public void m() { java.util.List list = true ? new java.util.ArrayList<String>() : java.util.Collections.emptyList();}}";
         ResolvedType rt3 = StaticJavaParser.parse(code).findFirst(ConditionalExpr.class).get().calculateResolvedType();
         assertEquals("java.util.List<java.lang.String>", rt3.describe());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
@@ -148,10 +148,10 @@ class DefaultPackageTest {
             throw new UnsupportedOperationException();
         }
 
-		@Override
-		public Set<ResolvedAnnotationDeclaration> getDeclaredAnnotations() {
-			return new HashSet<>();
-		}
+        @Override
+        public Set<ResolvedAnnotationDeclaration> getDeclaredAnnotations() {
+            return new HashSet<>();
+        }
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
@@ -275,13 +275,13 @@ class JavaParserFacadeResolutionTest extends AbstractResolutionTest {
     @Test
     void resolveTypeParameterFromPrimitiveArrayArgumentOnNonGenericExpectedParameter() {
         String sourceCode = "" +
-        		"import java.util.OptionalDouble;\n" +
-				"import java.util.stream.IntStream;\n" +
+                "import java.util.OptionalDouble;\n" +
+                "import java.util.stream.IntStream;\n" +
                 "\n" +
                 "public class Main {\n" +
-                "	OptionalDouble pre(int[] values) {\n" +
-				"		return IntStream.of(values).map(s -> s).average();\n" +
-				"	}\n" +
+                "    OptionalDouble pre(int[] values) {\n" +
+                "        return IntStream.of(values).map(s -> s).average();\n" +
+                "    }\n" +
                 "}";
 
         JavaParser parser = createParserWithResolver(defaultTypeSolver());
@@ -322,7 +322,7 @@ class JavaParserFacadeResolutionTest extends AbstractResolutionTest {
     // See issue 3725
     @Test
     void resolveVarTypeInForEachLoopFromIterableExpression_withRawType() {
-    		String sourceCode = "" +
+            String sourceCode = "" +
                     "import java.util.ArrayList;\n" +
                     "import java.util.List;\n" +
                     "\n" +

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/NotQuiteCyclicParentTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/NotQuiteCyclicParentTest.java
@@ -37,21 +37,21 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class NotQuiteCyclicParentTest extends AbstractResolutionTest {
 
-	@Test
-	void testSimilarNameInterface() {
-		CompilationUnit cu = parseSample("NotQuiteCyclicParent");
-		ClassOrInterfaceDeclaration clazz = Navigator.demandInterface(cu, "NotQuiteCyclicParent");
-		MethodDeclaration method = Navigator.demandMethod(clazz, "main");
-		VariableDeclarationExpr varDec =
-				(VariableDeclarationExpr) ((ExpressionStmt) method.getBody().get().getStatement(0)).getExpression();
+    @Test
+    void testSimilarNameInterface() {
+        CompilationUnit cu = parseSample("NotQuiteCyclicParent");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandInterface(cu, "NotQuiteCyclicParent");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "main");
+        VariableDeclarationExpr varDec =
+                (VariableDeclarationExpr) ((ExpressionStmt) method.getBody().get().getStatement(0)).getExpression();
 
-		try {
-			ResolvedType ref = JavaParserFacade.get(new ReflectionTypeSolver()).getType(varDec);
-		} catch (UnsolvedSymbolException e) {
-			return;
-		}
+        try {
+            ResolvedType ref = JavaParserFacade.get(new ReflectionTypeSolver()).getType(varDec);
+        } catch (UnsolvedSymbolException e) {
+            return;
+        }
 
-		fail("We shouldn't be able to resolve the type (it is not defined).");
-	}
+        fail("We shouldn't be able to resolve the type (it is not defined).");
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ReferenceTypeResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ReferenceTypeResolutionTest.java
@@ -44,56 +44,56 @@ public class ReferenceTypeResolutionTest extends AbstractResolutionTest {
         StaticJavaParser.setConfiguration(config);
     }
     
-	@Test
-	void enumTest() {
-	    String code = "enum DAY { MONDAY }";
+    @Test
+    void enumTest() {
+        String code = "enum DAY { MONDAY }";
         ResolvedEnumConstantDeclaration rt = StaticJavaParser.parse(code).findFirst(EnumConstantDeclaration.class).get().resolve();
         assertTrue(rt.isEnumConstant());
-	}
-	
-	@Test
+    }
+    
+    @Test
     void objectTest() {
         String code = "class A { Object o; }";
         ResolvedReferenceType rt = StaticJavaParser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType().asReferenceType();
         assertTrue(rt.isJavaLangObject());
     }
-	
-	@Test
+    
+    @Test
     void cannotUnboxReferenceTypeTest() {
         String code = "class A { Object o; }";
         ResolvedReferenceType rt = StaticJavaParser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType().asReferenceType();
         assertFalse(rt.isUnboxable());
     }
-	
-	@Test
+    
+    @Test
     void unboxableTypeTest() {
         String code = "class A { Integer o; }";
         ResolvedReferenceType rt = StaticJavaParser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType().asReferenceType();
         assertTrue(rt.asReferenceType().isUnboxable());
     }
-	
-	@Test
+    
+    @Test
     void cannotUnboxTypeToSpecifiedPrimitiveTypeTest() {
         String code = "class A { Object o; }";
         ResolvedReferenceType rt = StaticJavaParser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType().asReferenceType();
         assertFalse(rt.isUnboxableTo(ResolvedPrimitiveType.INT));
     }
-	
-	@Test
+    
+    @Test
     void unboxTypeToSpecifiedPrimitiveTypeTest() {
         String code = "class A { Integer o; }";
         ResolvedReferenceType rt = StaticJavaParser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType().asReferenceType();
         assertTrue(rt.isUnboxableTo(ResolvedPrimitiveType.INT));
     }
-	
-	@Test
+    
+    @Test
     void cannotUnboxTypeToPrimitiveTypeTest() {
         String code = "class A { Object o; }";
         ResolvedReferenceType rt = StaticJavaParser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType().asReferenceType();
         assertFalse(rt.toUnboxedType().isPresent());
     }
-	
-	@Test
+    
+    @Test
     void unboxTypeToPrimitiveTypeTest() {
         String code = "class A { Integer o; }";
         ResolvedReferenceType rt = StaticJavaParser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType().asReferenceType();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistClassTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistClassTest.java
@@ -85,7 +85,7 @@ class SymbolSolverWithJavassistClassTest extends AbstractSymbolResolutionTest {
         assertFalse(solvedSymbol.isSolved());
 
         assertThrows(UnsolvedSymbolException.class, () -> {
-        	solvedSymbol.getCorrespondingDeclaration();
+            solvedSymbol.getCorrespondingDeclaration();
         }, "Expected UnsolvedSymbolException when requesting CorrespondingDeclaration on unsolved SymbolRefernce");
 
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistEnumTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistEnumTest.java
@@ -89,7 +89,7 @@ class SymbolSolverWithJavassistEnumTest extends AbstractSymbolResolutionTest {
         assertFalse(solvedSymbol.isSolved());
 
         assertThrows(UnsolvedSymbolException.class, () -> {
-        	solvedSymbol.getCorrespondingDeclaration();
+            solvedSymbol.getCorrespondingDeclaration();
         }, "Expected UnsolvedSymbolException when requesting CorrespondingDeclaration on unsolved SymbolRefernce");
 
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistInterfaceTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SymbolSolverWithJavassistInterfaceTest.java
@@ -79,7 +79,7 @@ class SymbolSolverWithJavassistInterfaceTest extends AbstractSymbolResolutionTes
         assertFalse(solvedSymbol.isSolved());
 
         assertThrows(UnsolvedSymbolException.class, () -> {
-        	solvedSymbol.getCorrespondingDeclaration();
+            solvedSymbol.getCorrespondingDeclaration();
         }, "Expected UnsolvedSymbolException when requesting CorrespondingDeclaration on unsolved SymbolRefernce");
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/TypeInClassWithAnnotationAncestorTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/TypeInClassWithAnnotationAncestorTest.java
@@ -35,14 +35,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class TypeInClassWithAnnotationAncestorTest extends AbstractResolutionTest {
 
-	@Test
-	void resolveStringReturnType() {
-		CompilationUnit cu = parseSample("ClassWithAnnotationAncestor");
-		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ClassWithAnnotationAncestor");
-		MethodDeclaration method = Navigator.demandMethod(clazz, "testMethod");
-		ResolvedType type = JavaParserFacade.get(new ReflectionTypeSolver())
-				                    .convertToUsage(method.getType());
-		assertFalse(type.isTypeVariable());
-		assertEquals("java.lang.String", type.describe());
-	}
+    @Test
+    void resolveStringReturnType() {
+        CompilationUnit cu = parseSample("ClassWithAnnotationAncestor");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "ClassWithAnnotationAncestor");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "testMethod");
+        ResolvedType type = JavaParserFacade.get(new ReflectionTypeSolver())
+                                    .convertToUsage(method.getType());
+        assertFalse(type.isTypeVariable());
+        assertEquals("java.lang.String", type.describe());
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/UnknownMethodsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/UnknownMethodsResolutionTest.java
@@ -37,27 +37,27 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UnknownMethodsResolutionTest extends AbstractResolutionTest {
 
-	@Test
-	void testUnknownMethod1() {
-		assertThrows(UnsolvedSymbolException.class, () -> {
-		    CompilationUnit cu = parseSample("UnknownMethods");
-		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
-		MethodDeclaration method = Navigator.demandMethod(clazz, "test1");
-		MethodCallExpr methodCallExpr = method.getBody().get().getStatement(0).asExpressionStmt().getExpression().asMethodCallExpr();
-		SymbolReference<ResolvedMethodDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
+    @Test
+    void testUnknownMethod1() {
+        assertThrows(UnsolvedSymbolException.class, () -> {
+            CompilationUnit cu = parseSample("UnknownMethods");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "test1");
+        MethodCallExpr methodCallExpr = method.getBody().get().getStatement(0).asExpressionStmt().getExpression().asMethodCallExpr();
+        SymbolReference<ResolvedMethodDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
 });
-						
+                        
 }
 
-	@Test
-	void testUnknownMethod2() {
-		assertThrows(UnsolvedSymbolException.class, () -> {
-		    CompilationUnit cu = parseSample("UnknownMethods");
-		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
-		MethodDeclaration method = Navigator.demandMethod(clazz, "test2");
-		MethodCallExpr methodCallExpr = method.getBody().get().getStatement(1).asExpressionStmt().getExpression().asMethodCallExpr();
-		SymbolReference<ResolvedMethodDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
+    @Test
+    void testUnknownMethod2() {
+        assertThrows(UnsolvedSymbolException.class, () -> {
+            CompilationUnit cu = parseSample("UnknownMethods");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "UnknownMethods");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "test2");
+        MethodCallExpr methodCallExpr = method.getBody().get().getStatement(1).asExpressionStmt().getExpression().asMethodCallExpr();
+        SymbolReference<ResolvedMethodDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(methodCallExpr);
 });
-						
+                        
 }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariableResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariableResolutionTest.java
@@ -34,31 +34,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VariableResolutionTest extends AbstractResolutionTest {
 
-	@Test
-	void variableResolutionNoBlockStmt() {
-		// Test without nested block statement
+    @Test
+    void variableResolutionNoBlockStmt() {
+        // Test without nested block statement
 
-		CompilationUnit cu = parseSample("VariableResolutionInVariousScopes");
-		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "VariableResolutionInVariousScopes");
+        CompilationUnit cu = parseSample("VariableResolutionInVariousScopes");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "VariableResolutionInVariousScopes");
 
-		MethodDeclaration method = Navigator.demandMethod(clazz, "noBlock");
-		MethodCallExpr callExpr = method.findFirst(MethodCallExpr.class).get();
-		MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(callExpr);
+        MethodDeclaration method = Navigator.demandMethod(clazz, "noBlock");
+        MethodCallExpr callExpr = method.findFirst(MethodCallExpr.class).get();
+        MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(callExpr);
 
-		assertTrue(methodUsage.declaringType().getQualifiedName().equals("java.lang.String"));
-	}
+        assertTrue(methodUsage.declaringType().getQualifiedName().equals("java.lang.String"));
+    }
 
-	@Test
-	void variableResolutionWithBlockStmt() {
-		// Test without nested block statement
+    @Test
+    void variableResolutionWithBlockStmt() {
+        // Test without nested block statement
 
-		CompilationUnit cu = parseSample("VariableResolutionInVariousScopes");
-		ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "VariableResolutionInVariousScopes");
+        CompilationUnit cu = parseSample("VariableResolutionInVariousScopes");
+        ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "VariableResolutionInVariousScopes");
 
-		MethodDeclaration method = Navigator.demandMethod(clazz, "withBlock");
-		MethodCallExpr callExpr = method.findFirst(MethodCallExpr.class).get();
-		MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(callExpr);
+        MethodDeclaration method = Navigator.demandMethod(clazz, "withBlock");
+        MethodCallExpr callExpr = method.findFirst(MethodCallExpr.class).get();
+        MethodUsage methodUsage = JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(callExpr);
 
-		assertTrue(methodUsage.declaringType().getQualifiedName().equals("java.lang.String"));
-	}
+        assertTrue(methodUsage.declaringType().getQualifiedName().equals("java.lang.String"));
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
@@ -58,155 +58,155 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Malte Langkabel
  */
 class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
-	private MethodCallExpr getMethodCallExpr(String methodName, String callingMethodName) {
-		CompilationUnit cu = parseSample("MethodCalls");
+    private MethodCallExpr getMethodCallExpr(String methodName, String callingMethodName) {
+        CompilationUnit cu = parseSample("MethodCalls");
 
-		com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodCalls");
-		MethodDeclaration method = Navigator.demandMethod(clazz, methodName);
-		return Navigator.findMethodCall(method, callingMethodName).get();
-	}
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "MethodCalls");
+        MethodDeclaration method = Navigator.demandMethod(clazz, methodName);
+        return Navigator.findMethodCall(method, callingMethodName).get();
+    }
 
-	private CombinedTypeSolver createTypeSolver() {
-		Path src = adaptPath("src/test/resources");
-		CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
-		combinedTypeSolver.add(new ReflectionTypeSolver());
-		combinedTypeSolver.add(new JavaParserTypeSolver(src, new LeanParserConfiguration()));
-		return combinedTypeSolver;
-	}
+    private CombinedTypeSolver createTypeSolver() {
+        Path src = adaptPath("src/test/resources");
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver());
+        combinedTypeSolver.add(new JavaParserTypeSolver(src, new LeanParserConfiguration()));
+        return combinedTypeSolver;
+    }
 
-	@Test
-	void solveNestedMethodCallExprContextWithoutScope() {
-		MethodCallExpr methodCallExpr = getMethodCallExpr("bar1", "foo");
-		CombinedTypeSolver typeSolver = createTypeSolver();
+    @Test
+    void solveNestedMethodCallExprContextWithoutScope() {
+        MethodCallExpr methodCallExpr = getMethodCallExpr("bar1", "foo");
+        CombinedTypeSolver typeSolver = createTypeSolver();
 
-		Context context = new MethodCallExprContext(methodCallExpr, typeSolver);
+        Context context = new MethodCallExprContext(methodCallExpr, typeSolver);
 
-		Optional<MethodUsage> ref = context.solveMethodAsUsage("foo", Collections.emptyList());
-		assertTrue(ref.isPresent());
-		assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
-	}
+        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo", Collections.emptyList());
+        assertTrue(ref.isPresent());
+        assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
+    }
 
-	@Test
-	void solveGenericMethodCallMustUseProvidedTypeArgs() {
-		assertCanSolveGenericMethodCallMustUseProvidedTypeArgs("genericMethod0");
-	}
+    @Test
+    void solveGenericMethodCallMustUseProvidedTypeArgs() {
+        assertCanSolveGenericMethodCallMustUseProvidedTypeArgs("genericMethod0");
+    }
 
-	@Test
-	void solveStaticGenericMethodCallMustUseProvidedTypeArgs() {
-		assertCanSolveGenericMethodCallMustUseProvidedTypeArgs("staticGenericMethod0");
-	}
+    @Test
+    void solveStaticGenericMethodCallMustUseProvidedTypeArgs() {
+        assertCanSolveGenericMethodCallMustUseProvidedTypeArgs("staticGenericMethod0");
+    }
 
-	private void assertCanSolveGenericMethodCallMustUseProvidedTypeArgs(String callMethodName) {
-		MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", callMethodName);
-		CombinedTypeSolver typeSolver = createTypeSolver();
+    private void assertCanSolveGenericMethodCallMustUseProvidedTypeArgs(String callMethodName) {
+        MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", callMethodName);
+        CombinedTypeSolver typeSolver = createTypeSolver();
 
-		MethodCallExprContext context = new MethodCallExprContext(methodCallExpr, typeSolver);
+        MethodCallExprContext context = new MethodCallExprContext(methodCallExpr, typeSolver);
 
-		Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, Collections.emptyList());
-		assertTrue(ref.isPresent());
-		assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
-		assertEquals(Collections.singletonList("java.lang.Integer"), ref.get().typeParametersMap().getTypes().stream()
-				.map(ty -> ty.asReferenceType().describe()).collect(Collectors.toList()));
-	}
+        Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, Collections.emptyList());
+        assertTrue(ref.isPresent());
+        assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
+        assertEquals(Collections.singletonList("java.lang.Integer"), ref.get().typeParametersMap().getTypes().stream()
+                .map(ty -> ty.asReferenceType().describe()).collect(Collectors.toList()));
+    }
 
-	@Test
-	void solveGenericMethodCallCanInferFromArguments() {
-		assertCanSolveGenericMethodCallCanInferFromArguments("genericMethod1");
-	}
+    @Test
+    void solveGenericMethodCallCanInferFromArguments() {
+        assertCanSolveGenericMethodCallCanInferFromArguments("genericMethod1");
+    }
 
-	@Test
-	void solveStaticGenericMethodCallCanInferFromArguments() {
-		assertCanSolveGenericMethodCallCanInferFromArguments("staticGenericMethod1");
-	}
+    @Test
+    void solveStaticGenericMethodCallCanInferFromArguments() {
+        assertCanSolveGenericMethodCallCanInferFromArguments("staticGenericMethod1");
+    }
 
-	private void assertCanSolveGenericMethodCallCanInferFromArguments(String callMethodName) {
-		MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", callMethodName);
-		CombinedTypeSolver typeSolver = createTypeSolver();
+    private void assertCanSolveGenericMethodCallCanInferFromArguments(String callMethodName) {
+        MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", callMethodName);
+        CombinedTypeSolver typeSolver = createTypeSolver();
 
-		MethodCallExprContext context = new MethodCallExprContext(methodCallExpr, typeSolver);
+        MethodCallExprContext context = new MethodCallExprContext(methodCallExpr, typeSolver);
 
-		ResolvedReferenceTypeDeclaration stringType = typeSolver.solveType("java.lang.String");
+        ResolvedReferenceTypeDeclaration stringType = typeSolver.solveType("java.lang.String");
 
-		List<ResolvedType> argumentsTypes = new ArrayList<>();
-		argumentsTypes.add(new ReferenceTypeImpl(stringType));
+        List<ResolvedType> argumentsTypes = new ArrayList<>();
+        argumentsTypes.add(new ReferenceTypeImpl(stringType));
 
-		Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, argumentsTypes);
-		assertTrue(ref.isPresent());
-		assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
-		assertEquals(Collections.singletonList("java.lang.String"), ref.get().typeParametersMap().getTypes().stream()
-				.map(ty -> ty.asReferenceType().describe()).collect(Collectors.toList()));
-	}
+        Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, argumentsTypes);
+        assertTrue(ref.isPresent());
+        assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
+        assertEquals(Collections.singletonList("java.lang.String"), ref.get().typeParametersMap().getTypes().stream()
+                .map(ty -> ty.asReferenceType().describe()).collect(Collectors.toList()));
+    }
 
-	@Test
-	public void test() {
-		ParserConfiguration config = new ParserConfiguration()
-				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
-		StaticJavaParser.setConfiguration(config);
-		CompilationUnit cu = parseSample("Issue2258");
-		List<MethodCallExpr> expressions = cu.getChildNodesByType(MethodCallExpr.class);
-		assertEquals(2, expressions.size());
-		ResolvedType r = expressions.get(1).calculateResolvedType();
-		assertTrue(ResolvedVoidType.class.isAssignableFrom(r.getClass()));
-	}
+    @Test
+    public void test() {
+        ParserConfiguration config = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+        CompilationUnit cu = parseSample("Issue2258");
+        List<MethodCallExpr> expressions = cu.getChildNodesByType(MethodCallExpr.class);
+        assertEquals(2, expressions.size());
+        ResolvedType r = expressions.get(1).calculateResolvedType();
+        assertTrue(ResolvedVoidType.class.isAssignableFrom(r.getClass()));
+    }
 
-	@Test
-	public void testGenericParameter() {
-		ParserConfiguration config = new ParserConfiguration()
-				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
-		StaticJavaParser.setConfiguration(config);
-		CompilationUnit cu = parseSample("ISSUES_Generic_Parameter");
-		List<MethodCallExpr> expressions = cu.getChildNodesByType(MethodCallExpr.class);
-		assertEquals(1, expressions.size());
-		ResolvedType r = expressions.get(0).calculateResolvedType();
-		assertTrue(ReferenceTypeImpl.class.isAssignableFrom(r.getClass()));
-	}
+    @Test
+    public void testGenericParameter() {
+        ParserConfiguration config = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+        CompilationUnit cu = parseSample("ISSUES_Generic_Parameter");
+        List<MethodCallExpr> expressions = cu.getChildNodesByType(MethodCallExpr.class);
+        assertEquals(1, expressions.size());
+        ResolvedType r = expressions.get(0).calculateResolvedType();
+        assertTrue(ReferenceTypeImpl.class.isAssignableFrom(r.getClass()));
+    }
 
-	@Test
-	public void testResolveChainedCallOnReflectionType() throws Exception {
-		Path pathToJar = adaptPath("src/test/resources/issue2667/jsonobject.jar");
+    @Test
+    public void testResolveChainedCallOnReflectionType() throws Exception {
+        Path pathToJar = adaptPath("src/test/resources/issue2667/jsonobject.jar");
 
-		CombinedTypeSolver typeSolver = createTypeSolver();
-		typeSolver.add(new ClassLoaderTypeSolver(new URLClassLoader(new URL[] {pathToJar.toUri().toURL()})));
+        CombinedTypeSolver typeSolver = createTypeSolver();
+        typeSolver.add(new ClassLoaderTypeSolver(new URLClassLoader(new URL[] {pathToJar.toUri().toURL()})));
 
-		ParserConfiguration config = new ParserConfiguration()
-				.setSymbolResolver(new JavaSymbolSolver(typeSolver));
-		StaticJavaParser.setConfiguration(config);
-		CompilationUnit cu = parseSample("Issue2667");
-		Set<MethodCallExpr> methodCallExpr = new HashSet<>(cu.findAll(MethodCallExpr.class));
+        ParserConfiguration config = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        StaticJavaParser.setConfiguration(config);
+        CompilationUnit cu = parseSample("Issue2667");
+        Set<MethodCallExpr> methodCallExpr = new HashSet<>(cu.findAll(MethodCallExpr.class));
 
-		int errorCount = 0;
+        int errorCount = 0;
 
-		for (MethodCallExpr expr : methodCallExpr) {
-			try {
-				ResolvedMethodDeclaration rd = expr.resolve();
-			} catch (UnsolvedSymbolException e) {
-				errorCount++;
-			}
-		}
+        for (MethodCallExpr expr : methodCallExpr) {
+            try {
+                ResolvedMethodDeclaration rd = expr.resolve();
+            } catch (UnsolvedSymbolException e) {
+                errorCount++;
+            }
+        }
 
-		assertEquals(0, errorCount, "Expected zero UnsolvedSymbolException s");
-	}
-	
-	@Test
-	void solveVariadicStaticGenericMethodCallCanInferFromArguments() {
-		ParserConfiguration config = new ParserConfiguration()
-				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
-		StaticJavaParser.setConfiguration(config);
-		MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", "variadicStaticGenericMethod");
+        assertEquals(0, errorCount, "Expected zero UnsolvedSymbolException s");
+    }
+    
+    @Test
+    void solveVariadicStaticGenericMethodCallCanInferFromArguments() {
+        ParserConfiguration config = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+        MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", "variadicStaticGenericMethod");
 
-		ResolvedType resolvedType = methodCallExpr.calculateResolvedType();
+        ResolvedType resolvedType = methodCallExpr.calculateResolvedType();
         assertEquals("java.lang.String", resolvedType.describe());
-	}
-	
-	// Related to issue #3195
-	@Test
-	void solveVariadicStaticGenericMethodCallCanInferFromArguments2() {
-		ParserConfiguration config = new ParserConfiguration()
-				.setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
-		StaticJavaParser.setConfiguration(config);
-		MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", "asList");
+    }
+    
+    // Related to issue #3195
+    @Test
+    void solveVariadicStaticGenericMethodCallCanInferFromArguments2() {
+        ParserConfiguration config = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(createTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+        MethodCallExpr methodCallExpr = getMethodCallExpr("genericMethodTest", "asList");
 
-		ResolvedType resolvedType = methodCallExpr.calculateResolvedType();
+        ResolvedType resolvedType = methodCallExpr.calculateResolvedType();
         assertEquals("java.util.List<java.lang.String>", resolvedType.describe());
-	}
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
@@ -24,276 +24,276 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 
 class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
 
-	private TypeSolver typeSolver;
+    private TypeSolver typeSolver;
 
-	@BeforeEach
-	void setup() throws Exception {
-		CombinedTypeSolver combinedtypeSolver = new CombinedTypeSolver();
-		combinedtypeSolver.add(new ReflectionTypeSolver());
-		typeSolver = combinedtypeSolver;
-	}
+    @BeforeEach
+    void setup() throws Exception {
+        CombinedTypeSolver combinedtypeSolver = new CombinedTypeSolver();
+        combinedtypeSolver.add(new ReflectionTypeSolver());
+        typeSolver = combinedtypeSolver;
+    }
 
-	/*
-	 * A simple example of a functional interface
-	 */
-	@Test
-	void simpleExampleOfFunctionnalInterface() {
-		String code = "interface Runnable {\n"
-				+ "    void run();\n"
-				+ "}";
+    /*
+     * A simple example of a functional interface
+     */
+    @Test
+    void simpleExampleOfFunctionnalInterface() {
+        String code = "interface Runnable {\n"
+                + "    void run();\n"
+                + "}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
+    }
 
-	/*
-	 * The following interface is not functional because it declares nothing which
-	 * is not already a member of Object
-	 */
-	@Test
-	void notFunctionalBecauseItDeclaresNothingWhichIsNotAlreadyAMemberOfObject() {
-		String code = "interface NonFunc {\n"
-				+ "    boolean equals(Object obj);\n"
-				+ "}";
+    /*
+     * The following interface is not functional because it declares nothing which
+     * is not already a member of Object
+     */
+    @Test
+    void notFunctionalBecauseItDeclaresNothingWhichIsNotAlreadyAMemberOfObject() {
+        String code = "interface NonFunc {\n"
+                + "    boolean equals(Object obj);\n"
+                + "}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertFalse(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertFalse(methodUsage.isPresent());
+    }
 
-	/*
-	 * its subinterface can be functional by declaring an abstract method which is
-	 * not a member of Object
-	 */
-	@Test
-	void subinterfaceCanBeFunctionalByDclaringAnAbstractMethodWhichIsNotAMemberOfObject() {
-		String code = "interface NonFunc {\n"
-				+ "    boolean equals(Object obj);\n" + "}\n"
-				+ "interface Func extends NonFunc {\n"
-				+ "    int compare(String o1, String o2);\n" + "}";
+    /*
+     * its subinterface can be functional by declaring an abstract method which is
+     * not a member of Object
+     */
+    @Test
+    void subinterfaceCanBeFunctionalByDclaringAnAbstractMethodWhichIsNotAMemberOfObject() {
+        String code = "interface NonFunc {\n"
+                + "    boolean equals(Object obj);\n" + "}\n"
+                + "interface Func extends NonFunc {\n"
+                + "    int compare(String o1, String o2);\n" + "}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Func");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Func");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
+    }
 
-	/*
-	 * the well known interface java.util.Comparator<T> is functional because it has
-	 * one abstract non-Object method:
-	 */
-	@Test
-	void isFunctionalBecauseItHasOneAbstractNonObjectMethod() {
-		String code = "interface Comparator<T> {\n"
-				+ "    boolean equals(Object obj);\n"
-				+ "    int compare(T o1, T o2);\n" + "}";
+    /*
+     * the well known interface java.util.Comparator<T> is functional because it has
+     * one abstract non-Object method:
+     */
+    @Test
+    void isFunctionalBecauseItHasOneAbstractNonObjectMethod() {
+        String code = "interface Comparator<T> {\n"
+                + "    boolean equals(Object obj);\n"
+                + "    int compare(T o1, T o2);\n" + "}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Comparator");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Comparator");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
+    }
 
-	/*
-	 * The following interface is not functional because while it only declares one
-	 * abstract method which is not a member of Object, it declares two abstract
-	 * methods which are not public members of Object:
-	 */
-	@Test
-	void isNotFunctionalBecauseItDeclaresTwoAbstractMethodsWhichAreNotPublicMembersOfObject() {
-		String code = "interface Foo {\n"
-				+ "    int m();\n"
-				+ "    Object clone();\n"
-				+ "}";
+    /*
+     * The following interface is not functional because while it only declares one
+     * abstract method which is not a member of Object, it declares two abstract
+     * methods which are not public members of Object:
+     */
+    @Test
+    void isNotFunctionalBecauseItDeclaresTwoAbstractMethodsWhichAreNotPublicMembersOfObject() {
+        String code = "interface Foo {\n"
+                + "    int m();\n"
+                + "    Object clone();\n"
+                + "}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Foo");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertFalse(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Foo");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertFalse(methodUsage.isPresent());
+    }
 
-	/*
-	 * Z is a functional interface because while it inherits two abstract methods
-	 * which are not members of Object, they have the same signature, so the
-	 * inherited methods logically represent a single method:
-	 */
-	@Test
-	void isFunctionalInterfaceBecauseInheritedAbstractMethodsHaveTheSameSignature() {
-		String code = "interface X { int m(Iterable<String> arg); }\n"
-				+ "interface Y { int m(Iterable<String> arg); }\n"
-				+ "interface Z extends X, Y {}";
+    /*
+     * Z is a functional interface because while it inherits two abstract methods
+     * which are not members of Object, they have the same signature, so the
+     * inherited methods logically represent a single method:
+     */
+    @Test
+    void isFunctionalInterfaceBecauseInheritedAbstractMethodsHaveTheSameSignature() {
+        String code = "interface X { int m(Iterable<String> arg); }\n"
+                + "interface Y { int m(Iterable<String> arg); }\n"
+                + "interface Z extends X, Y {}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
+    }
 
-	/*
-	 * Z is a functional interface in the following interface hierarchy because Y.m
-	 * is a subsignature of X.m and is return-type-substitutable for X.m:
-	 */
-	@Test
-	@Disabled("Return-Type-Substituable must be implemented on reference type")
-	void isFunctionalInterfaceBecauseOfSubsignatureAndSubstitutableReturnType() {
-		String code = "interface X { Iterable m(Iterable<String> arg); }\n"
-				+ "interface Y { Iterable<String> m(Iterable arg); }\n"
-				+ "interface Z extends X, Y {}";
+    /*
+     * Z is a functional interface in the following interface hierarchy because Y.m
+     * is a subsignature of X.m and is return-type-substitutable for X.m:
+     */
+    @Test
+    @Disabled("Return-Type-Substituable must be implemented on reference type")
+    void isFunctionalInterfaceBecauseOfSubsignatureAndSubstitutableReturnType() {
+        String code = "interface X { Iterable m(Iterable<String> arg); }\n"
+                + "interface Y { Iterable<String> m(Iterable arg); }\n"
+                + "interface Z extends X, Y {}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
+    }
 
-	/*
-	 * the definition of "functional interface" respects the fact that an interface
-	 * may only have methods with override-equivalent signatures if one is
-	 * return-type-substitutable for all the others. Thus, in the following
-	 * interface hierarchy where Z causes a compile-time error, Z is not a
-	 * functional interface: (because none of its abstract members are
-	 * return-type-substitutable for all other abstract members)
-	 */
-	@Test
-	void isNotFunctionalInterfaceBecauseNoneOfItsAbstractMembersAreReturnTypeSubstitutableForAllOtherAbstractMembers() {
-		String code = "interface X { long m(); }\n"
-				+ "interface Y { int m(); }\n"
-				+ "interface Z extends X, Y {}";
+    /*
+     * the definition of "functional interface" respects the fact that an interface
+     * may only have methods with override-equivalent signatures if one is
+     * return-type-substitutable for all the others. Thus, in the following
+     * interface hierarchy where Z causes a compile-time error, Z is not a
+     * functional interface: (because none of its abstract members are
+     * return-type-substitutable for all other abstract members)
+     */
+    @Test
+    void isNotFunctionalInterfaceBecauseNoneOfItsAbstractMembersAreReturnTypeSubstitutableForAllOtherAbstractMembers() {
+        String code = "interface X { long m(); }\n"
+                + "interface Y { int m(); }\n"
+                + "interface Z extends X, Y {}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertFalse(methodUsage.isPresent());
-	}
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Z");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertFalse(methodUsage.isPresent());
+    }
 
-	/*
-	 * In the following example, the declarations of Foo<T,N> and Bar are legal: in
-	 * each, the methods called m are not subsignatures of each other, but do have
-	 * different erasures. Still, the fact that the methods in each are not
-	 * subsignatures means Foo<T,N> and Bar are not functional interfaces. However,
-	 * Baz is a functional interface because the methods it inherits from
-	 * Foo<Integer,Integer> have the same signature and so logically represent a
-	 * single method.
-	 */
-	@Test
-	void bazIsAFunctionalInterfaceBecauseMethodsItInheritsFromFooHaveTheSameSignature() {
-		String code = "interface Foo<T, N extends Number> {\n"
-				+ "    void m(T arg);\n"
-				+ "    void m(N arg);\n"
-				+ "}\n"
-				+ "interface Bar extends Foo<String, Integer> {}\n"
-				+ "interface Baz extends Foo<Integer, Integer> {}";
+    /*
+     * In the following example, the declarations of Foo<T,N> and Bar are legal: in
+     * each, the methods called m are not subsignatures of each other, but do have
+     * different erasures. Still, the fact that the methods in each are not
+     * subsignatures means Foo<T,N> and Bar are not functional interfaces. However,
+     * Baz is a functional interface because the methods it inherits from
+     * Foo<Integer,Integer> have the same signature and so logically represent a
+     * single method.
+     */
+    @Test
+    void bazIsAFunctionalInterfaceBecauseMethodsItInheritsFromFooHaveTheSameSignature() {
+        String code = "interface Foo<T, N extends Number> {\n"
+                + "    void m(T arg);\n"
+                + "    void m(N arg);\n"
+                + "}\n"
+                + "interface Bar extends Foo<String, Integer> {}\n"
+                + "interface Baz extends Foo<Integer, Integer> {}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Baz");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Baz");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
 
-		classOrInterfaceDecl = Navigator.demandInterface(cu, "Bar");
-		resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertFalse(methodUsage.isPresent());
-	}
+        classOrInterfaceDecl = Navigator.demandInterface(cu, "Bar");
+        resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertFalse(methodUsage.isPresent());
+    }
 
-	/*
-	 * Functional: signatures are logically "the same"
-	 */
-	@Test
-	void withGenericMethodsWithSameSignatures() {
-		String code = "interface Action<T> {};\n"
-				+ "interface X { <T> T execute(Action<T> a); }\n"
-				+ "interface Y { <S> S execute(Action<S> a); }\n"
-				+ "interface Exec extends X, Y {}\n";
+    /*
+     * Functional: signatures are logically "the same"
+     */
+    @Test
+    void withGenericMethodsWithSameSignatures() {
+        String code = "interface Action<T> {};\n"
+                + "interface X { <T> T execute(Action<T> a); }\n"
+                + "interface Y { <S> S execute(Action<S> a); }\n"
+                + "interface Exec extends X, Y {}\n";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Exec");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Exec");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
 
-	}
+    }
 
-	/*
-	 * Error: different signatures, same erasure
-	 */
-	@Test
-	void withGenericMethodsWithDifferentSignaturesAndSameErasure() {
-		String code = "interface Action<T> {};\n"
-				+ "interface X { <T>   T execute(Action<T> a); }\n"
-				+ "interface Y { <S,T> S execute(Action<S> a); }\n"
-				+ "interface Exec extends X, Y {}";
+    /*
+     * Error: different signatures, same erasure
+     */
+    @Test
+    void withGenericMethodsWithDifferentSignaturesAndSameErasure() {
+        String code = "interface Action<T> {};\n"
+                + "interface X { <T>   T execute(Action<T> a); }\n"
+                + "interface Y { <S,T> S execute(Action<S> a); }\n"
+                + "interface Exec extends X, Y {}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Exec");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Exec");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
 
-	}
+    }
 
-	/*
-	 * Functional interfaces can be generic, such as
-	 * java.util.function.Predicate<T>. Such a functional interface may be
-	 * parameterized in a way that produces distinct abstract methods - that is,
-	 * multiple methods that cannot be legally overridden with a single declaration.
-	 */
-	@Test
-	@Disabled("Waiting Return-Type-Substituable is fully implemented on reference type.")
-	void genericFunctionalInterfacesWithReturnTypeSubstituable() {
-		String code = "interface I    { Object m(Class c); }\r\n"
-				+ "interface J<S> { S m(Class<?> c); }\r\n"
-				+ "interface K<T> { T m(Class<?> c); }\r\n"
-				+ "interface Functional<S,T> extends I, J<S>, K<T> {}";
+    /*
+     * Functional interfaces can be generic, such as
+     * java.util.function.Predicate<T>. Such a functional interface may be
+     * parameterized in a way that produces distinct abstract methods - that is,
+     * multiple methods that cannot be legally overridden with a single declaration.
+     */
+    @Test
+    @Disabled("Waiting Return-Type-Substituable is fully implemented on reference type.")
+    void genericFunctionalInterfacesWithReturnTypeSubstituable() {
+        String code = "interface I    { Object m(Class c); }\r\n"
+                + "interface J<S> { S m(Class<?> c); }\r\n"
+                + "interface K<T> { T m(Class<?> c); }\r\n"
+                + "interface Functional<S,T> extends I, J<S>, K<T> {}";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Functional");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Functional");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
 
-	}
+    }
 
-	@Test
-	@Disabled("Waiting Return-Type-Substituable is fully implemented on reference type.")
-	void genericFunctionalInterfacesWithGenericParameter() {
-		String code =
-				"    public interface Foo<T> extends java.util.function.Function<String, T> {\n" +
+    @Test
+    @Disabled("Waiting Return-Type-Substituable is fully implemented on reference type.")
+    void genericFunctionalInterfacesWithGenericParameter() {
+        String code =
+                "    public interface Foo<T> extends java.util.function.Function<String, T> {\n" +
                 "        @Override\n" +
                 "        T apply(String c);\n" +
                 "    }\n";
 
-		CompilationUnit cu = StaticJavaParser.parse(code);
-		ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Foo");
-		ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
-				typeSolver);
-		Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
-		assertTrue(methodUsage.isPresent());
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        ClassOrInterfaceDeclaration classOrInterfaceDecl = Navigator.demandInterface(cu, "Foo");
+        ResolvedInterfaceDeclaration resolvedDecl = new JavaParserInterfaceDeclaration(classOrInterfaceDecl,
+                typeSolver);
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
+        assertTrue(methodUsage.isPresent());
 
-	}
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundTest.java
@@ -181,12 +181,12 @@ class LeastUpperBoundTest {
 
     @Test
     public void lub_of_enum() {
-    	ResolvedType type = type("java.math.RoundingMode");
+        ResolvedType type = type("java.math.RoundingMode");
 
         ResolvedReferenceTypeDeclaration typeDeclaration = type.asReferenceType().getTypeDeclaration().get();
 
-		List<ResolvedType> constanteTypes = typeDeclaration.asEnum().getEnumConstants().stream()
-				.map(enumConst -> enumConst.getType()).collect(Collectors.toList());
+        List<ResolvedType> constanteTypes = typeDeclaration.asEnum().getEnumConstants().stream()
+                .map(enumConst -> enumConst.getType()).collect(Collectors.toList());
 
         ResolvedType expected = constanteTypes.get(0);
 
@@ -325,39 +325,39 @@ class LeastUpperBoundTest {
     }
 
 
-	@Test
-	@Disabled("Waiting for generic type resolution")
-	public void lub_of_generics_without_loop2() {
-		List<ResolvedType> typesFromInput = declaredTypes(
-				"class Parent<X> {}",
-				"class Child<Y> extends Parent<Y> {}",
-				"class Other<Z> {}",
-				"class A {}",
-				"class ChildP extends Parent<Other<? extends A>> {}",
-				"class ChildC extends Child<Other<? extends A>> {}");
+    @Test
+    @Disabled("Waiting for generic type resolution")
+    public void lub_of_generics_without_loop2() {
+        List<ResolvedType> typesFromInput = declaredTypes(
+                "class Parent<X> {}",
+                "class Child<Y> extends Parent<Y> {}",
+                "class Other<Z> {}",
+                "class A {}",
+                "class ChildP extends Parent<Other<? extends A>> {}",
+                "class ChildC extends Child<Other<? extends A>> {}");
 
-		ResolvedType ChildP = typesFromInput.get(4);
-		ResolvedType childC = typesFromInput.get(5);
+        ResolvedType ChildP = typesFromInput.get(4);
+        ResolvedType childC = typesFromInput.get(5);
 
-		ResolvedType lub = leastUpperBound(ChildP, childC);
-		System.out.println(lub.describe());
+        ResolvedType lub = leastUpperBound(ChildP, childC);
+        System.out.println(lub.describe());
     }
 
-	@Test
-	@Disabled("Waiting for generic type resolution")
-	public void lub_of_generics_infinite_types() {
-		List<ResolvedType> types = declaredTypes(
-				"class Parent<X> {}",
-				"class Child<Y> extends Parent<Y> {}",
-				"class ChildInteger extends Child<Integer> {}",
-				"class ChildString extends Child<String> {}");
+    @Test
+    @Disabled("Waiting for generic type resolution")
+    public void lub_of_generics_infinite_types() {
+        List<ResolvedType> types = declaredTypes(
+                "class Parent<X> {}",
+                "class Child<Y> extends Parent<Y> {}",
+                "class ChildInteger extends Child<Integer> {}",
+                "class ChildString extends Child<String> {}");
 
-		ResolvedType childInteger = types.get(2);
-		ResolvedType childString = types.get(3);
+        ResolvedType childInteger = types.get(2);
+        ResolvedType childString = types.get(3);
 
-		ResolvedType lub = leastUpperBound(childInteger, childString);
-		System.out.println(lub.describe());
-	}
+        ResolvedType lub = leastUpperBound(childInteger, childString);
+        System.out.println(lub.describe());
+    }
 
     private List<ResolvedType> types(String... types) {
         return Arrays.stream(types).map(type -> type(type)).collect(Collectors.toList());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/types/ResolvedArrayTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/types/ResolvedArrayTypeTest.java
@@ -39,156 +39,156 @@ import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 
 class ResolvedArrayTypeTest extends AbstractResolutionTest {
 
-	JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+    JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
 
-	ResolvedType rByte = getType("class A {java.lang.Byte x;}");
-	ResolvedType rShort = getType("class A {java.lang.Short x;}");
-	ResolvedType rChar = getType("class A {java.lang.Character x;}");
-	ResolvedType rInteger = getType("class A {java.lang.Integer x;}");
-	ResolvedType rLong = getType("class A {java.lang.Long x;}");
-	ResolvedType rFloat = getType("class A {java.lang.Float x;}");
-	ResolvedType rDouble = getType("class A {java.lang.Double x;}");
-	ResolvedType rString = getType("class A {java.lang.String x;}");
-	ResolvedType rCharSequence = getType("class A {java.lang.CharSequence x;}");
-	ResolvedType rObject = getType("class A {java.lang.Object x;}");
-	ResolvedType rCloneable = getType("class A {java.lang.Cloneable x;}");
-	ResolvedType rSerializable = getType("class A {java.io.Serializable x;}");
-	ResolvedType rArrayList = getType("class A {java.util.ArrayList x;}");
+    ResolvedType rByte = getType("class A {java.lang.Byte x;}");
+    ResolvedType rShort = getType("class A {java.lang.Short x;}");
+    ResolvedType rChar = getType("class A {java.lang.Character x;}");
+    ResolvedType rInteger = getType("class A {java.lang.Integer x;}");
+    ResolvedType rLong = getType("class A {java.lang.Long x;}");
+    ResolvedType rFloat = getType("class A {java.lang.Float x;}");
+    ResolvedType rDouble = getType("class A {java.lang.Double x;}");
+    ResolvedType rString = getType("class A {java.lang.String x;}");
+    ResolvedType rCharSequence = getType("class A {java.lang.CharSequence x;}");
+    ResolvedType rObject = getType("class A {java.lang.Object x;}");
+    ResolvedType rCloneable = getType("class A {java.lang.Cloneable x;}");
+    ResolvedType rSerializable = getType("class A {java.io.Serializable x;}");
+    ResolvedType rArrayList = getType("class A {java.util.ArrayList x;}");
 
-	@Test
-	// An array of primitive type can be assigned another array of primitive type
-	// if primitive type are the same.
-	void arrayOfPrimitiveIsAssignableByArrayOfSamePrimitiveType() {
-		assertTrue(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
-		assertTrue(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
-		assertTrue(array(ResolvedPrimitiveType.LONG).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
-		assertTrue(array(ResolvedPrimitiveType.INT).isAssignableBy(array(ResolvedPrimitiveType.INT)));
-		assertTrue(array(ResolvedPrimitiveType.BYTE).isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
-		assertTrue(array(ResolvedPrimitiveType.SHORT).isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
-		assertTrue(array(ResolvedPrimitiveType.CHAR).isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
-	}
+    @Test
+    // An array of primitive type can be assigned another array of primitive type
+    // if primitive type are the same.
+    void arrayOfPrimitiveIsAssignableByArrayOfSamePrimitiveType() {
+        assertTrue(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
+        assertTrue(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
+        assertTrue(array(ResolvedPrimitiveType.LONG).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
+        assertTrue(array(ResolvedPrimitiveType.INT).isAssignableBy(array(ResolvedPrimitiveType.INT)));
+        assertTrue(array(ResolvedPrimitiveType.BYTE).isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
+        assertTrue(array(ResolvedPrimitiveType.SHORT).isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
+        assertTrue(array(ResolvedPrimitiveType.CHAR).isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
+    }
 
-	@Test
-	void arrayOfPrimitiveIsNotAssignableByArrayOfDifferentPrimitiveType() {
-		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.DOUBLE),
-				arrays(ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG, ResolvedPrimitiveType.INT,
-						ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
-		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.FLOAT),
-				arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.LONG, ResolvedPrimitiveType.INT,
-						ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
-		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.LONG),
-				arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.INT,
-						ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
-		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.INT),
-				arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
-						ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
-		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.BYTE),
-				arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
-						ResolvedPrimitiveType.INT, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
-		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.SHORT),
-				arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
-						ResolvedPrimitiveType.INT, ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.CHAR)));
-		assertFalse(isAssignableBy(array(ResolvedPrimitiveType.CHAR),
-				arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
-						ResolvedPrimitiveType.INT, ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT)));
-	}
+    @Test
+    void arrayOfPrimitiveIsNotAssignableByArrayOfDifferentPrimitiveType() {
+        assertFalse(isAssignableBy(array(ResolvedPrimitiveType.DOUBLE),
+                arrays(ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG, ResolvedPrimitiveType.INT,
+                        ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
+        assertFalse(isAssignableBy(array(ResolvedPrimitiveType.FLOAT),
+                arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.LONG, ResolvedPrimitiveType.INT,
+                        ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
+        assertFalse(isAssignableBy(array(ResolvedPrimitiveType.LONG),
+                arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.INT,
+                        ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
+        assertFalse(isAssignableBy(array(ResolvedPrimitiveType.INT),
+                arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
+                        ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
+        assertFalse(isAssignableBy(array(ResolvedPrimitiveType.BYTE),
+                arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
+                        ResolvedPrimitiveType.INT, ResolvedPrimitiveType.SHORT, ResolvedPrimitiveType.CHAR)));
+        assertFalse(isAssignableBy(array(ResolvedPrimitiveType.SHORT),
+                arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
+                        ResolvedPrimitiveType.INT, ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.CHAR)));
+        assertFalse(isAssignableBy(array(ResolvedPrimitiveType.CHAR),
+                arrays(ResolvedPrimitiveType.DOUBLE, ResolvedPrimitiveType.FLOAT, ResolvedPrimitiveType.LONG,
+                        ResolvedPrimitiveType.INT, ResolvedPrimitiveType.BYTE, ResolvedPrimitiveType.SHORT)));
+    }
 
-	@Test
-	// An array of primitive type cannot be assigned to a Boxed type variable,
-	// because Boxed type is a class type other than Object
-	void arrayOfPrimitiveIsNotAssignableByArrayOfBoxedType() {
-		assertFalse(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(array(rDouble)));
-		assertFalse(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(array(rFloat)));
-		assertFalse(array(ResolvedPrimitiveType.LONG).isAssignableBy(array(rLong)));
-		assertFalse(array(ResolvedPrimitiveType.INT).isAssignableBy(array(rInteger)));
-		assertFalse(array(ResolvedPrimitiveType.BYTE).isAssignableBy(array(rByte)));
-		assertFalse(array(ResolvedPrimitiveType.SHORT).isAssignableBy(array(rShort)));
-		assertFalse(array(ResolvedPrimitiveType.CHAR).isAssignableBy(array(rChar)));
-	}
+    @Test
+    // An array of primitive type cannot be assigned to a Boxed type variable,
+    // because Boxed type is a class type other than Object
+    void arrayOfPrimitiveIsNotAssignableByArrayOfBoxedType() {
+        assertFalse(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(array(rDouble)));
+        assertFalse(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(array(rFloat)));
+        assertFalse(array(ResolvedPrimitiveType.LONG).isAssignableBy(array(rLong)));
+        assertFalse(array(ResolvedPrimitiveType.INT).isAssignableBy(array(rInteger)));
+        assertFalse(array(ResolvedPrimitiveType.BYTE).isAssignableBy(array(rByte)));
+        assertFalse(array(ResolvedPrimitiveType.SHORT).isAssignableBy(array(rShort)));
+        assertFalse(array(ResolvedPrimitiveType.CHAR).isAssignableBy(array(rChar)));
+    }
 
-	@Test
-	void arrayOfPrimitiveIsAssignableByNullType() {
-		assertTrue(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(NullType.INSTANCE));
-		assertTrue(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(NullType.INSTANCE));
-		assertTrue(array(ResolvedPrimitiveType.LONG).isAssignableBy(NullType.INSTANCE));
-		assertTrue(array(ResolvedPrimitiveType.INT).isAssignableBy(NullType.INSTANCE));
-		assertTrue(array(ResolvedPrimitiveType.BYTE).isAssignableBy(NullType.INSTANCE));
-		assertTrue(array(ResolvedPrimitiveType.SHORT).isAssignableBy(NullType.INSTANCE));
-		assertTrue(array(ResolvedPrimitiveType.CHAR).isAssignableBy(NullType.INSTANCE));
-	}
+    @Test
+    void arrayOfPrimitiveIsAssignableByNullType() {
+        assertTrue(array(ResolvedPrimitiveType.DOUBLE).isAssignableBy(NullType.INSTANCE));
+        assertTrue(array(ResolvedPrimitiveType.FLOAT).isAssignableBy(NullType.INSTANCE));
+        assertTrue(array(ResolvedPrimitiveType.LONG).isAssignableBy(NullType.INSTANCE));
+        assertTrue(array(ResolvedPrimitiveType.INT).isAssignableBy(NullType.INSTANCE));
+        assertTrue(array(ResolvedPrimitiveType.BYTE).isAssignableBy(NullType.INSTANCE));
+        assertTrue(array(ResolvedPrimitiveType.SHORT).isAssignableBy(NullType.INSTANCE));
+        assertTrue(array(ResolvedPrimitiveType.CHAR).isAssignableBy(NullType.INSTANCE));
+    }
 
-	@Test
-	// An array can be assigned only to a variable of a compatible array type, or to
-	// a variable of type Object, Cloneable or java.io.Serializable.
-	void objectIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
-		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
-		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
-		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
-		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.INT)));
-		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
-		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
-		assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
-		assertTrue(rObject.isAssignableBy(array(rString)));
-	}
+    @Test
+    // An array can be assigned only to a variable of a compatible array type, or to
+    // a variable of type Object, Cloneable or java.io.Serializable.
+    void objectIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
+        assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
+        assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
+        assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
+        assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.INT)));
+        assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
+        assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
+        assertTrue(rObject.isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
+        assertTrue(rObject.isAssignableBy(array(rString)));
+    }
 
-	@Test
-	void cloneableIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
-		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
-		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
-		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
-		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.INT)));
-		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
-		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
-		assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
-		assertTrue(rCloneable.isAssignableBy(array(rString)));
-	}
+    @Test
+    void cloneableIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
+        assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
+        assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
+        assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
+        assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.INT)));
+        assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
+        assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
+        assertTrue(rCloneable.isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
+        assertTrue(rCloneable.isAssignableBy(array(rString)));
+    }
 
-	@Test
-	void serializableIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
-		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
-		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
-		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
-		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.INT)));
-		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
-		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
-		assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
-		assertTrue(rSerializable.isAssignableBy(array(rString)));
-	}
+    @Test
+    void serializableIsAssignableByAnyArrayOfPrimitiveTypeOrReference() {
+        assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.DOUBLE)));
+        assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.FLOAT)));
+        assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.LONG)));
+        assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.INT)));
+        assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.BYTE)));
+        assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.SHORT)));
+        assertTrue(rSerializable.isAssignableBy(array(ResolvedPrimitiveType.CHAR)));
+        assertTrue(rSerializable.isAssignableBy(array(rString)));
+    }
 
-	@Test
-	void arrayOfSubTypeIsAssignableByArrayOfSuperType() {
-		assertTrue(array(rCharSequence).isAssignableBy(array(rString)));
-	}
+    @Test
+    void arrayOfSubTypeIsAssignableByArrayOfSuperType() {
+        assertTrue(array(rCharSequence).isAssignableBy(array(rString)));
+    }
 
-	@Test
-	void arrayOfReferenceIsNotAssignableByArrayOfOtherReference() {
-		assertFalse(array(rString).isAssignableBy(array(rCharSequence)));
-	}
+    @Test
+    void arrayOfReferenceIsNotAssignableByArrayOfOtherReference() {
+        assertFalse(array(rString).isAssignableBy(array(rCharSequence)));
+    }
 
-	@Test
-	void arrayOfObjectIsAssignableByArrayOfReference() {
-		assertTrue(array(rObject).isAssignableBy(array(rLong)));
-	}
+    @Test
+    void arrayOfObjectIsAssignableByArrayOfReference() {
+        assertTrue(array(rObject).isAssignableBy(array(rLong)));
+    }
 
-	@Test
-	void arrayOfObjectIsNotAssignableByArrayOfPrimitiveType() {
-		assertFalse(array(rObject).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
-	}
+    @Test
+    void arrayOfObjectIsNotAssignableByArrayOfPrimitiveType() {
+        assertFalse(array(rObject).isAssignableBy(array(ResolvedPrimitiveType.LONG)));
+    }
 
-	private boolean isAssignableBy(ResolvedType type, ResolvedType... types) {
-		return Arrays.stream(types).anyMatch(t -> type.isAssignableBy(t));
-	}
+    private boolean isAssignableBy(ResolvedType type, ResolvedType... types) {
+        return Arrays.stream(types).anyMatch(t -> type.isAssignableBy(t));
+    }
 
-	private ResolvedArrayType[] arrays(ResolvedType... types) {
-		return Arrays.stream(types).map(t -> array(t)).collect(Collectors.toList()).toArray(new ResolvedArrayType[] {});
-	}
+    private ResolvedArrayType[] arrays(ResolvedType... types) {
+        return Arrays.stream(types).map(t -> array(t)).collect(Collectors.toList()).toArray(new ResolvedArrayType[] {});
+    }
 
-	private ResolvedArrayType array(ResolvedType type) {
-		return new ResolvedArrayType(type);
-	}
+    private ResolvedArrayType array(ResolvedType type) {
+        return new ResolvedArrayType(type);
+    }
 
-	private ResolvedType getType(String code) {
-		return parser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType();
-	}
+    private ResolvedType getType(String code) {
+        return parser.parse(code).findFirst(FieldDeclaration.class).get().resolve().getType();
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/ReflectionTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/ReflectionTypeSolverTest.java
@@ -59,11 +59,11 @@ class ReflectionTypeSolverTest extends ClassLoaderTypeSolverTest<ReflectionTypeS
     void testInvalidArgumentNumber() throws IOException {
         Path file = adaptPath("src/test/resources/issue2366/Test.java");
 
-        CombinedTypeSolver combinedSolver = new CombinedTypeSolver(new ReflectionTypeSolver());	    
+        CombinedTypeSolver combinedSolver = new CombinedTypeSolver(new ReflectionTypeSolver());        
 
         ParserConfiguration pc = new ParserConfiguration()
-            	                        .setSymbolResolver(new JavaSymbolSolver(combinedSolver))
-            	                        .setLanguageLevel(LanguageLevel.JAVA_8);
+                                        .setSymbolResolver(new JavaSymbolSolver(combinedSolver))
+                                        .setLanguageLevel(LanguageLevel.JAVA_8);
 
         JavaParser javaParser = new JavaParser(pc);
 
@@ -73,7 +73,7 @@ class ReflectionTypeSolverTest extends ClassLoaderTypeSolverTest<ReflectionTypeS
         Assertions.assertThrows(UnsolvedSymbolException.class, () -> unit.accept(new VoidVisitorAdapter<Object>() {
             @Override
             public void visit(ObjectCreationExpr exp, Object arg) {
-            	super.visit(exp, arg);
+                super.visit(exp, arg);
                 exp.resolve().getSignature();
             }            
         }, null));

--- a/javaparser-symbol-solver-testing/src/test/resources/issue128/foo/Issue128.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue128/foo/Issue128.java
@@ -4,7 +4,7 @@ import static foo.JavaTest.*;
 // here could be the correct import for bar
 
 public class JavaTest {
-	public void test() {
-		bar();
-	}
+    public void test() {
+        bar();
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/implementations/HairTypeWool.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/implementations/HairTypeWool.java
@@ -2,10 +2,10 @@ package issue1945.implementations;
 import issue1945.interfaces.HairType;
 
 public class HairTypeWool implements HairType<WoolRenderer> {
-	
-	@Override
-	public WoolRenderer getRenderer() {
-		return WoolRenderer.INSTANCE;
-	}
-	
+    
+    @Override
+    public WoolRenderer getRenderer() {
+        return WoolRenderer.INSTANCE;
+    }
+    
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/implementations/Sheep.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/implementations/Sheep.java
@@ -3,11 +3,11 @@ import issue1945.interfaces.HairType;
 import issue1945.interfaces.HairyAnimal;
 
 public class Sheep implements HairyAnimal {
-	
-	@Override
-	public HairType<?> getHairType() {
-		//simplified
-		return new HairTypeWool();
-	}
-	
+    
+    @Override
+    public HairType<?> getHairType() {
+        //simplified
+        return new HairTypeWool();
+    }
+    
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/implementations/WoolRenderer.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/implementations/WoolRenderer.java
@@ -3,16 +3,16 @@ import issue1945.interfaces.HairTypeRenderer;
 import issue1945.interfaces.HairyAnimal;
 
 public class WoolRenderer extends HairTypeRenderer<HairTypeWool> {
-	
-	public final static WoolRenderer INSTANCE = new WoolRenderer();
-	
-	private WoolRenderer() {
-		//I'm a singleton
-	}
-	
-	@Override
-	public void renderHair(HairTypeWool type, HairyAnimal animal) {
-		//... snip ...
-	}
-	
+    
+    public final static WoolRenderer INSTANCE = new WoolRenderer();
+    
+    private WoolRenderer() {
+        //I'm a singleton
+    }
+    
+    @Override
+    public void renderHair(HairTypeWool type, HairyAnimal animal) {
+        //... snip ...
+    }
+    
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/interfaces/HairType.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/interfaces/HairType.java
@@ -1,7 +1,7 @@
 package issue1945.interfaces;
 
 public interface HairType<R extends HairTypeRenderer<?>> {
-	
-	R getRenderer();
-	
+    
+    R getRenderer();
+    
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/interfaces/HairTypeRenderer.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/interfaces/HairTypeRenderer.java
@@ -1,20 +1,20 @@
 package issue1945.interfaces;
 
 public abstract class HairTypeRenderer<T> {
-	
-	protected abstract void renderHair(T typeInstance, HairyAnimal animal);
-	
-	/**
-	 * A proxy method casting the <code>typeInstance</code> parameter to the appropriate type for this renderer.
-	 * This is necessary because the type that's retrieved by {@link HairyAnimal#getHairType()} is the generic {@link HairType} super interface.
-	 */
-	@SuppressWarnings("unchecked")
-	public final void renderHair(HairType<?> typeInstance, HairyAnimal animal) {
-		try {
-			renderHair((T)typeInstance, animal);
-		} catch (ClassCastException e) {
-			throw new IllegalStateException("Renderer type and instance type don't match", e);
-		}
-	}
-	
+    
+    protected abstract void renderHair(T typeInstance, HairyAnimal animal);
+    
+    /**
+     * A proxy method casting the <code>typeInstance</code> parameter to the appropriate type for this renderer.
+     * This is necessary because the type that's retrieved by {@link HairyAnimal#getHairType()} is the generic {@link HairType} super interface.
+     */
+    @SuppressWarnings("unchecked")
+    public final void renderHair(HairType<?> typeInstance, HairyAnimal animal) {
+        try {
+            renderHair((T)typeInstance, animal);
+        } catch (ClassCastException e) {
+            throw new IllegalStateException("Renderer type and instance type don't match", e);
+        }
+    }
+    
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/interfaces/HairyAnimal.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/interfaces/HairyAnimal.java
@@ -1,7 +1,7 @@
 package issue1945.interfaces;
 
 public interface HairyAnimal {
-	
-	HairType<?> getHairType();
-	
+    
+    HairType<?> getHairType();
+    
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/main/MainIssue1945.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1945/issue1945/main/MainIssue1945.java
@@ -6,43 +6,43 @@ import issue1945.interfaces.HairTypeRenderer;
 import issue1945.interfaces.HairyAnimal;
 
 public class MainIssue1945 {
-	
-	private final HairyAnimal sheep = new Sheep();
-	
-	public void chokes() {
-		sheep.getHairType().getRenderer().renderHair(sheep.getHairType(), sheep);
-	}
-	
-	public void chokes2() {
-		HairType<?> hairType = sheep.getHairType();
-		hairType.getRenderer().renderHair(hairType, sheep);
-	}
-	
-	public void chokes3() {
-		HairType<?> hairType = sheep.getHairType();
-		hairType.getRenderer().renderHair(sheep.getHairType(), sheep);
-	}
-	
-	
-	
-	
-	
-	public void works() {
-		HairType<?> hairType = sheep.getHairType();
-		HairTypeRenderer<?> hairTypeRenderer = hairType.getRenderer();
-		
-		hairTypeRenderer.renderHair(hairType, sheep);
-	}
-	
-	public void works2() {
-		HairTypeRenderer<?> hairTypeRenderer = sheep.getHairType().getRenderer();
-		hairTypeRenderer.renderHair(sheep.getHairType(), sheep);
-	}
-	
-	public void works3() {
-		HairType<?> hairType = sheep.getHairType();
-		HairTypeRenderer<?> hairTypeRenderer = hairType.getRenderer();
-		
-		hairTypeRenderer.renderHair(sheep.getHairType(), sheep);
-	}
+    
+    private final HairyAnimal sheep = new Sheep();
+    
+    public void chokes() {
+        sheep.getHairType().getRenderer().renderHair(sheep.getHairType(), sheep);
+    }
+    
+    public void chokes2() {
+        HairType<?> hairType = sheep.getHairType();
+        hairType.getRenderer().renderHair(hairType, sheep);
+    }
+    
+    public void chokes3() {
+        HairType<?> hairType = sheep.getHairType();
+        hairType.getRenderer().renderHair(sheep.getHairType(), sheep);
+    }
+    
+    
+    
+    
+    
+    public void works() {
+        HairType<?> hairType = sheep.getHairType();
+        HairTypeRenderer<?> hairTypeRenderer = hairType.getRenderer();
+        
+        hairTypeRenderer.renderHair(hairType, sheep);
+    }
+    
+    public void works2() {
+        HairTypeRenderer<?> hairTypeRenderer = sheep.getHairType().getRenderer();
+        hairTypeRenderer.renderHair(sheep.getHairType(), sheep);
+    }
+    
+    public void works3() {
+        HairType<?> hairType = sheep.getHairType();
+        HairTypeRenderer<?> hairTypeRenderer = hairType.getRenderer();
+        
+        hairTypeRenderer.renderHair(sheep.getHairType(), sheep);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue241/TypeWithMemberType.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue241/TypeWithMemberType.java
@@ -2,8 +2,8 @@ package issue241;
 
 public class TypeWithMemberType {
 
-	public interface MemberInterface {
-	
-	}
+    public interface MemberInterface {
+    
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue276/foo/A.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue276/foo/A.java
@@ -2,10 +2,10 @@ package foo;
 
 interface A {
 
-	enum FindMeIfYouCan {
-		CONSTANT
-	}
-	
-	void overrideMe(FindMeIfYouCan v);
+    enum FindMeIfYouCan {
+        CONSTANT
+    }
+    
+    void overrideMe(FindMeIfYouCan v);
 }
-	
+    

--- a/javaparser-symbol-solver-testing/src/test/resources/issue276/foo/C.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue276/foo/C.java
@@ -1,11 +1,11 @@
 package foo;
 
 public class C {
-	public static A getFoo() {
-		return new B() {
-			@Override
-			public void overrideMe(FindMeIfYouCan v) {
-			}
-		};
-	}
+    public static A getFoo() {
+        return new B() {
+            @Override
+            public void overrideMe(FindMeIfYouCan v) {
+            }
+        };
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/JavaParser.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/JavaParser.java
@@ -46,147 +46,147 @@ import static com.github.javaparser.Providers.provider;
  * @author Júlio Vilmar Gesser
  */
 public final class JavaParser {
-	private final CommentsInserter commentsInserter;
+    private final CommentsInserter commentsInserter;
 
-	private ASTParser astParser = null;
+    private ASTParser astParser = null;
 
-	/**
-	 * Instantiate the parser with default configuration. Note that parsing can also be done with the static methods on this class.
-	 * Creating an instance will reduce setup time between parsing files.
-	 */
-	public JavaParser() {
-		this(new ParserConfiguration());
-	}
+    /**
+     * Instantiate the parser with default configuration. Note that parsing can also be done with the static methods on this class.
+     * Creating an instance will reduce setup time between parsing files.
+     */
+    public JavaParser() {
+        this(new ParserConfiguration());
+    }
 
-	/**
-	 * Instantiate the parser. Note that parsing can also be done with the static methods on this class.
-	 * Creating an instance will reduce setup time between parsing files.
-	 */
-	public JavaParser(ParserConfiguration configuration) {
-		commentsInserter = new CommentsInserter(configuration);
-	}
+    /**
+     * Instantiate the parser. Note that parsing can also be done with the static methods on this class.
+     * Creating an instance will reduce setup time between parsing files.
+     */
+    public JavaParser(ParserConfiguration configuration) {
+        commentsInserter = new CommentsInserter(configuration);
+    }
 
-	private ASTParser getParserForProvider(Provider provider) {
-		if (astParser == null) {
-			astParser = new ASTParser(provider);
-		} else {
-			astParser.ReInit(provider);
-		}
-		return astParser;
-	}
+    private ASTParser getParserForProvider(Provider provider) {
+        if (astParser == null) {
+            astParser = new ASTParser(provider);
+        } else {
+            astParser.ReInit(provider);
+        }
+        return astParser;
+    }
 
-	/**
-	 * Parses source code.
-	 * It takes the source code from a Provider.
-	 * The start indicates what can be found in the source code (compilation unit, block, import...)
-	 *
+    /**
+     * Parses source code.
+     * It takes the source code from a Provider.
+     * The start indicates what can be found in the source code (compilation unit, block, import...)
+     *
      * @param start    refer to the constants in ParseStart to see what can be parsed.
      * @param provider refer to Providers to see how you can read source.
      * @param <N>      the subclass of Node that is the result of parsing in the start.
      * @return the parse result, a collection of encountered problems, and some extra data.
      */
-	public <N extends Node> ParseResult<N> parse(ParseStart<N> start, Provider provider) {
-		try {
+    public <N extends Node> ParseResult<N> parse(ParseStart<N> start, Provider provider) {
+        try {
             final ASTParser parser = getParserForProvider(provider);
-			N resultNode = start.parse(parser);
+            N resultNode = start.parse(parser);
             final CommentsCollection comments = astParser.getCommentsCollection();
             commentsInserter.insertComments(resultNode, comments.copy().getComments());
             
-			return new ParseResult<>(Optional.of(resultNode), parser.problems, Optional.of(astParser.getTokens()), Optional.of(astParser.getCommentsCollection()));
-		} catch (ParseException e) {
-			return new ParseResult<>(e);
+            return new ParseResult<>(Optional.of(resultNode), parser.problems, Optional.of(astParser.getTokens()), Optional.of(astParser.getCommentsCollection()));
+        } catch (ParseException e) {
+            return new ParseResult<>(e);
         } catch (TokenMgrException e) {
             return new ParseResult<>(e);
-		} finally {
-			try {
-				provider.close();
-			} catch (IOException e) {
-				// Since we're done parsing and have our result, we don't care about any errors.
-			}
-		}
-	}
+        } finally {
+            try {
+                provider.close();
+            } catch (IOException e) {
+                // Since we're done parsing and have our result, we don't care about any errors.
+            }
+        }
+    }
 
-	/**
-	 * Parses the Java code contained in the {@link InputStream} and returns a
-	 * {@link CompilationUnit} that represents it.
-	 *
-	 * @param in       {@link InputStream} containing Java source code
-	 * @param encoding encoding of the source code
-	 * @return CompilationUnit representing the Java source code
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static CompilationUnit parse(final InputStream in, Charset encoding) {
-		return simplifiedParse(COMPILATION_UNIT, provider(in, encoding));
-	}
+    /**
+     * Parses the Java code contained in the {@link InputStream} and returns a
+     * {@link CompilationUnit} that represents it.
+     *
+     * @param in       {@link InputStream} containing Java source code
+     * @param encoding encoding of the source code
+     * @return CompilationUnit representing the Java source code
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static CompilationUnit parse(final InputStream in, Charset encoding) {
+        return simplifiedParse(COMPILATION_UNIT, provider(in, encoding));
+    }
 
-	/**
-	 * Parses the Java code contained in the {@link InputStream} and returns a
-	 * {@link CompilationUnit} that represents it.<br>
-	 * Note: Uses UTF-8 encoding
-	 *
-	 * @param in {@link InputStream} containing Java source code
-	 * @return CompilationUnit representing the Java source code
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static CompilationUnit parse(final InputStream in) {
-		return parse(in, UTF8);
-	}
+    /**
+     * Parses the Java code contained in the {@link InputStream} and returns a
+     * {@link CompilationUnit} that represents it.<br>
+     * Note: Uses UTF-8 encoding
+     *
+     * @param in {@link InputStream} containing Java source code
+     * @return CompilationUnit representing the Java source code
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static CompilationUnit parse(final InputStream in) {
+        return parse(in, UTF8);
+    }
 
-	/**
-	 * Parses the Java code contained in a {@link File} and returns a
-	 * {@link CompilationUnit} that represents it.
-	 *
-	 * @param file     {@link File} containing Java source code
-	 * @param encoding encoding of the source code
-	 * @return CompilationUnit representing the Java source code
-	 * @throws ParseProblemException if the source code has parser errors
+    /**
+     * Parses the Java code contained in a {@link File} and returns a
+     * {@link CompilationUnit} that represents it.
+     *
+     * @param file     {@link File} containing Java source code
+     * @param encoding encoding of the source code
+     * @return CompilationUnit representing the Java source code
+     * @throws ParseProblemException if the source code has parser errors
      * @throws FileNotFoundException the file was not found
-	 */
-	public static CompilationUnit parse(final File file, final Charset encoding) throws FileNotFoundException {
-		return simplifiedParse(COMPILATION_UNIT, provider(file, encoding));
-	}
+     */
+    public static CompilationUnit parse(final File file, final Charset encoding) throws FileNotFoundException {
+        return simplifiedParse(COMPILATION_UNIT, provider(file, encoding));
+    }
 
-	/**
-	 * Parses the Java code contained in a {@link File} and returns a
-	 * {@link CompilationUnit} that represents it.<br>
-	 * Note: Uses UTF-8 encoding
-	 *
-	 * @param file {@link File} containing Java source code
-	 * @return CompilationUnit representing the Java source code
-	 * @throws ParseProblemException if the source code has parser errors
-	 * @throws FileNotFoundException the file was not found
-	 */
-	public static CompilationUnit parse(final File file) throws FileNotFoundException {
-		return simplifiedParse(COMPILATION_UNIT, provider(file));
-	}
+    /**
+     * Parses the Java code contained in a {@link File} and returns a
+     * {@link CompilationUnit} that represents it.<br>
+     * Note: Uses UTF-8 encoding
+     *
+     * @param file {@link File} containing Java source code
+     * @return CompilationUnit representing the Java source code
+     * @throws ParseProblemException if the source code has parser errors
+     * @throws FileNotFoundException the file was not found
+     */
+    public static CompilationUnit parse(final File file) throws FileNotFoundException {
+        return simplifiedParse(COMPILATION_UNIT, provider(file));
+    }
 
-	/**
-	 * Parses the Java code contained in a file and returns a
-	 * {@link CompilationUnit} that represents it.
-	 *
-	 * @param path     path to a file containing Java source code
-	 * @param encoding encoding of the source code
-	 * @return CompilationUnit representing the Java source code
-	 * @throws IOException the path could not be accessed
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static CompilationUnit parse(final Path path, final Charset encoding) throws IOException {
-		return simplifiedParse(COMPILATION_UNIT, provider(path, encoding));
-	}
+    /**
+     * Parses the Java code contained in a file and returns a
+     * {@link CompilationUnit} that represents it.
+     *
+     * @param path     path to a file containing Java source code
+     * @param encoding encoding of the source code
+     * @return CompilationUnit representing the Java source code
+     * @throws IOException the path could not be accessed
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static CompilationUnit parse(final Path path, final Charset encoding) throws IOException {
+        return simplifiedParse(COMPILATION_UNIT, provider(path, encoding));
+    }
 
-	/**
-	 * Parses the Java code contained in a file and returns a
-	 * {@link CompilationUnit} that represents it.<br>
-	 * Note: Uses UTF-8 encoding
-	 *
-	 * @param path     path to a file containing Java source code
-	 * @return CompilationUnit representing the Java source code
-	 * @throws ParseProblemException if the source code has parser errors
-	 * @throws IOException the path could not be accessed
-	 */
-	public static CompilationUnit parse(final Path path) throws IOException {
-		return simplifiedParse(COMPILATION_UNIT, provider(path));
-	}
+    /**
+     * Parses the Java code contained in a file and returns a
+     * {@link CompilationUnit} that represents it.<br>
+     * Note: Uses UTF-8 encoding
+     *
+     * @param path     path to a file containing Java source code
+     * @return CompilationUnit representing the Java source code
+     * @throws ParseProblemException if the source code has parser errors
+     * @throws IOException the path could not be accessed
+     */
+    public static CompilationUnit parse(final Path path) throws IOException {
+        return simplifiedParse(COMPILATION_UNIT, provider(path));
+    }
 
     /**
      * Parses Java code from a Reader and returns a
@@ -196,123 +196,123 @@ public final class JavaParser {
      * @return CompilationUnit representing the Java source code
      * @throws ParseProblemException if the source code has parser errors
      */
-	public static CompilationUnit parse(final Reader reader) {
-		return simplifiedParse(COMPILATION_UNIT, provider(reader));
-	}
+    public static CompilationUnit parse(final Reader reader) {
+        return simplifiedParse(COMPILATION_UNIT, provider(reader));
+    }
 
-	/**
-	 * Parses the Java code contained in code and returns a
-	 * {@link CompilationUnit} that represents it.
-	 *
-	 * @param code             Java source code
-	 * @return CompilationUnit representing the Java source code
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static CompilationUnit parse(String code) {
-		return simplifiedParse(COMPILATION_UNIT, provider(code));
-	}
+    /**
+     * Parses the Java code contained in code and returns a
+     * {@link CompilationUnit} that represents it.
+     *
+     * @param code             Java source code
+     * @return CompilationUnit representing the Java source code
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static CompilationUnit parse(String code) {
+        return simplifiedParse(COMPILATION_UNIT, provider(code));
+    }
 
-	/**
-	 * Parses the Java block contained in a {@link String} and returns a
-	 * {@link BlockStmt} that represents it.
-	 *
-	 * @param blockStatement {@link String} containing Java block code
-	 * @return BlockStmt representing the Java block
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static BlockStmt parseBlock(final String blockStatement) {
-		return simplifiedParse(BLOCK, provider(blockStatement));
-	}
+    /**
+     * Parses the Java block contained in a {@link String} and returns a
+     * {@link BlockStmt} that represents it.
+     *
+     * @param blockStatement {@link String} containing Java block code
+     * @return BlockStmt representing the Java block
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static BlockStmt parseBlock(final String blockStatement) {
+        return simplifiedParse(BLOCK, provider(blockStatement));
+    }
 
-	/**
-	 * Parses the Java statement contained in a {@link String} and returns a
-	 * {@link Statement} that represents it.
-	 *
-	 * @param statement {@link String} containing Java statement code
-	 * @return Statement representing the Java statement
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static Statement parseStatement(final String statement) {
-		return simplifiedParse(STATEMENT, provider(statement));
-	}
+    /**
+     * Parses the Java statement contained in a {@link String} and returns a
+     * {@link Statement} that represents it.
+     *
+     * @param statement {@link String} containing Java statement code
+     * @return Statement representing the Java statement
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static Statement parseStatement(final String statement) {
+        return simplifiedParse(STATEMENT, provider(statement));
+    }
 
-	private static <T extends Node> T simplifiedParse(ParseStart<T> context, Provider provider) {
-		ParseResult<T> result = new JavaParser(new ParserConfiguration()).parse(context, provider);
-		if (result.isSuccessful()) {
-			return result.getResult().get();
-		}
-		throw new ParseProblemException(result.getProblems());
-	}
+    private static <T extends Node> T simplifiedParse(ParseStart<T> context, Provider provider) {
+        ParseResult<T> result = new JavaParser(new ParserConfiguration()).parse(context, provider);
+        if (result.isSuccessful()) {
+            return result.getResult().get();
+        }
+        throw new ParseProblemException(result.getProblems());
+    }
 
-	/**
-	 * Parses the Java import contained in a {@link String} and returns a
-	 * {@link ImportDeclaration} that represents it.
-	 *
-	 * @param importDeclaration {@link String} containing Java import code
-	 * @return ImportDeclaration representing the Java import declaration
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static ImportDeclaration parseImport(final String importDeclaration) {
-		return simplifiedParse(IMPORT_DECLARATION, provider(importDeclaration));
-	}
+    /**
+     * Parses the Java import contained in a {@link String} and returns a
+     * {@link ImportDeclaration} that represents it.
+     *
+     * @param importDeclaration {@link String} containing Java import code
+     * @return ImportDeclaration representing the Java import declaration
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static ImportDeclaration parseImport(final String importDeclaration) {
+        return simplifiedParse(IMPORT_DECLARATION, provider(importDeclaration));
+    }
 
-	/**
-	 * Parses the Java expression contained in a {@link String} and returns a
-	 * {@link Expression} that represents it.
-	 *
-	 * @param expression {@link String} containing Java expression
-	 * @return Expression representing the Java expression
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static Expression parseExpression(final String expression) {
-		return simplifiedParse(EXPRESSION, provider(expression));
-	}
+    /**
+     * Parses the Java expression contained in a {@link String} and returns a
+     * {@link Expression} that represents it.
+     *
+     * @param expression {@link String} containing Java expression
+     * @return Expression representing the Java expression
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static Expression parseExpression(final String expression) {
+        return simplifiedParse(EXPRESSION, provider(expression));
+    }
 
-	/**
-	 * Parses the Java annotation contained in a {@link String} and returns a
-	 * {@link AnnotationExpr} that represents it.
-	 *
-	 * @param annotation {@link String} containing Java annotation
-	 * @return AnnotationExpr representing the Java annotation
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static AnnotationExpr parseAnnotation(final String annotation) {
-		return simplifiedParse(ANNOTATION, provider(annotation));
-	}
+    /**
+     * Parses the Java annotation contained in a {@link String} and returns a
+     * {@link AnnotationExpr} that represents it.
+     *
+     * @param annotation {@link String} containing Java annotation
+     * @return AnnotationExpr representing the Java annotation
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static AnnotationExpr parseAnnotation(final String annotation) {
+        return simplifiedParse(ANNOTATION, provider(annotation));
+    }
 
-	/**
-	 * Parses the Java annotation body declaration(e.g fields or methods) contained in a
-	 * {@link String} and returns a {@link BodyDeclaration} that represents it.
-	 *
-	 * @param body {@link String} containing Java body declaration
-	 * @return BodyDeclaration representing the Java annotation
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static BodyDeclaration<?> parseAnnotationBodyDeclaration(final String body) {
-		return simplifiedParse(ANNOTATION_BODY, provider(body));
-	}
+    /**
+     * Parses the Java annotation body declaration(e.g fields or methods) contained in a
+     * {@link String} and returns a {@link BodyDeclaration} that represents it.
+     *
+     * @param body {@link String} containing Java body declaration
+     * @return BodyDeclaration representing the Java annotation
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static BodyDeclaration<?> parseAnnotationBodyDeclaration(final String body) {
+        return simplifiedParse(ANNOTATION_BODY, provider(body));
+    }
 
-	/**
-	 * Parses a Java class body declaration(e.g fields or methods) and returns a
-	 * {@link BodyDeclaration} that represents it.
-	 *
-	 * @param body the body of a class
-	 * @return BodyDeclaration representing the Java class body
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static BodyDeclaration<?> parseClassBodyDeclaration(String body) {
-		return simplifiedParse(CLASS_BODY, provider(body));
-	}
+    /**
+     * Parses a Java class body declaration(e.g fields or methods) and returns a
+     * {@link BodyDeclaration} that represents it.
+     *
+     * @param body the body of a class
+     * @return BodyDeclaration representing the Java class body
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static BodyDeclaration<?> parseClassBodyDeclaration(String body) {
+        return simplifiedParse(CLASS_BODY, provider(body));
+    }
 
-	/**
-	 * Parses a Java interface body declaration(e.g fields or methods) and returns a
-	 * {@link BodyDeclaration} that represents it.
-	 *
-	 * @param body the body of an interface
-	 * @return BodyDeclaration representing the Java interface body
-	 * @throws ParseProblemException if the source code has parser errors
-	 */
-	public static BodyDeclaration parseInterfaceBodyDeclaration(String body) {
-		return simplifiedParse(INTERFACE_BODY, provider(body));
-	}
+    /**
+     * Parses a Java interface body declaration(e.g fields or methods) and returns a
+     * {@link BodyDeclaration} that represents it.
+     *
+     * @param body the body of an interface
+     * @return BodyDeclaration representing the Java interface body
+     * @throws ParseProblemException if the source code has parser errors
+     */
+    public static BodyDeclaration parseInterfaceBodyDeclaration(String body) {
+        return simplifiedParse(INTERFACE_BODY, provider(body));
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ParseStart.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ParseStart.java
@@ -18,15 +18,15 @@ import com.github.javaparser.ast.stmt.Statement;
  */
 @FunctionalInterface
 public interface ParseStart<R> {
-	ParseStart<CompilationUnit> COMPILATION_UNIT = ASTParser::CompilationUnit;
-	ParseStart<BlockStmt> BLOCK = ASTParser::Block;
-	ParseStart<Statement> STATEMENT = ASTParser::BlockStatement;
-	ParseStart<ImportDeclaration> IMPORT_DECLARATION= ASTParser::ImportDeclaration;
-	ParseStart<Expression> EXPRESSION = ASTParser::Expression;
-	ParseStart<AnnotationExpr> ANNOTATION = ASTParser::Annotation;
-	ParseStart<BodyDeclaration<?>> ANNOTATION_BODY = ASTParser::AnnotationBodyDeclaration;
-	ParseStart<BodyDeclaration<?>> CLASS_BODY = p -> p.ClassOrInterfaceBodyDeclaration(false);
-	ParseStart<BodyDeclaration<?>> INTERFACE_BODY = p -> p.ClassOrInterfaceBodyDeclaration(true);
+    ParseStart<CompilationUnit> COMPILATION_UNIT = ASTParser::CompilationUnit;
+    ParseStart<BlockStmt> BLOCK = ASTParser::Block;
+    ParseStart<Statement> STATEMENT = ASTParser::BlockStatement;
+    ParseStart<ImportDeclaration> IMPORT_DECLARATION= ASTParser::ImportDeclaration;
+    ParseStart<Expression> EXPRESSION = ASTParser::Expression;
+    ParseStart<AnnotationExpr> ANNOTATION = ASTParser::Annotation;
+    ParseStart<BodyDeclaration<?>> ANNOTATION_BODY = ASTParser::AnnotationBodyDeclaration;
+    ParseStart<BodyDeclaration<?>> CLASS_BODY = p -> p.ClassOrInterfaceBodyDeclaration(false);
+    ParseStart<BodyDeclaration<?>> INTERFACE_BODY = p -> p.ClassOrInterfaceBodyDeclaration(true);
 
-	R parse(ASTParser parser) throws ParseException;
+    R parse(ASTParser parser) throws ParseException;
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/Position.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/Position.java
@@ -29,114 +29,114 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * A position in a source file. Lines and columns start counting at 1.
  */
 public class Position implements Comparable<Position> {
-	public final int line;
-	public final int column;
+    public final int line;
+    public final int column;
 
-	public static final Position ABSOLUTE_START = new Position(Node.ABSOLUTE_BEGIN_LINE, -1);
-	public static final Position ABSOLUTE_END = new Position(Node.ABSOLUTE_END_LINE, -1);
+    public static final Position ABSOLUTE_START = new Position(Node.ABSOLUTE_BEGIN_LINE, -1);
+    public static final Position ABSOLUTE_END = new Position(Node.ABSOLUTE_END_LINE, -1);
 
-	/**
-	 * The first position in the file
-	 */
-	public static final Position HOME = new Position(1, 1);
-	public static final Position UNKNOWN = new Position(0, 0);
+    /**
+     * The first position in the file
+     */
+    public static final Position HOME = new Position(1, 1);
+    public static final Position UNKNOWN = new Position(0, 0);
 
-	public Position(int line, int column) {
-		if (line < Node.ABSOLUTE_END_LINE) {
-			throw new IllegalArgumentException("Can't position at line " + line);
-		}
-		if (column < -1) {
-			throw new IllegalArgumentException("Can't position at column " + column);
-		}
-		this.line = line;
-		this.column = column;
-	}
+    public Position(int line, int column) {
+        if (line < Node.ABSOLUTE_END_LINE) {
+            throw new IllegalArgumentException("Can't position at line " + line);
+        }
+        if (column < -1) {
+            throw new IllegalArgumentException("Can't position at column " + column);
+        }
+        this.line = line;
+        this.column = column;
+    }
 
-	/**
-	 * Convenient factory method.
-	 */
-	public static Position pos(int line, int column) {
-		return new Position(line, column);
-	}
+    /**
+     * Convenient factory method.
+     */
+    public static Position pos(int line, int column) {
+        return new Position(line, column);
+    }
 
-	public Position withColumn(int column) {
-		return new Position(this.line, column);
-	}
+    public Position withColumn(int column) {
+        return new Position(this.line, column);
+    }
 
-	public Position withLine(int line) {
-		return new Position(line, this.column);
-	}
+    public Position withLine(int line) {
+        return new Position(line, this.column);
+    }
 
-	/**
-	 * Check if the position is usable. Does not know what it is pointing at, so it can't check if the position is after the end of the source.
-	 */
-	public boolean valid() {
-		return line > 0 && column > 0;
-	}
+    /**
+     * Check if the position is usable. Does not know what it is pointing at, so it can't check if the position is after the end of the source.
+     */
+    public boolean valid() {
+        return line > 0 && column > 0;
+    }
 
-	public boolean invalid() {
-		return !valid();
-	}
+    public boolean invalid() {
+        return !valid();
+    }
 
-	public Position orIfInvalid(Position anotherPosition) {
-		if (valid()) {
-			return this;
-		}
-		return anotherPosition;
-	}
-	
-	public boolean isAfter(Position position) {
-		assertNotNull(position);
-		if (position.line == Node.ABSOLUTE_BEGIN_LINE) return true;
-		if (line > position.line) {
-			return true;
-		} else if (line == position.line) {
-			return column > position.column;
-		}
-		return false;
+    public Position orIfInvalid(Position anotherPosition) {
+        if (valid()) {
+            return this;
+        }
+        return anotherPosition;
+    }
+    
+    public boolean isAfter(Position position) {
+        assertNotNull(position);
+        if (position.line == Node.ABSOLUTE_BEGIN_LINE) return true;
+        if (line > position.line) {
+            return true;
+        } else if (line == position.line) {
+            return column > position.column;
+        }
+        return false;
 
-	}
+    }
 
-	public boolean isBefore(Position position) {
-		assertNotNull(position);
-		if (position.line == Node.ABSOLUTE_END_LINE) return true;
-		if (line < position.line) {
-			return true;
-		} else if (line == position.line) {
-			return column < position.column;
-		}
-		return false;
-	}
+    public boolean isBefore(Position position) {
+        assertNotNull(position);
+        if (position.line == Node.ABSOLUTE_END_LINE) return true;
+        if (line < position.line) {
+            return true;
+        } else if (line == position.line) {
+            return column < position.column;
+        }
+        return false;
+    }
 
-	@Override
-	public int compareTo(Position o) {
-		assertNotNull(o);
-		if (isBefore(o)) {
-			return -1;
-		}
-		if (isAfter(o)) {
-			return 1;
-		}
-		return 0;
-	}
+    @Override
+    public int compareTo(Position o) {
+        assertNotNull(o);
+        if (isBefore(o)) {
+            return -1;
+        }
+        if (isAfter(o)) {
+            return 1;
+        }
+        return 0;
+    }
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
-		Position position = (Position) o;
+        Position position = (Position) o;
 
-		return line == position.line && column == position.column;
-	}
+        return line == position.line && column == position.column;
+    }
 
-	@Override
-	public int hashCode() {
-		return 31 * line + column;
-	}
+    @Override
+    public int hashCode() {
+        return 31 * line + column;
+    }
 
-	@Override
-	public String toString() {
-		return "(line " + line + ",col " + column + ")";
-	}
+    @Override
+    public String toString() {
+        return "(line " + line + ",col " + column + ")";
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/Providers.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/Providers.java
@@ -13,49 +13,49 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  * Providers that have no parameter for encoding but need it will use UTF-8.
  */
 public final class Providers {
-	public static final Charset UTF8 = Charset.forName("utf-8");
+    public static final Charset UTF8 = Charset.forName("utf-8");
 
-	private Providers() {
-	}
+    private Providers() {
+    }
 
-	public static Provider provider(Reader reader) {
-		return new StreamProvider(assertNotNull(reader));
-	}
+    public static Provider provider(Reader reader) {
+        return new StreamProvider(assertNotNull(reader));
+    }
 
-	public static Provider provider(InputStream input, Charset encoding) {
-		assertNotNull(input);
-		assertNotNull(encoding);
-		try {
-			return new StreamProvider(input, encoding.name());
-		} catch (IOException e) {
-			// The only one that is thrown is UnsupportedCharacterEncodingException,
-			// and that's a fundamental problem, so runtime exception.
-			throw new RuntimeException(e);
-		}
-	}
+    public static Provider provider(InputStream input, Charset encoding) {
+        assertNotNull(input);
+        assertNotNull(encoding);
+        try {
+            return new StreamProvider(input, encoding.name());
+        } catch (IOException e) {
+            // The only one that is thrown is UnsupportedCharacterEncodingException,
+            // and that's a fundamental problem, so runtime exception.
+            throw new RuntimeException(e);
+        }
+    }
 
-	public static Provider provider(InputStream input) {
-		return provider(input, UTF8);
-	}
+    public static Provider provider(InputStream input) {
+        return provider(input, UTF8);
+    }
 
-	public static Provider provider(File file, Charset encoding) throws FileNotFoundException {
-		return provider(new FileInputStream(assertNotNull(file)), assertNotNull(encoding));
-	}
+    public static Provider provider(File file, Charset encoding) throws FileNotFoundException {
+        return provider(new FileInputStream(assertNotNull(file)), assertNotNull(encoding));
+    }
 
-	public static Provider provider(File file) throws FileNotFoundException {
-		return provider(assertNotNull(file), UTF8);
-	}
+    public static Provider provider(File file) throws FileNotFoundException {
+        return provider(assertNotNull(file), UTF8);
+    }
 
-	public static Provider provider(Path path, Charset encoding) throws IOException {
-		return provider(Files.newInputStream(assertNotNull(path)), assertNotNull(encoding));
-	}
+    public static Provider provider(Path path, Charset encoding) throws IOException {
+        return provider(Files.newInputStream(assertNotNull(path)), assertNotNull(encoding));
+    }
 
-	public static Provider provider(Path path) throws IOException {
-		return provider(assertNotNull(path), UTF8);
-	}
+    public static Provider provider(Path path) throws IOException {
+        return provider(assertNotNull(path), UTF8);
+    }
 
-	public static Provider provider(String source) {
-		return new StringProvider(assertNotNull(source));
-	}
+    public static Provider provider(String source) {
+        return new StringProvider(assertNotNull(source));
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/ArrayBracketPair.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/ArrayBracketPair.java
@@ -28,7 +28,7 @@ public class ArrayBracketPair extends Node implements NodeWithAnnotations<ArrayB
     }
 
     @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
+        v.visit(this, arg);
     }
 
     public List<AnnotationExpr> getAnnotations() {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/Modifier.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/Modifier.java
@@ -3,17 +3,17 @@ package com.github.javaparser.ast;
 import java.util.EnumSet;
 
 public enum Modifier {
-	PUBLIC("public"),
+    PUBLIC("public"),
     PROTECTED("protected"),
-	PRIVATE("private"),
+    PRIVATE("private"),
     ABSTRACT("abstract"),
-	STATIC("static"),
-	FINAL("final"),
+    STATIC("static"),
+    FINAL("final"),
     TRANSIENT("transient"), 
     VOLATILE("volatile"),
-	SYNCHRONIZED("synchronized"),
-	NATIVE("native"),
-	STRICTFP("strictfp");
+    SYNCHRONIZED("synchronized"),
+    NATIVE("native"),
+    STRICTFP("strictfp");
 
     String lib;
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/BodyDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/BodyDeclaration.java
@@ -40,12 +40,12 @@ public abstract class BodyDeclaration<T> extends Node implements NodeWithAnnotat
     }
 
     public BodyDeclaration(List<AnnotationExpr> annotations) {
-    	setAnnotations(annotations);
+        setAnnotations(annotations);
     }
 
     public BodyDeclaration(Range range, List<AnnotationExpr> annotations) {
         super(range);
-    	setAnnotations(annotations);
+        setAnnotations(annotations);
     }
 
     @Override
@@ -63,7 +63,7 @@ public abstract class BodyDeclaration<T> extends Node implements NodeWithAnnotat
     @Override
     public final T setAnnotations(List<AnnotationExpr> annotations) {
         this.annotations = annotations;
-		setAsParentNodeOf(this.annotations);
+        setAsParentNodeOf(this.annotations);
         return (T) this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/EnumConstantDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/EnumConstantDeclaration.java
@@ -102,13 +102,13 @@ public final class EnumConstantDeclaration extends BodyDeclaration<EnumConstantD
 
     public EnumConstantDeclaration setArgs(List<Expression> args) {
         this.args = args;
-		setAsParentNodeOf(this.args);
+        setAsParentNodeOf(this.args);
         return this;
     }
 
     public EnumConstantDeclaration setClassBody(List<BodyDeclaration<?>> classBody) {
         this.classBody = classBody;
-		setAsParentNodeOf(this.classBody);
+        setAsParentNodeOf(this.classBody);
         return this;
     }
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -91,14 +91,14 @@ public final class EnumDeclaration extends TypeDeclaration<EnumDeclaration>
 
     public EnumDeclaration setEntries(List<EnumConstantDeclaration> entries) {
         this.entries = entries;
-		setAsParentNodeOf(this.entries);
+        setAsParentNodeOf(this.entries);
         return this;
     }
 
     @Override
     public EnumDeclaration setImplements(List<ClassOrInterfaceType> implementsList) {
         this.implementsList = implementsList;
-		setAsParentNodeOf(this.implementsList);
+        setAsParentNodeOf(this.implementsList);
         return this;
     }
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/InitializerDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/InitializerDeclaration.java
@@ -73,7 +73,7 @@ public final class InitializerDeclaration extends BodyDeclaration<InitializerDec
 
     public InitializerDeclaration setBlock(BlockStmt block) {
         this.block = block;
-		setAsParentNodeOf(this.block);
+        setAsParentNodeOf(this.block);
         return this;
     }
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -383,7 +383,7 @@ public final class MethodDeclaration extends BodyDeclaration<MethodDeclaration> 
         return this;
     }
 
-	/**
+    /**
      * @return the array brackets in this position: <code>int abc()[] {...}</code>
      */
     public List<ArrayBracketPair> getArrayBracketPairsAfterParameterList() {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -44,117 +44,117 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 public abstract class TypeDeclaration<T> extends BodyDeclaration<T>
         implements NodeWithName<T>, NodeWithJavaDoc<T>, NodeWithModifiers<T>, NodeWithMembers<T> {
 
-	private NameExpr name;
+    private NameExpr name;
 
     private EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
 
     private List<BodyDeclaration<?>> members;
 
-	public TypeDeclaration() {
-	}
+    public TypeDeclaration() {
+    }
 
     public TypeDeclaration(EnumSet<Modifier> modifiers, String name) {
-		setName(name);
-		setModifiers(modifiers);
-	}
+        setName(name);
+        setModifiers(modifiers);
+    }
 
-	public TypeDeclaration(List<AnnotationExpr> annotations,
+    public TypeDeclaration(List<AnnotationExpr> annotations,
                            EnumSet<Modifier> modifiers, String name,
                            List<BodyDeclaration<?>> members) {
-		super(annotations);
-		setName(name);
-		setModifiers(modifiers);
-		setMembers(members);
-	}
+        super(annotations);
+        setName(name);
+        setModifiers(modifiers);
+        setMembers(members);
+    }
 
-	public TypeDeclaration(Range range, List<AnnotationExpr> annotations,
+    public TypeDeclaration(Range range, List<AnnotationExpr> annotations,
                            EnumSet<Modifier> modifiers, String name,
                            List<BodyDeclaration<?>> members) {
-		super(range, annotations);
-		setName(name);
-		setModifiers(modifiers);
-		setMembers(members);
-	}
+        super(range, annotations);
+        setName(name);
+        setModifiers(modifiers);
+        setMembers(members);
+    }
 
-	/**
-	 * Adds the given declaration to the specified type. The list of members
-	 * will be initialized if it is <code>null</code>.
-	 *
-	 * @param decl
-	 *            member declaration
-	 */
-	public TypeDeclaration<T> addMember(BodyDeclaration<?> decl) {
-		List<BodyDeclaration<?>> members = getMembers();
-		if (isNullOrEmpty(members)) {
-			members = new ArrayList<>();
-			setMembers(members);
-		}
-		members.add(decl);
-		decl.setParentNode(this);
-		return this;
-	}
+    /**
+     * Adds the given declaration to the specified type. The list of members
+     * will be initialized if it is <code>null</code>.
+     *
+     * @param decl
+     *            member declaration
+     */
+    public TypeDeclaration<T> addMember(BodyDeclaration<?> decl) {
+        List<BodyDeclaration<?>> members = getMembers();
+        if (isNullOrEmpty(members)) {
+            members = new ArrayList<>();
+            setMembers(members);
+        }
+        members.add(decl);
+        decl.setParentNode(this);
+        return this;
+    }
 
     @Override
     public List<BodyDeclaration<?>> getMembers() {
-        	members = ensureNotNull(members);
-        	return members;
-	}
+            members = ensureNotNull(members);
+            return members;
+    }
 
-	/**
+    /**
      * Return the modifiers of this type declaration.
      * 
      * @see Modifier
      * @return modifiers
      */
-	@Override
+    @Override
     public final EnumSet<Modifier> getModifiers() {
-		return modifiers;
-	}
+        return modifiers;
+    }
 
-	@Override
-	public final String getName() {
-		return name.getName();
-	}
+    @Override
+    public final String getName() {
+        return name.getName();
+    }
 
     @SuppressWarnings("unchecked")
     @Override
     public T setMembers(List<BodyDeclaration<?>> members) {
-		this.members = members;
-		setAsParentNodeOf(this.members);
+        this.members = members;
+        setAsParentNodeOf(this.members);
         return (T) this;
-	}
+    }
 
     @SuppressWarnings("unchecked")
     @Override
     public T setModifiers(EnumSet<Modifier> modifiers) {
-		this.modifiers = modifiers;
+        this.modifiers = modifiers;
         return (T) this;
-	}
+    }
 
     @Override
     @SuppressWarnings("unchecked")
     public T setName(String name) {
-		setNameExpr(new NameExpr(name));
+        setNameExpr(new NameExpr(name));
         return (T) this;
-	}
+    }
 
     @SuppressWarnings("unchecked")
     public T setNameExpr(NameExpr nameExpr) {
-		this.name = nameExpr;
-		setAsParentNodeOf(this.name);
+        this.name = nameExpr;
+        setAsParentNodeOf(this.name);
         return (T) this;
-	}
+    }
 
-	public final NameExpr getNameExpr() {
-		return name;
-	}
+    public final NameExpr getNameExpr() {
+        return name;
+    }
 
-	@Override
-	public JavadocComment getJavaDoc() {
-		if(getComment() instanceof JavadocComment){
-			return (JavadocComment) getComment();
-		}
-		return null;
-	}
+    @Override
+    public JavadocComment getJavaDoc() {
+        if(getComment() instanceof JavadocComment){
+            return (JavadocComment) getComment();
+        }
+        return null;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -28,21 +28,21 @@ import com.github.javaparser.Range;
  */
 public abstract class AnnotationExpr extends Expression {
 
-	protected NameExpr name;
+    protected NameExpr name;
 
-	public AnnotationExpr() {}
+    public AnnotationExpr() {}
 
-	public AnnotationExpr(Range range) {
-		super(range);
-	}
+    public AnnotationExpr(Range range) {
+        super(range);
+    }
 
-	public NameExpr getName() {
-		return name;
-	}
+    public NameExpr getName() {
+        return name;
+    }
 
-	public AnnotationExpr setName(NameExpr name) {
-		this.name = name;
-		setAsParentNodeOf(name);
-		return this;
-	}
+    public AnnotationExpr setName(NameExpr name) {
+        this.name = name;
+        setAsParentNodeOf(name);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ArrayAccessExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ArrayAccessExpr.java
@@ -68,13 +68,13 @@ public final class ArrayAccessExpr extends Expression {
 
     public ArrayAccessExpr setIndex(Expression index) {
         this.index = index;
-		setAsParentNodeOf(this.index);
+        setAsParentNodeOf(this.index);
         return this;
     }
 
     public ArrayAccessExpr setName(Expression name) {
         this.name = name;
-		setAsParentNodeOf(this.name);
+        setAsParentNodeOf(this.name);
         return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -91,14 +91,14 @@ public final class ArrayCreationExpr extends Expression implements NodeWithType<
 
     public ArrayCreationExpr setInitializer(ArrayInitializerExpr initializer) {
         this.initializer = initializer;
-		setAsParentNodeOf(this.initializer);
+        setAsParentNodeOf(this.initializer);
         return this;
     }
 
     @Override
     public ArrayCreationExpr setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
         return this;
     }
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
@@ -65,7 +65,7 @@ public final class ArrayInitializerExpr extends Expression {
 
     public ArrayInitializerExpr setValues(List<Expression> values) {
         this.values = values;
-		setAsParentNodeOf(this.values);
+        setAsParentNodeOf(this.values);
         return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/AssignExpr.java
@@ -96,13 +96,13 @@ public final class AssignExpr extends Expression {
 
     public AssignExpr setTarget(Expression target) {
         this.target = target;
-		setAsParentNodeOf(this.target);
+        setAsParentNodeOf(this.target);
         return this;
     }
 
     public AssignExpr setValue(Expression value) {
         this.value = value;
-		setAsParentNodeOf(this.value);
+        setAsParentNodeOf(this.value);
         return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -62,16 +62,16 @@ public final class BinaryExpr extends Expression {
     }
 
     public BinaryExpr(Expression left, Expression right, Operator op) {
-    	setLeft(left);
-    	setRight(right);
-    	setOperator(op);
+        setLeft(left);
+        setRight(right);
+        setOperator(op);
     }
 
     public BinaryExpr(Range range, Expression left, Expression right, Operator op) {
         super(range);
-    	setLeft(left);
-    	setRight(right);
-    	setOperator(op);
+        setLeft(left);
+        setRight(right);
+        setOperator(op);
     }
 
     @Override
@@ -98,7 +98,7 @@ public final class BinaryExpr extends Expression {
 
     public BinaryExpr setLeft(Expression left) {
         this.left = left;
-		setAsParentNodeOf(this.left);
+        setAsParentNodeOf(this.left);
         return this;
     }
 
@@ -109,7 +109,7 @@ public final class BinaryExpr extends Expression {
 
     public BinaryExpr setRight(Expression right) {
         this.right = right;
-		setAsParentNodeOf(this.right);
+        setAsParentNodeOf(this.right);
         return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
@@ -36,7 +36,7 @@ public final class BooleanLiteralExpr extends LiteralExpr {
     }
 
     public BooleanLiteralExpr(boolean value) {
-    	setValue(value);
+        setValue(value);
     }
 
     public BooleanLiteralExpr(Range range, boolean value) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/CastExpr.java
@@ -40,14 +40,14 @@ public final class CastExpr extends Expression implements NodeWithType<CastExpr>
     }
 
     public CastExpr(Type type, Expression expr) {
-    	setType(type);
-    	setExpr(expr);
+        setType(type);
+        setExpr(expr);
     }
 
     public CastExpr(Range range, Type type, Expression expr) {
         super(range);
         setType(type);
-    	setExpr(expr);
+        setExpr(expr);
     }
 
     @Override
@@ -71,14 +71,14 @@ public final class CastExpr extends Expression implements NodeWithType<CastExpr>
 
     public CastExpr setExpr(Expression expr) {
         this.expr = expr;
-		setAsParentNodeOf(this.expr);
+        setAsParentNodeOf(this.expr);
         return this;
     }
 
     @Override
     public CastExpr setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
         return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ClassExpr.java
@@ -69,7 +69,7 @@ public final class ClassExpr extends Expression implements NodeWithType<ClassExp
     @Override
     public ClassExpr setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
         return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ConditionalExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ConditionalExpr.java
@@ -76,19 +76,19 @@ public final class ConditionalExpr extends Expression {
 
     public ConditionalExpr setCondition(Expression condition) {
         this.condition = condition;
-		setAsParentNodeOf(this.condition);
+        setAsParentNodeOf(this.condition);
         return this;
     }
 
     public ConditionalExpr setElseExpr(Expression elseExpr) {
         this.elseExpr = elseExpr;
-		setAsParentNodeOf(this.elseExpr);
+        setAsParentNodeOf(this.elseExpr);
         return this;
     }
 
     public ConditionalExpr setThenExpr(Expression thenExpr) {
         this.thenExpr = thenExpr;
-		setAsParentNodeOf(this.thenExpr);
+        setAsParentNodeOf(this.thenExpr);
         return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
@@ -30,22 +30,22 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class DoubleLiteralExpr extends StringLiteralExpr {
 
-	public DoubleLiteralExpr() {
-	}
+    public DoubleLiteralExpr() {
+    }
 
-	public DoubleLiteralExpr(final String value) {
-		super(value);
-	}
+    public DoubleLiteralExpr(final String value) {
+        super(value);
+    }
 
-	public DoubleLiteralExpr(final Range range, final String value) {
-		super(range, value);
-	}
+    public DoubleLiteralExpr(final Range range, final String value) {
+        super(range, value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/EnclosedExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/EnclosedExpr.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class EnclosedExpr extends Expression {
 
-	private Expression inner;
+    private Expression inner;
 
-	public EnclosedExpr() {
-	}
+    public EnclosedExpr() {
+    }
 
-	public EnclosedExpr(final Expression inner) {
-		setInner(inner);
-	}
+    public EnclosedExpr(final Expression inner) {
+        setInner(inner);
+    }
 
-	public EnclosedExpr(final Range range, final Expression inner) {
-		super(range);
-		setInner(inner);
-	}
+    public EnclosedExpr(final Range range, final Expression inner) {
+        super(range);
+        setInner(inner);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getInner() {
-		return inner;
-	}
+    public Expression getInner() {
+        return inner;
+    }
 
-	public EnclosedExpr setInner(final Expression inner) {
-		this.inner = inner;
-		setAsParentNodeOf(this.inner);
-		return this;
-	}
+    public EnclosedExpr setInner(final Expression inner) {
+        this.inner = inner;
+        setAsParentNodeOf(this.inner);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/Expression.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/Expression.java
@@ -29,11 +29,11 @@ import com.github.javaparser.ast.Node;
  */
 public abstract class Expression extends Node {
 
-	public Expression() {
-	}
+    public Expression() {
+    }
 
-	public Expression(Range range) {
-		super(range);
-	}
+    public Expression(Range range) {
+        super(range);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -34,74 +34,74 @@ import java.util.List;
  */
 public final class FieldAccessExpr extends Expression implements NodeWithTypeArguments<FieldAccessExpr> {
 
-	private Expression scope;
+    private Expression scope;
 
-	private List<Type<?>> typeArguments;
+    private List<Type<?>> typeArguments;
 
-	private NameExpr field;
+    private NameExpr field;
 
-	public FieldAccessExpr() {
-	}
+    public FieldAccessExpr() {
+    }
 
-	public FieldAccessExpr(final Expression scope, final String field) {
-		setScope(scope);
-		setField(field);
-	}
+    public FieldAccessExpr(final Expression scope, final String field) {
+        setScope(scope);
+        setField(field);
+    }
 
-	public FieldAccessExpr(final Range range, final Expression scope, final List<Type<?>> typeArguments, final String field) {
-		super(range);
-		setScope(scope);
-		setTypeArguments(typeArguments);
-		setField(field);
-	}
+    public FieldAccessExpr(final Range range, final Expression scope, final List<Type<?>> typeArguments, final String field) {
+        super(range);
+        setScope(scope);
+        setTypeArguments(typeArguments);
+        setField(field);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getField() {
-		return field.getName();
-	}
+    public String getField() {
+        return field.getName();
+    }
 
-	public NameExpr getFieldExpr() {
-		return field;
-	}
+    public NameExpr getFieldExpr() {
+        return field;
+    }
 
-	public Expression getScope() {
-		return scope;
-	}
+    public Expression getScope() {
+        return scope;
+    }
 
-	public FieldAccessExpr setField(final String field) {
-		setFieldExpr(new NameExpr(field));
-		return this;
-	}
+    public FieldAccessExpr setField(final String field) {
+        setFieldExpr(new NameExpr(field));
+        return this;
+    }
 
-	public FieldAccessExpr setFieldExpr(NameExpr field) {
-		this.field = field;
-		setAsParentNodeOf(this.field);
-		return this;
-	}
+    public FieldAccessExpr setFieldExpr(NameExpr field) {
+        this.field = field;
+        setAsParentNodeOf(this.field);
+        return this;
+    }
 
-	public FieldAccessExpr setScope(final Expression scope) {
-		this.scope = scope;
-		setAsParentNodeOf(this.scope);
-		return this;
-	}
+    public FieldAccessExpr setScope(final Expression scope) {
+        this.scope = scope;
+        setAsParentNodeOf(this.scope);
+        return this;
+    }
 
 
-	@Override
-	public List<Type<?>> getTypeArguments() {
-		return typeArguments;
-	}
+    @Override
+    public List<Type<?>> getTypeArguments() {
+        return typeArguments;
+    }
 
-	@Override
-	public FieldAccessExpr setTypeArguments(final List<Type<?>> types) {
-		this.typeArguments = types;
-		setAsParentNodeOf(this.typeArguments);
-		return this;
-	}
+    @Override
+    public FieldAccessExpr setTypeArguments(final List<Type<?>> types) {
+        this.typeArguments = types;
+        setAsParentNodeOf(this.typeArguments);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -32,51 +32,51 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class InstanceOfExpr extends Expression implements NodeWithType<InstanceOfExpr> {
 
-	private Expression expr;
+    private Expression expr;
 
-	private Type type;
+    private Type type;
 
-	public InstanceOfExpr() {
-	}
+    public InstanceOfExpr() {
+    }
 
-	public InstanceOfExpr(final Expression expr, final Type type) {
-		setExpr(expr);
-		setType(type);
-	}
+    public InstanceOfExpr(final Expression expr, final Type type) {
+        setExpr(expr);
+        setType(type);
+    }
 
-	public InstanceOfExpr(final Range range, final Expression expr, final Type type) {
-		super(range);
-		setExpr(expr);
-		setType(type);
-	}
+    public InstanceOfExpr(final Range range, final Expression expr, final Type type) {
+        super(range);
+        setExpr(expr);
+        setType(type);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	@Override
-	public Type getType() {
-		return type;
-	}
+    @Override
+    public Type getType() {
+        return type;
+    }
 
-	public InstanceOfExpr setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-		return this;
-	}
-
-	@Override
-    public InstanceOfExpr setType(final Type type) {
-		this.type = type;
-		setAsParentNodeOf(this.type);
+    public InstanceOfExpr setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
         return this;
-	}
+    }
+
+    @Override
+    public InstanceOfExpr setType(final Type type) {
+        this.type = type;
+        setAsParentNodeOf(this.type);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -30,32 +30,32 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class IntegerLiteralExpr extends StringLiteralExpr {
 
-	private static final String UNSIGNED_MIN_VALUE = "2147483648";
+    private static final String UNSIGNED_MIN_VALUE = "2147483648";
 
-	protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE;
+    protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE;
 
-	public IntegerLiteralExpr() {
-	}
+    public IntegerLiteralExpr() {
+    }
 
-	public IntegerLiteralExpr(final String value) {
-		super(value);
-	}
+    public IntegerLiteralExpr(final String value) {
+        super(value);
+    }
 
-	public IntegerLiteralExpr(final Range range, final String value) {
-		super(range, value);
-	}
+    public IntegerLiteralExpr(final Range range, final String value) {
+        super(range, value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public final boolean isMinValue() {
-		return value != null && //
-				value.length() == 10 && //
-				value.equals(UNSIGNED_MIN_VALUE);
-	}
+    public final boolean isMinValue() {
+        return value != null && //
+                value.length() == 10 && //
+                value.equals(UNSIGNED_MIN_VALUE);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/IntegerLiteralMinValueExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/IntegerLiteralMinValueExpr.java
@@ -30,20 +30,20 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class IntegerLiteralMinValueExpr extends IntegerLiteralExpr {
 
-	public IntegerLiteralMinValueExpr() {
-		super(MIN_VALUE);
-	}
+    public IntegerLiteralMinValueExpr() {
+        super(MIN_VALUE);
+    }
 
-	public IntegerLiteralMinValueExpr(final Range range) {
-		super(range, MIN_VALUE);
-	}
+    public IntegerLiteralMinValueExpr(final Range range) {
+        super(range, MIN_VALUE);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -38,62 +38,62 @@ import static com.github.javaparser.utils.Utils.*;
  */
 public class LambdaExpr extends Expression {
 
-	private List<Parameter> parameters;
+    private List<Parameter> parameters;
 
-	private boolean parametersEnclosed;
+    private boolean parametersEnclosed;
 
-	private Statement body;
+    private Statement body;
 
-	public LambdaExpr() {
-	}
+    public LambdaExpr() {
+    }
 
-	public LambdaExpr(Range range, List<Parameter> parameters, Statement body,
+    public LambdaExpr(Range range, List<Parameter> parameters, Statement body,
                       boolean parametersEnclosed) {
 
-		super(range);
-		setParameters(parameters);
-		setBody(body);
+        super(range);
+        setParameters(parameters);
+        setBody(body);
         setParametersEnclosed(parametersEnclosed);
-	}
+    }
 
-	public List<Parameter> getParameters() {
+    public List<Parameter> getParameters() {
         parameters = ensureNotNull(parameters);
         return parameters;
-	}
+    }
 
-	public LambdaExpr setParameters(List<Parameter> parameters) {
-		this.parameters = parameters;
-		setAsParentNodeOf(this.parameters);
-		return this;
-	}
+    public LambdaExpr setParameters(List<Parameter> parameters) {
+        this.parameters = parameters;
+        setAsParentNodeOf(this.parameters);
+        return this;
+    }
 
-	public Statement getBody() {
-		return body;
-	}
+    public Statement getBody() {
+        return body;
+    }
 
-	public LambdaExpr setBody(Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
-		return this;
-	}
+    public LambdaExpr setBody(Statement body) {
+        this.body = body;
+        setAsParentNodeOf(this.body);
+        return this;
+    }
 
-	@Override
-	public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(VoidVisitor<A> v, A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
 
-	public boolean isParametersEnclosed() {
-		return parametersEnclosed;
-	}
+    public boolean isParametersEnclosed() {
+        return parametersEnclosed;
+    }
 
-	public LambdaExpr setParametersEnclosed(boolean parametersEnclosed) {
-		this.parametersEnclosed = parametersEnclosed;
-		return this;
-	}
+    public LambdaExpr setParametersEnclosed(boolean parametersEnclosed) {
+        this.parametersEnclosed = parametersEnclosed;
+        return this;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LiteralExpr.java
@@ -28,10 +28,10 @@ import com.github.javaparser.Range;
  */
 public abstract class LiteralExpr extends Expression {
 
-	public LiteralExpr() {
-	}
+    public LiteralExpr() {
+    }
 
-	public LiteralExpr(Range range) {
-		super(range);
-	}
+    public LiteralExpr(Range range) {
+        super(range);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -30,33 +30,33 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class LongLiteralExpr extends StringLiteralExpr {
 
-	private static final String UNSIGNED_MIN_VALUE = "9223372036854775808";
+    private static final String UNSIGNED_MIN_VALUE = "9223372036854775808";
 
-	protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE + "L";
+    protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE + "L";
 
-	public LongLiteralExpr() {
-	}
+    public LongLiteralExpr() {
+    }
 
-	public LongLiteralExpr(final String value) {
-		super(value);
-	}
+    public LongLiteralExpr(final String value) {
+        super(value);
+    }
 
-	public LongLiteralExpr(final Range range, final String value) {
-		super(range, value);
-	}
+    public LongLiteralExpr(final Range range, final String value) {
+        super(range, value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public final boolean isMinValue() {
-		return value != null && //
-				value.length() == 20 && //
-				value.startsWith(UNSIGNED_MIN_VALUE) && //
-				(value.charAt(19) == 'L' || value.charAt(19) == 'l');
-	}
+    public final boolean isMinValue() {
+        return value != null && //
+                value.length() == 20 && //
+                value.startsWith(UNSIGNED_MIN_VALUE) && //
+                (value.charAt(19) == 'L' || value.charAt(19) == 'l');
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LongLiteralMinValueExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/LongLiteralMinValueExpr.java
@@ -30,20 +30,20 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class LongLiteralMinValueExpr extends LongLiteralExpr {
 
-	public LongLiteralMinValueExpr() {
-		super(MIN_VALUE);
-	}
+    public LongLiteralMinValueExpr() {
+        super(MIN_VALUE);
+    }
 
-	public LongLiteralMinValueExpr(final Range range) {
-		super(range, MIN_VALUE);
-	}
+    public LongLiteralMinValueExpr(final Range range) {
+        super(range, MIN_VALUE);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
@@ -30,24 +30,24 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class MarkerAnnotationExpr extends AnnotationExpr {
 
-	public MarkerAnnotationExpr() {
-	}
+    public MarkerAnnotationExpr() {
+    }
 
-	public MarkerAnnotationExpr(final NameExpr name) {
-		setName(name);
-	}
+    public MarkerAnnotationExpr(final NameExpr name) {
+        setName(name);
+    }
 
-	public MarkerAnnotationExpr(final Range range, final NameExpr name) {
-		super(range);
-		setName(name);
-	}
+    public MarkerAnnotationExpr(final Range range, final NameExpr name) {
+        super(range);
+        setName(name);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/MemberValuePair.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/MemberValuePair.java
@@ -32,50 +32,50 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class MemberValuePair extends Node implements NodeWithName<MemberValuePair> {
 
-	private String name;
+    private String name;
 
-	private Expression value;
+    private Expression value;
 
-	public MemberValuePair() {
-	}
+    public MemberValuePair() {
+    }
 
-	public MemberValuePair(final String name, final Expression value) {
-		setName(name);
-		setValue(value);
-	}
+    public MemberValuePair(final String name, final Expression value) {
+        setName(name);
+        setValue(value);
+    }
 
-	public MemberValuePair(final Range range, final String name, final Expression value) {
-		super(range);
-		setName(name);
-		setValue(value);
-	}
+    public MemberValuePair(final Range range, final String name, final Expression value) {
+        super(range);
+        setName(name);
+        setValue(value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	@Override
-	public String getName() {
-		return name;
-	}
+    @Override
+    public String getName() {
+        return name;
+    }
 
-	public Expression getValue() {
-		return value;
-	}
+    public Expression getValue() {
+        return value;
+    }
 
     @Override
     public MemberValuePair setName(final String name) {
-		this.name = name;
+        this.name = name;
         return this;
-	}
+    }
 
-	public MemberValuePair setValue(final Expression value) {
-		this.value = value;
-		setAsParentNodeOf(this.value);
-		return this;
-	}
+    public MemberValuePair setValue(final Expression value) {
+        this.value = value;
+        setAsParentNodeOf(this.value);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -58,13 +58,13 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
         setArgs(args);
     }
 
-	public MethodCallExpr(final Range range, final Expression scope, final List<Type<?>> typeArguments, final String name, final List<Expression> args) {
-		super(range);
-		setScope(scope);
-		setTypeArguments(typeArguments);
-		setName(name);
-		setArgs(args);
-	}
+    public MethodCallExpr(final Range range, final Expression scope, final List<Type<?>> typeArguments, final String name, final List<Expression> args) {
+        super(range);
+        setScope(scope);
+        setTypeArguments(typeArguments);
+        setName(name);
+        setArgs(args);
+    }
 
     /**
      * Adds the given argument to the method call.
@@ -109,10 +109,10 @@ public final class MethodCallExpr extends Expression implements NodeWithTypeArgu
         return scope;
     }
 
-	public void setArgs(final List<Expression> args) {
-		this.args = args;
-		setAsParentNodeOf(this.args);
-	}
+    public void setArgs(final List<Expression> args) {
+        this.args = args;
+        setAsParentNodeOf(this.args);
+    }
 
     public MethodCallExpr setName(final String name) {
         setNameExpr(new NameExpr(name));

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/NameExpr.java
@@ -31,55 +31,55 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class NameExpr extends Expression implements NodeWithName<NameExpr> {
 
-	private String name;
+    private String name;
 
-	public NameExpr() {
-	}
+    public NameExpr() {
+    }
 
-	public NameExpr(final String name) {
-		this.name = name;
-	}
+    public NameExpr(final String name) {
+        this.name = name;
+    }
 
-	public NameExpr(Range range, final String name) {
-		super(range);
-		this.name = name;
-	}
+    public NameExpr(Range range, final String name) {
+        super(range);
+        this.name = name;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	@Override
-	public final String getName() {
-		return name;
-	}
+    @Override
+    public final String getName() {
+        return name;
+    }
 
     @Override
     public NameExpr setName(final String name) {
-		this.name = name;
+        this.name = name;
         return this;
-	}
+    }
 
 
-	/**
-	 * Creates a new {@link NameExpr} from a qualified name.<br>
-	 * The qualified name can contains "." (dot) characters.
-	 *
-	 * @param qualifiedName
-	 *            qualified name
-	 * @return instanceof {@link NameExpr}
-	 */
-	public static NameExpr name(String qualifiedName) {
-		String[] split = qualifiedName.split("\\.");
-		NameExpr ret = new NameExpr(split[0]);
-		for (int i = 1; i < split.length; i++) {
-			ret = new QualifiedNameExpr(ret, split[i]);
-		}
-		return ret;
-	}
+    /**
+     * Creates a new {@link NameExpr} from a qualified name.<br>
+     * The qualified name can contains "." (dot) characters.
+     *
+     * @param qualifiedName
+     *            qualified name
+     * @return instanceof {@link NameExpr}
+     */
+    public static NameExpr name(String qualifiedName) {
+        String[] split = qualifiedName.split("\\.");
+        NameExpr ret = new NameExpr(split[0]);
+        for (int i = 1; i < split.length; i++) {
+            ret = new QualifiedNameExpr(ret, split[i]);
+        }
+        return ret;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/NullLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/NullLiteralExpr.java
@@ -30,18 +30,18 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class NullLiteralExpr extends LiteralExpr {
 
-	public NullLiteralExpr() {
-	}
+    public NullLiteralExpr() {
+    }
 
-	public NullLiteralExpr(final Range range) {
-		super(range);
-	}
+    public NullLiteralExpr(final Range range) {
+        super(range);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -75,16 +75,16 @@ public final class ObjectCreationExpr extends Expression implements
         setArgs(args);
     }
 
-	public ObjectCreationExpr(final Range range,
-			final Expression scope, final ClassOrInterfaceType type, final List<Type<?>> typeArguments,
+    public ObjectCreationExpr(final Range range,
+            final Expression scope, final ClassOrInterfaceType type, final List<Type<?>> typeArguments,
                               final List<Expression> args, final List<BodyDeclaration<?>> anonymousBody) {
-		super(range);
-		setScope(scope);
-		setType(type);
-		setTypeArguments(typeArguments);
-		setArgs(args);
-		setAnonymousClassBody(anonymousBody);
-	}
+        super(range);
+        setScope(scope);
+        setType(type);
+        setTypeArguments(typeArguments);
+        setArgs(args);
+        setAnonymousClassBody(anonymousBody);
+    }
 
     @Override
     public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/QualifiedNameExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/QualifiedNameExpr.java
@@ -30,36 +30,36 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class QualifiedNameExpr extends NameExpr {
 
-	private NameExpr qualifier;
+    private NameExpr qualifier;
 
-	public QualifiedNameExpr() {
-	}
+    public QualifiedNameExpr() {
+    }
 
-	public QualifiedNameExpr(final NameExpr scope, final String name) {
-		super(name);
-		setQualifier(scope);
-	}
+    public QualifiedNameExpr(final NameExpr scope, final String name) {
+        super(name);
+        setQualifier(scope);
+    }
 
-	public QualifiedNameExpr(final Range range, final NameExpr scope, final String name) {
-		super(range, name);
-		setQualifier(scope);
-	}
+    public QualifiedNameExpr(final Range range, final NameExpr scope, final String name) {
+        super(range, name);
+        setQualifier(scope);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public NameExpr getQualifier() {
-		return qualifier;
-	}
+    public NameExpr getQualifier() {
+        return qualifier;
+    }
 
-	public QualifiedNameExpr setQualifier(final NameExpr qualifier) {
-		this.qualifier = qualifier;
-		setAsParentNodeOf(this.qualifier);
-		return this;
-	}
+    public QualifiedNameExpr setQualifier(final NameExpr qualifier) {
+        this.qualifier = qualifier;
+        setAsParentNodeOf(this.qualifier);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
@@ -30,37 +30,37 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class SingleMemberAnnotationExpr extends AnnotationExpr {
 
-	private Expression memberValue;
+    private Expression memberValue;
 
-	public SingleMemberAnnotationExpr() {
-	}
+    public SingleMemberAnnotationExpr() {
+    }
 
-	public SingleMemberAnnotationExpr(final NameExpr name, final Expression memberValue) {
-		setName(name);
-		setMemberValue(memberValue);
-	}
+    public SingleMemberAnnotationExpr(final NameExpr name, final Expression memberValue) {
+        setName(name);
+        setMemberValue(memberValue);
+    }
 
-	public SingleMemberAnnotationExpr(final Range range, final NameExpr name, final Expression memberValue) {
-		super(range);
-		setName(name);
-		setMemberValue(memberValue);
-	}
+    public SingleMemberAnnotationExpr(final Range range, final NameExpr name, final Expression memberValue) {
+        super(range);
+        setName(name);
+        setMemberValue(memberValue);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getMemberValue() {
-		return memberValue;
-	}
+    public Expression getMemberValue() {
+        return memberValue;
+    }
 
-	public SingleMemberAnnotationExpr setMemberValue(final Expression memberValue) {
-		this.memberValue = memberValue;
-		setAsParentNodeOf(this.memberValue);
-		return this;
-	}
+    public SingleMemberAnnotationExpr setMemberValue(final Expression memberValue) {
+        this.memberValue = memberValue;
+        setAsParentNodeOf(this.memberValue);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -32,45 +32,45 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class StringLiteralExpr extends LiteralExpr {
 
-	protected String value;
+    protected String value;
 
-	public StringLiteralExpr() {
+    public StringLiteralExpr() {
         this.value = "";
-	}
+    }
 
-	public StringLiteralExpr(final String value) {
+    public StringLiteralExpr(final String value) {
         if (value.contains("\n") || value.contains("\r")) {
             throw new IllegalArgumentException("Illegal literal expression: newlines (line feed or carriage return) have to be escaped");
         }
-		this.value = value;
-	}
+        this.value = value;
+    }
 
-	/**
-	 * Utility method that creates a new StringLiteralExpr. Escapes EOL characters.
-	 */
-	public static StringLiteralExpr escape(String string) {
-		return new StringLiteralExpr(Utils.escapeEndOfLines(string));
-	}
+    /**
+     * Utility method that creates a new StringLiteralExpr. Escapes EOL characters.
+     */
+    public static StringLiteralExpr escape(String string) {
+        return new StringLiteralExpr(Utils.escapeEndOfLines(string));
+    }
 
-	public StringLiteralExpr(final Range range, final String value) {
-		super(range);
-		this.value = value;
-	}
+    public StringLiteralExpr(final Range range, final String value) {
+        super(range);
+        this.value = value;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public final String getValue() {
-		return value;
-	}
+    public final String getValue() {
+        return value;
+    }
 
-	public final StringLiteralExpr setValue(final String value) {
-		this.value = value;
-		return this;
-	}
+    public final StringLiteralExpr setValue(final String value) {
+        this.value = value;
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/SuperExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/SuperExpr.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class SuperExpr extends Expression {
 
-	private Expression classExpr;
+    private Expression classExpr;
 
-	public SuperExpr() {
-	}
+    public SuperExpr() {
+    }
 
-	public SuperExpr(final Expression classExpr) {
-		setClassExpr(classExpr);
-	}
+    public SuperExpr(final Expression classExpr) {
+        setClassExpr(classExpr);
+    }
 
-	public SuperExpr(final Range range, final Expression classExpr) {
-		super(range);
-		setClassExpr(classExpr);
-	}
+    public SuperExpr(final Range range, final Expression classExpr) {
+        super(range);
+        setClassExpr(classExpr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getClassExpr() {
-		return classExpr;
-	}
+    public Expression getClassExpr() {
+        return classExpr;
+    }
 
-	public SuperExpr setClassExpr(final Expression classExpr) {
-		this.classExpr = classExpr;
-		setAsParentNodeOf(this.classExpr);
-		return this;
-	}
+    public SuperExpr setClassExpr(final Expression classExpr) {
+        this.classExpr = classExpr;
+        setAsParentNodeOf(this.classExpr);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ThisExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/ThisExpr.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ThisExpr extends Expression {
 
-	private Expression classExpr;
+    private Expression classExpr;
 
-	public ThisExpr() {
-	}
+    public ThisExpr() {
+    }
 
-	public ThisExpr(final Expression classExpr) {
-		setClassExpr(classExpr);
-	}
+    public ThisExpr(final Expression classExpr) {
+        setClassExpr(classExpr);
+    }
 
-	public ThisExpr(final Range range, final Expression classExpr) {
-		super(range);
-		setClassExpr(classExpr);
-	}
+    public ThisExpr(final Range range, final Expression classExpr) {
+        super(range);
+        setClassExpr(classExpr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getClassExpr() {
-		return classExpr;
-	}
+    public Expression getClassExpr() {
+        return classExpr;
+    }
 
-	public ThisExpr setClassExpr(final Expression classExpr) {
-		this.classExpr = classExpr;
-		setAsParentNodeOf(this.classExpr);
-		return this;
-	}
+    public ThisExpr setClassExpr(final Expression classExpr) {
+        this.classExpr = classExpr;
+        setAsParentNodeOf(this.classExpr);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/UnaryExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/expr/UnaryExpr.java
@@ -30,59 +30,59 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class UnaryExpr extends Expression {
 
-	public enum Operator {
-		positive, // +
-		negative, // -
-		preIncrement, // ++
-		preDecrement, // --
-		not, // !
-		inverse, // ~
-		posIncrement, // ++
-		posDecrement, // --
-	}
+    public enum Operator {
+        positive, // +
+        negative, // -
+        preIncrement, // ++
+        preDecrement, // --
+        not, // !
+        inverse, // ~
+        posIncrement, // ++
+        posDecrement, // --
+    }
 
-	private Expression expr;
+    private Expression expr;
 
-	private Operator op;
+    private Operator op;
 
-	public UnaryExpr() {
-	}
+    public UnaryExpr() {
+    }
 
-	public UnaryExpr(final Expression expr, final Operator op) {
-		setExpr(expr);
-		setOperator(op);
-	}
+    public UnaryExpr(final Expression expr, final Operator op) {
+        setExpr(expr);
+        setOperator(op);
+    }
 
-	public UnaryExpr(final Range range, final Expression expr, final Operator op) {
-		super(range);
-		setExpr(expr);
-		setOperator(op);
-	}
+    public UnaryExpr(final Range range, final Expression expr, final Operator op) {
+        super(range);
+        setExpr(expr);
+        setOperator(op);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public Operator getOperator() {
-		return op;
-	}
+    public Operator getOperator() {
+        return op;
+    }
 
-	public UnaryExpr setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-		return this;
-	}
+    public UnaryExpr setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+        return this;
+    }
 
-	public UnaryExpr setOperator(final Operator op) {
-		this.op = op;
-		return this;
-	}
+    public UnaryExpr setOperator(final Operator op) {
+        this.op = op;
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/nodeTypes/NodeWithMembers.java
@@ -271,9 +271,9 @@ public interface NodeWithMembers<T> {
     }
 
     /**
-	 * Find all fields in the members of this node.
+     * Find all fields in the members of this node.
      *
-	 * @return the fields found. This list is immutable.
+     * @return the fields found. This list is immutable.
      */
     default List<FieldDeclaration> getFields() {
         return unmodifiableList(getMembers().stream()

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/AssertStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/AssertStmt.java
@@ -31,55 +31,55 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class AssertStmt extends Statement {
 
-	private Expression check;
+    private Expression check;
 
-	private Expression msg;
+    private Expression msg;
 
-	public AssertStmt() {
-	}
+    public AssertStmt() {
+    }
 
-	public AssertStmt(final Expression check) {
-		setCheck(check);
-	}
+    public AssertStmt(final Expression check) {
+        setCheck(check);
+    }
 
-	public AssertStmt(final Expression check, final Expression msg) {
-		setCheck(check);
-		setMessage(msg);
-	}
+    public AssertStmt(final Expression check, final Expression msg) {
+        setCheck(check);
+        setMessage(msg);
+    }
 
-	public AssertStmt(final Range range, final Expression check, final Expression msg) {
-		super(range);
-		
-		setCheck(check);
-		setMessage(msg);
-		
-	}
+    public AssertStmt(final Range range, final Expression check, final Expression msg) {
+        super(range);
+        
+        setCheck(check);
+        setMessage(msg);
+        
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getCheck() {
-		return check;
-	}
+    public Expression getCheck() {
+        return check;
+    }
 
-	public Expression getMessage() {
-		return msg;
-	}
+    public Expression getMessage() {
+        return msg;
+    }
 
-	public AssertStmt setCheck(final Expression check) {
-		this.check = check;
-		setAsParentNodeOf(this.check);
-		return this;
-	}
+    public AssertStmt setCheck(final Expression check) {
+        this.check = check;
+        setAsParentNodeOf(this.check);
+        return this;
+    }
 
-	public AssertStmt setMessage(final Expression msg) {
-		this.msg = msg;
-		setAsParentNodeOf(this.msg);
-		return this;
-	}
+    public AssertStmt setMessage(final Expression msg) {
+        this.msg = msg;
+        setAsParentNodeOf(this.msg);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/BreakStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/BreakStmt.java
@@ -30,34 +30,34 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class BreakStmt extends Statement {
 
-	private String id;
+    private String id;
 
-	public BreakStmt() {
-	}
+    public BreakStmt() {
+    }
 
-	public BreakStmt(final String id) {
-		this.id = id;
-	}
+    public BreakStmt(final String id) {
+        this.id = id;
+    }
 
-	public BreakStmt(final Range range, final String id) {
-		super(range);
-		this.id = id;
-	}
+    public BreakStmt(final Range range, final String id) {
+        super(range);
+        this.id = id;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public BreakStmt setId(final String id) {
-		this.id = id;
-		return this;
-	}
+    public BreakStmt setId(final String id) {
+        this.id = id;
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/CatchClause.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/CatchClause.java
@@ -64,29 +64,29 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
         setBody(catchBlock);
     }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
     /**
      * Use {@link #getBody()} instead
      */
     @Deprecated
-	public BlockStmt getCatchBlock() {
-		return catchBlock;
-	}
+    public BlockStmt getCatchBlock() {
+        return catchBlock;
+    }
 
-	/**
-	 * Note that the type of the Parameter can be a UnionType. In this case, any annotations found at the start of the catch(@X A a |...)
-	 * are found directly in the Parameter. Annotations that are on the second or later type - catch(A a | @X B b ...) are found on those types.
-	 */
-	public Parameter getParam() {
-		return param;
-	}
+    /**
+     * Note that the type of the Parameter can be a UnionType. In this case, any annotations found at the start of the catch(@X A a |...)
+     * are found directly in the Parameter. Annotations that are on the second or later type - catch(A a | @X B b ...) are found on those types.
+     */
+    public Parameter getParam() {
+        return param;
+    }
 
     /**
      * Use {@link #setBody(BlockStmt)} instead
@@ -94,17 +94,17 @@ public final class CatchClause extends Node implements NodeWithBlockStmt<CatchCl
      * @param catchBlock
      */
     @Deprecated
-	public CatchClause setCatchBlock(final BlockStmt catchBlock) {
-		this.catchBlock = catchBlock;
-		setAsParentNodeOf(this.catchBlock);
+    public CatchClause setCatchBlock(final BlockStmt catchBlock) {
+        this.catchBlock = catchBlock;
+        setAsParentNodeOf(this.catchBlock);
         return this;
-	}
+    }
 
-	public CatchClause setParam(final Parameter param) {
-		this.param = param;
-		setAsParentNodeOf(this.param);
+    public CatchClause setParam(final Parameter param) {
+        this.param = param;
+        setAsParentNodeOf(this.param);
         return this;
-	}
+    }
 
     @Override
     public BlockStmt getBody() {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ContinueStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ContinueStmt.java
@@ -30,34 +30,34 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ContinueStmt extends Statement {
 
-	private String id;
+    private String id;
 
-	public ContinueStmt() {
-	}
+    public ContinueStmt() {
+    }
 
-	public ContinueStmt(final String id) {
-		this.id = id;
-	}
+    public ContinueStmt(final String id) {
+        this.id = id;
+    }
 
-	public ContinueStmt(Range range, final String id) {
-		super(range);
-		this.id = id;
-	}
+    public ContinueStmt(Range range, final String id) {
+        super(range);
+        this.id = id;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public ContinueStmt setId(final String id) {
-		this.id = id;
-		return this;
-	}
+    public ContinueStmt setId(final String id) {
+        this.id = id;
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/DoStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/DoStmt.java
@@ -32,51 +32,51 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class DoStmt extends Statement implements NodeWithBody<DoStmt> {
 
-	private Statement body;
+    private Statement body;
 
-	private Expression condition;
+    private Expression condition;
 
-	public DoStmt() {
-	}
+    public DoStmt() {
+    }
 
-	public DoStmt(final Statement body, final Expression condition) {
-		setBody(body);
-		setCondition(condition);
-	}
+    public DoStmt(final Statement body, final Expression condition) {
+        setBody(body);
+        setCondition(condition);
+    }
 
-	public DoStmt(Range range, final Statement body, final Expression condition) {
-		super(range);
-		setBody(body);
-		setCondition(condition);
-	}
+    public DoStmt(Range range, final Statement body, final Expression condition) {
+        super(range);
+        setBody(body);
+        setCondition(condition);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	@Override
+    @Override
     public Statement getBody() {
-		return body;
-	}
+        return body;
+    }
 
-	public Expression getCondition() {
-		return condition;
-	}
+    public Expression getCondition() {
+        return condition;
+    }
 
-	@Override
+    @Override
     public DoStmt setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
+        this.body = body;
+        setAsParentNodeOf(this.body);
         return this;
-	}
+    }
 
-	public DoStmt setCondition(final Expression condition) {
-		this.condition = condition;
-		setAsParentNodeOf(this.condition);
-		return this;
-	}
+    public DoStmt setCondition(final Expression condition) {
+        this.condition = condition;
+        setAsParentNodeOf(this.condition);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/EmptyStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/EmptyStmt.java
@@ -30,18 +30,18 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class EmptyStmt extends Statement {
 
-	public EmptyStmt() {
-	}
+    public EmptyStmt() {
+    }
 
-	public EmptyStmt(Range range) {
-		super(range);
-	}
+    public EmptyStmt(Range range) {
+        super(range);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -41,69 +41,69 @@ public final class ExplicitConstructorInvocationStmt extends Statement implement
 
     private boolean isThis;
 
-	private Expression expr;
+    private Expression expr;
 
-	private List<Expression> args;
+    private List<Expression> args;
 
-	public ExplicitConstructorInvocationStmt() {
-	}
+    public ExplicitConstructorInvocationStmt() {
+    }
 
-	public ExplicitConstructorInvocationStmt(final boolean isThis,
-			final Expression expr, final List<Expression> args) {
-		setThis(isThis);
-		setExpr(expr);
-		setArgs(args);
-	}
+    public ExplicitConstructorInvocationStmt(final boolean isThis,
+            final Expression expr, final List<Expression> args) {
+        setThis(isThis);
+        setExpr(expr);
+        setArgs(args);
+    }
 
-	public ExplicitConstructorInvocationStmt(Range range,
-	                                         final List<Type<?>> typeArguments, final boolean isThis,
-	                                         final Expression expr, final List<Expression> args) {
-		super(range);
-		setTypeArguments(typeArguments);
-		setThis(isThis);
-		setExpr(expr);
-		setArgs(args);
-	}
+    public ExplicitConstructorInvocationStmt(Range range,
+                                             final List<Type<?>> typeArguments, final boolean isThis,
+                                             final Expression expr, final List<Expression> args) {
+        super(range);
+        setTypeArguments(typeArguments);
+        setThis(isThis);
+        setExpr(expr);
+        setArgs(args);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<Expression> getArgs() {
+    public List<Expression> getArgs() {
         args = ensureNotNull(args);
         return args;
-	}
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public boolean isThis() {
-		return isThis;
-	}
+    public boolean isThis() {
+        return isThis;
+    }
 
-	public ExplicitConstructorInvocationStmt setArgs(final List<Expression> args) {
-		this.args = args;
-		setAsParentNodeOf(this.args);
-		return this;
-	}
+    public ExplicitConstructorInvocationStmt setArgs(final List<Expression> args) {
+        this.args = args;
+        setAsParentNodeOf(this.args);
+        return this;
+    }
 
-	public ExplicitConstructorInvocationStmt setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-		return this;
-	}
+    public ExplicitConstructorInvocationStmt setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+        return this;
+    }
 
-	public ExplicitConstructorInvocationStmt setThis(final boolean isThis) {
-		this.isThis = isThis;
-		return this;
-	}
+    public ExplicitConstructorInvocationStmt setThis(final boolean isThis) {
+        this.isThis = isThis;
+        return this;
+    }
 
     @Override
     public List<Type<?>> getTypeArguments() {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ExpressionStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ExpressionStmt.java
@@ -31,36 +31,36 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ExpressionStmt extends Statement {
 
-	private Expression expr;
+    private Expression expr;
 
-	public ExpressionStmt() {
-	}
+    public ExpressionStmt() {
+    }
 
-	public ExpressionStmt(final Expression expr) {
-		setExpression(expr);
-	}
+    public ExpressionStmt(final Expression expr) {
+        setExpression(expr);
+    }
 
-	public ExpressionStmt(Range range,
-	                      final Expression expr) {
-		super(range);
-		setExpression(expr);
-	}
+    public ExpressionStmt(Range range,
+                          final Expression expr) {
+        super(range);
+        setExpression(expr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpression() {
-		return expr;
-	}
+    public Expression getExpression() {
+        return expr;
+    }
 
-	public ExpressionStmt setExpression(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-		return this;
-	}
+    public ExpressionStmt setExpression(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ForStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ForStmt.java
@@ -36,86 +36,86 @@ import static com.github.javaparser.utils.Utils.ensureNotNull;
  */
 public final class ForStmt extends Statement implements NodeWithBody<ForStmt> {
 
-	private List<Expression> init;
+    private List<Expression> init;
 
-	private Expression compare;
+    private Expression compare;
 
-	private List<Expression> update;
+    private List<Expression> update;
 
-	private Statement body;
+    private Statement body;
 
-	public ForStmt() {
-	}
+    public ForStmt() {
+    }
 
-	public ForStmt(final List<Expression> init, final Expression compare,
-			final List<Expression> update, final Statement body) {
-		setCompare(compare);
-		setInit(init);
-		setUpdate(update);
-		setBody(body);
-	}
+    public ForStmt(final List<Expression> init, final Expression compare,
+            final List<Expression> update, final Statement body) {
+        setCompare(compare);
+        setInit(init);
+        setUpdate(update);
+        setBody(body);
+    }
 
-	public ForStmt(Range range,
-	               final List<Expression> init, final Expression compare,
-	               final List<Expression> update, final Statement body) {
-		super(range);
-		setCompare(compare);
-		setInit(init);
-		setUpdate(update);
-		setBody(body);
-	}
+    public ForStmt(Range range,
+                   final List<Expression> init, final Expression compare,
+                   final List<Expression> update, final Statement body) {
+        super(range);
+        setCompare(compare);
+        setInit(init);
+        setUpdate(update);
+        setBody(body);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	@Override
+    @Override
     public Statement getBody() {
-		return body;
-	}
+        return body;
+    }
 
-	public Expression getCompare() {
-		return compare;
-	}
+    public Expression getCompare() {
+        return compare;
+    }
 
-	public List<Expression> getInit() {
+    public List<Expression> getInit() {
         init = ensureNotNull(init);
         return init;
-	}
+    }
 
-	public List<Expression> getUpdate() {
+    public List<Expression> getUpdate() {
         update = ensureNotNull(update);
         return update;
-	}
+    }
 
-	@Override
+    @Override
     public ForStmt setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
+        this.body = body;
+        setAsParentNodeOf(this.body);
         return this;
-	}
+    }
 
-	public ForStmt setCompare(final Expression compare) {
-		this.compare = compare;
-		setAsParentNodeOf(this.compare);
-		return this;
-	}
+    public ForStmt setCompare(final Expression compare) {
+        this.compare = compare;
+        setAsParentNodeOf(this.compare);
+        return this;
+    }
 
-	public ForStmt setInit(final List<Expression> init) {
-		this.init = init;
-		setAsParentNodeOf(this.init);
-		return this;
-	}
+    public ForStmt setInit(final List<Expression> init) {
+        this.init = init;
+        setAsParentNodeOf(this.init);
+        return this;
+    }
 
-	public ForStmt setUpdate(final List<Expression> update) {
-		this.update = update;
-		setAsParentNodeOf(this.update);
-		return this;
-	}
+    public ForStmt setUpdate(final List<Expression> update) {
+        this.update = update;
+        setAsParentNodeOf(this.update);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ForeachStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ForeachStmt.java
@@ -34,30 +34,30 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ForeachStmt extends Statement implements NodeWithBody<ForeachStmt> {
 
-	private VariableDeclarationExpr var;
+    private VariableDeclarationExpr var;
 
-	private Expression iterable;
+    private Expression iterable;
 
-	private Statement body;
+    private Statement body;
 
-	public ForeachStmt() {
-	}
+    public ForeachStmt() {
+    }
 
-	public ForeachStmt(final VariableDeclarationExpr var,
-			final Expression iterable, final Statement body) {
-		setVariable(var);
-		setIterable(iterable);
-		setBody(body);
-	}
+    public ForeachStmt(final VariableDeclarationExpr var,
+            final Expression iterable, final Statement body) {
+        setVariable(var);
+        setIterable(iterable);
+        setBody(body);
+    }
 
-	public ForeachStmt(Range range,
-	                   final VariableDeclarationExpr var, final Expression iterable,
-	                   final Statement body) {
-		super(range);
-		setVariable(var);
-		setIterable(iterable);
-		setBody(body);
-	}
+    public ForeachStmt(Range range,
+                       final VariableDeclarationExpr var, final Expression iterable,
+                       final Statement body) {
+        super(range);
+        setVariable(var);
+        setIterable(iterable);
+        setBody(body);
+    }
 
     /**
      * Will create a {@link NameExpr} with the iterable param
@@ -73,44 +73,44 @@ public final class ForeachStmt extends Statement implements NodeWithBody<Foreach
     }
 
     @Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	@Override
+    @Override
     public Statement getBody() {
-		return body;
-	}
+        return body;
+    }
 
-	public Expression getIterable() {
-		return iterable;
-	}
+    public Expression getIterable() {
+        return iterable;
+    }
 
-	public VariableDeclarationExpr getVariable() {
-		return var;
-	}
+    public VariableDeclarationExpr getVariable() {
+        return var;
+    }
 
-	@Override
+    @Override
     public ForeachStmt setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
+        this.body = body;
+        setAsParentNodeOf(this.body);
         return this;
-	}
+    }
 
-	public ForeachStmt setIterable(final Expression iterable) {
-		this.iterable = iterable;
-		setAsParentNodeOf(this.iterable);
-		return this;
-	}
+    public ForeachStmt setIterable(final Expression iterable) {
+        this.iterable = iterable;
+        setAsParentNodeOf(this.iterable);
+        return this;
+    }
 
-	public ForeachStmt setVariable(final VariableDeclarationExpr var) {
-		this.var = var;
-		setAsParentNodeOf(this.var);
-		return this;
-	}
+    public ForeachStmt setVariable(final VariableDeclarationExpr var) {
+        this.var = var;
+        setAsParentNodeOf(this.var);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/IfStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/IfStmt.java
@@ -31,64 +31,64 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class IfStmt extends Statement {
 
-	private Expression condition;
+    private Expression condition;
 
-	private Statement thenStmt;
+    private Statement thenStmt;
 
-	private Statement elseStmt;
+    private Statement elseStmt;
 
-	public IfStmt() {
-	}
+    public IfStmt() {
+    }
 
-	public IfStmt(final Expression condition, final Statement thenStmt, final Statement elseStmt) {
-		setCondition(condition);
-		setThenStmt(thenStmt);
-		setElseStmt(elseStmt);
-	}
+    public IfStmt(final Expression condition, final Statement thenStmt, final Statement elseStmt) {
+        setCondition(condition);
+        setThenStmt(thenStmt);
+        setElseStmt(elseStmt);
+    }
 
-	public IfStmt(Range range,
-	              final Expression condition, final Statement thenStmt, final Statement elseStmt) {
-		super(range);
-		setCondition(condition);
-		setThenStmt(thenStmt);
-		setElseStmt(elseStmt);
-	}
+    public IfStmt(Range range,
+                  final Expression condition, final Statement thenStmt, final Statement elseStmt) {
+        super(range);
+        setCondition(condition);
+        setThenStmt(thenStmt);
+        setElseStmt(elseStmt);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getCondition() {
-		return condition;
-	}
+    public Expression getCondition() {
+        return condition;
+    }
 
-	public Statement getElseStmt() {
-		return elseStmt;
-	}
+    public Statement getElseStmt() {
+        return elseStmt;
+    }
 
-	public Statement getThenStmt() {
-		return thenStmt;
-	}
+    public Statement getThenStmt() {
+        return thenStmt;
+    }
 
-	public IfStmt setCondition(final Expression condition) {
-		this.condition = condition;
-		setAsParentNodeOf(this.condition);
-		return this;
-	}
+    public IfStmt setCondition(final Expression condition) {
+        this.condition = condition;
+        setAsParentNodeOf(this.condition);
+        return this;
+    }
 
-	public IfStmt setElseStmt(final Statement elseStmt) {
-		this.elseStmt = elseStmt;
-		setAsParentNodeOf(this.elseStmt);
-		return this;
-	}
+    public IfStmt setElseStmt(final Statement elseStmt) {
+        this.elseStmt = elseStmt;
+        setAsParentNodeOf(this.elseStmt);
+        return this;
+    }
 
-	public IfStmt setThenStmt(final Statement thenStmt) {
-		this.thenStmt = thenStmt;
-		setAsParentNodeOf(this.thenStmt);
-		return this;
-	}
+    public IfStmt setThenStmt(final Statement thenStmt) {
+        this.thenStmt = thenStmt;
+        setAsParentNodeOf(this.thenStmt);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/LabeledStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/LabeledStmt.java
@@ -30,48 +30,48 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class LabeledStmt extends Statement {
 
-	private String label;
+    private String label;
 
-	private Statement stmt;
+    private Statement stmt;
 
-	public LabeledStmt() {
-	}
+    public LabeledStmt() {
+    }
 
-	public LabeledStmt(final String label, final Statement stmt) {
-		setLabel(label);
-		setStmt(stmt);
-	}
+    public LabeledStmt(final String label, final Statement stmt) {
+        setLabel(label);
+        setStmt(stmt);
+    }
 
-	public LabeledStmt(Range range, final String label, final Statement stmt) {
-		super(range);
-		setLabel(label);
-		setStmt(stmt);
-	}
+    public LabeledStmt(Range range, final String label, final Statement stmt) {
+        super(range);
+        setLabel(label);
+        setStmt(stmt);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getLabel() {
-		return label;
-	}
+    public String getLabel() {
+        return label;
+    }
 
-	public Statement getStmt() {
-		return stmt;
-	}
+    public Statement getStmt() {
+        return stmt;
+    }
 
-	public LabeledStmt setLabel(final String label) {
-		this.label = label;
-		return this;
-	}
+    public LabeledStmt setLabel(final String label) {
+        this.label = label;
+        return this;
+    }
 
-	public LabeledStmt setStmt(final Statement stmt) {
-		this.stmt = stmt;
-		setAsParentNodeOf(this.stmt);
-		return this;
-	}
+    public LabeledStmt setStmt(final Statement stmt) {
+        this.stmt = stmt;
+        setAsParentNodeOf(this.stmt);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ReturnStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ReturnStmt.java
@@ -32,19 +32,19 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ReturnStmt extends Statement {
 
-	private Expression expr;
+    private Expression expr;
 
-	public ReturnStmt() {
-	}
+    public ReturnStmt() {
+    }
 
-	public ReturnStmt(final Expression expr) {
-		setExpr(expr);
-	}
+    public ReturnStmt(final Expression expr) {
+        setExpr(expr);
+    }
 
-	public ReturnStmt(Range range, final Expression expr) {
-		super(range);
-		setExpr(expr);
-	}
+    public ReturnStmt(Range range, final Expression expr) {
+        super(range);
+        setExpr(expr);
+    }
 
     /**
      * Will create a NameExpr with the string param
@@ -57,20 +57,20 @@ public final class ReturnStmt extends Statement {
 
     @Override
     public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public ReturnStmt setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-		return this;
-	}
+    public ReturnStmt setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/Statement.java
@@ -29,11 +29,11 @@ import com.github.javaparser.ast.Node;
  */
 public abstract class Statement extends Node {
 
-	public Statement() {
-	}
+    public Statement() {
+    }
 
-	public Statement(final Range range) {
-		super(range);
-	}
+    public Statement(final Range range) {
+        super(range);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -36,55 +36,55 @@ import static com.github.javaparser.utils.Utils.ensureNotNull;
  */
 public final class SwitchEntryStmt extends Statement implements NodeWithStatements<SwitchEntryStmt> {
 
-	private Expression label;
+    private Expression label;
 
-	private List<Statement> stmts;
+    private List<Statement> stmts;
 
-	public SwitchEntryStmt() {
-	}
+    public SwitchEntryStmt() {
+    }
 
-	public SwitchEntryStmt(final Expression label, final List<Statement> stmts) {
-		setLabel(label);
-		setStmts(stmts);
-	}
+    public SwitchEntryStmt(final Expression label, final List<Statement> stmts) {
+        setLabel(label);
+        setStmts(stmts);
+    }
 
-	public SwitchEntryStmt(Range range, final Expression label,
-	                       final List<Statement> stmts) {
-		super(range);
-		setLabel(label);
-		setStmts(stmts);
-	}
+    public SwitchEntryStmt(Range range, final Expression label,
+                           final List<Statement> stmts) {
+        super(range);
+        setLabel(label);
+        setStmts(stmts);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getLabel() {
-		return label;
-	}
+    public Expression getLabel() {
+        return label;
+    }
 
-	@Override
+    @Override
     public List<Statement> getStmts() {
         stmts = ensureNotNull(stmts);
         return stmts;
-	}
+    }
 
-	public SwitchEntryStmt setLabel(final Expression label) {
-		this.label = label;
-		setAsParentNodeOf(this.label);
-		return this;
-	}
-
-	@Override
-    public SwitchEntryStmt setStmts(final List<Statement> stmts) {
-		this.stmts = stmts;
-		setAsParentNodeOf(this.stmts);
+    public SwitchEntryStmt setLabel(final Expression label) {
+        this.label = label;
+        setAsParentNodeOf(this.label);
         return this;
-	}
+    }
+
+    @Override
+    public SwitchEntryStmt setStmts(final List<Statement> stmts) {
+        this.stmts = stmts;
+        setAsParentNodeOf(this.stmts);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/SwitchStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/SwitchStmt.java
@@ -35,54 +35,54 @@ import static com.github.javaparser.utils.Utils.*;
  */
 public final class SwitchStmt extends Statement {
 
-	private Expression selector;
+    private Expression selector;
 
-	private List<SwitchEntryStmt> entries;
+    private List<SwitchEntryStmt> entries;
 
-	public SwitchStmt() {
-	}
+    public SwitchStmt() {
+    }
 
-	public SwitchStmt(final Expression selector,
-			final List<SwitchEntryStmt> entries) {
-		setSelector(selector);
-		setEntries(entries);
-	}
+    public SwitchStmt(final Expression selector,
+            final List<SwitchEntryStmt> entries) {
+        setSelector(selector);
+        setEntries(entries);
+    }
 
-	public SwitchStmt(Range range, final Expression selector,
-	                  final List<SwitchEntryStmt> entries) {
-		super(range);
-		setSelector(selector);
-		setEntries(entries);
-	}
+    public SwitchStmt(Range range, final Expression selector,
+                      final List<SwitchEntryStmt> entries) {
+        super(range);
+        setSelector(selector);
+        setEntries(entries);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<SwitchEntryStmt> getEntries() {
+    public List<SwitchEntryStmt> getEntries() {
         entries = ensureNotNull(entries);
         return entries;
-	}
+    }
 
-	public Expression getSelector() {
-		return selector;
-	}
+    public Expression getSelector() {
+        return selector;
+    }
 
-	public SwitchStmt setEntries(final List<SwitchEntryStmt> entries) {
-		this.entries = entries;
-		setAsParentNodeOf(this.entries);
-		return this;
-	}
+    public SwitchStmt setEntries(final List<SwitchEntryStmt> entries) {
+        this.entries = entries;
+        setAsParentNodeOf(this.entries);
+        return this;
+    }
 
-	public SwitchStmt setSelector(final Expression selector) {
-		this.selector = selector;
-		setAsParentNodeOf(this.selector);
-		return this;
-	}
+    public SwitchStmt setSelector(final Expression selector) {
+        this.selector = selector;
+        setAsParentNodeOf(this.selector);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ThrowStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/ThrowStmt.java
@@ -31,35 +31,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ThrowStmt extends Statement {
 
-	private Expression expr;
+    private Expression expr;
 
-	public ThrowStmt() {
-	}
+    public ThrowStmt() {
+    }
 
-	public ThrowStmt(final Expression expr) {
-		setExpr(expr);
-	}
+    public ThrowStmt(final Expression expr) {
+        setExpr(expr);
+    }
 
-	public ThrowStmt(Range range, final Expression expr) {
-		super(range);
-		setExpr(expr);
-	}
+    public ThrowStmt(Range range, final Expression expr) {
+        super(range);
+        setExpr(expr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public ThrowStmt setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-		return this;
-	}
+    public ThrowStmt setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/TryStmt.java
@@ -34,83 +34,83 @@ import static com.github.javaparser.utils.Utils.*;
  * @author Julio Vilmar Gesser
  */
 public final class TryStmt extends Statement {
-	
-	private List<VariableDeclarationExpr> resources;
+    
+    private List<VariableDeclarationExpr> resources;
 
-	private BlockStmt tryBlock;
+    private BlockStmt tryBlock;
 
-	private List<CatchClause> catchs;
+    private List<CatchClause> catchs;
 
-	private BlockStmt finallyBlock;
+    private BlockStmt finallyBlock;
 
-	public TryStmt() {
-	}
+    public TryStmt() {
+    }
 
-	public TryStmt(final BlockStmt tryBlock, final List<CatchClause> catchs,
-			final BlockStmt finallyBlock) {
-		setTryBlock(tryBlock);
-		setCatchs(catchs);
-		setFinallyBlock(finallyBlock);
-	}
+    public TryStmt(final BlockStmt tryBlock, final List<CatchClause> catchs,
+            final BlockStmt finallyBlock) {
+        setTryBlock(tryBlock);
+        setCatchs(catchs);
+        setFinallyBlock(finallyBlock);
+    }
 
-	public TryStmt(Range range, List<VariableDeclarationExpr> resources,
-	               final BlockStmt tryBlock, final List<CatchClause> catchs, final BlockStmt finallyBlock) {
-		super(range);
-		setResources(resources);
-		setTryBlock(tryBlock);
-		setCatchs(catchs);
-		setFinallyBlock(finallyBlock);
-	}
+    public TryStmt(Range range, List<VariableDeclarationExpr> resources,
+                   final BlockStmt tryBlock, final List<CatchClause> catchs, final BlockStmt finallyBlock) {
+        super(range);
+        setResources(resources);
+        setTryBlock(tryBlock);
+        setCatchs(catchs);
+        setFinallyBlock(finallyBlock);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<CatchClause> getCatchs() {
+    public List<CatchClause> getCatchs() {
         catchs = ensureNotNull(catchs);
         return catchs;
-	}
+    }
 
-	public BlockStmt getFinallyBlock() {
-		return finallyBlock;
-	}
+    public BlockStmt getFinallyBlock() {
+        return finallyBlock;
+    }
 
-	public BlockStmt getTryBlock() {
-		return tryBlock;
-	}
-	
-	public List<VariableDeclarationExpr> getResources() {
+    public BlockStmt getTryBlock() {
+        return tryBlock;
+    }
+    
+    public List<VariableDeclarationExpr> getResources() {
         resources = ensureNotNull(resources);
         return resources;
-	}
+    }
 
-	public TryStmt setCatchs(final List<CatchClause> catchs) {
-		this.catchs = catchs;
-		setAsParentNodeOf(this.catchs);
-		return this;
-	}
+    public TryStmt setCatchs(final List<CatchClause> catchs) {
+        this.catchs = catchs;
+        setAsParentNodeOf(this.catchs);
+        return this;
+    }
 
-	public TryStmt setFinallyBlock(final BlockStmt finallyBlock) {
-		this.finallyBlock = finallyBlock;
-		setAsParentNodeOf(this.finallyBlock);
-		return this;
-	}
+    public TryStmt setFinallyBlock(final BlockStmt finallyBlock) {
+        this.finallyBlock = finallyBlock;
+        setAsParentNodeOf(this.finallyBlock);
+        return this;
+    }
 
-	public TryStmt setTryBlock(final BlockStmt tryBlock) {
-		this.tryBlock = tryBlock;
-		setAsParentNodeOf(this.tryBlock);
-		return this;
-	}
-	
-	public TryStmt setResources(List<VariableDeclarationExpr> resources) {
-		this.resources = resources;
-		setAsParentNodeOf(this.resources);
-		return this;
-	}
+    public TryStmt setTryBlock(final BlockStmt tryBlock) {
+        this.tryBlock = tryBlock;
+        setAsParentNodeOf(this.tryBlock);
+        return this;
+    }
+    
+    public TryStmt setResources(List<VariableDeclarationExpr> resources) {
+        this.resources = resources;
+        setAsParentNodeOf(this.resources);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/TypeDeclarationStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/TypeDeclarationStmt.java
@@ -31,35 +31,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class TypeDeclarationStmt extends Statement {
 
-	private TypeDeclaration typeDecl;
+    private TypeDeclaration typeDecl;
 
-	public TypeDeclarationStmt() {
-	}
+    public TypeDeclarationStmt() {
+    }
 
-	public TypeDeclarationStmt(final TypeDeclaration typeDecl) {
-		setTypeDeclaration(typeDecl);
-	}
+    public TypeDeclarationStmt(final TypeDeclaration typeDecl) {
+        setTypeDeclaration(typeDecl);
+    }
 
-	public TypeDeclarationStmt(Range range, final TypeDeclaration typeDecl) {
-		super(range);
-		setTypeDeclaration(typeDecl);
-	}
+    public TypeDeclarationStmt(Range range, final TypeDeclaration typeDecl) {
+        super(range);
+        setTypeDeclaration(typeDecl);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public TypeDeclaration getTypeDeclaration() {
-		return typeDecl;
-	}
+    public TypeDeclaration getTypeDeclaration() {
+        return typeDecl;
+    }
 
-	public TypeDeclarationStmt setTypeDeclaration(final TypeDeclaration typeDecl) {
-		this.typeDecl = typeDecl;
-		setAsParentNodeOf(this.typeDecl);
-		return this;
-	}
+    public TypeDeclarationStmt setTypeDeclaration(final TypeDeclaration typeDecl) {
+        this.typeDecl = typeDecl;
+        setAsParentNodeOf(this.typeDecl);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/WhileStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/stmt/WhileStmt.java
@@ -32,51 +32,51 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class WhileStmt extends Statement implements NodeWithBody<WhileStmt> {
 
-	private Expression condition;
+    private Expression condition;
 
-	private Statement body;
+    private Statement body;
 
-	public WhileStmt() {
-	}
+    public WhileStmt() {
+    }
 
-	public WhileStmt(final Expression condition, final Statement body) {
-		setCondition(condition);
-		setBody(body);
-	}
+    public WhileStmt(final Expression condition, final Statement body) {
+        setCondition(condition);
+        setBody(body);
+    }
 
-	public WhileStmt(Range range, final Expression condition, final Statement body) {
-		super(range);
-		setCondition(condition);
-		setBody(body);
-	}
+    public WhileStmt(Range range, final Expression condition, final Statement body) {
+        super(range);
+        setCondition(condition);
+        setBody(body);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	@Override
+    @Override
     public Statement getBody() {
-		return body;
-	}
+        return body;
+    }
 
-	public Expression getCondition() {
-		return condition;
-	}
+    public Expression getCondition() {
+        return condition;
+    }
 
-	@Override
+    @Override
     public WhileStmt setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
+        this.body = body;
+        setAsParentNodeOf(this.body);
         return this;
-	}
+    }
 
-	public WhileStmt setCondition(final Expression condition) {
-		this.condition = condition;
-		setAsParentNodeOf(this.condition);
-		return this;
-	}
+    public WhileStmt setCondition(final Expression condition) {
+        this.condition = condition;
+        setAsParentNodeOf(this.condition);
+        return this;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/PrimitiveType.java
@@ -35,83 +35,83 @@ import java.util.HashMap;
  */
 public final class PrimitiveType extends Type<PrimitiveType> implements NodeWithAnnotations<PrimitiveType> {
 
-	public static final PrimitiveType BYTE_TYPE = new PrimitiveType(Primitive.Byte);
+    public static final PrimitiveType BYTE_TYPE = new PrimitiveType(Primitive.Byte);
 
-	public static final PrimitiveType SHORT_TYPE = new PrimitiveType(Primitive.Short);
+    public static final PrimitiveType SHORT_TYPE = new PrimitiveType(Primitive.Short);
 
-	public static final PrimitiveType INT_TYPE = new PrimitiveType(Primitive.Int);
+    public static final PrimitiveType INT_TYPE = new PrimitiveType(Primitive.Int);
 
-	public static final PrimitiveType LONG_TYPE = new PrimitiveType(Primitive.Long);
+    public static final PrimitiveType LONG_TYPE = new PrimitiveType(Primitive.Long);
 
-	public static final PrimitiveType FLOAT_TYPE = new PrimitiveType(Primitive.Float);
+    public static final PrimitiveType FLOAT_TYPE = new PrimitiveType(Primitive.Float);
 
-	public static final PrimitiveType DOUBLE_TYPE = new PrimitiveType(Primitive.Double);
+    public static final PrimitiveType DOUBLE_TYPE = new PrimitiveType(Primitive.Double);
 
-	public static final PrimitiveType BOOLEAN_TYPE = new PrimitiveType(Primitive.Boolean);
+    public static final PrimitiveType BOOLEAN_TYPE = new PrimitiveType(Primitive.Boolean);
 
-	public static final PrimitiveType CHAR_TYPE = new PrimitiveType(Primitive.Char);
+    public static final PrimitiveType CHAR_TYPE = new PrimitiveType(Primitive.Char);
 
-	public enum Primitive {
-		Boolean ("Boolean"),
-		Char    ("Character"),
-		Byte    ("Byte"),
-		Short   ("Short"),
-		Int     ("Integer"),
-		Long    ("Long"),
-		Float   ("Float"),
-		Double  ("Double");
+    public enum Primitive {
+        Boolean ("Boolean"),
+        Char    ("Character"),
+        Byte    ("Byte"),
+        Short   ("Short"),
+        Int     ("Integer"),
+        Long    ("Long"),
+        Float   ("Float"),
+        Double  ("Double");
 
-		final String nameOfBoxedType;
+        final String nameOfBoxedType;
 
-		public ClassOrInterfaceType toBoxedType() {
-			return new ClassOrInterfaceType(nameOfBoxedType);
-		}
+        public ClassOrInterfaceType toBoxedType() {
+            return new ClassOrInterfaceType(nameOfBoxedType);
+        }
 
-		Primitive(String nameOfBoxedType) {
-			this.nameOfBoxedType = nameOfBoxedType;
-		}
-	}
+        Primitive(String nameOfBoxedType) {
+            this.nameOfBoxedType = nameOfBoxedType;
+        }
+    }
 
-	static final HashMap<String, Primitive> unboxMap = new HashMap<>();
-	static {
-		for(Primitive unboxedType : Primitive.values()) {
-			unboxMap.put(unboxedType.nameOfBoxedType, unboxedType);
-		}
-	}
+    static final HashMap<String, Primitive> unboxMap = new HashMap<>();
+    static {
+        for(Primitive unboxedType : Primitive.values()) {
+            unboxMap.put(unboxedType.nameOfBoxedType, unboxedType);
+        }
+    }
 
-	private Primitive type;
+    private Primitive type;
 
-	public PrimitiveType() {
-	}
+    public PrimitiveType() {
+    }
 
-	public PrimitiveType(final Primitive type) {
-		this.type = type;
-	}
+    public PrimitiveType(final Primitive type) {
+        this.type = type;
+    }
 
-	public PrimitiveType(Range range, final Primitive type) {
-		super(range);
-		setType(type);
-	}
+    public PrimitiveType(Range range, final Primitive type) {
+        super(range);
+        setType(type);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Primitive getType() {
-		return type;
-	}
+    public Primitive getType() {
+        return type;
+    }
 
-	public ClassOrInterfaceType toBoxedType() {
-		return type.toBoxedType();
-	}
+    public ClassOrInterfaceType toBoxedType() {
+        return type.toBoxedType();
+    }
 
-	public PrimitiveType setType(final Primitive type) {
-		this.type = type;
-		return this;
-	}
+    public PrimitiveType setType(final Primitive type) {
+        this.type = type;
+        return this;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/ReferenceType.java
@@ -29,9 +29,9 @@ import com.github.javaparser.Range;
 public abstract class ReferenceType<T extends ReferenceType> extends Type<T> {
 
     public ReferenceType() {
-	}
+    }
 
-	public ReferenceType(final Range range) {
-		super(range);
-	}
+    public ReferenceType(final Range range) {
+        super(range);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/TypeParameter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/TypeParameter.java
@@ -46,84 +46,84 @@ import static com.github.javaparser.utils.Utils.ensureNotNull;
  */
 public final class TypeParameter extends ReferenceType<TypeParameter> implements NodeWithName<TypeParameter> {
 
-	private String name;
+    private String name;
 
     private List<AnnotationExpr> annotations;
 
-	private List<ClassOrInterfaceType> typeBound;
+    private List<ClassOrInterfaceType> typeBound;
 
-	public TypeParameter() {
-	}
+    public TypeParameter() {
+    }
 
-	public TypeParameter(final String name, final List<ClassOrInterfaceType> typeBound) {
-		setName(name);
-		setTypeBound(typeBound);
-	}
+    public TypeParameter(final String name, final List<ClassOrInterfaceType> typeBound) {
+        setName(name);
+        setTypeBound(typeBound);
+    }
 
-	public TypeParameter(Range range, final String name, final List<ClassOrInterfaceType> typeBound) {
-		super(range);
-		setName(name);
-		setTypeBound(typeBound);
-	}
+    public TypeParameter(Range range, final String name, final List<ClassOrInterfaceType> typeBound) {
+        super(range);
+        setName(name);
+        setTypeBound(typeBound);
+    }
 
-	public TypeParameter(Range range, String name, List<ClassOrInterfaceType> typeBound, List<AnnotationExpr> annotations) {
-		this(range, name, typeBound);
-		setTypeBound(typeBound);
-		setAnnotations(annotations);
-	}
+    public TypeParameter(Range range, String name, List<ClassOrInterfaceType> typeBound, List<AnnotationExpr> annotations) {
+        this(range, name, typeBound);
+        setTypeBound(typeBound);
+        setAnnotations(annotations);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	/**
-	 * Return the name of the paramenter.
-	 * 
-	 * @return the name of the paramenter
-	 */
-	@Override
-	public String getName() {
-		return name;
-	}
+    /**
+     * Return the name of the paramenter.
+     * 
+     * @return the name of the paramenter
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
 
-	/**
-	 * Return the list of {@link ClassOrInterfaceType} that this parameter
-	 * extends. Return <code>null</code> null if there are no type.
-	 * 
-	 * @return list of types that this paramente extends or <code>null</code>
-	 */
-	public List<ClassOrInterfaceType> getTypeBound() {
+    /**
+     * Return the list of {@link ClassOrInterfaceType} that this parameter
+     * extends. Return <code>null</code> null if there are no type.
+     * 
+     * @return list of types that this paramente extends or <code>null</code>
+     */
+    public List<ClassOrInterfaceType> getTypeBound() {
         typeBound = ensureNotNull(typeBound);
         return typeBound;
-	}
+    }
 
-	/**
-	 * Sets the name of this type parameter.
-	 * 
-	 * @param name
-	 *            the name to set
-	 */
+    /**
+     * Sets the name of this type parameter.
+     * 
+     * @param name
+     *            the name to set
+     */
     @Override
     public TypeParameter setName(final String name) {
-		this.name = name;
+        this.name = name;
         return this;
-	}
+    }
 
-	/**
-	 * Sets the list o types.
-	 * 
-	 * @param typeBound
-	 *            the typeBound to set
-	 */
-	public TypeParameter setTypeBound(final List<ClassOrInterfaceType> typeBound) {
-		this.typeBound = typeBound;
-		setAsParentNodeOf(typeBound);
-		return this;
-	}
+    /**
+     * Sets the list o types.
+     * 
+     * @param typeBound
+     *            the typeBound to set
+     */
+    public TypeParameter setTypeBound(final List<ClassOrInterfaceType> typeBound) {
+        this.typeBound = typeBound;
+        setAsParentNodeOf(typeBound);
+        return this;
+    }
 
     public List<AnnotationExpr> getAnnotations() {
         annotations = ensureNotNull(annotations);
@@ -132,7 +132,7 @@ public final class TypeParameter extends ReferenceType<TypeParameter> implements
 
     public TypeParameter setAnnotations(List<AnnotationExpr> annotations) {
         this.annotations = annotations;
-	    setAsParentNodeOf(this.annotations);
-		return this;
+        setAsParentNodeOf(this.annotations);
+        return this;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/VoidType.java
@@ -31,21 +31,21 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class VoidType extends Type<VoidType> implements NodeWithAnnotations<VoidType> {
 
-	public static final VoidType VOID_TYPE = new VoidType();
+    public static final VoidType VOID_TYPE = new VoidType();
 
-	public VoidType() {
-	}
+    public VoidType() {
+    }
 
-	public VoidType(Range range) {
-		super(range);
-	}
+    public VoidType(Range range) {
+        super(range);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/type/WildcardType.java
@@ -31,55 +31,55 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class WildcardType extends Type<WildcardType> implements NodeWithAnnotations<WildcardType> {
 
-	private ReferenceType ext;
+    private ReferenceType ext;
 
-	private ReferenceType sup;
+    private ReferenceType sup;
 
-	public WildcardType() {
-	}
+    public WildcardType() {
+    }
 
-	public WildcardType(final ReferenceType ext) {
-		setExtends(ext);
-	}
+    public WildcardType(final ReferenceType ext) {
+        setExtends(ext);
+    }
 
-	public WildcardType(final ReferenceType ext, final ReferenceType sup) {
-		setExtends(ext);
-		setSuper(sup);
-	}
+    public WildcardType(final ReferenceType ext, final ReferenceType sup) {
+        setExtends(ext);
+        setSuper(sup);
+    }
 
-	public WildcardType(final Range range,
-			final ReferenceType ext, final ReferenceType sup) {
-		super(range);
-		setExtends(ext);
-		setSuper(sup);
-	}
+    public WildcardType(final Range range,
+            final ReferenceType ext, final ReferenceType sup) {
+        super(range);
+        setExtends(ext);
+        setSuper(sup);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public ReferenceType getExtends() {
-		return ext;
-	}
+    public ReferenceType getExtends() {
+        return ext;
+    }
 
-	public ReferenceType getSuper() {
-		return sup;
-	}
+    public ReferenceType getSuper() {
+        return sup;
+    }
 
-	public WildcardType setExtends(final ReferenceType ext) {
-		this.ext = ext;
-		setAsParentNodeOf(this.ext);
-		return this;
-	}
+    public WildcardType setExtends(final ReferenceType ext) {
+        this.ext = ext;
+        setAsParentNodeOf(this.ext);
+        return this;
+    }
 
-	public WildcardType setSuper(final ReferenceType sup) {
-		this.sup = sup;
-		setAsParentNodeOf(this.sup);
-		return this;
-	}
+    public WildcardType setSuper(final ReferenceType sup) {
+        this.sup = sup;
+        setAsParentNodeOf(this.sup);
+        return this;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -109,47 +109,47 @@ import com.github.javaparser.ast.type.*;
 
 public class CloneVisitor implements GenericVisitor<Node, Object> {
 
-	@Override
-	public Node visit(CompilationUnit _n, Object _arg) {
-		PackageDeclaration package_ = cloneNodes(_n.getPackage(), _arg);
-		List<ImportDeclaration> imports = visit(_n.getImports(), _arg);
+    @Override
+    public Node visit(CompilationUnit _n, Object _arg) {
+        PackageDeclaration package_ = cloneNodes(_n.getPackage(), _arg);
+        List<ImportDeclaration> imports = visit(_n.getImports(), _arg);
         List<TypeDeclaration<?>> types = visit(_n.getTypes(), _arg);
 
-		return new CompilationUnit(
-				_n.getRange(),
-				package_, imports, types
-		);
-	}
+        return new CompilationUnit(
+                _n.getRange(),
+                package_, imports, types
+        );
+    }
 
-	@Override
-	public Node visit(PackageDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(PackageDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		PackageDeclaration r = new PackageDeclaration(
-				_n.getRange(),
-				annotations, name
-		);
-		r.setComment(comment);
-		return r;
-	}
+        PackageDeclaration r = new PackageDeclaration(
+                _n.getRange(),
+                annotations, name
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ImportDeclaration _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ImportDeclaration _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ImportDeclaration r = new ImportDeclaration(
-				_n.getRange(),
-				name, _n.isStatic(), _n.isAsterisk()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ImportDeclaration r = new ImportDeclaration(
+                _n.getRange(),
+                name, _n.isStatic(), _n.isAsterisk()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(TypeParameter _n, Object _arg) {
+    @Override
+    public Node visit(TypeParameter _n, Object _arg) {
         List<ClassOrInterfaceType> typeBound = visit(_n.getTypeBound(), _arg);
 
         List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
@@ -158,189 +158,189 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
-		return r;
-	}
+        return r;
+    }
 
-	@Override
-	public Node visit(LineComment _n, Object _arg) {
-		return new LineComment(_n.getRange(), _n.getContent());
-	}
+    @Override
+    public Node visit(LineComment _n, Object _arg) {
+        return new LineComment(_n.getRange(), _n.getContent());
+    }
 
-	@Override
-	public Node visit(BlockComment _n, Object _arg) {
-		return new BlockComment(_n.getRange(), _n.getContent());
-	}
+    @Override
+    public Node visit(BlockComment _n, Object _arg) {
+        return new BlockComment(_n.getRange(), _n.getContent());
+    }
 
-	@Override
-	public Node visit(ClassOrInterfaceDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
-		List<ClassOrInterfaceType> extendsList = visit(_n.getExtends(), _arg);
-		List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
+    @Override
+    public Node visit(ClassOrInterfaceDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
+        List<ClassOrInterfaceType> extendsList = visit(_n.getExtends(), _arg);
+        List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
         List<BodyDeclaration<?>> members = visit(_n.getMembers(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ClassOrInterfaceDeclaration r = new ClassOrInterfaceDeclaration(
-				_n.getRange(),
-				_n.getModifiers(), annotations, _n.isInterface(), _n.getName(), typeParameters, extendsList, implementsList, members
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ClassOrInterfaceDeclaration r = new ClassOrInterfaceDeclaration(
+                _n.getRange(),
+                _n.getModifiers(), annotations, _n.isInterface(), _n.getName(), typeParameters, extendsList, implementsList, members
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EnumDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
-		List<EnumConstantDeclaration> entries = visit(_n.getEntries(), _arg);
+    @Override
+    public Node visit(EnumDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
+        List<EnumConstantDeclaration> entries = visit(_n.getEntries(), _arg);
         List<BodyDeclaration<?>> members = visit(_n.getMembers(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EnumDeclaration r = new EnumDeclaration(
-				_n.getRange(),
-				 _n.getModifiers(), annotations, _n.getName(), implementsList, entries, members
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EnumDeclaration r = new EnumDeclaration(
+                _n.getRange(),
+                 _n.getModifiers(), annotations, _n.getName(), implementsList, entries, members
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EmptyTypeDeclaration _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(EmptyTypeDeclaration _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EmptyTypeDeclaration r = new EmptyTypeDeclaration(
-				_n.getRange()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EmptyTypeDeclaration r = new EmptyTypeDeclaration(
+                _n.getRange()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EnumConstantDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<Expression> args = visit(_n.getArgs(), _arg);
+    @Override
+    public Node visit(EnumConstantDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<Expression> args = visit(_n.getArgs(), _arg);
         List<BodyDeclaration<?>> classBody = visit(_n.getClassBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EnumConstantDeclaration r = new EnumConstantDeclaration(
-				_n.getRange(),
-				 annotations, _n.getName(), args, classBody
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EnumConstantDeclaration r = new EnumConstantDeclaration(
+                _n.getRange(),
+                 annotations, _n.getName(), args, classBody
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(AnnotationDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+    @Override
+    public Node visit(AnnotationDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
         List<BodyDeclaration<?>> members = visit(_n.getMembers(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		AnnotationDeclaration r = new AnnotationDeclaration(
-				_n.getRange(),
-				 _n.getModifiers(), annotations, _n.getName(), members
-		);
-		r.setComment(comment);
-		return r;
-	}
+        AnnotationDeclaration r = new AnnotationDeclaration(
+                _n.getRange(),
+                 _n.getModifiers(), annotations, _n.getName(), members
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(AnnotationMemberDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Type<?> type_ = cloneNodes(_n.getType(), _arg);
-		Expression defaultValue = cloneNodes(_n.getDefaultValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(AnnotationMemberDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Type<?> type_ = cloneNodes(_n.getType(), _arg);
+        Expression defaultValue = cloneNodes(_n.getDefaultValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		AnnotationMemberDeclaration r = new AnnotationMemberDeclaration(
-				_n.getRange(),
-				 _n.getModifiers(), annotations, type_, _n.getName(), defaultValue
-		);
-		r.setComment(comment);
-		return r;
-	}
+        AnnotationMemberDeclaration r = new AnnotationMemberDeclaration(
+                _n.getRange(),
+                 _n.getModifiers(), annotations, type_, _n.getName(), defaultValue
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(FieldDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations_ = visit(_n.getAnnotations(), _arg);
-		Type<?> elementType_ = cloneNodes(_n.getElementType(), _arg);
-		List<VariableDeclarator> variables_ = visit(_n.getVariables(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(FieldDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations_ = visit(_n.getAnnotations(), _arg);
+        Type<?> elementType_ = cloneNodes(_n.getElementType(), _arg);
+        List<VariableDeclarator> variables_ = visit(_n.getVariables(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
         List<ArrayBracketPair> arrayBracketPairsAfterType_ = visit(_n.getArrayBracketPairsAfterElementType(), _arg);
 
         FieldDeclaration r = new FieldDeclaration(
-				_n.getRange(),
-				 _n.getModifiers(), 
+                _n.getRange(),
+                 _n.getModifiers(), 
                 annotations_, 
                 elementType_, 
                 variables_,
                 arrayBracketPairsAfterType_
                 
-		);
-		r.setComment(comment);
-		return r;
-	}
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(VariableDeclarator _n, Object _arg) {
-		VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
-		Expression init = cloneNodes(_n.getInit(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(VariableDeclarator _n, Object _arg) {
+        VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
+        Expression init = cloneNodes(_n.getInit(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		VariableDeclarator r = new VariableDeclarator(
-				_n.getRange(),
-				id, init
-		);
-		r.setComment(comment);
-		return r;
-	}
+        VariableDeclarator r = new VariableDeclarator(
+                _n.getRange(),
+                id, init
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(VariableDeclaratorId _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		List<ArrayBracketPair> arrayBracketPairsAfterId_ = visit(_n.getArrayBracketPairsAfterId(), _arg);
+    @Override
+    public Node visit(VariableDeclaratorId _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        List<ArrayBracketPair> arrayBracketPairsAfterId_ = visit(_n.getArrayBracketPairsAfterId(), _arg);
 
-		VariableDeclaratorId r = new VariableDeclaratorId(
-				_n.getRange(),
-				_n.getName(),
-				arrayBracketPairsAfterId_
-		);
-		r.setComment(comment);
-		return r;
-	}
+        VariableDeclaratorId r = new VariableDeclaratorId(
+                _n.getRange(),
+                _n.getName(),
+                arrayBracketPairsAfterId_
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ConstructorDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
-		List<Parameter> parameters = visit(_n.getParameters(), _arg);
-		List<ReferenceType> throws_ = visit(_n.getThrows(), _arg);
-		BlockStmt block = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ConstructorDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
+        List<Parameter> parameters = visit(_n.getParameters(), _arg);
+        List<ReferenceType> throws_ = visit(_n.getThrows(), _arg);
+        BlockStmt block = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ConstructorDeclaration r = new ConstructorDeclaration(
-				_n.getRange(),
-				 _n.getModifiers(), annotations, typeParameters, _n.getName(), parameters, throws_, block
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ConstructorDeclaration r = new ConstructorDeclaration(
+                _n.getRange(),
+                 _n.getModifiers(), annotations, typeParameters, _n.getName(), parameters, throws_, block
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(MethodDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations_ = visit(_n.getAnnotations(), _arg);
-		List<TypeParameter> typeParameters_ = visit(_n.getTypeParameters(), _arg);
-		Type<?> type_ = cloneNodes(_n.getElementType(), _arg);
+    @Override
+    public Node visit(MethodDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations_ = visit(_n.getAnnotations(), _arg);
+        List<TypeParameter> typeParameters_ = visit(_n.getTypeParameters(), _arg);
+        Type<?> type_ = cloneNodes(_n.getElementType(), _arg);
         NameExpr nameExpr_ = cloneNodes(_n.getNameExpr(), _arg);
         List<Parameter> parameters_ = visit(_n.getParameters(), _arg);
-		List<ReferenceType> throws_ = visit(_n.getThrows(), _arg);
-		BlockStmt block_ = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		List<ArrayBracketPair> arrayBracketPairsAfterElementType_ = visit(_n.getArrayBracketPairsAfterElementType(), _arg);
-		List<ArrayBracketPair> arrayBracketPairsAfterParameterList_ = visit(_n.getArrayBracketPairsAfterParameterList(), _arg);
+        List<ReferenceType> throws_ = visit(_n.getThrows(), _arg);
+        BlockStmt block_ = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        List<ArrayBracketPair> arrayBracketPairsAfterElementType_ = visit(_n.getArrayBracketPairsAfterElementType(), _arg);
+        List<ArrayBracketPair> arrayBracketPairsAfterParameterList_ = visit(_n.getArrayBracketPairsAfterParameterList(), _arg);
 
-		MethodDeclaration r = new MethodDeclaration(
-				_n.getRange(),
-				 _n.getModifiers(), 
+        MethodDeclaration r = new MethodDeclaration(
+                _n.getRange(),
+                 _n.getModifiers(), 
                 annotations_, 
                 typeParameters_, 
                 type_,
@@ -350,929 +350,929 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
                 arrayBracketPairsAfterParameterList_, 
                 throws_, 
                 block_
-		);
-		r.setComment(comment);
-		return r;
-	}
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(Parameter _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Type<?> type_ = cloneNodes(_n.getElementType(), _arg);
-		VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(Parameter _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Type<?> type_ = cloneNodes(_n.getElementType(), _arg);
+        VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
         List<ArrayBracketPair> arrayBracketPairsAfterType_ = visit(_n.getArrayBracketPairsAfterElementType(), _arg);
 
         Parameter r = new Parameter(
-				_n.getRange(),
-				_n.getModifiers(), 
+                _n.getRange(),
+                _n.getModifiers(), 
                 annotations, 
                 type_,
                 arrayBracketPairsAfterType_,
                 _n.isVarArgs(), 
                 id
-		);
-		r.setComment(comment);
-		return r;
-	}
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EmptyMemberDeclaration _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(EmptyMemberDeclaration _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EmptyMemberDeclaration r = new EmptyMemberDeclaration(
-				_n.getRange()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EmptyMemberDeclaration r = new EmptyMemberDeclaration(
+                _n.getRange()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(InitializerDeclaration _n, Object _arg) {
-		BlockStmt block = cloneNodes(_n.getBlock(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(InitializerDeclaration _n, Object _arg) {
+        BlockStmt block = cloneNodes(_n.getBlock(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		InitializerDeclaration r = new InitializerDeclaration(
-				_n.getRange(),
-				 _n.isStatic(), block
-		);
-		r.setComment(comment);
-		return r;
-	}
+        InitializerDeclaration r = new InitializerDeclaration(
+                _n.getRange(),
+                 _n.isStatic(), block
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(JavadocComment _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		JavadocComment r = new JavadocComment(
-				_n.getRange(),
-				_n.getContent()
-		);
-		r.setComment(comment);
-		return r;
-	}
+    @Override
+    public Node visit(JavadocComment _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        JavadocComment r = new JavadocComment(
+                _n.getRange(),
+                _n.getContent()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ClassOrInterfaceType _n, Object _arg) {
-		ClassOrInterfaceType scope = cloneNodes(_n.getScope(), _arg);
-		List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ClassOrInterfaceType _n, Object _arg) {
+        ClassOrInterfaceType scope = cloneNodes(_n.getScope(), _arg);
+        List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ClassOrInterfaceType r = new ClassOrInterfaceType(
-				_n.getRange(),
-				scope,
-				_n.getName(),
-				_n.getTypeArguments()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ClassOrInterfaceType r = new ClassOrInterfaceType(
+                _n.getRange(),
+                scope,
+                _n.getName(),
+                _n.getTypeArguments()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(PrimitiveType _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+    @Override
+    public Node visit(PrimitiveType _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 
-		PrimitiveType r = new PrimitiveType(
-				_n.getRange(),
-				_n.getType()
-		);
-		r.setComment(comment);
-		r.setAnnotations(annotations);
-		return r;
-	}
+        PrimitiveType r = new PrimitiveType(
+                _n.getRange(),
+                _n.getType()
+        );
+        r.setComment(comment);
+        r.setAnnotations(annotations);
+        return r;
+    }
 
-	@Override
-	public Node visit(ArrayType _n, Object _arg) {
-		List<AnnotationExpr> ann = visit(_n.getAnnotations(), _arg);
-		Type<?> type_ = cloneNodes(_n.getComponentType(), _arg);
+    @Override
+    public Node visit(ArrayType _n, Object _arg) {
+        List<AnnotationExpr> ann = visit(_n.getAnnotations(), _arg);
+        Type<?> type_ = cloneNodes(_n.getComponentType(), _arg);
 
-		ArrayType r = new ArrayType(_n.getRange(), type_, ann);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		r.setComment(comment);
-		return r;
-	}
+        ArrayType r = new ArrayType(_n.getRange(), type_, ann);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ArrayCreationLevel _n, Object _arg) {
-		List<AnnotationExpr> ann = visit(_n.getAnnotations(), _arg);
-		Expression dimension_ = cloneNodes(_n.getDimension(), _arg);
+    @Override
+    public Node visit(ArrayCreationLevel _n, Object _arg) {
+        List<AnnotationExpr> ann = visit(_n.getAnnotations(), _arg);
+        Expression dimension_ = cloneNodes(_n.getDimension(), _arg);
 
-		ArrayCreationLevel r = new ArrayCreationLevel(_n.getRange(), dimension_, ann);
+        ArrayCreationLevel r = new ArrayCreationLevel(_n.getRange(), dimension_, ann);
 
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		r.setComment(comment);
-		return r;
-	}
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
+    @Override
     public Node visit(IntersectionType _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
         List<ReferenceType> elements = visit(_n.getElements(), _arg);
 
         IntersectionType r = new IntersectionType(_n.getRange(), elements);
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
-		r.setAnnotations(annotations);
+        r.setAnnotations(annotations);
         return r;
     }
 
     @Override
     public Node visit(UnionType _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
         List<ReferenceType> elements = visit(_n.getElements(), _arg);
 
         UnionType r = new UnionType(_n.getRange(),
                 elements);
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
-		r.setAnnotations(annotations);
+        r.setAnnotations(annotations);
         return r;
     }
 
-	@Override
-	public Node visit(VoidType _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(VoidType _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		VoidType r = new VoidType(_n.getRange());
-		r.setAnnotations(annotations);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(WildcardType _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		ReferenceType ext = cloneNodes(_n.getExtends(), _arg);
-		ReferenceType sup = cloneNodes(_n.getSuper(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		WildcardType r = new WildcardType(
-				_n.getRange(),
-				ext, sup
-		);
-		r.setComment(comment);
-		r.setAnnotations(annotations);
-		return r;
-	}
-
-	@Override
-	public Node visit(UnknownType _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		UnknownType r = new UnknownType();
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ArrayAccessExpr _n, Object _arg) {
-		Expression name = cloneNodes(_n.getName(), _arg);
-		Expression index = cloneNodes(_n.getIndex(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ArrayAccessExpr r = new ArrayAccessExpr(
-				_n.getRange(),
-				name, index
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ArrayCreationExpr _n, Object _arg) {
-		Type<?> type_ = cloneNodes(_n.getType(), _arg);
-		List<ArrayCreationLevel> levels_ = visit(_n.getLevels(), _arg);
-		ArrayInitializerExpr initializer_ = cloneNodes(_n.getInitializer(), _arg);
-
-		ArrayCreationExpr r = new ArrayCreationExpr(_n.getRange(), type_, levels_, initializer_);
-
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        VoidType r = new VoidType(_n.getRange());
+        r.setAnnotations(annotations);
         r.setComment(comment);
-		return r;
-	}
+        return r;
+    }
 
-	@Override
-	public Node visit(ArrayInitializerExpr _n, Object _arg) {
-		List<Expression> values = visit(_n.getValues(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(WildcardType _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        ReferenceType ext = cloneNodes(_n.getExtends(), _arg);
+        ReferenceType sup = cloneNodes(_n.getSuper(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ArrayInitializerExpr r = new ArrayInitializerExpr(
-				_n.getRange(),
-				values
-		);
-		r.setComment(comment);
-		return r;
-	}
+        WildcardType r = new WildcardType(
+                _n.getRange(),
+                ext, sup
+        );
+        r.setComment(comment);
+        r.setAnnotations(annotations);
+        return r;
+    }
 
-	@Override
-	public Node visit(AssignExpr _n, Object _arg) {
-		Expression target = cloneNodes(_n.getTarget(), _arg);
-		Expression value = cloneNodes(_n.getValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(UnknownType _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		AssignExpr r = new AssignExpr(
-				_n.getRange(),
-				target, value, _n.getOperator());
-		r.setComment(comment);
-		return r;
-	}
+        UnknownType r = new UnknownType();
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(BinaryExpr _n, Object _arg) {
-		Expression left = cloneNodes(_n.getLeft(), _arg);
-		Expression right = cloneNodes(_n.getRight(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ArrayAccessExpr _n, Object _arg) {
+        Expression name = cloneNodes(_n.getName(), _arg);
+        Expression index = cloneNodes(_n.getIndex(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		BinaryExpr r = new BinaryExpr(
-				_n.getRange(),
-				left, right, _n.getOperator()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ArrayAccessExpr r = new ArrayAccessExpr(
+                _n.getRange(),
+                name, index
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(CastExpr _n, Object _arg) {
-		Type<?> type_ = cloneNodes(_n.getType(), _arg);
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ArrayCreationExpr _n, Object _arg) {
+        Type<?> type_ = cloneNodes(_n.getType(), _arg);
+        List<ArrayCreationLevel> levels_ = visit(_n.getLevels(), _arg);
+        ArrayInitializerExpr initializer_ = cloneNodes(_n.getInitializer(), _arg);
 
-		CastExpr r = new CastExpr(
-				_n.getRange(),
-				type_, expr
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ArrayCreationExpr r = new ArrayCreationExpr(_n.getRange(), type_, levels_, initializer_);
 
-	@Override
-	public Node visit(ClassExpr _n, Object _arg) {
-		Type<?> type_ = cloneNodes(_n.getType(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        r.setComment(comment);
+        return r;
+    }
 
-		ClassExpr r = new ClassExpr(
-				_n.getRange(),
-				type_
-		);
-		r.setComment(comment);
-		return r;
-	}
+    @Override
+    public Node visit(ArrayInitializerExpr _n, Object _arg) {
+        List<Expression> values = visit(_n.getValues(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-	@Override
-	public Node visit(ConditionalExpr _n, Object _arg) {
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Expression thenExpr = cloneNodes(_n.getThenExpr(), _arg);
-		Expression elseExpr = cloneNodes(_n.getElseExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        ArrayInitializerExpr r = new ArrayInitializerExpr(
+                _n.getRange(),
+                values
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-		ConditionalExpr r = new ConditionalExpr(
-				_n.getRange(),
-				condition, thenExpr, elseExpr
-		);
-		r.setComment(comment);
-		return r;
-	}
+    @Override
+    public Node visit(AssignExpr _n, Object _arg) {
+        Expression target = cloneNodes(_n.getTarget(), _arg);
+        Expression value = cloneNodes(_n.getValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-	@Override
-	public Node visit(EnclosedExpr _n, Object _arg) {
-		Expression inner = cloneNodes(_n.getInner(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        AssignExpr r = new AssignExpr(
+                _n.getRange(),
+                target, value, _n.getOperator());
+        r.setComment(comment);
+        return r;
+    }
 
-		EnclosedExpr r = new EnclosedExpr(
-				_n.getRange(),
-				inner
-		);
-		r.setComment(comment);
-		return r;
-	}
+    @Override
+    public Node visit(BinaryExpr _n, Object _arg) {
+        Expression left = cloneNodes(_n.getLeft(), _arg);
+        Expression right = cloneNodes(_n.getRight(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-	@Override
-	public Node visit(FieldAccessExpr _n, Object _arg) {
-		Expression scope_ = cloneNodes(_n.getScope(), _arg);
-		List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        BinaryExpr r = new BinaryExpr(
+                _n.getRange(),
+                left, right, _n.getOperator()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-		FieldAccessExpr r = new FieldAccessExpr(
-				_n.getRange(),
-				scope_, 
+    @Override
+    public Node visit(CastExpr _n, Object _arg) {
+        Type<?> type_ = cloneNodes(_n.getType(), _arg);
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        CastExpr r = new CastExpr(
+                _n.getRange(),
+                type_, expr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ClassExpr _n, Object _arg) {
+        Type<?> type_ = cloneNodes(_n.getType(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ClassExpr r = new ClassExpr(
+                _n.getRange(),
+                type_
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ConditionalExpr _n, Object _arg) {
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Expression thenExpr = cloneNodes(_n.getThenExpr(), _arg);
+        Expression elseExpr = cloneNodes(_n.getElseExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ConditionalExpr r = new ConditionalExpr(
+                _n.getRange(),
+                condition, thenExpr, elseExpr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(EnclosedExpr _n, Object _arg) {
+        Expression inner = cloneNodes(_n.getInner(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        EnclosedExpr r = new EnclosedExpr(
+                _n.getRange(),
+                inner
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(FieldAccessExpr _n, Object _arg) {
+        Expression scope_ = cloneNodes(_n.getScope(), _arg);
+        List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        FieldAccessExpr r = new FieldAccessExpr(
+                _n.getRange(),
+                scope_, 
                 typeArguments_, 
                 _n.getField()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(InstanceOfExpr _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Type<?> type_ = cloneNodes(_n.getType(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(InstanceOfExpr _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Type<?> type_ = cloneNodes(_n.getType(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		InstanceOfExpr r = new InstanceOfExpr(
-				_n.getRange(),
-				expr, type_
-		);
-		r.setComment(comment);
-		return r;
-	}
+        InstanceOfExpr r = new InstanceOfExpr(
+                _n.getRange(),
+                expr, type_
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(StringLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		StringLiteralExpr r = new StringLiteralExpr(
-				_n.getRange(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
+    @Override
+    public Node visit(StringLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        StringLiteralExpr r = new StringLiteralExpr(
+                _n.getRange(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(IntegerLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(IntegerLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		IntegerLiteralExpr r = new IntegerLiteralExpr(
-				_n.getRange(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        IntegerLiteralExpr r = new IntegerLiteralExpr(
+                _n.getRange(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(LongLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(LongLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		LongLiteralExpr r = new LongLiteralExpr(
-				_n.getRange(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        LongLiteralExpr r = new LongLiteralExpr(
+                _n.getRange(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(IntegerLiteralMinValueExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(IntegerLiteralMinValueExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		IntegerLiteralMinValueExpr r = new IntegerLiteralMinValueExpr(_n.getRange());
-		r.setComment(comment);
-		return r;
-	}
+        IntegerLiteralMinValueExpr r = new IntegerLiteralMinValueExpr(_n.getRange());
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(LongLiteralMinValueExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(LongLiteralMinValueExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		LongLiteralMinValueExpr r = new LongLiteralMinValueExpr(_n.getRange());
-		r.setComment(comment);
-		return r;
-	}
+        LongLiteralMinValueExpr r = new LongLiteralMinValueExpr(_n.getRange());
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(CharLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(CharLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		CharLiteralExpr r = new CharLiteralExpr(
-				_n.getRange(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        CharLiteralExpr r = new CharLiteralExpr(
+                _n.getRange(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(DoubleLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(DoubleLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		DoubleLiteralExpr r = new DoubleLiteralExpr(
-				_n.getRange(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        DoubleLiteralExpr r = new DoubleLiteralExpr(
+                _n.getRange(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(BooleanLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(BooleanLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		BooleanLiteralExpr r = new BooleanLiteralExpr(
-				_n.getRange(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        BooleanLiteralExpr r = new BooleanLiteralExpr(
+                _n.getRange(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(NullLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(NullLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		NullLiteralExpr r = new NullLiteralExpr(_n.getRange());
-		r.setComment(comment);
-		return r;
-	}
+        NullLiteralExpr r = new NullLiteralExpr(_n.getRange());
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(MethodCallExpr _n, Object _arg) {
-		Expression scope_ = cloneNodes(_n.getScope(), _arg);
-		List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
-		List<Expression> args_ = visit(_n.getArgs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(MethodCallExpr _n, Object _arg) {
+        Expression scope_ = cloneNodes(_n.getScope(), _arg);
+        List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
+        List<Expression> args_ = visit(_n.getArgs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		MethodCallExpr r = new MethodCallExpr(
-				_n.getRange(),
-				scope_, 
+        MethodCallExpr r = new MethodCallExpr(
+                _n.getRange(),
+                scope_, 
                 typeArguments_, 
                 _n.getName(), 
                 args_
-		);
-		r.setComment(comment);
-		return r;
-	}
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(NameExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(NameExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		NameExpr r = new NameExpr(
-				_n.getRange(),
-				_n.getName()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        NameExpr r = new NameExpr(
+                _n.getRange(),
+                _n.getName()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ObjectCreationExpr _n, Object _arg) {
-		Expression scope = cloneNodes(_n.getScope(), _arg);
-		ClassOrInterfaceType type_ = cloneNodes(_n.getType(), _arg);
-		List<Type<?>> typeArgs = visit(_n.getTypeArguments(), _arg);
-		List<Expression> args = visit(_n.getArgs(), _arg);
+    @Override
+    public Node visit(ObjectCreationExpr _n, Object _arg) {
+        Expression scope = cloneNodes(_n.getScope(), _arg);
+        ClassOrInterfaceType type_ = cloneNodes(_n.getType(), _arg);
+        List<Type<?>> typeArgs = visit(_n.getTypeArguments(), _arg);
+        List<Expression> args = visit(_n.getArgs(), _arg);
         List<BodyDeclaration<?>> anonymousBody = visit(_n.getAnonymousClassBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ObjectCreationExpr r = new ObjectCreationExpr(
-				_n.getRange(),
-				scope, type_, typeArgs, args, anonymousBody
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ObjectCreationExpr r = new ObjectCreationExpr(
+                _n.getRange(),
+                scope, type_, typeArgs, args, anonymousBody
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(QualifiedNameExpr _n, Object _arg) {
-		NameExpr scope = cloneNodes(_n.getQualifier(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(QualifiedNameExpr _n, Object _arg) {
+        NameExpr scope = cloneNodes(_n.getQualifier(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		QualifiedNameExpr r = new QualifiedNameExpr(
-				_n.getRange(),
-				scope, _n.getName()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        QualifiedNameExpr r = new QualifiedNameExpr(
+                _n.getRange(),
+                scope, _n.getName()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ThisExpr _n, Object _arg) {
-		Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ThisExpr _n, Object _arg) {
+        Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ThisExpr r = new ThisExpr(
-				_n.getRange(),
-				classExpr
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ThisExpr r = new ThisExpr(
+                _n.getRange(),
+                classExpr
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(SuperExpr _n, Object _arg) {
-		Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(SuperExpr _n, Object _arg) {
+        Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		SuperExpr r = new SuperExpr(
-				_n.getRange(),
-				classExpr
-		);
-		r.setComment(comment);
-		return r;
-	}
+        SuperExpr r = new SuperExpr(
+                _n.getRange(),
+                classExpr
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(UnaryExpr _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(UnaryExpr _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		UnaryExpr r = new UnaryExpr(
-				_n.getRange(),
-				expr, _n.getOperator()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        UnaryExpr r = new UnaryExpr(
+                _n.getRange(),
+                expr, _n.getOperator()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(VariableDeclarationExpr _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Type<?> type_ = cloneNodes(_n.getElementType(), _arg);
-		List<VariableDeclarator> vars = visit(_n.getVariables(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(VariableDeclarationExpr _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Type<?> type_ = cloneNodes(_n.getElementType(), _arg);
+        List<VariableDeclarator> vars = visit(_n.getVariables(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
         List<ArrayBracketPair> arrayBracketPairsAfterType_ = visit(_n.getArrayBracketPairsAfterElementType(), _arg);
 
-		VariableDeclarationExpr r = new VariableDeclarationExpr(
-				_n.getRange(),
-				_n.getModifiers(), 
+        VariableDeclarationExpr r = new VariableDeclarationExpr(
+                _n.getRange(),
+                _n.getModifiers(), 
                 annotations, 
                 type_, 
                 vars,
                 arrayBracketPairsAfterType_
-		);
-		r.setComment(comment);
-		return r;
-	}
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(MarkerAnnotationExpr _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(MarkerAnnotationExpr _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		MarkerAnnotationExpr r = new MarkerAnnotationExpr(
-				_n.getRange(),
-				name
-		);
-		r.setComment(comment);
-		return r;
-	}
+        MarkerAnnotationExpr r = new MarkerAnnotationExpr(
+                _n.getRange(),
+                name
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(SingleMemberAnnotationExpr _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Expression memberValue = cloneNodes(_n.getMemberValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(SingleMemberAnnotationExpr _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Expression memberValue = cloneNodes(_n.getMemberValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		SingleMemberAnnotationExpr r = new SingleMemberAnnotationExpr(
-				_n.getRange(),
-				name, memberValue
-		);
-		r.setComment(comment);
-		return r;
-	}
+        SingleMemberAnnotationExpr r = new SingleMemberAnnotationExpr(
+                _n.getRange(),
+                name, memberValue
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(NormalAnnotationExpr _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		List<MemberValuePair> pairs = visit(_n.getPairs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(NormalAnnotationExpr _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        List<MemberValuePair> pairs = visit(_n.getPairs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		NormalAnnotationExpr r = new NormalAnnotationExpr(
-				_n.getRange(),
-				name, pairs
-		);
-		r.setComment(comment);
-		return r;
-	}
+        NormalAnnotationExpr r = new NormalAnnotationExpr(
+                _n.getRange(),
+                name, pairs
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(MemberValuePair _n, Object _arg) {
-		Expression value = cloneNodes(_n.getValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(MemberValuePair _n, Object _arg) {
+        Expression value = cloneNodes(_n.getValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		MemberValuePair r = new MemberValuePair(
-				_n.getRange(),
-				_n.getName(), value
-		);
-		r.setComment(comment);
-		return r;
-	}
+        MemberValuePair r = new MemberValuePair(
+                _n.getRange(),
+                _n.getName(), value
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ExplicitConstructorInvocationStmt _n, Object _arg) {
-		List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
-		Expression expr_ = cloneNodes(_n.getExpr(), _arg);
-		List<Expression> args_ = visit(_n.getArgs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ExplicitConstructorInvocationStmt _n, Object _arg) {
+        List<Type<?>> typeArguments_ = visit(_n.getTypeArguments(), _arg);
+        Expression expr_ = cloneNodes(_n.getExpr(), _arg);
+        List<Expression> args_ = visit(_n.getArgs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ExplicitConstructorInvocationStmt r = new ExplicitConstructorInvocationStmt(
-				_n.getRange(),
-				typeArguments_, 
+        ExplicitConstructorInvocationStmt r = new ExplicitConstructorInvocationStmt(
+                _n.getRange(),
+                typeArguments_, 
                 _n.isThis(), 
                 expr_, 
                 args_
-		);
-		r.setComment(comment);
-		return r;
-	}
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(TypeDeclarationStmt _n, Object _arg) {
+    @Override
+    public Node visit(TypeDeclarationStmt _n, Object _arg) {
         TypeDeclaration<?> typeDecl = cloneNodes(_n.getTypeDeclaration(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		TypeDeclarationStmt r = new TypeDeclarationStmt(
-				_n.getRange(),
-				typeDecl
-		);
-		r.setComment(comment);
-		return r;
-	}
+        TypeDeclarationStmt r = new TypeDeclarationStmt(
+                _n.getRange(),
+                typeDecl
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(AssertStmt _n, Object _arg) {
-		Expression check = cloneNodes(_n.getCheck(), _arg);
-		Expression message = cloneNodes(_n.getMessage(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(AssertStmt _n, Object _arg) {
+        Expression check = cloneNodes(_n.getCheck(), _arg);
+        Expression message = cloneNodes(_n.getMessage(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		AssertStmt r = new AssertStmt(
-				_n.getRange(),
-				check, message
-		);
-		r.setComment(comment);
-		return r;
-	}
+        AssertStmt r = new AssertStmt(
+                _n.getRange(),
+                check, message
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(BlockStmt _n, Object _arg) {
-		List<Statement> stmts = visit(_n.getStmts(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(BlockStmt _n, Object _arg) {
+        List<Statement> stmts = visit(_n.getStmts(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		BlockStmt r = new BlockStmt(
-				_n.getRange(),
-				stmts
-		);
-		r.setComment(comment);
-		return r;
-	}
+        BlockStmt r = new BlockStmt(
+                _n.getRange(),
+                stmts
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(LabeledStmt _n, Object _arg) {
-		Statement stmt = cloneNodes(_n.getStmt(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(LabeledStmt _n, Object _arg) {
+        Statement stmt = cloneNodes(_n.getStmt(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		LabeledStmt r = new LabeledStmt(
-				_n.getRange(),
-				_n.getLabel(), stmt
-		);
-		r.setComment(comment);
-		return r;
-	}
+        LabeledStmt r = new LabeledStmt(
+                _n.getRange(),
+                _n.getLabel(), stmt
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EmptyStmt _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(EmptyStmt _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EmptyStmt r = new EmptyStmt(_n.getRange());
-		r.setComment(comment);
-		return r;
-	}
+        EmptyStmt r = new EmptyStmt(_n.getRange());
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ExpressionStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpression(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ExpressionStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpression(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ExpressionStmt r = new ExpressionStmt(
-				_n.getRange(),
-				expr
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ExpressionStmt r = new ExpressionStmt(
+                _n.getRange(),
+                expr
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(SwitchStmt _n, Object _arg) {
-		Expression selector = cloneNodes(_n.getSelector(), _arg);
-		List<SwitchEntryStmt> entries = visit(_n.getEntries(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(SwitchStmt _n, Object _arg) {
+        Expression selector = cloneNodes(_n.getSelector(), _arg);
+        List<SwitchEntryStmt> entries = visit(_n.getEntries(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		SwitchStmt r = new SwitchStmt(
-				_n.getRange(),
-				selector, entries
-		);
-		r.setComment(comment);
-		return r;
-	}
+        SwitchStmt r = new SwitchStmt(
+                _n.getRange(),
+                selector, entries
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(SwitchEntryStmt _n, Object _arg) {
-		Expression label = cloneNodes(_n.getLabel(), _arg);
-		List<Statement> stmts = visit(_n.getStmts(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(SwitchEntryStmt _n, Object _arg) {
+        Expression label = cloneNodes(_n.getLabel(), _arg);
+        List<Statement> stmts = visit(_n.getStmts(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		SwitchEntryStmt r = new SwitchEntryStmt(
-				_n.getRange(),
-				label, stmts
-		);
-		r.setComment(comment);
-		return r;
-	}
+        SwitchEntryStmt r = new SwitchEntryStmt(
+                _n.getRange(),
+                label, stmts
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(BreakStmt _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(BreakStmt _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		BreakStmt r = new BreakStmt(
-				_n.getRange(),
-				_n.getId()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        BreakStmt r = new BreakStmt(
+                _n.getRange(),
+                _n.getId()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ReturnStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ReturnStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ReturnStmt r = new ReturnStmt(
-				_n.getRange(),
-				expr
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ReturnStmt r = new ReturnStmt(
+                _n.getRange(),
+                expr
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(IfStmt _n, Object _arg) {
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Statement thenStmt = cloneNodes(_n.getThenStmt(), _arg);
-		Statement elseStmt = cloneNodes(_n.getElseStmt(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(IfStmt _n, Object _arg) {
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Statement thenStmt = cloneNodes(_n.getThenStmt(), _arg);
+        Statement elseStmt = cloneNodes(_n.getElseStmt(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		IfStmt r = new IfStmt(
-				_n.getRange(),
-				condition, thenStmt, elseStmt
-		);
-		r.setComment(comment);
-		return r;
-	}
+        IfStmt r = new IfStmt(
+                _n.getRange(),
+                condition, thenStmt, elseStmt
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(WhileStmt _n, Object _arg) {
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(WhileStmt _n, Object _arg) {
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		WhileStmt r = new WhileStmt(
-				_n.getRange(),
-				condition, body
-		);
-		r.setComment(comment);
-		return r;
-	}
+        WhileStmt r = new WhileStmt(
+                _n.getRange(),
+                condition, body
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ContinueStmt _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ContinueStmt _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ContinueStmt r = new ContinueStmt(
-				_n.getRange(),
-				_n.getId()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ContinueStmt r = new ContinueStmt(
+                _n.getRange(),
+                _n.getId()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(DoStmt _n, Object _arg) {
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(DoStmt _n, Object _arg) {
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		DoStmt r = new DoStmt(
-				_n.getRange(),
-				body, condition
-		);
-		r.setComment(comment);
-		return r;
-	}
+        DoStmt r = new DoStmt(
+                _n.getRange(),
+                body, condition
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ForeachStmt _n, Object _arg) {
-		VariableDeclarationExpr var = cloneNodes(_n.getVariable(), _arg);
-		Expression iterable = cloneNodes(_n.getIterable(), _arg);
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ForeachStmt _n, Object _arg) {
+        VariableDeclarationExpr var = cloneNodes(_n.getVariable(), _arg);
+        Expression iterable = cloneNodes(_n.getIterable(), _arg);
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ForeachStmt r = new ForeachStmt(
-				_n.getRange(),
-				var, iterable, body
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ForeachStmt r = new ForeachStmt(
+                _n.getRange(),
+                var, iterable, body
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ForStmt _n, Object _arg) {
-		List<Expression> init = visit(_n.getInit(), _arg);
-		Expression compare = cloneNodes(_n.getCompare(), _arg);
-		List<Expression> update = visit(_n.getUpdate(), _arg);
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ForStmt _n, Object _arg) {
+        List<Expression> init = visit(_n.getInit(), _arg);
+        Expression compare = cloneNodes(_n.getCompare(), _arg);
+        List<Expression> update = visit(_n.getUpdate(), _arg);
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ForStmt r = new ForStmt(
-				_n.getRange(),
-				init, compare, update, body
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ForStmt r = new ForStmt(
+                _n.getRange(),
+                init, compare, update, body
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ThrowStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ThrowStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ThrowStmt r = new ThrowStmt(
-				_n.getRange(),
-				expr
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ThrowStmt r = new ThrowStmt(
+                _n.getRange(),
+                expr
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(SynchronizedStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		BlockStmt block = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(SynchronizedStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        BlockStmt block = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		SynchronizedStmt r = new SynchronizedStmt(
-				_n.getRange(),
-				expr, block
-		);
-		r.setComment(comment);
-		return r;
-	}
+        SynchronizedStmt r = new SynchronizedStmt(
+                _n.getRange(),
+                expr, block
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(TryStmt _n, Object _arg) {
-		List<VariableDeclarationExpr> resources = visit(_n.getResources(),_arg);
-		BlockStmt tryBlock = cloneNodes(_n.getTryBlock(), _arg);
-		List<CatchClause> catchs = visit(_n.getCatchs(), _arg);
-		BlockStmt finallyBlock = cloneNodes(_n.getFinallyBlock(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(TryStmt _n, Object _arg) {
+        List<VariableDeclarationExpr> resources = visit(_n.getResources(),_arg);
+        BlockStmt tryBlock = cloneNodes(_n.getTryBlock(), _arg);
+        List<CatchClause> catchs = visit(_n.getCatchs(), _arg);
+        BlockStmt finallyBlock = cloneNodes(_n.getFinallyBlock(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		TryStmt r = new TryStmt(
-				_n.getRange(),
-				resources, tryBlock, catchs, finallyBlock
-		);
-		r.setComment(comment);
-		return r;
-	}
+        TryStmt r = new TryStmt(
+                _n.getRange(),
+                resources, tryBlock, catchs, finallyBlock
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(CatchClause _n, Object _arg) {
-		Parameter param = cloneNodes(_n.getParam(), _arg);
-		BlockStmt catchBlock = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(CatchClause _n, Object _arg) {
+        Parameter param = cloneNodes(_n.getParam(), _arg);
+        BlockStmt catchBlock = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		CatchClause r = new CatchClause(
-				_n.getRange(),
-				param.getModifiers(), param.getAnnotations(), param.getElementType(), param.getId(), catchBlock
-		);
-		r.setComment(comment);
-		return r;
-	}
+        CatchClause r = new CatchClause(
+                _n.getRange(),
+                param.getModifiers(), param.getAnnotations(), param.getElementType(), param.getId(), catchBlock
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(LambdaExpr _n, Object _arg) {
+    @Override
+    public Node visit(LambdaExpr _n, Object _arg) {
 
-		List<Parameter> lambdaParameters = visit(_n.getParameters(), _arg);
+        List<Parameter> lambdaParameters = visit(_n.getParameters(), _arg);
 
-		Statement body = cloneNodes(_n.getBody(), _arg);
+        Statement body = cloneNodes(_n.getBody(), _arg);
 
-		return new LambdaExpr(_n.getRange(), lambdaParameters, body,
-				_n.isParametersEnclosed());
-	}
+        return new LambdaExpr(_n.getRange(), lambdaParameters, body,
+                _n.isParametersEnclosed());
+    }
 
-	@Override
-	public Node visit(MethodReferenceExpr _n, Object arg) {
+    @Override
+    public Node visit(MethodReferenceExpr _n, Object arg) {
 
-		Expression scope = cloneNodes(_n.getScope(), arg);
+        Expression scope = cloneNodes(_n.getScope(), arg);
 
-		return new MethodReferenceExpr(_n.getRange(), scope,
-				_n.getTypeArguments(), _n.getIdentifier());
-	}
+        return new MethodReferenceExpr(_n.getRange(), scope,
+                _n.getTypeArguments(), _n.getIdentifier());
+    }
 
-	@Override
-	public Node visit(TypeExpr n, Object arg) {
+    @Override
+    public Node visit(TypeExpr n, Object arg) {
 
-		Type<?> t = cloneNodes(n.getType(), arg);
+        Type<?> t = cloneNodes(n.getType(), arg);
 
-		return new TypeExpr(n.getRange(), t);
-	}
+        return new TypeExpr(n.getRange(), t);
+    }
 
-	@Override
-	public Node visit(ArrayBracketPair _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+    @Override
+    public Node visit(ArrayBracketPair _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
 
-		return new ArrayBracketPair(_n.getRange(), annotations);
-	}
+        return new ArrayBracketPair(_n.getRange(), annotations);
+    }
 
-	public <T extends Node> List<T> visit(List<T> _nodes, Object _arg) {
+    public <T extends Node> List<T> visit(List<T> _nodes, Object _arg) {
         if (_nodes == null)
             return null;
         List<T> r = new ArrayList<>(_nodes.size());

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -49,381 +49,381 @@ import static com.github.javaparser.utils.Utils.isNullOrEmpty;
  */
 public class DumpVisitor implements VoidVisitor<Object> {
 
-	private boolean printComments;
+    private boolean printComments;
 
-	public DumpVisitor() {
-		this(true);
-	}
+    public DumpVisitor() {
+        this(true);
+    }
 
-	public DumpVisitor(boolean printComments) {
-		this.printComments = printComments;
-	}
+    public DumpVisitor(boolean printComments) {
+        this.printComments = printComments;
+    }
 
-	public static class SourcePrinter {
+    public static class SourcePrinter {
 
-		private final String indentation;
+        private final String indentation;
 
-		public SourcePrinter(final String indentation) {
-			this.indentation = indentation;
-		}
+        public SourcePrinter(final String indentation) {
+            this.indentation = indentation;
+        }
 
-		private int level = 0;
+        private int level = 0;
 
-		private boolean indented = false;
+        private boolean indented = false;
 
-		private final StringBuilder buf = new StringBuilder();
+        private final StringBuilder buf = new StringBuilder();
 
-		public void indent() {
-			level++;
-		}
+        public void indent() {
+            level++;
+        }
 
-		public void unindent() {
-			level--;
-		}
+        public void unindent() {
+            level--;
+        }
 
-		private void makeIndent() {
-			for (int i = 0; i < level; i++) {
-				buf.append(indentation);
-			}
-		}
+        private void makeIndent() {
+            for (int i = 0; i < level; i++) {
+                buf.append(indentation);
+            }
+        }
 
-		public void print(final String arg) {
-			if (!indented) {
-				makeIndent();
-				indented = true;
-			}
-			buf.append(arg);
-		}
+        public void print(final String arg) {
+            if (!indented) {
+                makeIndent();
+                indented = true;
+            }
+            buf.append(arg);
+        }
 
-		public void printLn(final String arg) {
-			print(arg);
-			printLn();
-		}
+        public void printLn(final String arg) {
+            print(arg);
+            printLn();
+        }
 
-		public void printLn() {
-			buf.append(EOL);
-			indented = false;
-		}
+        public void printLn() {
+            buf.append(EOL);
+            indented = false;
+        }
 
-		public String getSource() {
-			return buf.toString();
-		}
+        public String getSource() {
+            return buf.toString();
+        }
 
-		@Override
-		public String toString() {
-			return getSource();
-		}
-	}
+        @Override
+        public String toString() {
+            return getSource();
+        }
+    }
 
-	private final SourcePrinter printer = createSourcePrinter();
+    private final SourcePrinter printer = createSourcePrinter();
 
-	protected SourcePrinter createSourcePrinter() {
-		return new SourcePrinter("    ");
-	}
+    protected SourcePrinter createSourcePrinter() {
+        return new SourcePrinter("    ");
+    }
 
-	public String getSource() {
-		return printer.getSource();
-	}
+    public String getSource() {
+        return printer.getSource();
+    }
 
-	private void printModifiers(final EnumSet<Modifier> modifiers) {
-		if (modifiers.size() > 0)
-			printer.print(modifiers.stream().map(Modifier::getLib).collect(Collectors.joining(" ")) + " ");
-	}
+    private void printModifiers(final EnumSet<Modifier> modifiers) {
+        if (modifiers.size() > 0)
+            printer.print(modifiers.stream().map(Modifier::getLib).collect(Collectors.joining(" ")) + " ");
+    }
 
-	private void printMembers(final List<BodyDeclaration<?>> members, final Object arg) {
-		for (final BodyDeclaration<?> member : members) {
-			printer.printLn();
-			member.accept(this, arg);
-			printer.printLn();
-		}
-	}
+    private void printMembers(final List<BodyDeclaration<?>> members, final Object arg) {
+        for (final BodyDeclaration<?> member : members) {
+            printer.printLn();
+            member.accept(this, arg);
+            printer.printLn();
+        }
+    }
 
-	private void printMemberAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
-		if (!isNullOrEmpty(annotations)) {
-			for (final AnnotationExpr a : annotations) {
-				a.accept(this, arg);
-				printer.printLn();
-			}
-		}
-	}
+    private void printMemberAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
+        if (!isNullOrEmpty(annotations)) {
+            for (final AnnotationExpr a : annotations) {
+                a.accept(this, arg);
+                printer.printLn();
+            }
+        }
+    }
 
-	private void printAnnotations(final List<AnnotationExpr> annotations, boolean prefixWithASpace, final Object arg) {
-		if (!isNullOrEmpty(annotations)) {
-			if(prefixWithASpace){
-				printer.print(" ");
-			}
-			for (AnnotationExpr annotation : annotations) {
-				annotation.accept(this, arg);
-				printer.print(" ");
-			}
-		}
-	}
+    private void printAnnotations(final List<AnnotationExpr> annotations, boolean prefixWithASpace, final Object arg) {
+        if (!isNullOrEmpty(annotations)) {
+            if(prefixWithASpace){
+                printer.print(" ");
+            }
+            for (AnnotationExpr annotation : annotations) {
+                annotation.accept(this, arg);
+                printer.print(" ");
+            }
+        }
+    }
 
-	private void printTypeArgs(final NodeWithTypeArguments<?> nodeWithTypeArguments, final Object arg) {
-		List<Type<?>> typeArguments = nodeWithTypeArguments.getTypeArguments();
-		if (!isNullOrEmpty(typeArguments)) {
-			printer.print("<");
-			for (final Iterator<Type<?>> i = typeArguments.iterator(); i.hasNext(); ) {
-				final Type<?> t = i.next();
-				t.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-			printer.print(">");
-		}
-	}
+    private void printTypeArgs(final NodeWithTypeArguments<?> nodeWithTypeArguments, final Object arg) {
+        List<Type<?>> typeArguments = nodeWithTypeArguments.getTypeArguments();
+        if (!isNullOrEmpty(typeArguments)) {
+            printer.print("<");
+            for (final Iterator<Type<?>> i = typeArguments.iterator(); i.hasNext(); ) {
+                final Type<?> t = i.next();
+                t.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+            printer.print(">");
+        }
+    }
 
-	private void printTypeParameters(final List<TypeParameter> args, final Object arg) {
-		if (!isNullOrEmpty(args)) {
-			printer.print("<");
-			for (final Iterator<TypeParameter> i = args.iterator(); i.hasNext(); ) {
-				final TypeParameter t = i.next();
-				t.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-			printer.print(">");
-		}
-	}
+    private void printTypeParameters(final List<TypeParameter> args, final Object arg) {
+        if (!isNullOrEmpty(args)) {
+            printer.print("<");
+            for (final Iterator<TypeParameter> i = args.iterator(); i.hasNext(); ) {
+                final TypeParameter t = i.next();
+                t.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+            printer.print(">");
+        }
+    }
 
-	private void printArguments(final List<Expression> args, final Object arg) {
-		printer.print("(");
-		if (!isNullOrEmpty(args)) {
-			for (final Iterator<Expression> i = args.iterator(); i.hasNext(); ) {
-				final Expression e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
-	}
+    private void printArguments(final List<Expression> args, final Object arg) {
+        printer.print("(");
+        if (!isNullOrEmpty(args)) {
+            for (final Iterator<Expression> i = args.iterator(); i.hasNext(); ) {
+                final Expression e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
+    }
 
-	private void printJavaComment(final Comment javacomment, final Object arg) {
-		if (javacomment != null) {
-			javacomment.accept(this, arg);
-		}
-	}
+    private void printJavaComment(final Comment javacomment, final Object arg) {
+        if (javacomment != null) {
+            javacomment.accept(this, arg);
+        }
+    }
 
-	@Override
-	public void visit(final CompilationUnit n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
+    @Override
+    public void visit(final CompilationUnit n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
 
-		if (n.getPackage() != null) {
-			n.getPackage().accept(this, arg);
-		}
+        if (n.getPackage() != null) {
+            n.getPackage().accept(this, arg);
+        }
 
-		if (!isNullOrEmpty(n.getImports())) {
-			for (final ImportDeclaration i : n.getImports()) {
-				i.accept(this, arg);
-			}
-			printer.printLn();
-		}
+        if (!isNullOrEmpty(n.getImports())) {
+            for (final ImportDeclaration i : n.getImports()) {
+                i.accept(this, arg);
+            }
+            printer.printLn();
+        }
 
-		if (!isNullOrEmpty(n.getTypes())) {
-			for (final Iterator<TypeDeclaration<?>> i = n.getTypes().iterator(); i.hasNext(); ) {
-				i.next().accept(this, arg);
-				printer.printLn();
-				if (i.hasNext()) {
-					printer.printLn();
-				}
-			}
-		}
+        if (!isNullOrEmpty(n.getTypes())) {
+            for (final Iterator<TypeDeclaration<?>> i = n.getTypes().iterator(); i.hasNext(); ) {
+                i.next().accept(this, arg);
+                printer.printLn();
+                if (i.hasNext()) {
+                    printer.printLn();
+                }
+            }
+        }
 
-		printOrphanCommentsEnding(n);
-	}
+        printOrphanCommentsEnding(n);
+    }
 
-	@Override
-	public void visit(final PackageDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), false, arg);
-		printer.print("package ");
-		n.getName().accept(this, arg);
-		printer.printLn(";");
-		printer.printLn();
+    @Override
+    public void visit(final PackageDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), false, arg);
+        printer.print("package ");
+        n.getName().accept(this, arg);
+        printer.printLn(";");
+        printer.printLn();
 
-		printOrphanCommentsEnding(n);
-	}
+        printOrphanCommentsEnding(n);
+    }
 
-	@Override
-	public void visit(final NameExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getName());
+    @Override
+    public void visit(final NameExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getName());
 
-		printOrphanCommentsEnding(n);
-	}
+        printOrphanCommentsEnding(n);
+    }
 
-	@Override
-	public void visit(final QualifiedNameExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getQualifier().accept(this, arg);
-		printer.print(".");
-		printer.print(n.getName());
+    @Override
+    public void visit(final QualifiedNameExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getQualifier().accept(this, arg);
+        printer.print(".");
+        printer.print(n.getName());
 
-		printOrphanCommentsEnding(n);
-	}
+        printOrphanCommentsEnding(n);
+    }
 
-	@Override
-	public void visit(final ImportDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (!n.isEmptyImportDeclaration()) {
-			printer.print("import ");
-			if (n.isStatic()) {
-				printer.print("static ");
-			}
-			n.getName().accept(this, arg);
-			if (n.isAsterisk()) {
-				printer.print(".*");
-			}
-		}
-		printer.printLn(";");
+    @Override
+    public void visit(final ImportDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (!n.isEmptyImportDeclaration()) {
+            printer.print("import ");
+            if (n.isStatic()) {
+                printer.print("static ");
+            }
+            n.getName().accept(this, arg);
+            if (n.isAsterisk()) {
+                printer.print(".*");
+            }
+        }
+        printer.printLn(";");
 
-		printOrphanCommentsEnding(n);
-	}
+        printOrphanCommentsEnding(n);
+    }
 
-	@Override
-	public void visit(final ClassOrInterfaceDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
+    @Override
+    public void visit(final ClassOrInterfaceDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
 
-		if (n.isInterface()) {
-			printer.print("interface ");
-		} else {
-			printer.print("class ");
-		}
+        if (n.isInterface()) {
+            printer.print("interface ");
+        } else {
+            printer.print("class ");
+        }
 
-		printer.print(n.getName());
+        printer.print(n.getName());
 
-		printTypeParameters(n.getTypeParameters(), arg);
+        printTypeParameters(n.getTypeParameters(), arg);
 
-		if (!isNullOrEmpty(n.getExtends())) {
-			printer.print(" extends ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getExtends().iterator(); i.hasNext(); ) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
+        if (!isNullOrEmpty(n.getExtends())) {
+            printer.print(" extends ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getExtends().iterator(); i.hasNext(); ) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
 
-		if (!isNullOrEmpty(n.getImplements())) {
-			printer.print(" implements ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext(); ) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
+        if (!isNullOrEmpty(n.getImplements())) {
+            printer.print(" implements ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext(); ) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
 
-		printer.printLn(" {");
-		printer.indent();
-		if (!isNullOrEmpty(n.getMembers())) {
-			printMembers(n.getMembers(), arg);
-		}
+        printer.printLn(" {");
+        printer.indent();
+        if (!isNullOrEmpty(n.getMembers())) {
+            printMembers(n.getMembers(), arg);
+        }
 
-		printOrphanCommentsEnding(n);
+        printOrphanCommentsEnding(n);
 
-		printer.unindent();
-		printer.print("}");
-	}
+        printer.unindent();
+        printer.print("}");
+    }
 
-	@Override
-	public void visit(final EmptyTypeDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(";");
+    @Override
+    public void visit(final EmptyTypeDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(";");
 
-		printOrphanCommentsEnding(n);
-	}
+        printOrphanCommentsEnding(n);
+    }
 
-	@Override
-	public void visit(final JavadocComment n, final Object arg) {
-		printer.print("/**");
-		printer.print(n.getContent());
-		printer.printLn("*/");
-	}
+    @Override
+    public void visit(final JavadocComment n, final Object arg) {
+        printer.print("/**");
+        printer.print(n.getContent());
+        printer.printLn("*/");
+    }
 
-	@Override
-	public void visit(final ClassOrInterfaceType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
+    @Override
+    public void visit(final ClassOrInterfaceType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
 
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-			printer.print(".");
-		}
-		for (AnnotationExpr ae : n.getAnnotations()) {
-			ae.accept(this, arg);
-			printer.print(" ");
-		}
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+            printer.print(".");
+        }
+        for (AnnotationExpr ae : n.getAnnotations()) {
+            ae.accept(this, arg);
+            printer.print(" ");
+        }
 
-		printer.print(n.getName());
+        printer.print(n.getName());
 
-		if (n.isUsingDiamondOperator()) {
-			printer.print("<>");
-		} else {
-			printTypeArgs(n, arg);
-		}
-	}
+        if (n.isUsingDiamondOperator()) {
+            printer.print("<>");
+        } else {
+            printTypeArgs(n, arg);
+        }
+    }
 
-	@Override
-	public void visit(final TypeParameter n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		for (AnnotationExpr ann : n.getAnnotations()) {
-			ann.accept(this, arg);
-			printer.print(" ");
-		}
-		printer.print(n.getName());
-		if (!isNullOrEmpty(n.getTypeBound())) {
-			printer.print(" extends ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getTypeBound().iterator(); i.hasNext(); ) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(" & ");
-				}
-			}
-		}
-	}
+    @Override
+    public void visit(final TypeParameter n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        for (AnnotationExpr ann : n.getAnnotations()) {
+            ann.accept(this, arg);
+            printer.print(" ");
+        }
+        printer.print(n.getName());
+        if (!isNullOrEmpty(n.getTypeBound())) {
+            printer.print(" extends ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getTypeBound().iterator(); i.hasNext(); ) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(" & ");
+                }
+            }
+        }
+    }
 
-	@Override
-	public void visit(final PrimitiveType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), true, arg);
-		switch (n.getType()) {
-			case Boolean:
-				printer.print("boolean");
-				break;
-			case Byte:
-				printer.print("byte");
-				break;
-			case Char:
-				printer.print("char");
-				break;
-			case Double:
-				printer.print("double");
-				break;
-			case Float:
-				printer.print("float");
-				break;
-			case Int:
-				printer.print("int");
-				break;
-			case Long:
-				printer.print("long");
-				break;
-			case Short:
-				printer.print("short");
-				break;
-		}
-	}
+    @Override
+    public void visit(final PrimitiveType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), true, arg);
+        switch (n.getType()) {
+            case Boolean:
+                printer.print("boolean");
+                break;
+            case Byte:
+                printer.print("byte");
+                break;
+            case Char:
+                printer.print("char");
+                break;
+            case Double:
+                printer.print("double");
+                break;
+            case Float:
+                printer.print("float");
+                break;
+            case Int:
+                printer.print("int");
+                break;
+            case Long:
+                printer.print("long");
+                break;
+            case Short:
+                printer.print("short");
+                break;
+        }
+    }
 
-	@Override
+    @Override
     public void visit(final ArrayType n, final Object arg) {
         final List<ArrayType> arrayTypeBuffer = new LinkedList<>();
         Type type = n;
@@ -440,34 +440,34 @@ public class DumpVisitor implements VoidVisitor<Object> {
         }
     }
 
-	@Override
-	public void visit(final ArrayCreationLevel n, final Object arg) {
-		printAnnotations(n.getAnnotations(), true, arg);
-		printer.print("[");
-		if (n.getDimension() != null) {
-			n.getDimension().accept(this, arg);
-		}
-		printer.print("]");
-	}
+    @Override
+    public void visit(final ArrayCreationLevel n, final Object arg) {
+        printAnnotations(n.getAnnotations(), true, arg);
+        printer.print("[");
+        if (n.getDimension() != null) {
+            n.getDimension().accept(this, arg);
+        }
+        printer.print("]");
+    }
 
-	@Override
-	public void visit(final IntersectionType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), false, arg);
-		boolean isFirst = true;
-		for (ReferenceType element : n.getElements()) {
-			element.accept(this, arg);
-			if (isFirst) {
-				isFirst = false;
-			} else {
-				printer.print(" & ");
-			}
-		}
-	}
+    @Override
+    public void visit(final IntersectionType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), false, arg);
+        boolean isFirst = true;
+        for (ReferenceType element : n.getElements()) {
+            element.accept(this, arg);
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                printer.print(" & ");
+            }
+        }
+    }
 
     @Override public void visit(final UnionType n, final Object arg) {
         printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), true, arg);
+        printAnnotations(n.getAnnotations(), true, arg);
         boolean isFirst = true;
         for (ReferenceType element : n.getElements()) {
             if (isFirst) {
@@ -475,1170 +475,1170 @@ public class DumpVisitor implements VoidVisitor<Object> {
             } else {
                 printer.print(" | ");
             }
-	        element.accept(this, arg);
+            element.accept(this, arg);
         }
     }
 
 
-	@Override
-	public void visit(final WildcardType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), false, arg);
-		printer.print("?");
-		if (n.getExtends() != null) {
-			printer.print(" extends ");
-			n.getExtends().accept(this, arg);
-		}
-		if (n.getSuper() != null) {
-			printer.print(" super ");
-			n.getSuper().accept(this, arg);
-		}
-	}
-
-	@Override
-	public void visit(final UnknownType n, final Object arg) {
-		// Nothing to dump
-	}
-
-	@Override
-	public void visit(final FieldDeclaration n, final Object arg) {
-		printOrphanCommentsBeforeThisChildNode(n);
-
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-		n.getElementType().accept(this, arg);
-		for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
-			pair.accept(this, arg);
-		}
-
-		printer.print(" ");
-		for (final Iterator<VariableDeclarator> i = n.getVariables().iterator(); i.hasNext(); ) {
-			final VariableDeclarator var = i.next();
-			var.accept(this, arg);
-			if (i.hasNext()) {
-				printer.print(", ");
-			}
-		}
-
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final VariableDeclarator n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getId().accept(this, arg);
-		if (n.getInit() != null) {
-			printer.print(" = ");
-			n.getInit().accept(this, arg);
-		}
-	}
-
-	@Override
-	public void visit(final VariableDeclaratorId n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getName());
-		for(ArrayBracketPair pair: n.getArrayBracketPairsAfterId()){
-			pair.accept(this, arg);
-		}
-	}
-
-	@Override
-	public void visit(final ArrayInitializerExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("{");
-		if (!isNullOrEmpty(n.getValues())) {
-			printer.print(" ");
-			for (final Iterator<Expression> i = n.getValues().iterator(); i.hasNext(); ) {
-				final Expression expr = i.next();
-				expr.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-			printer.print(" ");
-		}
-		printer.print("}");
-	}
-
-	@Override
-	public void visit(final VoidType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), false, arg);
-		printer.print("void");
-	}
-
-	@Override
-	public void visit(final ArrayAccessExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		printer.print("[");
-		n.getIndex().accept(this, arg);
-		printer.print("]");
-	}
-
-	@Override
-	public void visit(final ArrayCreationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("new ");
-		n.getType().accept(this, arg);
-		for (ArrayCreationLevel level : n.getLevels()) {
-			level.accept(this, arg);
-		}
-		if (n.getInitializer() != null) {
-			printer.print(" ");
-			n.getInitializer().accept(this, arg);
-		}
-	}
-
-	@Override
-	public void visit(final AssignExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getTarget().accept(this, arg);
-		printer.print(" ");
-		switch (n.getOperator()) {
-			case assign:
-				printer.print("=");
-				break;
-			case and:
-				printer.print("&=");
-				break;
-			case or:
-				printer.print("|=");
-				break;
-			case xor:
-				printer.print("^=");
-				break;
-			case plus:
-				printer.print("+=");
-				break;
-			case minus:
-				printer.print("-=");
-				break;
-			case rem:
-				printer.print("%=");
-				break;
-			case slash:
-				printer.print("/=");
-				break;
-			case star:
-				printer.print("*=");
-				break;
-			case lShift:
-				printer.print("<<=");
-				break;
-			case rSignedShift:
-				printer.print(">>=");
-				break;
-			case rUnsignedShift:
-				printer.print(">>>=");
-				break;
-		}
-		printer.print(" ");
-		n.getValue().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final BinaryExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getLeft().accept(this, arg);
-		printer.print(" ");
-		switch (n.getOperator()) {
-			case or:
-				printer.print("||");
-				break;
-			case and:
-				printer.print("&&");
-				break;
-			case binOr:
-				printer.print("|");
-				break;
-			case binAnd:
-				printer.print("&");
-				break;
-			case xor:
-				printer.print("^");
-				break;
-			case equals:
-				printer.print("==");
-				break;
-			case notEquals:
-				printer.print("!=");
-				break;
-			case less:
-				printer.print("<");
-				break;
-			case greater:
-				printer.print(">");
-				break;
-			case lessEquals:
-				printer.print("<=");
-				break;
-			case greaterEquals:
-				printer.print(">=");
-				break;
-			case lShift:
-				printer.print("<<");
-				break;
-			case rSignedShift:
-				printer.print(">>");
-				break;
-			case rUnsignedShift:
-				printer.print(">>>");
-				break;
-			case plus:
-				printer.print("+");
-				break;
-			case minus:
-				printer.print("-");
-				break;
-			case times:
-				printer.print("*");
-				break;
-			case divide:
-				printer.print("/");
-				break;
-			case remainder:
-				printer.print("%");
-				break;
-		}
-		printer.print(" ");
-		n.getRight().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final CastExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("(");
-		n.getType().accept(this, arg);
-		printer.print(") ");
-		n.getExpr().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final ClassExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-		printer.print(".class");
-	}
-
-	@Override
-	public void visit(final ConditionalExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		printer.print(" ? ");
-		n.getThenExpr().accept(this, arg);
-		printer.print(" : ");
-		n.getElseExpr().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final EnclosedExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("(");
-		if (n.getInner() != null) {
-			n.getInner().accept(this, arg);
-		}
-		printer.print(")");
-	}
-
-	@Override
-	public void visit(final FieldAccessExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getScope().accept(this, arg);
-		printer.print(".");
-		printer.print(n.getField());
-	}
-
-	@Override
-	public void visit(final InstanceOfExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-		printer.print(" instanceof ");
-		n.getType().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final CharLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("'");
-		printer.print(n.getValue());
-		printer.print("'");
-	}
-
-	@Override
-	public void visit(final DoubleLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
-
-	@Override
-	public void visit(final IntegerLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
-
-	@Override
-	public void visit(final LongLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
-
-	@Override
-	public void visit(final IntegerLiteralMinValueExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
-
-	@Override
-	public void visit(final LongLiteralMinValueExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
-
-	@Override
-	public void visit(final StringLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("\"");
-		printer.print(n.getValue());
-		printer.print("\"");
-	}
-
-	@Override
-	public void visit(final BooleanLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(String.valueOf(n.getValue()));
-	}
-
-	@Override
-	public void visit(final NullLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("null");
-	}
-
-	@Override
-	public void visit(final ThisExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-			printer.print(".");
-		}
-		printer.print("this");
-	}
-
-	@Override
-	public void visit(final SuperExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-			printer.print(".");
-		}
-		printer.print("super");
-	}
-
-	@Override
-	public void visit(final MethodCallExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-			printer.print(".");
-		}
-		printTypeArgs(n, arg);
-		printer.print(n.getName());
-		printArguments(n.getArgs(), arg);
-	}
-
-	@Override
-	public void visit(final ObjectCreationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-			printer.print(".");
-		}
-
-		printer.print("new ");
-
-		printTypeArgs(n, arg);
-		if (!isNullOrEmpty(n.getTypeArguments())) {
-			printer.print(" ");
-		}
-
-		n.getType().accept(this, arg);
-
-		printArguments(n.getArgs(), arg);
-
-		if (n.getAnonymousClassBody() != null) {
-			printer.printLn(" {");
-			printer.indent();
-			printMembers(n.getAnonymousClassBody(), arg);
-			printer.unindent();
-			printer.print("}");
-		}
-	}
-
-	@Override
-	public void visit(final UnaryExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		switch (n.getOperator()) {
-			case positive:
-				printer.print("+");
-				break;
-			case negative:
-				printer.print("-");
-				break;
-			case inverse:
-				printer.print("~");
-				break;
-			case not:
-				printer.print("!");
-				break;
-			case preIncrement:
-				printer.print("++");
-				break;
-			case preDecrement:
-				printer.print("--");
-				break;
-			default:
-		}
-
-		n.getExpr().accept(this, arg);
-
-		switch (n.getOperator()) {
-			case posIncrement:
-				printer.print("++");
-				break;
-			case posDecrement:
-				printer.print("--");
-				break;
-			default:
-		}
-	}
-
-	@Override
-	public void visit(final ConstructorDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-
-		printTypeParameters(n.getTypeParameters(), arg);
-		if (!n.getTypeParameters().isEmpty()) {
-			printer.print(" ");
-		}
-		printer.print(n.getName());
-
-		printer.print("(");
-		if (!n.getParameters().isEmpty()) {
-			for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext(); ) {
-				final Parameter p = i.next();
-				p.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
-
-		if (!isNullOrEmpty(n.getThrows())) {
-			printer.print(" throws ");
-			for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext(); ) {
-				final ReferenceType name = i.next();
-				name.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(" ");
-		n.getBody().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final MethodDeclaration n, final Object arg) {
-		printOrphanCommentsBeforeThisChildNode(n);
-
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-		if (n.isDefault()) {
-			printer.print("default ");
-		}
-		printTypeParameters(n.getTypeParameters(), arg);
-		if (!isNullOrEmpty(n.getTypeParameters())) {
-			printer.print(" ");
-		}
-
-		n.getElementType().accept(this, arg);
-		for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
-			pair.accept(this, arg);
-		}
-		printer.print(" ");
-		printer.print(n.getName());
-
-		printer.print("(");
-		if (!isNullOrEmpty(n.getParameters())) {
-			for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext(); ) {
-				final Parameter p = i.next();
-				p.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
-
-		for(ArrayBracketPair pair: n.getArrayBracketPairsAfterParameterList()){
-			pair.accept(this, arg);
-		}
-
-		if (!isNullOrEmpty(n.getThrows())) {
-			printer.print(" throws ");
-			for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext(); ) {
-				final ReferenceType name = i.next();
-				name.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		if (n.getBody() == null) {
-			printer.print(";");
-		} else {
-			printer.print(" ");
-			n.getBody().accept(this, arg);
-		}
-	}
-
-	@Override
-	public void visit(final Parameter n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), false, arg);
-		printModifiers(n.getModifiers());
-		if (n.getElementType() != null) {
-			n.getElementType().accept(this, arg);
-		}
-		for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
-			pair.accept(this, arg);
-		}
-		if (n.isVarArgs()) {
-			printer.print("...");
-		}
-		printer.print(" ");
-		n.getId().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final ExplicitConstructorInvocationStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.isThis()) {
-			printTypeArgs(n, arg);
-			printer.print("this");
-		} else {
-			if (n.getExpr() != null) {
-				n.getExpr().accept(this, arg);
-				printer.print(".");
-			}
-			printTypeArgs(n, arg);
-			printer.print("super");
-		}
-		printArguments(n.getArgs(), arg);
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final VariableDeclarationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), false, arg);
-		printModifiers(n.getModifiers());
-
-		n.getElementType().accept(this, arg);
-		for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
-			pair.accept(this, arg);
-		}
-		printer.print(" ");
-
-		for (final Iterator<VariableDeclarator> i = n.getVariables().iterator(); i.hasNext(); ) {
-			final VariableDeclarator v = i.next();
-			v.accept(this, arg);
-			if (i.hasNext()) {
-				printer.print(", ");
-			}
-		}
-	}
-
-	@Override
-	public void visit(final TypeDeclarationStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getTypeDeclaration().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final AssertStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("assert ");
-		n.getCheck().accept(this, arg);
-		if (n.getMessage() != null) {
-			printer.print(" : ");
-			n.getMessage().accept(this, arg);
-		}
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final BlockStmt n, final Object arg) {
-		printOrphanCommentsBeforeThisChildNode(n);
-		printJavaComment(n.getComment(), arg);
-		printer.printLn("{");
-		if (n.getStmts() != null) {
-			printer.indent();
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-				printer.printLn();
-			}
-			printer.unindent();
-		}
-		printOrphanCommentsEnding(n);
-		printer.print("}");
-
-	}
-
-	@Override
-	public void visit(final LabeledStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getLabel());
-		printer.print(": ");
-		n.getStmt().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final EmptyStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final ExpressionStmt n, final Object arg) {
-		printOrphanCommentsBeforeThisChildNode(n);
-		printJavaComment(n.getComment(), arg);
-		n.getExpression().accept(this, arg);
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final SwitchStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("switch(");
-		n.getSelector().accept(this, arg);
-		printer.printLn(") {");
-		if (n.getEntries() != null) {
-			printer.indent();
-			for (final SwitchEntryStmt e : n.getEntries()) {
-				e.accept(this, arg);
-			}
-			printer.unindent();
-		}
-		printer.print("}");
-
-	}
-
-	@Override
-	public void visit(final SwitchEntryStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getLabel() != null) {
-			printer.print("case ");
-			n.getLabel().accept(this, arg);
-			printer.print(":");
-		} else {
-			printer.print("default:");
-		}
-		printer.printLn();
-		printer.indent();
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-				printer.printLn();
-			}
-		}
-		printer.unindent();
-	}
-
-	@Override
-	public void visit(final BreakStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("break");
-		if (n.getId() != null) {
-			printer.print(" ");
-			printer.print(n.getId());
-		}
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final ReturnStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("return");
-		if (n.getExpr() != null) {
-			printer.print(" ");
-			n.getExpr().accept(this, arg);
-		}
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final EnumDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-
-		printer.print("enum ");
-		printer.print(n.getName());
-
-		if (!n.getImplements().isEmpty()) {
-			printer.print(" implements ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext(); ) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-
-		printer.printLn(" {");
-		printer.indent();
-		if (n.getEntries() != null) {
-			printer.printLn();
-			for (final Iterator<EnumConstantDeclaration> i = n.getEntries().iterator(); i.hasNext(); ) {
-				final EnumConstantDeclaration e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		if (!n.getMembers().isEmpty()) {
-			printer.printLn(";");
-			printMembers(n.getMembers(), arg);
-		} else {
-			if (!n.getEntries().isEmpty()) {
-				printer.printLn();
-			}
-		}
-		printer.unindent();
-		printer.print("}");
-	}
-
-	@Override
-	public void visit(final EnumConstantDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printer.print(n.getName());
-
-		if (!n.getArgs().isEmpty()) {
-			printArguments(n.getArgs(), arg);
-		}
-
-		if (!n.getClassBody().isEmpty()) {
-			printer.printLn(" {");
-			printer.indent();
-			printMembers(n.getClassBody(), arg);
-			printer.unindent();
-			printer.printLn("}");
-		}
-	}
-
-	@Override
-	public void visit(final EmptyMemberDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final InitializerDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.isStatic()) {
-			printer.print("static ");
-		}
-		n.getBlock().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final IfStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("if (");
-		n.getCondition().accept(this, arg);
-		final boolean thenBlock = n.getThenStmt() instanceof BlockStmt;
-		if (thenBlock) // block statement should start on the same line
-			printer.print(") ");
-		else {
-			printer.printLn(")");
-			printer.indent();
-		}
-		n.getThenStmt().accept(this, arg);
-		if (!thenBlock)
-			printer.unindent();
-		if (n.getElseStmt() != null) {
-			if (thenBlock)
-				printer.print(" ");
-			else
-				printer.printLn();
-			final boolean elseIf = n.getElseStmt() instanceof IfStmt;
-			final boolean elseBlock = n.getElseStmt() instanceof BlockStmt;
-			if (elseIf || elseBlock) // put chained if and start of block statement on a same level
-				printer.print("else ");
-			else {
-				printer.printLn("else");
-				printer.indent();
-			}
-			n.getElseStmt().accept(this, arg);
-			if (!(elseIf || elseBlock))
-				printer.unindent();
-		}
-	}
-
-	@Override
-	public void visit(final WhileStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("while (");
-		n.getCondition().accept(this, arg);
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final ContinueStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("continue");
-		if (n.getId() != null) {
-			printer.print(" ");
-			printer.print(n.getId());
-		}
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final DoStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("do ");
-		n.getBody().accept(this, arg);
-		printer.print(" while (");
-		n.getCondition().accept(this, arg);
-		printer.print(");");
-	}
-
-	@Override
-	public void visit(final ForeachStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("for (");
-		n.getVariable().accept(this, arg);
-		printer.print(" : ");
-		n.getIterable().accept(this, arg);
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final ForStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("for (");
-		if (n.getInit() != null) {
-			for (final Iterator<Expression> i = n.getInit().iterator(); i.hasNext(); ) {
-				final Expression e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print("; ");
-		if (n.getCompare() != null) {
-			n.getCompare().accept(this, arg);
-		}
-		printer.print("; ");
-		if (n.getUpdate() != null) {
-			for (final Iterator<Expression> i = n.getUpdate().iterator(); i.hasNext(); ) {
-				final Expression e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final ThrowStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("throw ");
-		n.getExpr().accept(this, arg);
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final SynchronizedStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("synchronized (");
-		n.getExpr().accept(this, arg);
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final TryStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("try ");
-		if (!n.getResources().isEmpty()) {
-			printer.print("(");
-			Iterator<VariableDeclarationExpr> resources = n.getResources().iterator();
-			boolean first = true;
-			while (resources.hasNext()) {
-				visit(resources.next(), arg);
-				if (resources.hasNext()) {
-					printer.print(";");
-					printer.printLn();
-					if (first) {
-						printer.indent();
-					}
-				}
-				first = false;
-			}
-			if (n.getResources().size() > 1) {
-				printer.unindent();
-			}
-			printer.print(") ");
-		}
-		n.getTryBlock().accept(this, arg);
-		if (n.getCatchs() != null) {
-			for (final CatchClause c : n.getCatchs()) {
-				c.accept(this, arg);
-			}
-		}
-		if (n.getFinallyBlock() != null) {
-			printer.print(" finally ");
-			n.getFinallyBlock().accept(this, arg);
-		}
-	}
-
-	@Override
-	public void visit(final CatchClause n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(" catch (");
-		n.getParam().accept(this, arg);
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-
-	}
-
-	@Override
-	public void visit(final AnnotationDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-
-		printer.print("@interface ");
-		printer.print(n.getName());
-		printer.printLn(" {");
-		printer.indent();
-		if (n.getMembers() != null) {
-			printMembers(n.getMembers(), arg);
-		}
-		printer.unindent();
-		printer.print("}");
-	}
-
-	@Override
-	public void visit(final AnnotationMemberDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-
-		n.getType().accept(this, arg);
-		printer.print(" ");
-		printer.print(n.getName());
-		printer.print("()");
-		if (n.getDefaultValue() != null) {
-			printer.print(" default ");
-			n.getDefaultValue().accept(this, arg);
-		}
-		printer.print(";");
-	}
-
-	@Override
-	public void visit(final MarkerAnnotationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("@");
-		n.getName().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final SingleMemberAnnotationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("@");
-		n.getName().accept(this, arg);
-		printer.print("(");
-		n.getMemberValue().accept(this, arg);
-		printer.print(")");
-	}
-
-	@Override
-	public void visit(final NormalAnnotationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("@");
-		n.getName().accept(this, arg);
-		printer.print("(");
-		if (n.getPairs() != null) {
-			for (final Iterator<MemberValuePair> i = n.getPairs().iterator(); i.hasNext(); ) {
-				final MemberValuePair m = i.next();
-				m.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
-	}
-
-	@Override
-	public void visit(final MemberValuePair n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getName());
-		printer.print(" = ");
-		n.getValue().accept(this, arg);
-	}
-
-	@Override
-	public void visit(final LineComment n, final Object arg) {
-		if (!this.printComments) {
-			return;
-		}
-		printer.print("//");
-		String tmp = n.getContent();
-		tmp = tmp.replace('\r', ' ');
-		tmp = tmp.replace('\n', ' ');
-		printer.printLn(tmp);
-	}
-
-	@Override
-	public void visit(final BlockComment n, final Object arg) {
-		if (!this.printComments) {
-			return;
-		}
-		printer.print("/*");
-		printer.print(n.getContent());
-		printer.printLn("*/");
-	}
-
-	@Override
-	public void visit(LambdaExpr n, Object arg) {
-		printJavaComment(n.getComment(), arg);
-
-		final List<Parameter> parameters = n.getParameters();
-		final boolean printPar = n.isParametersEnclosed();
-
-		if (printPar) {
-			printer.print("(");
-		}
-		if (parameters != null) {
-			for (Iterator<Parameter> i = parameters.iterator(); i.hasNext(); ) {
-				Parameter p = i.next();
-				p.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		if (printPar) {
-			printer.print(")");
-		}
-
-		printer.print(" -> ");
-		final Statement body = n.getBody();
-		if (body instanceof ExpressionStmt) {
-			// Print the expression directly
-			((ExpressionStmt) body).getExpression().accept(this, arg);
-		} else {
-			body.accept(this, arg);
-		}
-	}
-
-
-	@Override
-	public void visit(MethodReferenceExpr n, Object arg) {
-		printJavaComment(n.getComment(), arg);
-		Expression scope = n.getScope();
-		String identifier = n.getIdentifier();
-		if (scope != null) {
-			n.getScope().accept(this, arg);
-		}
-
-		printer.print("::");
-		printTypeArgs(n, arg);
-		if (identifier != null) {
-			printer.print(identifier);
-		}
-
-	}
-
-	@Override
-	public void visit(TypeExpr n, Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getType() != null) {
-			n.getType().accept(this, arg);
-		}
-	}
-
-	@Override
-	public void visit(ArrayBracketPair arrayBracketPair, Object arg) {
-		printAnnotations(arrayBracketPair.getAnnotations(), true, arg);
-		printer.print("[]");
-	}
-
-	private void printOrphanCommentsBeforeThisChildNode(final Node node) {
-		if (node instanceof Comment) return;
-
-		Node parent = node.getParentNode();
-		if (parent == null) return;
-		List<Node> everything = new LinkedList<>();
-		everything.addAll(parent.getChildrenNodes());
-		sortByBeginPosition(everything);
-		int positionOfTheChild = -1;
-		for (int i = 0; i < everything.size(); i++) {
-			if (everything.get(i) == node) positionOfTheChild = i;
-		}
-		if (positionOfTheChild == -1) throw new RuntimeException("My index not found!!! " + node);
-		int positionOfPreviousChild = -1;
-		for (int i = positionOfTheChild - 1; i >= 0 && positionOfPreviousChild == -1; i--) {
-			if (!(everything.get(i) instanceof Comment)) positionOfPreviousChild = i;
-		}
-		for (int i = positionOfPreviousChild + 1; i < positionOfTheChild; i++) {
-			Node nodeToPrint = everything.get(i);
-			if (!(nodeToPrint instanceof Comment))
-				throw new RuntimeException("Expected comment, instead " + nodeToPrint.getClass() + ". Position of previous child: " + positionOfPreviousChild + ", position of child " + positionOfTheChild);
-			nodeToPrint.accept(this, null);
-		}
-	}
-
-
-	private void printOrphanCommentsEnding(final Node node) {
-		List<Node> everything = new LinkedList<>();
-		everything.addAll(node.getChildrenNodes());
-		sortByBeginPosition(everything);
-		if (everything.isEmpty()) {
-			return;
-		}
-
-		int commentsAtEnd = 0;
-		boolean findingComments = true;
-		while (findingComments && commentsAtEnd < everything.size()) {
-			Node last = everything.get(everything.size() - 1 - commentsAtEnd);
-			findingComments = (last instanceof Comment);
-			if (findingComments) {
-				commentsAtEnd++;
-			}
-		}
-		for (int i = 0; i < commentsAtEnd; i++) {
-			everything.get(everything.size() - commentsAtEnd + i).accept(this, null);
-		}
-	}
+    @Override
+    public void visit(final WildcardType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), false, arg);
+        printer.print("?");
+        if (n.getExtends() != null) {
+            printer.print(" extends ");
+            n.getExtends().accept(this, arg);
+        }
+        if (n.getSuper() != null) {
+            printer.print(" super ");
+            n.getSuper().accept(this, arg);
+        }
+    }
+
+    @Override
+    public void visit(final UnknownType n, final Object arg) {
+        // Nothing to dump
+    }
+
+    @Override
+    public void visit(final FieldDeclaration n, final Object arg) {
+        printOrphanCommentsBeforeThisChildNode(n);
+
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+        n.getElementType().accept(this, arg);
+        for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
+            pair.accept(this, arg);
+        }
+
+        printer.print(" ");
+        for (final Iterator<VariableDeclarator> i = n.getVariables().iterator(); i.hasNext(); ) {
+            final VariableDeclarator var = i.next();
+            var.accept(this, arg);
+            if (i.hasNext()) {
+                printer.print(", ");
+            }
+        }
+
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final VariableDeclarator n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getId().accept(this, arg);
+        if (n.getInit() != null) {
+            printer.print(" = ");
+            n.getInit().accept(this, arg);
+        }
+    }
+
+    @Override
+    public void visit(final VariableDeclaratorId n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getName());
+        for(ArrayBracketPair pair: n.getArrayBracketPairsAfterId()){
+            pair.accept(this, arg);
+        }
+    }
+
+    @Override
+    public void visit(final ArrayInitializerExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("{");
+        if (!isNullOrEmpty(n.getValues())) {
+            printer.print(" ");
+            for (final Iterator<Expression> i = n.getValues().iterator(); i.hasNext(); ) {
+                final Expression expr = i.next();
+                expr.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+            printer.print(" ");
+        }
+        printer.print("}");
+    }
+
+    @Override
+    public void visit(final VoidType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), false, arg);
+        printer.print("void");
+    }
+
+    @Override
+    public void visit(final ArrayAccessExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        printer.print("[");
+        n.getIndex().accept(this, arg);
+        printer.print("]");
+    }
+
+    @Override
+    public void visit(final ArrayCreationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("new ");
+        n.getType().accept(this, arg);
+        for (ArrayCreationLevel level : n.getLevels()) {
+            level.accept(this, arg);
+        }
+        if (n.getInitializer() != null) {
+            printer.print(" ");
+            n.getInitializer().accept(this, arg);
+        }
+    }
+
+    @Override
+    public void visit(final AssignExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getTarget().accept(this, arg);
+        printer.print(" ");
+        switch (n.getOperator()) {
+            case assign:
+                printer.print("=");
+                break;
+            case and:
+                printer.print("&=");
+                break;
+            case or:
+                printer.print("|=");
+                break;
+            case xor:
+                printer.print("^=");
+                break;
+            case plus:
+                printer.print("+=");
+                break;
+            case minus:
+                printer.print("-=");
+                break;
+            case rem:
+                printer.print("%=");
+                break;
+            case slash:
+                printer.print("/=");
+                break;
+            case star:
+                printer.print("*=");
+                break;
+            case lShift:
+                printer.print("<<=");
+                break;
+            case rSignedShift:
+                printer.print(">>=");
+                break;
+            case rUnsignedShift:
+                printer.print(">>>=");
+                break;
+        }
+        printer.print(" ");
+        n.getValue().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final BinaryExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getLeft().accept(this, arg);
+        printer.print(" ");
+        switch (n.getOperator()) {
+            case or:
+                printer.print("||");
+                break;
+            case and:
+                printer.print("&&");
+                break;
+            case binOr:
+                printer.print("|");
+                break;
+            case binAnd:
+                printer.print("&");
+                break;
+            case xor:
+                printer.print("^");
+                break;
+            case equals:
+                printer.print("==");
+                break;
+            case notEquals:
+                printer.print("!=");
+                break;
+            case less:
+                printer.print("<");
+                break;
+            case greater:
+                printer.print(">");
+                break;
+            case lessEquals:
+                printer.print("<=");
+                break;
+            case greaterEquals:
+                printer.print(">=");
+                break;
+            case lShift:
+                printer.print("<<");
+                break;
+            case rSignedShift:
+                printer.print(">>");
+                break;
+            case rUnsignedShift:
+                printer.print(">>>");
+                break;
+            case plus:
+                printer.print("+");
+                break;
+            case minus:
+                printer.print("-");
+                break;
+            case times:
+                printer.print("*");
+                break;
+            case divide:
+                printer.print("/");
+                break;
+            case remainder:
+                printer.print("%");
+                break;
+        }
+        printer.print(" ");
+        n.getRight().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final CastExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("(");
+        n.getType().accept(this, arg);
+        printer.print(") ");
+        n.getExpr().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final ClassExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+        printer.print(".class");
+    }
+
+    @Override
+    public void visit(final ConditionalExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        printer.print(" ? ");
+        n.getThenExpr().accept(this, arg);
+        printer.print(" : ");
+        n.getElseExpr().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final EnclosedExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("(");
+        if (n.getInner() != null) {
+            n.getInner().accept(this, arg);
+        }
+        printer.print(")");
+    }
+
+    @Override
+    public void visit(final FieldAccessExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getScope().accept(this, arg);
+        printer.print(".");
+        printer.print(n.getField());
+    }
+
+    @Override
+    public void visit(final InstanceOfExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+        printer.print(" instanceof ");
+        n.getType().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final CharLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("'");
+        printer.print(n.getValue());
+        printer.print("'");
+    }
+
+    @Override
+    public void visit(final DoubleLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
+
+    @Override
+    public void visit(final IntegerLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
+
+    @Override
+    public void visit(final LongLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
+
+    @Override
+    public void visit(final IntegerLiteralMinValueExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
+
+    @Override
+    public void visit(final LongLiteralMinValueExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
+
+    @Override
+    public void visit(final StringLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("\"");
+        printer.print(n.getValue());
+        printer.print("\"");
+    }
+
+    @Override
+    public void visit(final BooleanLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(String.valueOf(n.getValue()));
+    }
+
+    @Override
+    public void visit(final NullLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("null");
+    }
+
+    @Override
+    public void visit(final ThisExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+            printer.print(".");
+        }
+        printer.print("this");
+    }
+
+    @Override
+    public void visit(final SuperExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+            printer.print(".");
+        }
+        printer.print("super");
+    }
+
+    @Override
+    public void visit(final MethodCallExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+            printer.print(".");
+        }
+        printTypeArgs(n, arg);
+        printer.print(n.getName());
+        printArguments(n.getArgs(), arg);
+    }
+
+    @Override
+    public void visit(final ObjectCreationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+            printer.print(".");
+        }
+
+        printer.print("new ");
+
+        printTypeArgs(n, arg);
+        if (!isNullOrEmpty(n.getTypeArguments())) {
+            printer.print(" ");
+        }
+
+        n.getType().accept(this, arg);
+
+        printArguments(n.getArgs(), arg);
+
+        if (n.getAnonymousClassBody() != null) {
+            printer.printLn(" {");
+            printer.indent();
+            printMembers(n.getAnonymousClassBody(), arg);
+            printer.unindent();
+            printer.print("}");
+        }
+    }
+
+    @Override
+    public void visit(final UnaryExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        switch (n.getOperator()) {
+            case positive:
+                printer.print("+");
+                break;
+            case negative:
+                printer.print("-");
+                break;
+            case inverse:
+                printer.print("~");
+                break;
+            case not:
+                printer.print("!");
+                break;
+            case preIncrement:
+                printer.print("++");
+                break;
+            case preDecrement:
+                printer.print("--");
+                break;
+            default:
+        }
+
+        n.getExpr().accept(this, arg);
+
+        switch (n.getOperator()) {
+            case posIncrement:
+                printer.print("++");
+                break;
+            case posDecrement:
+                printer.print("--");
+                break;
+            default:
+        }
+    }
+
+    @Override
+    public void visit(final ConstructorDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+
+        printTypeParameters(n.getTypeParameters(), arg);
+        if (!n.getTypeParameters().isEmpty()) {
+            printer.print(" ");
+        }
+        printer.print(n.getName());
+
+        printer.print("(");
+        if (!n.getParameters().isEmpty()) {
+            for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext(); ) {
+                final Parameter p = i.next();
+                p.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
+
+        if (!isNullOrEmpty(n.getThrows())) {
+            printer.print(" throws ");
+            for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext(); ) {
+                final ReferenceType name = i.next();
+                name.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(" ");
+        n.getBody().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final MethodDeclaration n, final Object arg) {
+        printOrphanCommentsBeforeThisChildNode(n);
+
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+        if (n.isDefault()) {
+            printer.print("default ");
+        }
+        printTypeParameters(n.getTypeParameters(), arg);
+        if (!isNullOrEmpty(n.getTypeParameters())) {
+            printer.print(" ");
+        }
+
+        n.getElementType().accept(this, arg);
+        for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
+            pair.accept(this, arg);
+        }
+        printer.print(" ");
+        printer.print(n.getName());
+
+        printer.print("(");
+        if (!isNullOrEmpty(n.getParameters())) {
+            for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext(); ) {
+                final Parameter p = i.next();
+                p.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
+
+        for(ArrayBracketPair pair: n.getArrayBracketPairsAfterParameterList()){
+            pair.accept(this, arg);
+        }
+
+        if (!isNullOrEmpty(n.getThrows())) {
+            printer.print(" throws ");
+            for (final Iterator<ReferenceType> i = n.getThrows().iterator(); i.hasNext(); ) {
+                final ReferenceType name = i.next();
+                name.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        if (n.getBody() == null) {
+            printer.print(";");
+        } else {
+            printer.print(" ");
+            n.getBody().accept(this, arg);
+        }
+    }
+
+    @Override
+    public void visit(final Parameter n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), false, arg);
+        printModifiers(n.getModifiers());
+        if (n.getElementType() != null) {
+            n.getElementType().accept(this, arg);
+        }
+        for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
+            pair.accept(this, arg);
+        }
+        if (n.isVarArgs()) {
+            printer.print("...");
+        }
+        printer.print(" ");
+        n.getId().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final ExplicitConstructorInvocationStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.isThis()) {
+            printTypeArgs(n, arg);
+            printer.print("this");
+        } else {
+            if (n.getExpr() != null) {
+                n.getExpr().accept(this, arg);
+                printer.print(".");
+            }
+            printTypeArgs(n, arg);
+            printer.print("super");
+        }
+        printArguments(n.getArgs(), arg);
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final VariableDeclarationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), false, arg);
+        printModifiers(n.getModifiers());
+
+        n.getElementType().accept(this, arg);
+        for(ArrayBracketPair pair: n.getArrayBracketPairsAfterElementType()){
+            pair.accept(this, arg);
+        }
+        printer.print(" ");
+
+        for (final Iterator<VariableDeclarator> i = n.getVariables().iterator(); i.hasNext(); ) {
+            final VariableDeclarator v = i.next();
+            v.accept(this, arg);
+            if (i.hasNext()) {
+                printer.print(", ");
+            }
+        }
+    }
+
+    @Override
+    public void visit(final TypeDeclarationStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getTypeDeclaration().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final AssertStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("assert ");
+        n.getCheck().accept(this, arg);
+        if (n.getMessage() != null) {
+            printer.print(" : ");
+            n.getMessage().accept(this, arg);
+        }
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final BlockStmt n, final Object arg) {
+        printOrphanCommentsBeforeThisChildNode(n);
+        printJavaComment(n.getComment(), arg);
+        printer.printLn("{");
+        if (n.getStmts() != null) {
+            printer.indent();
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+                printer.printLn();
+            }
+            printer.unindent();
+        }
+        printOrphanCommentsEnding(n);
+        printer.print("}");
+
+    }
+
+    @Override
+    public void visit(final LabeledStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getLabel());
+        printer.print(": ");
+        n.getStmt().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final EmptyStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final ExpressionStmt n, final Object arg) {
+        printOrphanCommentsBeforeThisChildNode(n);
+        printJavaComment(n.getComment(), arg);
+        n.getExpression().accept(this, arg);
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final SwitchStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("switch(");
+        n.getSelector().accept(this, arg);
+        printer.printLn(") {");
+        if (n.getEntries() != null) {
+            printer.indent();
+            for (final SwitchEntryStmt e : n.getEntries()) {
+                e.accept(this, arg);
+            }
+            printer.unindent();
+        }
+        printer.print("}");
+
+    }
+
+    @Override
+    public void visit(final SwitchEntryStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getLabel() != null) {
+            printer.print("case ");
+            n.getLabel().accept(this, arg);
+            printer.print(":");
+        } else {
+            printer.print("default:");
+        }
+        printer.printLn();
+        printer.indent();
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+                printer.printLn();
+            }
+        }
+        printer.unindent();
+    }
+
+    @Override
+    public void visit(final BreakStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("break");
+        if (n.getId() != null) {
+            printer.print(" ");
+            printer.print(n.getId());
+        }
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final ReturnStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("return");
+        if (n.getExpr() != null) {
+            printer.print(" ");
+            n.getExpr().accept(this, arg);
+        }
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final EnumDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+
+        printer.print("enum ");
+        printer.print(n.getName());
+
+        if (!n.getImplements().isEmpty()) {
+            printer.print(" implements ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext(); ) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+
+        printer.printLn(" {");
+        printer.indent();
+        if (n.getEntries() != null) {
+            printer.printLn();
+            for (final Iterator<EnumConstantDeclaration> i = n.getEntries().iterator(); i.hasNext(); ) {
+                final EnumConstantDeclaration e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        if (!n.getMembers().isEmpty()) {
+            printer.printLn(";");
+            printMembers(n.getMembers(), arg);
+        } else {
+            if (!n.getEntries().isEmpty()) {
+                printer.printLn();
+            }
+        }
+        printer.unindent();
+        printer.print("}");
+    }
+
+    @Override
+    public void visit(final EnumConstantDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printer.print(n.getName());
+
+        if (!n.getArgs().isEmpty()) {
+            printArguments(n.getArgs(), arg);
+        }
+
+        if (!n.getClassBody().isEmpty()) {
+            printer.printLn(" {");
+            printer.indent();
+            printMembers(n.getClassBody(), arg);
+            printer.unindent();
+            printer.printLn("}");
+        }
+    }
+
+    @Override
+    public void visit(final EmptyMemberDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final InitializerDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.isStatic()) {
+            printer.print("static ");
+        }
+        n.getBlock().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final IfStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("if (");
+        n.getCondition().accept(this, arg);
+        final boolean thenBlock = n.getThenStmt() instanceof BlockStmt;
+        if (thenBlock) // block statement should start on the same line
+            printer.print(") ");
+        else {
+            printer.printLn(")");
+            printer.indent();
+        }
+        n.getThenStmt().accept(this, arg);
+        if (!thenBlock)
+            printer.unindent();
+        if (n.getElseStmt() != null) {
+            if (thenBlock)
+                printer.print(" ");
+            else
+                printer.printLn();
+            final boolean elseIf = n.getElseStmt() instanceof IfStmt;
+            final boolean elseBlock = n.getElseStmt() instanceof BlockStmt;
+            if (elseIf || elseBlock) // put chained if and start of block statement on a same level
+                printer.print("else ");
+            else {
+                printer.printLn("else");
+                printer.indent();
+            }
+            n.getElseStmt().accept(this, arg);
+            if (!(elseIf || elseBlock))
+                printer.unindent();
+        }
+    }
+
+    @Override
+    public void visit(final WhileStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("while (");
+        n.getCondition().accept(this, arg);
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final ContinueStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("continue");
+        if (n.getId() != null) {
+            printer.print(" ");
+            printer.print(n.getId());
+        }
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final DoStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("do ");
+        n.getBody().accept(this, arg);
+        printer.print(" while (");
+        n.getCondition().accept(this, arg);
+        printer.print(");");
+    }
+
+    @Override
+    public void visit(final ForeachStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("for (");
+        n.getVariable().accept(this, arg);
+        printer.print(" : ");
+        n.getIterable().accept(this, arg);
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final ForStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("for (");
+        if (n.getInit() != null) {
+            for (final Iterator<Expression> i = n.getInit().iterator(); i.hasNext(); ) {
+                final Expression e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print("; ");
+        if (n.getCompare() != null) {
+            n.getCompare().accept(this, arg);
+        }
+        printer.print("; ");
+        if (n.getUpdate() != null) {
+            for (final Iterator<Expression> i = n.getUpdate().iterator(); i.hasNext(); ) {
+                final Expression e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final ThrowStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("throw ");
+        n.getExpr().accept(this, arg);
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final SynchronizedStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("synchronized (");
+        n.getExpr().accept(this, arg);
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final TryStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("try ");
+        if (!n.getResources().isEmpty()) {
+            printer.print("(");
+            Iterator<VariableDeclarationExpr> resources = n.getResources().iterator();
+            boolean first = true;
+            while (resources.hasNext()) {
+                visit(resources.next(), arg);
+                if (resources.hasNext()) {
+                    printer.print(";");
+                    printer.printLn();
+                    if (first) {
+                        printer.indent();
+                    }
+                }
+                first = false;
+            }
+            if (n.getResources().size() > 1) {
+                printer.unindent();
+            }
+            printer.print(") ");
+        }
+        n.getTryBlock().accept(this, arg);
+        if (n.getCatchs() != null) {
+            for (final CatchClause c : n.getCatchs()) {
+                c.accept(this, arg);
+            }
+        }
+        if (n.getFinallyBlock() != null) {
+            printer.print(" finally ");
+            n.getFinallyBlock().accept(this, arg);
+        }
+    }
+
+    @Override
+    public void visit(final CatchClause n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(" catch (");
+        n.getParam().accept(this, arg);
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+
+    }
+
+    @Override
+    public void visit(final AnnotationDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+
+        printer.print("@interface ");
+        printer.print(n.getName());
+        printer.printLn(" {");
+        printer.indent();
+        if (n.getMembers() != null) {
+            printMembers(n.getMembers(), arg);
+        }
+        printer.unindent();
+        printer.print("}");
+    }
+
+    @Override
+    public void visit(final AnnotationMemberDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+
+        n.getType().accept(this, arg);
+        printer.print(" ");
+        printer.print(n.getName());
+        printer.print("()");
+        if (n.getDefaultValue() != null) {
+            printer.print(" default ");
+            n.getDefaultValue().accept(this, arg);
+        }
+        printer.print(";");
+    }
+
+    @Override
+    public void visit(final MarkerAnnotationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("@");
+        n.getName().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final SingleMemberAnnotationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("@");
+        n.getName().accept(this, arg);
+        printer.print("(");
+        n.getMemberValue().accept(this, arg);
+        printer.print(")");
+    }
+
+    @Override
+    public void visit(final NormalAnnotationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("@");
+        n.getName().accept(this, arg);
+        printer.print("(");
+        if (n.getPairs() != null) {
+            for (final Iterator<MemberValuePair> i = n.getPairs().iterator(); i.hasNext(); ) {
+                final MemberValuePair m = i.next();
+                m.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
+    }
+
+    @Override
+    public void visit(final MemberValuePair n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getName());
+        printer.print(" = ");
+        n.getValue().accept(this, arg);
+    }
+
+    @Override
+    public void visit(final LineComment n, final Object arg) {
+        if (!this.printComments) {
+            return;
+        }
+        printer.print("//");
+        String tmp = n.getContent();
+        tmp = tmp.replace('\r', ' ');
+        tmp = tmp.replace('\n', ' ');
+        printer.printLn(tmp);
+    }
+
+    @Override
+    public void visit(final BlockComment n, final Object arg) {
+        if (!this.printComments) {
+            return;
+        }
+        printer.print("/*");
+        printer.print(n.getContent());
+        printer.printLn("*/");
+    }
+
+    @Override
+    public void visit(LambdaExpr n, Object arg) {
+        printJavaComment(n.getComment(), arg);
+
+        final List<Parameter> parameters = n.getParameters();
+        final boolean printPar = n.isParametersEnclosed();
+
+        if (printPar) {
+            printer.print("(");
+        }
+        if (parameters != null) {
+            for (Iterator<Parameter> i = parameters.iterator(); i.hasNext(); ) {
+                Parameter p = i.next();
+                p.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        if (printPar) {
+            printer.print(")");
+        }
+
+        printer.print(" -> ");
+        final Statement body = n.getBody();
+        if (body instanceof ExpressionStmt) {
+            // Print the expression directly
+            ((ExpressionStmt) body).getExpression().accept(this, arg);
+        } else {
+            body.accept(this, arg);
+        }
+    }
+
+
+    @Override
+    public void visit(MethodReferenceExpr n, Object arg) {
+        printJavaComment(n.getComment(), arg);
+        Expression scope = n.getScope();
+        String identifier = n.getIdentifier();
+        if (scope != null) {
+            n.getScope().accept(this, arg);
+        }
+
+        printer.print("::");
+        printTypeArgs(n, arg);
+        if (identifier != null) {
+            printer.print(identifier);
+        }
+
+    }
+
+    @Override
+    public void visit(TypeExpr n, Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getType() != null) {
+            n.getType().accept(this, arg);
+        }
+    }
+
+    @Override
+    public void visit(ArrayBracketPair arrayBracketPair, Object arg) {
+        printAnnotations(arrayBracketPair.getAnnotations(), true, arg);
+        printer.print("[]");
+    }
+
+    private void printOrphanCommentsBeforeThisChildNode(final Node node) {
+        if (node instanceof Comment) return;
+
+        Node parent = node.getParentNode();
+        if (parent == null) return;
+        List<Node> everything = new LinkedList<>();
+        everything.addAll(parent.getChildrenNodes());
+        sortByBeginPosition(everything);
+        int positionOfTheChild = -1;
+        for (int i = 0; i < everything.size(); i++) {
+            if (everything.get(i) == node) positionOfTheChild = i;
+        }
+        if (positionOfTheChild == -1) throw new RuntimeException("My index not found!!! " + node);
+        int positionOfPreviousChild = -1;
+        for (int i = positionOfTheChild - 1; i >= 0 && positionOfPreviousChild == -1; i--) {
+            if (!(everything.get(i) instanceof Comment)) positionOfPreviousChild = i;
+        }
+        for (int i = positionOfPreviousChild + 1; i < positionOfTheChild; i++) {
+            Node nodeToPrint = everything.get(i);
+            if (!(nodeToPrint instanceof Comment))
+                throw new RuntimeException("Expected comment, instead " + nodeToPrint.getClass() + ". Position of previous child: " + positionOfPreviousChild + ", position of child " + positionOfTheChild);
+            nodeToPrint.accept(this, null);
+        }
+    }
+
+
+    private void printOrphanCommentsEnding(final Node node) {
+        List<Node> everything = new LinkedList<>();
+        everything.addAll(node.getChildrenNodes());
+        sortByBeginPosition(everything);
+        if (everything.isEmpty()) {
+            return;
+        }
+
+        int commentsAtEnd = 0;
+        boolean findingComments = true;
+        while (findingComments && commentsAtEnd < everything.size()) {
+            Node last = everything.get(everything.size() - 1 - commentsAtEnd);
+            findingComments = (last instanceof Comment);
+            if (findingComments) {
+                commentsAtEnd++;
+            }
+        }
+        for (int i = 0; i < commentsAtEnd; i++) {
+            everything.get(everything.size() - commentsAtEnd + i).accept(this, null);
+        }
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -105,15 +105,15 @@ import com.github.javaparser.ast.type.*;
  */
 public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 
-	private static final EqualsVisitor SINGLETON = new EqualsVisitor();
+    private static final EqualsVisitor SINGLETON = new EqualsVisitor();
 
-	public static boolean equals(final Node n1, final Node n2) {
-		return SINGLETON.nodeEquals(n1, n2);
-	}
+    public static boolean equals(final Node n1, final Node n2) {
+        return SINGLETON.nodeEquals(n1, n2);
+    }
 
-	private EqualsVisitor() {
-		// hide constructor
-	}
+    private EqualsVisitor() {
+        // hide constructor
+    }
 
     /**
      * Check for equality that can be applied to each kind of node,
@@ -123,555 +123,555 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
         if (!nodeEquals(n1.getComment(), n2.getComment())) {
             return false;
         }
-		return nodesEquals(n1.getOrphanComments(), n2.getOrphanComments());
-	}
+        return nodesEquals(n1.getOrphanComments(), n2.getOrphanComments());
+    }
 
-	private <T extends Node> boolean nodesEquals(final List<T> nodes1, final List<T> nodes2) {
-		if (nodes1 == null) {
-			return nodes2 == null;
-		} else if (nodes2 == null) {
-			return false;
-		}
-		if (nodes1.size() != nodes2.size()) {
-			return false;
-		}
-		for (int i = 0; i < nodes1.size(); i++) {
-			if (!nodeEquals(nodes1.get(i), nodes2.get(i))) {
-				return false;
-			}
-		}
-		return true;
-	}
+    private <T extends Node> boolean nodesEquals(final List<T> nodes1, final List<T> nodes2) {
+        if (nodes1 == null) {
+            return nodes2 == null;
+        } else if (nodes2 == null) {
+            return false;
+        }
+        if (nodes1.size() != nodes2.size()) {
+            return false;
+        }
+        for (int i = 0; i < nodes1.size(); i++) {
+            if (!nodeEquals(nodes1.get(i), nodes2.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-	private <T extends Node> boolean nodeEquals(final T n1, final T n2) {
-		if (n1 == n2) {
-			return true;
-		}
-		if (n1 == null || n2 == null) {
-			return false;
-		}
-		if (n1.getClass() != n2.getClass()) {
-			return false;
-		}
+    private <T extends Node> boolean nodeEquals(final T n1, final T n2) {
+        if (n1 == n2) {
+            return true;
+        }
+        if (n1 == null || n2 == null) {
+            return false;
+        }
+        if (n1.getClass() != n2.getClass()) {
+            return false;
+        }
         if (!commonNodeEquality(n1, n2)){
             return false;
         }
-		return n1.accept(this, n2);
-	}
+        return n1.accept(this, n2);
+    }
 
-	private boolean objEquals(final Object n1, final Object n2) {
-		if (n1 == n2) {
-			return true;
-		}
-		if (n1 == null || n2 == null) {
-			return false;
-		}
-		return n1.equals(n2);
-	}
+    private boolean objEquals(final Object n1, final Object n2) {
+        if (n1 == n2) {
+            return true;
+        }
+        if (n1 == null || n2 == null) {
+            return false;
+        }
+        return n1.equals(n2);
+    }
 
-	@Override public Boolean visit(final CompilationUnit n1, final Node arg) {
-		final CompilationUnit n2 = (CompilationUnit) arg;
+    @Override public Boolean visit(final CompilationUnit n1, final Node arg) {
+        final CompilationUnit n2 = (CompilationUnit) arg;
 
-		if (!nodeEquals(n1.getPackage(), n2.getPackage())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getPackage(), n2.getPackage())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getImports(), n2.getImports())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getImports(), n2.getImports())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypes(), n2.getTypes())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getTypes(), n2.getTypes())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getComments(), n2.getComments())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getComments(), n2.getComments())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final PackageDeclaration n1, final Node arg) {
-		final PackageDeclaration n2 = (PackageDeclaration) arg;
+    @Override public Boolean visit(final PackageDeclaration n1, final Node arg) {
+        final PackageDeclaration n2 = (PackageDeclaration) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ImportDeclaration n1, final Node arg) {
-		final ImportDeclaration n2 = (ImportDeclaration) arg;
+    @Override public Boolean visit(final ImportDeclaration n1, final Node arg) {
+        final ImportDeclaration n2 = (ImportDeclaration) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final TypeParameter n1, final Node arg) {
-		final TypeParameter n2 = (TypeParameter) arg;
+    @Override public Boolean visit(final TypeParameter n1, final Node arg) {
+        final TypeParameter n2 = (TypeParameter) arg;
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypeBound(), n2.getTypeBound())) {
-			return false;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-		return true;
-	}
+        if (!nodesEquals(n1.getTypeBound(), n2.getTypeBound())) {
+            return false;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+        return true;
+    }
 
-	@Override public Boolean visit(final LineComment n1, final Node arg) {
-		final LineComment n2 = (LineComment) arg;
+    @Override public Boolean visit(final LineComment n1, final Node arg) {
+        final LineComment n2 = (LineComment) arg;
 
-		if (!objEquals(n1.getContent(), n2.getContent())) {
-			return false;
-		}
-
-        if (!objEquals(n1.getBegin().line, n2.getBegin().line)) {
-      		return false;
-      	}
-
-		return true;
-	}
-
-	@Override public Boolean visit(final BlockComment n1, final Node arg) {
-		final BlockComment n2 = (BlockComment) arg;
-
-		if (!objEquals(n1.getContent(), n2.getContent())) {
-			return false;
-		}
+        if (!objEquals(n1.getContent(), n2.getContent())) {
+            return false;
+        }
 
         if (!objEquals(n1.getBegin().line, n2.getBegin().line)) {
-      			return false;
-      	}
+              return false;
+          }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ClassOrInterfaceDeclaration n1, final Node arg) {
-		final ClassOrInterfaceDeclaration n2 = (ClassOrInterfaceDeclaration) arg;
+    @Override public Boolean visit(final BlockComment n1, final Node arg) {
+        final BlockComment n2 = (BlockComment) arg;
 
-		// javadoc are checked at CompilationUnit
+        if (!objEquals(n1.getContent(), n2.getContent())) {
+            return false;
+        }
 
-        if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+        if (!objEquals(n1.getBegin().line, n2.getBegin().line)) {
+                  return false;
+          }
 
-		if (n1.isInterface() != n2.isInterface()) {
-			return false;
-		}
+        return true;
+    }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+    @Override public Boolean visit(final ClassOrInterfaceDeclaration n1, final Node arg) {
+        final ClassOrInterfaceDeclaration n2 = (ClassOrInterfaceDeclaration) arg;
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getExtends(), n2.getExtends())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override public Boolean visit(final EnumDeclaration n1, final Node arg) {
-		final EnumDeclaration n2 = (EnumDeclaration) arg;
-
-		// javadoc are checked at CompilationUnit
+        // javadoc are checked at CompilationUnit
 
         if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+            return false;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (n1.isInterface() != n2.isInterface()) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getExtends(), n2.getExtends())) {
+            return false;
+        }
 
-		return true;
-	}
+        if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
+            return false;
+        }
 
-	@Override public Boolean visit(final EmptyTypeDeclaration n1, final Node arg) {
-		return true;
-	}
+        if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
+            return false;
+        }
 
-	@Override public Boolean visit(final EnumConstantDeclaration n1, final Node arg) {
-		final EnumConstantDeclaration n2 = (EnumConstantDeclaration) arg;
+        return true;
+    }
 
-		// javadoc are checked at CompilationUnit
+    @Override public Boolean visit(final EnumDeclaration n1, final Node arg) {
+        final EnumDeclaration n2 = (EnumDeclaration) arg;
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getClassBody(), n2.getClassBody())) {
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override public Boolean visit(final AnnotationDeclaration n1, final Node arg) {
-		final AnnotationDeclaration n2 = (AnnotationDeclaration) arg;
-
-		// javadoc are checked at CompilationUnit
+        // javadoc are checked at CompilationUnit
 
         if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+            return false;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
+            return false;
+        }
 
-		return true;
-	}
+        if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
+            return false;
+        }
 
-	@Override public Boolean visit(final AnnotationMemberDeclaration n1, final Node arg) {
-		final AnnotationMemberDeclaration n2 = (AnnotationMemberDeclaration) arg;
+        if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
+            return false;
+        }
 
-		// javadoc are checked at CompilationUnit
+        return true;
+    }
 
-        if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+    @Override public Boolean visit(final EmptyTypeDeclaration n1, final Node arg) {
+        return true;
+    }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+    @Override public Boolean visit(final EnumConstantDeclaration n1, final Node arg) {
+        final EnumConstantDeclaration n2 = (EnumConstantDeclaration) arg;
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        // javadoc are checked at CompilationUnit
 
-		if (!nodeEquals(n1.getDefaultValue(), n2.getDefaultValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		return true;
-	}
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return false;
+        }
 
-	@Override public Boolean visit(final FieldDeclaration n1, final Node arg) {
-		final FieldDeclaration n2 = (FieldDeclaration) arg;
+        if (!nodesEquals(n1.getClassBody(), n2.getClassBody())) {
+            return false;
+        }
 
-		// javadoc are checked at CompilationUnit
+        return true;
+    }
 
-        if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+    @Override public Boolean visit(final AnnotationDeclaration n1, final Node arg) {
+        final AnnotationDeclaration n2 = (AnnotationDeclaration) arg;
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-
-		if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
-			return false;
-		}
-
-		if (!nodesEquals(n1.getVariables(), n2.getVariables())) {
-			return false;
-		}
-
-		if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
-			return false;
-		}
-		
-		return true;
-	}
-
-	@Override public Boolean visit(final VariableDeclarator n1, final Node arg) {
-		final VariableDeclarator n2 = (VariableDeclarator) arg;
-
-		if (!nodeEquals(n1.getId(), n2.getId())) {
-			return false;
-		}
-
-		if (!nodeEquals(n1.getInit(), n2.getInit())) {
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override public Boolean visit(final VariableDeclaratorId n1, final Node arg) {
-		final VariableDeclaratorId n2 = (VariableDeclaratorId) arg;
-
-		if(!nodesEquals(n1.getArrayBracketPairsAfterId(), n2.getArrayBracketPairsAfterId())){
-			return false;
-		}
-
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override public Boolean visit(final ConstructorDeclaration n1, final Node arg) {
-		final ConstructorDeclaration n2 = (ConstructorDeclaration) arg;
-
-		// javadoc are checked at CompilationUnit
+        // javadoc are checked at CompilationUnit
 
         if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+            return false;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
-			return false;
-		}
+        return true;
+    }
 
-		if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
-			return false;
-		}
+    @Override public Boolean visit(final AnnotationMemberDeclaration n1, final Node arg) {
+        final AnnotationMemberDeclaration n2 = (AnnotationMemberDeclaration) arg;
 
-		if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override public Boolean visit(final MethodDeclaration n1, final Node arg) {
-		final MethodDeclaration n2 = (MethodDeclaration) arg;
-
-		// javadoc are checked at CompilationUnit
+        // javadoc are checked at CompilationUnit
 
         if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+            return false;
+        }
 
-		if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if(!nodesEquals(n1.getArrayBracketPairsAfterParameterList(), n2.getArrayBracketPairsAfterParameterList())){
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getDefaultValue(), n2.getDefaultValue())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        return true;
+    }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+    @Override public Boolean visit(final FieldDeclaration n1, final Node arg) {
+        final FieldDeclaration n2 = (FieldDeclaration) arg;
 
-		if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
-			return false;
-		}
+        // javadoc are checked at CompilationUnit
 
-		if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
-			return false;
-		}
+        if (!n1.getModifiers().equals(n2.getModifiers())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
-			return false;
-		}
-		if(n1.isDefault() != n2.isDefault()){
-			return false;
-		}
-		return true;
-	}
-	
-	@Override public Boolean visit(final Parameter n1, final Node arg) {
-		final Parameter n2 = (Parameter) arg;
-		if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
-			return false;
-		}
+        if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
+            return false;
+        }
 
-		if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getVariables(), n2.getVariables())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getId(), n2.getId())) {
-			return false;
-		}
+        if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
+            return false;
+        }
+        
+        return true;
+    }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+    @Override public Boolean visit(final VariableDeclarator n1, final Node arg) {
+        final VariableDeclarator n2 = (VariableDeclarator) arg;
 
-		return true;
-	}
-	
-	@Override public Boolean visit(final EmptyMemberDeclaration n1, final Node arg) {
-		return true;
-	}
+        if (!nodeEquals(n1.getId(), n2.getId())) {
+            return false;
+        }
 
-	@Override public Boolean visit(final InitializerDeclaration n1, final Node arg) {
-		final InitializerDeclaration n2 = (InitializerDeclaration) arg;
+        if (!nodeEquals(n1.getInit(), n2.getInit())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
-			return false;
-		}
+        return true;
+    }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+    @Override public Boolean visit(final VariableDeclaratorId n1, final Node arg) {
+        final VariableDeclaratorId n2 = (VariableDeclaratorId) arg;
 
-		return true;
-	}
+        if(!nodesEquals(n1.getArrayBracketPairsAfterId(), n2.getArrayBracketPairsAfterId())){
+            return false;
+        }
 
-	@Override public Boolean visit(final JavadocComment n1, final Node arg) {
-		final JavadocComment n2 = (JavadocComment) arg;
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!objEquals(n1.getContent(), n2.getContent())) {
-			return false;
-		}
+        return true;
+    }
 
-		return true;
-	}
+    @Override public Boolean visit(final ConstructorDeclaration n1, final Node arg) {
+        final ConstructorDeclaration n2 = (ConstructorDeclaration) arg;
 
-	@Override public Boolean visit(final ClassOrInterfaceType n1, final Node arg) {
-		final ClassOrInterfaceType n2 = (ClassOrInterfaceType) arg;
+        // javadoc are checked at CompilationUnit
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!n1.getModifiers().equals(n2.getModifiers())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
 
-		return true;
-	}
+        if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
+            return false;
+        }
 
-	@Override public Boolean visit(final PrimitiveType n1, final Node arg) {
-		final PrimitiveType n2 = (PrimitiveType) arg;
+        if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
+            return false;
+        }
 
-		if (n1.getType() != n2.getType()) {
-			return false;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-		return true;
-	}
+        if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
+            return false;
+        }
 
-	@Override
-	public Boolean visit(ArrayType n1, Node arg) {
-		final ArrayType n2 = (ArrayType) arg;
+        return true;
+    }
 
-		if (!nodeEquals(n1.getComponentType(), n2.getComponentType())) {
-			return false;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-		return true;
-	}
+    @Override public Boolean visit(final MethodDeclaration n1, final Node arg) {
+        final MethodDeclaration n2 = (MethodDeclaration) arg;
 
-	@Override
-	public Boolean visit(ArrayCreationLevel n1, Node arg) {
-		final ArrayCreationLevel n2 = (ArrayCreationLevel) arg;
+        // javadoc are checked at CompilationUnit
 
-		if (!nodeEquals(n1.getDimension(), n2.getDimension())) {
-			return false;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-		return true;
-	}
+        if (!n1.getModifiers().equals(n2.getModifiers())) {
+            return false;
+        }
 
-	@Override public Boolean visit(final IntersectionType n1, final Node arg) {
+        if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
+            return false;
+        }
+
+        if(!nodesEquals(n1.getArrayBracketPairsAfterParameterList(), n2.getArrayBracketPairsAfterParameterList())){
+            return false;
+        }
+
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
+
+        if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
+            return false;
+        }
+        if(n1.isDefault() != n2.isDefault()){
+            return false;
+        }
+        return true;
+    }
+    
+    @Override public Boolean visit(final Parameter n1, final Node arg) {
+        final Parameter n2 = (Parameter) arg;
+        if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
+            return false;
+        }
+
+        if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
+            return false;
+        }
+
+        if (!n1.getModifiers().equals(n2.getModifiers())) {
+            return false;
+        }
+
+        if (!nodeEquals(n1.getId(), n2.getId())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+
+        return true;
+    }
+    
+    @Override public Boolean visit(final EmptyMemberDeclaration n1, final Node arg) {
+        return true;
+    }
+
+    @Override public Boolean visit(final InitializerDeclaration n1, final Node arg) {
+        final InitializerDeclaration n2 = (InitializerDeclaration) arg;
+
+        if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override public Boolean visit(final JavadocComment n1, final Node arg) {
+        final JavadocComment n2 = (JavadocComment) arg;
+
+        if (!objEquals(n1.getContent(), n2.getContent())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override public Boolean visit(final ClassOrInterfaceType n1, final Node arg) {
+        final ClassOrInterfaceType n2 = (ClassOrInterfaceType) arg;
+
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
+
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
+            return false;
+        }
+
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override public Boolean visit(final PrimitiveType n1, final Node arg) {
+        final PrimitiveType n2 = (PrimitiveType) arg;
+
+        if (n1.getType() != n2.getType()) {
+            return false;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Boolean visit(ArrayType n1, Node arg) {
+        final ArrayType n2 = (ArrayType) arg;
+
+        if (!nodeEquals(n1.getComponentType(), n2.getComponentType())) {
+            return false;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Boolean visit(ArrayCreationLevel n1, Node arg) {
+        final ArrayCreationLevel n2 = (ArrayCreationLevel) arg;
+
+        if (!nodeEquals(n1.getDimension(), n2.getDimension())) {
+            return false;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override public Boolean visit(final IntersectionType n1, final Node arg) {
         final IntersectionType n2 = (IntersectionType) arg;
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
         List<ReferenceType> n1Elements = n1.getElements();
         List<ReferenceType> n2Elements = n2.getElements();
@@ -698,9 +698,9 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     @Override public Boolean visit(final UnionType n1, final Node arg) {
         final UnionType n2 = (UnionType) arg;
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
         List<ReferenceType> n1Elements = n1.getElements();
         List<ReferenceType> n2Elements = n2.getElements();
@@ -724,744 +724,744 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
         return true;
     }
 
-	@Override
-	public Boolean visit(VoidType n1, Node arg) {
-		VoidType n2 = (VoidType) arg;
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-		return true;
-	}
+    @Override
+    public Boolean visit(VoidType n1, Node arg) {
+        VoidType n2 = (VoidType) arg;
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+        return true;
+    }
 
-	@Override public Boolean visit(final WildcardType n1, final Node arg) {
-		final WildcardType n2 = (WildcardType) arg;
+    @Override public Boolean visit(final WildcardType n1, final Node arg) {
+        final WildcardType n2 = (WildcardType) arg;
 
-		if (!nodeEquals(n1.getExtends(), n2.getExtends())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExtends(), n2.getExtends())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getSuper(), n2.getSuper())) {
-			return false;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
-		return true;
-	}
+        if (!nodeEquals(n1.getSuper(), n2.getSuper())) {
+            return false;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
+        return true;
+    }
 
-	@Override public Boolean visit(final UnknownType n1, final Node arg) {
-		return true;
-	}
+    @Override public Boolean visit(final UnknownType n1, final Node arg) {
+        return true;
+    }
 
-	@Override public Boolean visit(final ArrayAccessExpr n1, final Node arg) {
-		final ArrayAccessExpr n2 = (ArrayAccessExpr) arg;
+    @Override public Boolean visit(final ArrayAccessExpr n1, final Node arg) {
+        final ArrayAccessExpr n2 = (ArrayAccessExpr) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getIndex(), n2.getIndex())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getIndex(), n2.getIndex())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ArrayCreationExpr n1, final Node arg) {
-		final ArrayCreationExpr n2 = (ArrayCreationExpr) arg;
+    @Override public Boolean visit(final ArrayCreationExpr n1, final Node arg) {
+        final ArrayCreationExpr n2 = (ArrayCreationExpr) arg;
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getLevels(), n2.getLevels())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getLevels(), n2.getLevels())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getInitializer(), n2.getInitializer())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getInitializer(), n2.getInitializer())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ArrayInitializerExpr n1, final Node arg) {
-		final ArrayInitializerExpr n2 = (ArrayInitializerExpr) arg;
+    @Override public Boolean visit(final ArrayInitializerExpr n1, final Node arg) {
+        final ArrayInitializerExpr n2 = (ArrayInitializerExpr) arg;
 
-		if (!nodesEquals(n1.getValues(), n2.getValues())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getValues(), n2.getValues())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final AssignExpr n1, final Node arg) {
-		final AssignExpr n2 = (AssignExpr) arg;
+    @Override public Boolean visit(final AssignExpr n1, final Node arg) {
+        final AssignExpr n2 = (AssignExpr) arg;
 
-		if (n1.getOperator() != n2.getOperator()) {
-			return false;
-		}
+        if (n1.getOperator() != n2.getOperator()) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getTarget(), n2.getTarget())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getTarget(), n2.getTarget())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final BinaryExpr n1, final Node arg) {
-		final BinaryExpr n2 = (BinaryExpr) arg;
+    @Override public Boolean visit(final BinaryExpr n1, final Node arg) {
+        final BinaryExpr n2 = (BinaryExpr) arg;
 
-		if (n1.getOperator() != n2.getOperator()) {
-			return false;
-		}
+        if (n1.getOperator() != n2.getOperator()) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getLeft(), n2.getLeft())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getLeft(), n2.getLeft())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getRight(), n2.getRight())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getRight(), n2.getRight())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final CastExpr n1, final Node arg) {
-		final CastExpr n2 = (CastExpr) arg;
+    @Override public Boolean visit(final CastExpr n1, final Node arg) {
+        final CastExpr n2 = (CastExpr) arg;
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ClassExpr n1, final Node arg) {
-		final ClassExpr n2 = (ClassExpr) arg;
+    @Override public Boolean visit(final ClassExpr n1, final Node arg) {
+        final ClassExpr n2 = (ClassExpr) arg;
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ConditionalExpr n1, final Node arg) {
-		final ConditionalExpr n2 = (ConditionalExpr) arg;
+    @Override public Boolean visit(final ConditionalExpr n1, final Node arg) {
+        final ConditionalExpr n2 = (ConditionalExpr) arg;
 
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getThenExpr(), n2.getThenExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getThenExpr(), n2.getThenExpr())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getElseExpr(), n2.getElseExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getElseExpr(), n2.getElseExpr())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final EnclosedExpr n1, final Node arg) {
-		final EnclosedExpr n2 = (EnclosedExpr) arg;
+    @Override public Boolean visit(final EnclosedExpr n1, final Node arg) {
+        final EnclosedExpr n2 = (EnclosedExpr) arg;
 
-		if (!nodeEquals(n1.getInner(), n2.getInner())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getInner(), n2.getInner())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final FieldAccessExpr n1, final Node arg) {
-		final FieldAccessExpr n2 = (FieldAccessExpr) arg;
+    @Override public Boolean visit(final FieldAccessExpr n1, final Node arg) {
+        final FieldAccessExpr n2 = (FieldAccessExpr) arg;
 
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return false;
+        }
 
-		if (!objEquals(n1.getField(), n2.getField())) {
-			return false;
-		}
+        if (!objEquals(n1.getField(), n2.getField())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final InstanceOfExpr n1, final Node arg) {
-		final InstanceOfExpr n2 = (InstanceOfExpr) arg;
+    @Override public Boolean visit(final InstanceOfExpr n1, final Node arg) {
+        final InstanceOfExpr n2 = (InstanceOfExpr) arg;
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final StringLiteralExpr n1, final Node arg) {
-		final StringLiteralExpr n2 = (StringLiteralExpr) arg;
+    @Override public Boolean visit(final StringLiteralExpr n1, final Node arg) {
+        final StringLiteralExpr n2 = (StringLiteralExpr) arg;
 
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final IntegerLiteralExpr n1, final Node arg) {
-		final IntegerLiteralExpr n2 = (IntegerLiteralExpr) arg;
+    @Override public Boolean visit(final IntegerLiteralExpr n1, final Node arg) {
+        final IntegerLiteralExpr n2 = (IntegerLiteralExpr) arg;
 
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final LongLiteralExpr n1, final Node arg) {
-		final LongLiteralExpr n2 = (LongLiteralExpr) arg;
+    @Override public Boolean visit(final LongLiteralExpr n1, final Node arg) {
+        final LongLiteralExpr n2 = (LongLiteralExpr) arg;
 
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final IntegerLiteralMinValueExpr n1, final Node arg) {
-		final IntegerLiteralMinValueExpr n2 = (IntegerLiteralMinValueExpr) arg;
+    @Override public Boolean visit(final IntegerLiteralMinValueExpr n1, final Node arg) {
+        final IntegerLiteralMinValueExpr n2 = (IntegerLiteralMinValueExpr) arg;
 
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final LongLiteralMinValueExpr n1, final Node arg) {
-		final LongLiteralMinValueExpr n2 = (LongLiteralMinValueExpr) arg;
+    @Override public Boolean visit(final LongLiteralMinValueExpr n1, final Node arg) {
+        final LongLiteralMinValueExpr n2 = (LongLiteralMinValueExpr) arg;
 
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final CharLiteralExpr n1, final Node arg) {
-		final CharLiteralExpr n2 = (CharLiteralExpr) arg;
+    @Override public Boolean visit(final CharLiteralExpr n1, final Node arg) {
+        final CharLiteralExpr n2 = (CharLiteralExpr) arg;
 
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final DoubleLiteralExpr n1, final Node arg) {
-		final DoubleLiteralExpr n2 = (DoubleLiteralExpr) arg;
+    @Override public Boolean visit(final DoubleLiteralExpr n1, final Node arg) {
+        final DoubleLiteralExpr n2 = (DoubleLiteralExpr) arg;
 
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final BooleanLiteralExpr n1, final Node arg) {
-		final BooleanLiteralExpr n2 = (BooleanLiteralExpr) arg;
+    @Override public Boolean visit(final BooleanLiteralExpr n1, final Node arg) {
+        final BooleanLiteralExpr n2 = (BooleanLiteralExpr) arg;
 
-		if (n1.getValue() != n2.getValue()) {
-			return false;
-		}
+        if (n1.getValue() != n2.getValue()) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final NullLiteralExpr n1, final Node arg) {
-		return true;
-	}
+    @Override public Boolean visit(final NullLiteralExpr n1, final Node arg) {
+        return true;
+    }
 
-	@Override public Boolean visit(final MethodCallExpr n1, final Node arg) {
-		final MethodCallExpr n2 = (MethodCallExpr) arg;
+    @Override public Boolean visit(final MethodCallExpr n1, final Node arg) {
+        final MethodCallExpr n2 = (MethodCallExpr) arg;
 
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return false;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final NameExpr n1, final Node arg) {
-		final NameExpr n2 = (NameExpr) arg;
+    @Override public Boolean visit(final NameExpr n1, final Node arg) {
+        final NameExpr n2 = (NameExpr) arg;
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ObjectCreationExpr n1, final Node arg) {
-		final ObjectCreationExpr n2 = (ObjectCreationExpr) arg;
+    @Override public Boolean visit(final ObjectCreationExpr n1, final Node arg) {
+        final ObjectCreationExpr n2 = (ObjectCreationExpr) arg;
 
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnonymousClassBody(), n2.getAnonymousClassBody())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnonymousClassBody(), n2.getAnonymousClassBody())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final QualifiedNameExpr n1, final Node arg) {
-		final QualifiedNameExpr n2 = (QualifiedNameExpr) arg;
+    @Override public Boolean visit(final QualifiedNameExpr n1, final Node arg) {
+        final QualifiedNameExpr n2 = (QualifiedNameExpr) arg;
 
-		if (!nodeEquals(n1.getQualifier(), n2.getQualifier())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getQualifier(), n2.getQualifier())) {
+            return false;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ThisExpr n1, final Node arg) {
-		final ThisExpr n2 = (ThisExpr) arg;
+    @Override public Boolean visit(final ThisExpr n1, final Node arg) {
+        final ThisExpr n2 = (ThisExpr) arg;
 
-		if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final SuperExpr n1, final Node arg) {
-		final SuperExpr n2 = (SuperExpr) arg;
+    @Override public Boolean visit(final SuperExpr n1, final Node arg) {
+        final SuperExpr n2 = (SuperExpr) arg;
 
-		if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final UnaryExpr n1, final Node arg) {
-		final UnaryExpr n2 = (UnaryExpr) arg;
+    @Override public Boolean visit(final UnaryExpr n1, final Node arg) {
+        final UnaryExpr n2 = (UnaryExpr) arg;
 
-		if (n1.getOperator() != n2.getOperator()) {
-			return false;
-		}
+        if (n1.getOperator() != n2.getOperator()) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final VariableDeclarationExpr n1, final Node arg) {
-		final VariableDeclarationExpr n2 = (VariableDeclarationExpr) arg;
+    @Override public Boolean visit(final VariableDeclarationExpr n1, final Node arg) {
+        final VariableDeclarationExpr n2 = (VariableDeclarationExpr) arg;
 
         if (!n1.getModifiers().equals(n2.getModifiers())) {
-			return false;
-		}
+            return false;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getElementType(), n2.getElementType())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getVariables(), n2.getVariables())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getVariables(), n2.getVariables())) {
+            return false;
+        }
 
-		if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
-			return false;
-		}
-		
-		return true;
-	}
+        if(!nodesEquals(n1.getArrayBracketPairsAfterElementType(), n2.getArrayBracketPairsAfterElementType())){
+            return false;
+        }
+        
+        return true;
+    }
 
-	@Override public Boolean visit(final MarkerAnnotationExpr n1, final Node arg) {
-		final MarkerAnnotationExpr n2 = (MarkerAnnotationExpr) arg;
+    @Override public Boolean visit(final MarkerAnnotationExpr n1, final Node arg) {
+        final MarkerAnnotationExpr n2 = (MarkerAnnotationExpr) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final SingleMemberAnnotationExpr n1, final Node arg) {
-		final SingleMemberAnnotationExpr n2 = (SingleMemberAnnotationExpr) arg;
+    @Override public Boolean visit(final SingleMemberAnnotationExpr n1, final Node arg) {
+        final SingleMemberAnnotationExpr n2 = (SingleMemberAnnotationExpr) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getMemberValue(), n2.getMemberValue())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getMemberValue(), n2.getMemberValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final NormalAnnotationExpr n1, final Node arg) {
-		final NormalAnnotationExpr n2 = (NormalAnnotationExpr) arg;
+    @Override public Boolean visit(final NormalAnnotationExpr n1, final Node arg) {
+        final NormalAnnotationExpr n2 = (NormalAnnotationExpr) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getPairs(), n2.getPairs())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getPairs(), n2.getPairs())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final MemberValuePair n1, final Node arg) {
-		final MemberValuePair n2 = (MemberValuePair) arg;
+    @Override public Boolean visit(final MemberValuePair n1, final Node arg) {
+        final MemberValuePair n2 = (MemberValuePair) arg;
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return false;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getValue(), n2.getValue())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getValue(), n2.getValue())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ExplicitConstructorInvocationStmt n1, final Node arg) {
-		final ExplicitConstructorInvocationStmt n2 = (ExplicitConstructorInvocationStmt) arg;
+    @Override public Boolean visit(final ExplicitConstructorInvocationStmt n1, final Node arg) {
+        final ExplicitConstructorInvocationStmt n2 = (ExplicitConstructorInvocationStmt) arg;
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final TypeDeclarationStmt n1, final Node arg) {
-		final TypeDeclarationStmt n2 = (TypeDeclarationStmt) arg;
+    @Override public Boolean visit(final TypeDeclarationStmt n1, final Node arg) {
+        final TypeDeclarationStmt n2 = (TypeDeclarationStmt) arg;
 
-		if (!nodeEquals(n1.getTypeDeclaration(), n2.getTypeDeclaration())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getTypeDeclaration(), n2.getTypeDeclaration())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final AssertStmt n1, final Node arg) {
-		final AssertStmt n2 = (AssertStmt) arg;
+    @Override public Boolean visit(final AssertStmt n1, final Node arg) {
+        final AssertStmt n2 = (AssertStmt) arg;
 
-		if (!nodeEquals(n1.getCheck(), n2.getCheck())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getCheck(), n2.getCheck())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getMessage(), n2.getMessage())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getMessage(), n2.getMessage())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final BlockStmt n1, final Node arg) {
-		final BlockStmt n2 = (BlockStmt) arg;
+    @Override public Boolean visit(final BlockStmt n1, final Node arg) {
+        final BlockStmt n2 = (BlockStmt) arg;
 
-		if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final LabeledStmt n1, final Node arg) {
-		final LabeledStmt n2 = (LabeledStmt) arg;
+    @Override public Boolean visit(final LabeledStmt n1, final Node arg) {
+        final LabeledStmt n2 = (LabeledStmt) arg;
 
-		if (!nodeEquals(n1.getStmt(), n2.getStmt())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getStmt(), n2.getStmt())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final EmptyStmt n1, final Node arg) {
-		return true;
-	}
+    @Override public Boolean visit(final EmptyStmt n1, final Node arg) {
+        return true;
+    }
 
-	@Override public Boolean visit(final ExpressionStmt n1, final Node arg) {
-		final ExpressionStmt n2 = (ExpressionStmt) arg;
+    @Override public Boolean visit(final ExpressionStmt n1, final Node arg) {
+        final ExpressionStmt n2 = (ExpressionStmt) arg;
 
-		if (!nodeEquals(n1.getExpression(), n2.getExpression())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpression(), n2.getExpression())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final SwitchStmt n1, final Node arg) {
-		final SwitchStmt n2 = (SwitchStmt) arg;
+    @Override public Boolean visit(final SwitchStmt n1, final Node arg) {
+        final SwitchStmt n2 = (SwitchStmt) arg;
 
-		if (!nodeEquals(n1.getSelector(), n2.getSelector())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getSelector(), n2.getSelector())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final SwitchEntryStmt n1, final Node arg) {
-		final SwitchEntryStmt n2 = (SwitchEntryStmt) arg;
+    @Override public Boolean visit(final SwitchEntryStmt n1, final Node arg) {
+        final SwitchEntryStmt n2 = (SwitchEntryStmt) arg;
 
-		if (!nodeEquals(n1.getLabel(), n2.getLabel())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getLabel(), n2.getLabel())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final BreakStmt n1, final Node arg) {
-		final BreakStmt n2 = (BreakStmt) arg;
+    @Override public Boolean visit(final BreakStmt n1, final Node arg) {
+        final BreakStmt n2 = (BreakStmt) arg;
 
-		if (!objEquals(n1.getId(), n2.getId())) {
-			return false;
-		}
+        if (!objEquals(n1.getId(), n2.getId())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ReturnStmt n1, final Node arg) {
-		final ReturnStmt n2 = (ReturnStmt) arg;
+    @Override public Boolean visit(final ReturnStmt n1, final Node arg) {
+        final ReturnStmt n2 = (ReturnStmt) arg;
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final IfStmt n1, final Node arg) {
-		final IfStmt n2 = (IfStmt) arg;
+    @Override public Boolean visit(final IfStmt n1, final Node arg) {
+        final IfStmt n2 = (IfStmt) arg;
 
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getThenStmt(), n2.getThenStmt())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getThenStmt(), n2.getThenStmt())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getElseStmt(), n2.getElseStmt())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getElseStmt(), n2.getElseStmt())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final WhileStmt n1, final Node arg) {
-		final WhileStmt n2 = (WhileStmt) arg;
+    @Override public Boolean visit(final WhileStmt n1, final Node arg) {
+        final WhileStmt n2 = (WhileStmt) arg;
 
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ContinueStmt n1, final Node arg) {
-		final ContinueStmt n2 = (ContinueStmt) arg;
+    @Override public Boolean visit(final ContinueStmt n1, final Node arg) {
+        final ContinueStmt n2 = (ContinueStmt) arg;
 
-		if (!objEquals(n1.getId(), n2.getId())) {
-			return false;
-		}
+        if (!objEquals(n1.getId(), n2.getId())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final DoStmt n1, final Node arg) {
-		final DoStmt n2 = (DoStmt) arg;
+    @Override public Boolean visit(final DoStmt n1, final Node arg) {
+        final DoStmt n2 = (DoStmt) arg;
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ForeachStmt n1, final Node arg) {
-		final ForeachStmt n2 = (ForeachStmt) arg;
+    @Override public Boolean visit(final ForeachStmt n1, final Node arg) {
+        final ForeachStmt n2 = (ForeachStmt) arg;
 
-		if (!nodeEquals(n1.getVariable(), n2.getVariable())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getVariable(), n2.getVariable())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getIterable(), n2.getIterable())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getIterable(), n2.getIterable())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ForStmt n1, final Node arg) {
-		final ForStmt n2 = (ForStmt) arg;
+    @Override public Boolean visit(final ForStmt n1, final Node arg) {
+        final ForStmt n2 = (ForStmt) arg;
 
-		if (!nodesEquals(n1.getInit(), n2.getInit())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getInit(), n2.getInit())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getCompare(), n2.getCompare())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getCompare(), n2.getCompare())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getUpdate(), n2.getUpdate())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getUpdate(), n2.getUpdate())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final ThrowStmt n1, final Node arg) {
-		final ThrowStmt n2 = (ThrowStmt) arg;
+    @Override public Boolean visit(final ThrowStmt n1, final Node arg) {
+        final ThrowStmt n2 = (ThrowStmt) arg;
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final SynchronizedStmt n1, final Node arg) {
-		final SynchronizedStmt n2 = (SynchronizedStmt) arg;
+    @Override public Boolean visit(final SynchronizedStmt n1, final Node arg) {
+        final SynchronizedStmt n2 = (SynchronizedStmt) arg;
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final TryStmt n1, final Node arg) {
-		final TryStmt n2 = (TryStmt) arg;
+    @Override public Boolean visit(final TryStmt n1, final Node arg) {
+        final TryStmt n2 = (TryStmt) arg;
 
-		if (!nodeEquals(n1.getTryBlock(), n2.getTryBlock())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getTryBlock(), n2.getTryBlock())) {
+            return false;
+        }
 
-		if (!nodesEquals(n1.getCatchs(), n2.getCatchs())) {
-			return false;
-		}
-		
-		if(!nodesEquals(n1.getResources(), n2.getResources())) {
-			return false;
-		}
+        if (!nodesEquals(n1.getCatchs(), n2.getCatchs())) {
+            return false;
+        }
+        
+        if(!nodesEquals(n1.getResources(), n2.getResources())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getFinallyBlock(), n2.getFinallyBlock())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getFinallyBlock(), n2.getFinallyBlock())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override public Boolean visit(final CatchClause n1, final Node arg) {
-		final CatchClause n2 = (CatchClause) arg;
+    @Override public Boolean visit(final CatchClause n1, final Node arg) {
+        final CatchClause n2 = (CatchClause) arg;
 
-		if (!nodeEquals(n1.getParam(), n2.getParam())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getParam(), n2.getParam())) {
+            return false;
+        }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return false;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
     @Override
     public Boolean visit(LambdaExpr n1, Node arg) {
@@ -1484,7 +1484,7 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
         if (!nodeEquals(n1.getScope(), n2.getScope())) {
             return false;
         }
-	    if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
+        if (!nodesEquals(n1.getTypeArguments(), n2.getTypeArguments())) {
             return false;
         }
         if (!objEquals(n1.getIdentifier(), n2.getIdentifier())) {
@@ -1502,13 +1502,13 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
         return true;
     }
 
-	@Override
-	public Boolean visit(ArrayBracketPair n1, Node arg) {
-		ArrayBracketPair n2 = (ArrayBracketPair) arg;
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return false;
-		}
+    @Override
+    public Boolean visit(ArrayBracketPair n1, Node arg) {
+        ArrayBracketPair n2 = (ArrayBracketPair) arg;
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/GenericVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/GenericVisitor.java
@@ -71,181 +71,181 @@ import com.github.javaparser.ast.type.*;
  */
 public interface GenericVisitor<R, A> {
 
-	//- Compilation Unit ----------------------------------
+    //- Compilation Unit ----------------------------------
 
-	R visit(CompilationUnit n, A arg);
+    R visit(CompilationUnit n, A arg);
 
-	R visit(PackageDeclaration n, A arg);
+    R visit(PackageDeclaration n, A arg);
 
-	R visit(ImportDeclaration n, A arg);
+    R visit(ImportDeclaration n, A arg);
 
-	R visit(TypeParameter n, A arg);
+    R visit(TypeParameter n, A arg);
 
-	R visit(LineComment n, A arg);
+    R visit(LineComment n, A arg);
 
-	R visit(BlockComment n, A arg);
+    R visit(BlockComment n, A arg);
 
-	//- Body ----------------------------------------------
+    //- Body ----------------------------------------------
 
-	R visit(ClassOrInterfaceDeclaration n, A arg);
+    R visit(ClassOrInterfaceDeclaration n, A arg);
 
-	R visit(EnumDeclaration n, A arg);
+    R visit(EnumDeclaration n, A arg);
 
-	R visit(EmptyTypeDeclaration n, A arg);
+    R visit(EmptyTypeDeclaration n, A arg);
 
-	R visit(EnumConstantDeclaration n, A arg);
+    R visit(EnumConstantDeclaration n, A arg);
 
-	R visit(AnnotationDeclaration n, A arg);
+    R visit(AnnotationDeclaration n, A arg);
 
-	R visit(AnnotationMemberDeclaration n, A arg);
+    R visit(AnnotationMemberDeclaration n, A arg);
 
-	R visit(FieldDeclaration n, A arg);
+    R visit(FieldDeclaration n, A arg);
 
-	R visit(VariableDeclarator n, A arg);
+    R visit(VariableDeclarator n, A arg);
 
-	R visit(VariableDeclaratorId n, A arg);
+    R visit(VariableDeclaratorId n, A arg);
 
-	R visit(ConstructorDeclaration n, A arg);
+    R visit(ConstructorDeclaration n, A arg);
 
-	R visit(MethodDeclaration n, A arg);
+    R visit(MethodDeclaration n, A arg);
 
-	R visit(Parameter n, A arg);
-	
-	R visit(EmptyMemberDeclaration n, A arg);
+    R visit(Parameter n, A arg);
+    
+    R visit(EmptyMemberDeclaration n, A arg);
 
-	R visit(InitializerDeclaration n, A arg);
+    R visit(InitializerDeclaration n, A arg);
 
-	R visit(JavadocComment n, A arg);
+    R visit(JavadocComment n, A arg);
 
-	//- Type ----------------------------------------------
+    //- Type ----------------------------------------------
 
-	R visit(ClassOrInterfaceType n, A arg);
+    R visit(ClassOrInterfaceType n, A arg);
 
-	R visit(PrimitiveType n, A arg);
+    R visit(PrimitiveType n, A arg);
 
-	R visit(ArrayType n, A arg);
-	
-	R visit(ArrayCreationLevel n, A arg);
+    R visit(ArrayType n, A arg);
+    
+    R visit(ArrayCreationLevel n, A arg);
 
     R visit(IntersectionType n, A arg);
 
     R visit(UnionType n, A arg);
 
-	R visit(VoidType n, A arg);
+    R visit(VoidType n, A arg);
 
-	R visit(WildcardType n, A arg);
+    R visit(WildcardType n, A arg);
 
-	R visit(UnknownType n, A arg);
+    R visit(UnknownType n, A arg);
 
-	//- Expression ----------------------------------------
+    //- Expression ----------------------------------------
 
-	R visit(ArrayAccessExpr n, A arg);
+    R visit(ArrayAccessExpr n, A arg);
 
-	R visit(ArrayCreationExpr n, A arg);
+    R visit(ArrayCreationExpr n, A arg);
 
-	R visit(ArrayInitializerExpr n, A arg);
+    R visit(ArrayInitializerExpr n, A arg);
 
-	R visit(AssignExpr n, A arg);
+    R visit(AssignExpr n, A arg);
 
-	R visit(BinaryExpr n, A arg);
+    R visit(BinaryExpr n, A arg);
 
-	R visit(CastExpr n, A arg);
+    R visit(CastExpr n, A arg);
 
-	R visit(ClassExpr n, A arg);
+    R visit(ClassExpr n, A arg);
 
-	R visit(ConditionalExpr n, A arg);
+    R visit(ConditionalExpr n, A arg);
 
-	R visit(EnclosedExpr n, A arg);
+    R visit(EnclosedExpr n, A arg);
 
-	R visit(FieldAccessExpr n, A arg);
+    R visit(FieldAccessExpr n, A arg);
 
-	R visit(InstanceOfExpr n, A arg);
+    R visit(InstanceOfExpr n, A arg);
 
-	R visit(StringLiteralExpr n, A arg);
+    R visit(StringLiteralExpr n, A arg);
 
-	R visit(IntegerLiteralExpr n, A arg);
+    R visit(IntegerLiteralExpr n, A arg);
 
-	R visit(LongLiteralExpr n, A arg);
+    R visit(LongLiteralExpr n, A arg);
 
-	R visit(IntegerLiteralMinValueExpr n, A arg);
+    R visit(IntegerLiteralMinValueExpr n, A arg);
 
-	R visit(LongLiteralMinValueExpr n, A arg);
+    R visit(LongLiteralMinValueExpr n, A arg);
 
-	R visit(CharLiteralExpr n, A arg);
+    R visit(CharLiteralExpr n, A arg);
 
-	R visit(DoubleLiteralExpr n, A arg);
+    R visit(DoubleLiteralExpr n, A arg);
 
-	R visit(BooleanLiteralExpr n, A arg);
+    R visit(BooleanLiteralExpr n, A arg);
 
-	R visit(NullLiteralExpr n, A arg);
+    R visit(NullLiteralExpr n, A arg);
 
-	R visit(MethodCallExpr n, A arg);
+    R visit(MethodCallExpr n, A arg);
 
-	R visit(NameExpr n, A arg);
+    R visit(NameExpr n, A arg);
 
-	R visit(ObjectCreationExpr n, A arg);
+    R visit(ObjectCreationExpr n, A arg);
 
-	R visit(QualifiedNameExpr n, A arg);
+    R visit(QualifiedNameExpr n, A arg);
 
-	R visit(ThisExpr n, A arg);
+    R visit(ThisExpr n, A arg);
 
-	R visit(SuperExpr n, A arg);
+    R visit(SuperExpr n, A arg);
 
-	R visit(UnaryExpr n, A arg);
+    R visit(UnaryExpr n, A arg);
 
-	R visit(VariableDeclarationExpr n, A arg);
+    R visit(VariableDeclarationExpr n, A arg);
 
-	R visit(MarkerAnnotationExpr n, A arg);
+    R visit(MarkerAnnotationExpr n, A arg);
 
-	R visit(SingleMemberAnnotationExpr n, A arg);
+    R visit(SingleMemberAnnotationExpr n, A arg);
 
-	R visit(NormalAnnotationExpr n, A arg);
+    R visit(NormalAnnotationExpr n, A arg);
 
-	R visit(MemberValuePair n, A arg);
+    R visit(MemberValuePair n, A arg);
 
-	//- Statements ----------------------------------------
+    //- Statements ----------------------------------------
 
-	R visit(ExplicitConstructorInvocationStmt n, A arg);
+    R visit(ExplicitConstructorInvocationStmt n, A arg);
 
-	R visit(TypeDeclarationStmt n, A arg);
+    R visit(TypeDeclarationStmt n, A arg);
 
-	R visit(AssertStmt n, A arg);
+    R visit(AssertStmt n, A arg);
 
-	R visit(BlockStmt n, A arg);
+    R visit(BlockStmt n, A arg);
 
-	R visit(LabeledStmt n, A arg);
+    R visit(LabeledStmt n, A arg);
 
-	R visit(EmptyStmt n, A arg);
+    R visit(EmptyStmt n, A arg);
 
-	R visit(ExpressionStmt n, A arg);
+    R visit(ExpressionStmt n, A arg);
 
-	R visit(SwitchStmt n, A arg);
+    R visit(SwitchStmt n, A arg);
 
-	R visit(SwitchEntryStmt n, A arg);
+    R visit(SwitchEntryStmt n, A arg);
 
-	R visit(BreakStmt n, A arg);
+    R visit(BreakStmt n, A arg);
 
-	R visit(ReturnStmt n, A arg);
+    R visit(ReturnStmt n, A arg);
 
-	R visit(IfStmt n, A arg);
+    R visit(IfStmt n, A arg);
 
-	R visit(WhileStmt n, A arg);
+    R visit(WhileStmt n, A arg);
 
-	R visit(ContinueStmt n, A arg);
+    R visit(ContinueStmt n, A arg);
 
-	R visit(DoStmt n, A arg);
+    R visit(DoStmt n, A arg);
 
-	R visit(ForeachStmt n, A arg);
+    R visit(ForeachStmt n, A arg);
 
-	R visit(ForStmt n, A arg);
+    R visit(ForStmt n, A arg);
 
-	R visit(ThrowStmt n, A arg);
+    R visit(ThrowStmt n, A arg);
 
-	R visit(SynchronizedStmt n, A arg);
+    R visit(SynchronizedStmt n, A arg);
 
-	R visit(TryStmt n, A arg);
+    R visit(TryStmt n, A arg);
 
-	R visit(CatchClause n, A arg);
+    R visit(CatchClause n, A arg);
 
     R visit(LambdaExpr n, A arg);
 
@@ -253,5 +253,5 @@ public interface GenericVisitor<R, A> {
 
     R visit(TypeExpr n, A arg);
 
-	R visit(ArrayBracketPair arrayBracketPair, A arg);
+    R visit(ArrayBracketPair arrayBracketPair, A arg);
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -38,650 +38,650 @@ import java.util.List;
  */
 public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A> {
 
-	@Override
-	public R visit(final AnnotationDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getMembers() != null) {
+    @Override
+    public R visit(final AnnotationDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getMembers() != null) {
             for (final BodyDeclaration<?> member : n.getMembers()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final AnnotationMemberDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getDefaultValue() != null) {
-			{
-				R result = n.getDefaultValue().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final AnnotationMemberDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getDefaultValue() != null) {
+            {
+                R result = n.getDefaultValue().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ArrayAccessExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getIndex().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ArrayAccessExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getIndex().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ArrayCreationExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		for(ArrayCreationLevel level: n.getLevels()){
-			R result = level.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getInitializer() != null) {
-			R result = n.getInitializer().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ArrayCreationExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        for(ArrayCreationLevel level: n.getLevels()){
+            R result = level.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getInitializer() != null) {
+            R result = n.getInitializer().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ArrayInitializerExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getValues() != null) {
-			for (final Expression expr : n.getValues()) {
-				{
-					R result = expr.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ArrayInitializerExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getValues() != null) {
+            for (final Expression expr : n.getValues()) {
+                {
+                    R result = expr.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final AssertStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getCheck().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getMessage() != null) {
-			{
-				R result = n.getMessage().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final AssertStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getCheck().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getMessage() != null) {
+            {
+                R result = n.getMessage().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final AssignExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getTarget().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getValue().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final AssignExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getTarget().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getValue().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final BinaryExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getLeft().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getRight().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final BinaryExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getLeft().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getRight().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final BlockStmt n, final A arg) {
-		visitComment(n, arg);
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				{
-					R result = s.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
+    @Override
+    public R visit(final BlockStmt n, final A arg) {
+        visitComment(n, arg);
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                {
+                    R result = s.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
 
-	}
+    }
 
-	@Override
-	public R visit(final BooleanLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final BooleanLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final BreakStmt n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final BreakStmt n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final CastExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final CastExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final CatchClause n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getParam().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
+    @Override
+    public R visit(final CatchClause n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getParam().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
 
-	}
+    }
 
-	@Override
-	public R visit(final CharLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final CharLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final ClassExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ClassExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ClassOrInterfaceDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getExtends() != null) {
-			for (final ClassOrInterfaceType c : n.getExtends()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
+    @Override
+    public R visit(final ClassOrInterfaceDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getExtends() != null) {
+            for (final ClassOrInterfaceType c : n.getExtends()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
 
-		if (n.getImplements() != null) {
-			for (final ClassOrInterfaceType c : n.getImplements()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getMembers() != null) {
+        if (n.getImplements() != null) {
+            for (final ClassOrInterfaceType c : n.getImplements()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getMembers() != null) {
             for (final BodyDeclaration<?> member : n.getMembers()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ClassOrInterfaceType n, final A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getScope() != null) {
-			{
-				R result = n.getScope().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getTypeArguments() != null) {
-			for (Type<?> type : n.getTypeArguments()) {
-				R result = type.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ClassOrInterfaceType n, final A arg) {
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getScope() != null) {
+            {
+                R result = n.getScope().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getTypeArguments() != null) {
+            for (Type<?> type : n.getTypeArguments()) {
+                R result = type.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final CompilationUnit n, final A arg) {
-		visitComment(n, arg);
-		if (n.getPackage() != null) {
-			{
-				R result = n.getPackage().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getImports() != null) {
-			for (final ImportDeclaration i : n.getImports()) {
-				{
-					R result = i.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypes() != null) {
+    @Override
+    public R visit(final CompilationUnit n, final A arg) {
+        visitComment(n, arg);
+        if (n.getPackage() != null) {
+            {
+                R result = n.getPackage().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getImports() != null) {
+            for (final ImportDeclaration i : n.getImports()) {
+                {
+                    R result = i.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypes() != null) {
             for (final TypeDeclaration<?> typeDeclaration : n.getTypes()) {
-				{
-					R result = typeDeclaration.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+                {
+                    R result = typeDeclaration.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ConditionalExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getThenExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getElseExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ConditionalExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getThenExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getElseExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ConstructorDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				{
-					R result = p.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final ReferenceType name : n.getThrows()) {
-				{
-					R result = name.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ConstructorDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                {
+                    R result = p.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final ReferenceType name : n.getThrows()) {
+                {
+                    R result = name.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ContinueStmt n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final ContinueStmt n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final DoStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final DoStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final DoubleLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final DoubleLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final EmptyMemberDeclaration n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final EmptyMemberDeclaration n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final EmptyStmt n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final EmptyStmt n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final EmptyTypeDeclaration n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final EmptyTypeDeclaration n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final EnclosedExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getInner().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final EnclosedExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getInner().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final EnumConstantDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getClassBody() != null) {
+    @Override
+    public R visit(final EnumConstantDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getClassBody() != null) {
             for (final BodyDeclaration<?> member : n.getClassBody()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final EnumDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getImplements() != null) {
-			for (final ClassOrInterfaceType c : n.getImplements()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getEntries() != null) {
-			for (final EnumConstantDeclaration e : n.getEntries()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getMembers() != null) {
+    @Override
+    public R visit(final EnumDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getImplements() != null) {
+            for (final ClassOrInterfaceType c : n.getImplements()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getEntries() != null) {
+            for (final EnumConstantDeclaration e : n.getEntries()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getMembers() != null) {
             for (final BodyDeclaration<?> member : n.getMembers()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-		visitComment(n, arg);
-		if (!n.isThis() && n.getExpr() != null) {
-			{
-				R result = n.getExpr().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getTypeArguments() != null) {
-			for (Type<?> type : n.getTypeArguments()) {
-				R result = type.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ExplicitConstructorInvocationStmt n, final A arg) {
+        visitComment(n, arg);
+        if (!n.isThis() && n.getExpr() != null) {
+            {
+                R result = n.getExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getTypeArguments() != null) {
+            for (Type<?> type : n.getTypeArguments()) {
+                R result = type.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ExpressionStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getExpression().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ExpressionStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getExpression().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final FieldAccessExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getScope().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
+    @Override
+    public R visit(final FieldAccessExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getScope().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
         {
             if (n.getTypeArguments() != null) {
                 for (Type<?> type : n.getTypeArguments()) {
@@ -692,531 +692,531 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
                 }
             }
         }
-		return null;
-	}
+        return null;
+    }
 
-	@Override
-	public R visit(final FieldDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getElementType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		for (final VariableDeclarator var : n.getVariables()) {
-			{
-				R result = var.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final FieldDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getElementType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        for (final VariableDeclarator var : n.getVariables()) {
+            {
+                R result = var.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ForeachStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getVariable().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getIterable().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ForeachStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getVariable().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getIterable().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ForStmt n, final A arg) {
-		visitComment(n, arg);
-		if (n.getInit() != null) {
-			for (final Expression e : n.getInit()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getCompare() != null) {
-			{
-				R result = n.getCompare().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getUpdate() != null) {
-			for (final Expression e : n.getUpdate()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ForStmt n, final A arg) {
+        visitComment(n, arg);
+        if (n.getInit() != null) {
+            for (final Expression e : n.getInit()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getCompare() != null) {
+            {
+                R result = n.getCompare().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getUpdate() != null) {
+            for (final Expression e : n.getUpdate()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final IfStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getThenStmt().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getElseStmt() != null) {
-			{
-				R result = n.getElseStmt().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final IfStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getThenStmt().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getElseStmt() != null) {
+            {
+                R result = n.getElseStmt().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ImportDeclaration n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ImportDeclaration n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final InitializerDeclaration n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getBlock().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final InitializerDeclaration n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getBlock().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final InstanceOfExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final InstanceOfExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final IntegerLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final IntegerLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final IntegerLiteralMinValueExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final IntegerLiteralMinValueExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final JavadocComment n, final A arg) {
-		return null;
-	}
+    @Override
+    public R visit(final JavadocComment n, final A arg) {
+        return null;
+    }
 
-	@Override
-	public R visit(final LabeledStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getStmt().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final LabeledStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getStmt().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final LongLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final LongLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final LongLiteralMinValueExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final LongLiteralMinValueExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final MarkerAnnotationExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final MarkerAnnotationExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final MemberValuePair n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getValue().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final MemberValuePair n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getValue().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final MethodCallExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getScope() != null) {
-			{
-				R result = n.getScope().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getTypeArguments() != null) {
-			for (Type<?> type : n.getTypeArguments()) {
-				R result = type.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final MethodCallExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getScope() != null) {
+            {
+                R result = n.getScope().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getTypeArguments() != null) {
+            for (Type<?> type : n.getTypeArguments()) {
+                R result = type.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final MethodDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getElementType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				{
-					R result = p.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final ReferenceType name : n.getThrows()) {
-				{
-					R result = name.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getBody() != null) {
-			{
-				R result = n.getBody().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final MethodDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getElementType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                {
+                    R result = p.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final ReferenceType name : n.getThrows()) {
+                {
+                    R result = name.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getBody() != null) {
+            {
+                R result = n.getBody().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final NameExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final NameExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final NormalAnnotationExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getPairs() != null) {
-			for (final MemberValuePair m : n.getPairs()) {
-				{
-					R result = m.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final NormalAnnotationExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getPairs() != null) {
+            for (final MemberValuePair m : n.getPairs()) {
+                {
+                    R result = m.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final NullLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final NullLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final ObjectCreationExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getScope() != null) {
-			{
-				R result = n.getScope().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getTypeArguments() != null) {
-			for (Type<?> type : n.getTypeArguments()) {
-				R result = type.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getAnonymousClassBody() != null) {
+    @Override
+    public R visit(final ObjectCreationExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getScope() != null) {
+            {
+                R result = n.getScope().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getTypeArguments() != null) {
+            for (Type<?> type : n.getTypeArguments()) {
+                R result = type.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getAnonymousClassBody() != null) {
             for (final BodyDeclaration<?> member : n.getAnonymousClassBody()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final PackageDeclaration n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final PackageDeclaration n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final Parameter n, final A arg) {
-		visitComment(n, arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getElementType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getId().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-	
-	@Override
-	public R visit(final PrimitiveType n, final A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final Parameter n, final A arg) {
+        visitComment(n, arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getElementType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getId().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+    
+    @Override
+    public R visit(final PrimitiveType n, final A arg) {
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final QualifiedNameExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getQualifier().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final QualifiedNameExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getQualifier().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(ArrayType n, A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getComponentType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(ArrayType n, A arg) {
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getComponentType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(ArrayCreationLevel n, A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			if(n.getDimension()!=null) {
-				R result = n.getDimension().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(ArrayCreationLevel n, A arg) {
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            if(n.getDimension()!=null) {
+                R result = n.getDimension().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
+    @Override
     public R visit(final IntersectionType n, final A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
         {
             for (ReferenceType element : n.getElements()) {
                 R result = element.accept(this, arg);
@@ -1230,13 +1230,13 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
 
     @Override
     public R visit(final UnionType n, final A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
         {
             for (ReferenceType element : n.getElements()) {
                 R result = element.accept(this, arg);
@@ -1248,365 +1248,365 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
         return null;
     }
 
-	@Override
-	public R visit(final ReturnStmt n, final A arg) {
-		visitComment(n, arg);
-		if (n.getExpr() != null) {
-			{
-				R result = n.getExpr().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ReturnStmt n, final A arg) {
+        visitComment(n, arg);
+        if (n.getExpr() != null) {
+            {
+                R result = n.getExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final SingleMemberAnnotationExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getMemberValue().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final SingleMemberAnnotationExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getMemberValue().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final StringLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final StringLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final SuperExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getClassExpr() != null) {
-			{
-				R result = n.getClassExpr().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final SuperExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getClassExpr() != null) {
+            {
+                R result = n.getClassExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final SwitchEntryStmt n, final A arg) {
-		visitComment(n, arg);
-		if (n.getLabel() != null) {
-			{
-				R result = n.getLabel().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				{
-					R result = s.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final SwitchEntryStmt n, final A arg) {
+        visitComment(n, arg);
+        if (n.getLabel() != null) {
+            {
+                R result = n.getLabel().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                {
+                    R result = s.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final SwitchStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getSelector().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getEntries() != null) {
-			for (final SwitchEntryStmt e : n.getEntries()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
+    @Override
+    public R visit(final SwitchStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getSelector().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getEntries() != null) {
+            for (final SwitchEntryStmt e : n.getEntries()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
 
-	}
+    }
 
-	@Override
-	public R visit(final SynchronizedStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			if (n.getExpr() != null) {
-			    R result = n.getExpr().accept(this, arg);
-			    if (result != null) {
-				    return result;
-			    }
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final SynchronizedStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            if (n.getExpr() != null) {
+                R result = n.getExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ThisExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getClassExpr() != null) {
-			{
-				R result = n.getClassExpr().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ThisExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getClassExpr() != null) {
+            {
+                R result = n.getClassExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final ThrowStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final ThrowStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final TryStmt n, final A arg) {
-		visitComment(n, arg);
-		if (n.getResources() != null) {
-			for (final VariableDeclarationExpr v : n.getResources()) {
-				{
-					R result = v.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getTryBlock().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getCatchs() != null) {
-			for (final CatchClause c : n.getCatchs()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getFinallyBlock() != null) {
-			{
-				R result = n.getFinallyBlock().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final TryStmt n, final A arg) {
+        visitComment(n, arg);
+        if (n.getResources() != null) {
+            for (final VariableDeclarationExpr v : n.getResources()) {
+                {
+                    R result = v.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getTryBlock().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getCatchs() != null) {
+            for (final CatchClause c : n.getCatchs()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getFinallyBlock() != null) {
+            {
+                R result = n.getFinallyBlock().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final TypeDeclarationStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getTypeDeclaration().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final TypeDeclarationStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getTypeDeclaration().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final TypeParameter n, final A arg) {
-		visitComment(n, arg);
-		if (n.getTypeBound() != null) {
-			for (final ClassOrInterfaceType c : n.getTypeBound()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final TypeParameter n, final A arg) {
+        visitComment(n, arg);
+        if (n.getTypeBound() != null) {
+            for (final ClassOrInterfaceType c : n.getTypeBound()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final UnaryExpr n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final UnaryExpr n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final UnknownType n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final UnknownType n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final VariableDeclarationExpr n, final A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getElementType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		for (final VariableDeclarator v : n.getVariables()) {
-			{
-				R result = v.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final VariableDeclarationExpr n, final A arg) {
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getElementType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        for (final VariableDeclarator v : n.getVariables()) {
+            {
+                R result = v.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final VariableDeclarator n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getId().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getInit() != null) {
-			{
-				R result = n.getInit().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final VariableDeclarator n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getId().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getInit() != null) {
+            {
+                R result = n.getInit().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final VariableDeclaratorId n, final A arg) {
-		visitComment(n, arg);
-		return null;
-	}
+    @Override
+    public R visit(final VariableDeclaratorId n, final A arg) {
+        visitComment(n, arg);
+        return null;
+    }
 
-	@Override
-	public R visit(final VoidType n, final A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final VoidType n, final A arg) {
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final WhileStmt n, final A arg) {
-		visitComment(n, arg);
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final WhileStmt n, final A arg) {
+        visitComment(n, arg);
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final WildcardType n, final A arg) {
-		visitComment(n, arg);
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			R result = a.accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getExtends() != null) {
-			{
-				R result = n.getExtends().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getSuper() != null) {
-			{
-				R result = n.getSuper().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final WildcardType n, final A arg) {
+        visitComment(n, arg);
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            R result = a.accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getExtends() != null) {
+            {
+                R result = n.getExtends().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getSuper() != null) {
+            {
+                R result = n.getSuper().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
     @Override
     public R visit(LambdaExpr n, A arg) {
-		visitComment(n, arg);
-		if (n.getParameters() != null) {
-			for (final Parameter a : n.getParameters()) {
-				R result = a.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getBody() != null) {
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
+        visitComment(n, arg);
+        if (n.getParameters() != null) {
+            for (final Parameter a : n.getParameters()) {
+                R result = a.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getBody() != null) {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -1623,55 +1623,55 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             }
         }
         if (n.getScope() != null) {
-			R result = n.getScope().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
+            R result = n.getScope().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
     }
 
     @Override
     public R visit(TypeExpr n, A arg){
-		visitComment(n, arg);
-		if (n.getType() != null) {
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
+        visitComment(n, arg);
+        if (n.getType() != null) {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
     }
 
-	@Override
-	public R visit(ArrayBracketPair n, A arg) {
-		for (final AnnotationExpr a : n.getAnnotations()) {
-			{
-				R result = a.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(ArrayBracketPair n, A arg) {
+        for (final AnnotationExpr a : n.getAnnotations()) {
+            {
+                R result = a.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public R visit(final BlockComment n, final A arg) {
-		return null;
-	}
+    @Override
+    public R visit(final BlockComment n, final A arg) {
+        return null;
+    }
 
-	@Override
-	public R visit(final LineComment n, final A arg) {
-		return null;
-	}
+    @Override
+    public R visit(final LineComment n, final A arg) {
+        return null;
+    }
 
-	private void visitComment(Node n, A arg) {
-		if(n.getComment()!=null){
-			Comment result = (Comment) n.getComment().accept(this, arg);
-			if(result!=null){
-				n.setComment(result);
-			}
-		}
-	}
+    private void visitComment(Node n, A arg) {
+        if(n.getComment()!=null){
+            Comment result = (Comment) n.getComment().accept(this, arg);
+            if(result!=null){
+                n.setComment(result);
+            }
+        }
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -116,413 +116,413 @@ import com.github.javaparser.ast.stmt.WhileStmt;
  */
 public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 
-	private void removeNulls(final List<?> list) {
-		for (int i = list.size() - 1; i >= 0; i--) {
-			if (list.get(i) == null) {
-				list.remove(i);
-			}
-		}
-	}
+    private void removeNulls(final List<?> list) {
+        for (int i = list.size() - 1; i >= 0; i--) {
+            if (list.get(i) == null) {
+                list.remove(i);
+            }
+        }
+    }
 
-	@Override public Node visit(final AnnotationDeclaration n, final A arg) {
-		visitAnnotations(n, arg);
-		visitComment(n, arg);
+    @Override public Node visit(final AnnotationDeclaration n, final A arg) {
+        visitAnnotations(n, arg);
+        visitComment(n, arg);
         final List<BodyDeclaration<?>> members = n.getMembers();
-		if (members != null) {
-			for (int i = 0; i < members.size(); i++) {
+        if (members != null) {
+            for (int i = 0; i < members.size(); i++) {
                 members.set(i, (BodyDeclaration<?>) members.get(i).accept(this, arg));
-			}
-			removeNulls(members);
-		}
-		return n;
-	}
+            }
+            removeNulls(members);
+        }
+        return n;
+    }
 
-	private void visitAnnotations(NodeWithAnnotations<?> n, A arg) {
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-	}
+    private void visitAnnotations(NodeWithAnnotations<?> n, A arg) {
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+    }
 
-	@Override public Node visit(final AnnotationMemberDeclaration n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		n.setType((Type) n.getType().accept(this, arg));
-		if (n.getDefaultValue() != null) {
-			n.setDefaultValue((Expression) n.getDefaultValue().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final AnnotationMemberDeclaration n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        n.setType((Type) n.getType().accept(this, arg));
+        if (n.getDefaultValue() != null) {
+            n.setDefaultValue((Expression) n.getDefaultValue().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ArrayAccessExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setName((Expression) n.getName().accept(this, arg));
-		n.setIndex((Expression) n.getIndex().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ArrayAccessExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setName((Expression) n.getName().accept(this, arg));
+        n.setIndex((Expression) n.getIndex().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ArrayCreationExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setType((Type) n.getType().accept(this, arg));
+    @Override public Node visit(final ArrayCreationExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setType((Type) n.getType().accept(this, arg));
 
-		final List<ArrayCreationLevel> values = n.getLevels();
-		for (int i = 0; i < values.size(); i++) {
-			values.set(i, (ArrayCreationLevel) values.get(i).accept(this, arg));
-		}
-		removeNulls(values);
+        final List<ArrayCreationLevel> values = n.getLevels();
+        for (int i = 0; i < values.size(); i++) {
+            values.set(i, (ArrayCreationLevel) values.get(i).accept(this, arg));
+        }
+        removeNulls(values);
 
-		if (n.getInitializer() != null) {
-			n.setInitializer((ArrayInitializerExpr) n.getInitializer().accept(this, arg));
-		}
-		return n;
-	}
+        if (n.getInitializer() != null) {
+            n.setInitializer((ArrayInitializerExpr) n.getInitializer().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ArrayInitializerExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getValues() != null) {
-			final List<Expression> values = n.getValues();
-			if (values != null) {
-				for (int i = 0; i < values.size(); i++) {
-					values.set(i, (Expression) values.get(i).accept(this, arg));
-				}
-				removeNulls(values);
-			}
-		}
-		return n;
-	}
+    @Override public Node visit(final ArrayInitializerExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getValues() != null) {
+            final List<Expression> values = n.getValues();
+            if (values != null) {
+                for (int i = 0; i < values.size(); i++) {
+                    values.set(i, (Expression) values.get(i).accept(this, arg));
+                }
+                removeNulls(values);
+            }
+        }
+        return n;
+    }
 
-	@Override public Node visit(final AssertStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setCheck((Expression) n.getCheck().accept(this, arg));
-		if (n.getMessage() != null) {
-			n.setMessage((Expression) n.getMessage().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final AssertStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setCheck((Expression) n.getCheck().accept(this, arg));
+        if (n.getMessage() != null) {
+            n.setMessage((Expression) n.getMessage().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final AssignExpr n, final A arg) {
-		visitComment(n, arg);
-		final Expression target = (Expression) n.getTarget().accept(this, arg);
-		if (target == null) {
-			return null;
-		}
+    @Override public Node visit(final AssignExpr n, final A arg) {
+        visitComment(n, arg);
+        final Expression target = (Expression) n.getTarget().accept(this, arg);
+        if (target == null) {
+            return null;
+        }
         n.setTarget(target);
 
-		final Expression value = (Expression) n.getValue().accept(this, arg);
-		if (value == null) {
-			return null;
-		}
-		n.setValue(value);
+        final Expression value = (Expression) n.getValue().accept(this, arg);
+        if (value == null) {
+            return null;
+        }
+        n.setValue(value);
 
-		return n;
-	}
+        return n;
+    }
 
-	@Override public Node visit(final BinaryExpr n, final A arg) {
-		visitComment(n, arg);
-		final Expression left = (Expression) n.getLeft().accept(this, arg);
-		final Expression right = (Expression) n.getRight().accept(this, arg);
-		if (left == null) {
-			return right;
-		}
-		if (right == null) {
-			return left;
-		}
-		n.setLeft(left);
-		n.setRight(right);
-		return n;
-	}
+    @Override public Node visit(final BinaryExpr n, final A arg) {
+        visitComment(n, arg);
+        final Expression left = (Expression) n.getLeft().accept(this, arg);
+        final Expression right = (Expression) n.getRight().accept(this, arg);
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+        n.setLeft(left);
+        n.setRight(right);
+        return n;
+    }
 
-	@Override public Node visit(final BlockStmt n, final A arg) {
-		visitComment(n, arg);
-		final List<Statement> stmts = n.getStmts();
-		if (stmts != null) {
-			for (int i = 0; i < stmts.size(); i++) {
-				stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
-			}
-			removeNulls(stmts);
-		}
-		return n;
-	}
+    @Override public Node visit(final BlockStmt n, final A arg) {
+        visitComment(n, arg);
+        final List<Statement> stmts = n.getStmts();
+        if (stmts != null) {
+            for (int i = 0; i < stmts.size(); i++) {
+                stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
+            }
+            removeNulls(stmts);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final BooleanLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final BooleanLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final BreakStmt n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final BreakStmt n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final CastExpr n, final A arg) {
-		visitComment(n, arg);
-		final Type type = (Type) n.getType().accept(this, arg);
-		final Expression expr = (Expression) n.getExpr().accept(this, arg);
-		if (type == null) {
-			return expr;
-		}
-		if (expr == null) {
-			return null;
-		}
-		n.setType(type);
-		n.setExpr(expr);
-		return n;
-	}
+    @Override public Node visit(final CastExpr n, final A arg) {
+        visitComment(n, arg);
+        final Type type = (Type) n.getType().accept(this, arg);
+        final Expression expr = (Expression) n.getExpr().accept(this, arg);
+        if (type == null) {
+            return expr;
+        }
+        if (expr == null) {
+            return null;
+        }
+        n.setType(type);
+        n.setExpr(expr);
+        return n;
+    }
 
-	@Override public Node visit(final CatchClause n, final A arg) {
-		visitComment(n, arg);
-		n.setParam((Parameter)n.getParam().accept(this, arg));
-		n.setBody((BlockStmt) n.getBody().accept(this, arg));
-		return n;
+    @Override public Node visit(final CatchClause n, final A arg) {
+        visitComment(n, arg);
+        n.setParam((Parameter)n.getParam().accept(this, arg));
+        n.setBody((BlockStmt) n.getBody().accept(this, arg));
+        return n;
 
-	}
+    }
 
-	@Override public Node visit(final CharLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final CharLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final ClassExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setType((Type) n.getType().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ClassExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setType((Type) n.getType().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ClassOrInterfaceDeclaration n, final A arg) {
-		visitAnnotations(n, arg);
-		visitComment(n, arg);
-		final List<TypeParameter> typeParameters = n.getTypeParameters();
-		if (typeParameters != null) {
-			for (int i = 0; i < typeParameters.size(); i++) {
-				typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
-			}
-			removeNulls(typeParameters);
-		}
-		final List<ClassOrInterfaceType> extendz = n.getExtends();
-		if (extendz != null) {
-			for (int i = 0; i < extendz.size(); i++) {
-				extendz.set(i, (ClassOrInterfaceType) extendz.get(i).accept(this, arg));
-			}
-			removeNulls(extendz);
-		}
-		final List<ClassOrInterfaceType> implementz = n.getImplements();
-		if (implementz != null) {
-			for (int i = 0; i < implementz.size(); i++) {
-				implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
-			}
-			removeNulls(implementz);
-		}
+    @Override public Node visit(final ClassOrInterfaceDeclaration n, final A arg) {
+        visitAnnotations(n, arg);
+        visitComment(n, arg);
+        final List<TypeParameter> typeParameters = n.getTypeParameters();
+        if (typeParameters != null) {
+            for (int i = 0; i < typeParameters.size(); i++) {
+                typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
+            }
+            removeNulls(typeParameters);
+        }
+        final List<ClassOrInterfaceType> extendz = n.getExtends();
+        if (extendz != null) {
+            for (int i = 0; i < extendz.size(); i++) {
+                extendz.set(i, (ClassOrInterfaceType) extendz.get(i).accept(this, arg));
+            }
+            removeNulls(extendz);
+        }
+        final List<ClassOrInterfaceType> implementz = n.getImplements();
+        if (implementz != null) {
+            for (int i = 0; i < implementz.size(); i++) {
+                implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
+            }
+            removeNulls(implementz);
+        }
         final List<BodyDeclaration<?>> members = n.getMembers();
-		if (members != null) {
-			for (int i = 0; i < members.size(); i++) {
+        if (members != null) {
+            for (int i = 0; i < members.size(); i++) {
                 members.set(i, (BodyDeclaration<?>) members.get(i).accept(this, arg));
-			}
-			removeNulls(members);
-		}
-		return n;
-	}
+            }
+            removeNulls(members);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ClassOrInterfaceType n, final A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		if (n.getScope() != null) {
-			n.setScope((ClassOrInterfaceType) n.getScope().accept(this, arg));
-		}
-		final List<Type<?>> typeArguments = n.getTypeArguments();
-		if (typeArguments != null) {
-			for (int i = 0; i < typeArguments.size(); i++) {
-				typeArguments.set(i, (Type<?>) typeArguments.get(i).accept(this, arg));
-			}
-			removeNulls(typeArguments);
-		}
-		return n;
-	}
+    @Override public Node visit(final ClassOrInterfaceType n, final A arg) {
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        if (n.getScope() != null) {
+            n.setScope((ClassOrInterfaceType) n.getScope().accept(this, arg));
+        }
+        final List<Type<?>> typeArguments = n.getTypeArguments();
+        if (typeArguments != null) {
+            for (int i = 0; i < typeArguments.size(); i++) {
+                typeArguments.set(i, (Type<?>) typeArguments.get(i).accept(this, arg));
+            }
+            removeNulls(typeArguments);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final CompilationUnit n, final A arg) {
-		visitComment(n, arg);
-		if (n.getPackage() != null) {
-			n.setPackage((PackageDeclaration) n.getPackage().accept(this, arg));
-		}
-		final List<ImportDeclaration> imports = n.getImports();
-		if (imports != null) {
-			for (int i = 0; i < imports.size(); i++) {
-				imports.set(i, (ImportDeclaration) imports.get(i).accept(this, arg));
-			}
-			removeNulls(imports);
-		}
+    @Override public Node visit(final CompilationUnit n, final A arg) {
+        visitComment(n, arg);
+        if (n.getPackage() != null) {
+            n.setPackage((PackageDeclaration) n.getPackage().accept(this, arg));
+        }
+        final List<ImportDeclaration> imports = n.getImports();
+        if (imports != null) {
+            for (int i = 0; i < imports.size(); i++) {
+                imports.set(i, (ImportDeclaration) imports.get(i).accept(this, arg));
+            }
+            removeNulls(imports);
+        }
         final List<TypeDeclaration<?>> types = n.getTypes();
-		if (types != null) {
-			for (int i = 0; i < types.size(); i++) {
+        if (types != null) {
+            for (int i = 0; i < types.size(); i++) {
                 types.set(i, (TypeDeclaration<?>) types.get(i).accept(this, arg));
-			}
-			removeNulls(types);
-		}
-		return n;
-	}
+            }
+            removeNulls(types);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ConditionalExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setCondition((Expression) n.getCondition().accept(this, arg));
-		n.setThenExpr((Expression) n.getThenExpr().accept(this, arg));
-		n.setElseExpr((Expression) n.getElseExpr().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ConditionalExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setCondition((Expression) n.getCondition().accept(this, arg));
+        n.setThenExpr((Expression) n.getThenExpr().accept(this, arg));
+        n.setElseExpr((Expression) n.getElseExpr().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ConstructorDeclaration n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<TypeParameter> typeParameters = n.getTypeParameters();
-		if (typeParameters != null) {
-			for (int i = 0; i < typeParameters.size(); i++) {
-				typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
-			}
-			removeNulls(typeParameters);
-		}
-		final List<Parameter> parameters = n.getParameters();
-		if (parameters != null) {
-			for (int i = 0; i < parameters.size(); i++) {
-				parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
-			}
-			removeNulls(parameters);
-		}
-		final List<ReferenceType> throwz = n.getThrows();
-		if (throwz != null) {
-			for (int i = 0; i < throwz.size(); i++) {
-				throwz.set(i, (ReferenceType) throwz.get(i).accept(this, arg));
-			}
-			removeNulls(throwz);
-		}
-		n.setBody((BlockStmt) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ConstructorDeclaration n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<TypeParameter> typeParameters = n.getTypeParameters();
+        if (typeParameters != null) {
+            for (int i = 0; i < typeParameters.size(); i++) {
+                typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
+            }
+            removeNulls(typeParameters);
+        }
+        final List<Parameter> parameters = n.getParameters();
+        if (parameters != null) {
+            for (int i = 0; i < parameters.size(); i++) {
+                parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
+            }
+            removeNulls(parameters);
+        }
+        final List<ReferenceType> throwz = n.getThrows();
+        if (throwz != null) {
+            for (int i = 0; i < throwz.size(); i++) {
+                throwz.set(i, (ReferenceType) throwz.get(i).accept(this, arg));
+            }
+            removeNulls(throwz);
+        }
+        n.setBody((BlockStmt) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ContinueStmt n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final ContinueStmt n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final DoStmt n, final A arg) {
-		visitComment(n, arg);
-		final Statement body = (Statement) n.getBody().accept(this, arg);
-		if (body == null) {
-			return null;
-		}
-		n.setBody(body);
+    @Override public Node visit(final DoStmt n, final A arg) {
+        visitComment(n, arg);
+        final Statement body = (Statement) n.getBody().accept(this, arg);
+        if (body == null) {
+            return null;
+        }
+        n.setBody(body);
 
-		final Expression condition = (Expression) n.getCondition().accept(this, arg);
-		if (condition == null) {
-			return null;
-		}
-		n.setCondition(condition);
+        final Expression condition = (Expression) n.getCondition().accept(this, arg);
+        if (condition == null) {
+            return null;
+        }
+        n.setCondition(condition);
 
-		return n;
-	}
+        return n;
+    }
 
-	@Override public Node visit(final DoubleLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final DoubleLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final EmptyMemberDeclaration n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final EmptyMemberDeclaration n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final EmptyStmt n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final EmptyStmt n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final EmptyTypeDeclaration n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final EmptyTypeDeclaration n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final EnclosedExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setInner((Expression) n.getInner().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final EnclosedExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setInner((Expression) n.getInner().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final EnumConstantDeclaration n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
+    @Override public Node visit(final EnumConstantDeclaration n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
         final List<BodyDeclaration<?>> classBody = n.getClassBody();
-		if (classBody != null) {
-			for (int i = 0; i < classBody.size(); i++) {
+        if (classBody != null) {
+            for (int i = 0; i < classBody.size(); i++) {
                 classBody.set(i, (BodyDeclaration<?>) classBody.get(i).accept(this, arg));
-			}
-			removeNulls(classBody);
-		}
-		return n;
-	}
+            }
+            removeNulls(classBody);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final EnumDeclaration n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<ClassOrInterfaceType> implementz = n.getImplements();
-		if (implementz != null) {
-			for (int i = 0; i < implementz.size(); i++) {
-				implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
-			}
-			removeNulls(implementz);
-		}
-		final List<EnumConstantDeclaration> entries = n.getEntries();
-		if (entries != null) {
-			for (int i = 0; i < entries.size(); i++) {
-				entries.set(i, (EnumConstantDeclaration) entries.get(i).accept(this, arg));
-			}
-			removeNulls(entries);
-		}
+    @Override public Node visit(final EnumDeclaration n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<ClassOrInterfaceType> implementz = n.getImplements();
+        if (implementz != null) {
+            for (int i = 0; i < implementz.size(); i++) {
+                implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
+            }
+            removeNulls(implementz);
+        }
+        final List<EnumConstantDeclaration> entries = n.getEntries();
+        if (entries != null) {
+            for (int i = 0; i < entries.size(); i++) {
+                entries.set(i, (EnumConstantDeclaration) entries.get(i).accept(this, arg));
+            }
+            removeNulls(entries);
+        }
         final List<BodyDeclaration<?>> members = n.getMembers();
-		if (members != null) {
-			for (int i = 0; i < members.size(); i++) {
+        if (members != null) {
+            for (int i = 0; i < members.size(); i++) {
                 members.set(i, (BodyDeclaration<?>) members.get(i).accept(this, arg));
-			}
-			removeNulls(members);
-		}
-		return n;
-	}
+            }
+            removeNulls(members);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-		visitComment(n, arg);
-		if (!n.isThis() && n.getExpr() != null) {
-			n.setExpr((Expression) n.getExpr().accept(this, arg));
-		}
+    @Override public Node visit(final ExplicitConstructorInvocationStmt n, final A arg) {
+        visitComment(n, arg);
+        if (!n.isThis() && n.getExpr() != null) {
+            n.setExpr((Expression) n.getExpr().accept(this, arg));
+        }
         final List<Type<?>> typeArguments = n.getTypeArguments();
         if (typeArguments != null) {
             for (int i = 0; i < typeArguments.size(); i++) {
@@ -530,173 +530,173 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
             }
             removeNulls(typeArguments);
         }
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
-		return n;
-	}
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ExpressionStmt n, final A arg) {
-		visitComment(n, arg);
-		final Expression expr = (Expression) n.getExpression().accept(this, arg);
-		if (expr == null) {
-			return null;
-		}
-		n.setExpression(expr);
-		return n;
-	}
+    @Override public Node visit(final ExpressionStmt n, final A arg) {
+        visitComment(n, arg);
+        final Expression expr = (Expression) n.getExpression().accept(this, arg);
+        if (expr == null) {
+            return null;
+        }
+        n.setExpression(expr);
+        return n;
+    }
 
-	@Override public Node visit(final FieldAccessExpr n, final A arg) {
-		visitComment(n, arg);
-		final Expression scope = (Expression) n.getScope().accept(this, arg);
-		if (scope == null) {
-			return null;
-		}
-		n.setScope(scope);
-		return n;
-	}
+    @Override public Node visit(final FieldAccessExpr n, final A arg) {
+        visitComment(n, arg);
+        final Expression scope = (Expression) n.getScope().accept(this, arg);
+        if (scope == null) {
+            return null;
+        }
+        n.setScope(scope);
+        return n;
+    }
 
-	@Override public Node visit(final FieldDeclaration n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		n.setElementType((Type) n.getElementType().accept(this, arg));
-		final List<VariableDeclarator> variables = n.getVariables();
-		for (int i = 0; i < variables.size(); i++) {
-			variables.set(i, (VariableDeclarator) variables.get(i).accept(this, arg));
-		}
-		removeNulls(variables);
-		return n;
-	}
+    @Override public Node visit(final FieldDeclaration n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        n.setElementType((Type) n.getElementType().accept(this, arg));
+        final List<VariableDeclarator> variables = n.getVariables();
+        for (int i = 0; i < variables.size(); i++) {
+            variables.set(i, (VariableDeclarator) variables.get(i).accept(this, arg));
+        }
+        removeNulls(variables);
+        return n;
+    }
 
-	@Override public Node visit(final ForeachStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setVariable((VariableDeclarationExpr) n.getVariable().accept(this, arg));
-		n.setIterable((Expression) n.getIterable().accept(this, arg));
-		n.setBody((Statement) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ForeachStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setVariable((VariableDeclarationExpr) n.getVariable().accept(this, arg));
+        n.setIterable((Expression) n.getIterable().accept(this, arg));
+        n.setBody((Statement) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ForStmt n, final A arg) {
-		visitComment(n, arg);
-		final List<Expression> init = n.getInit();
-		if (init != null) {
-			for (int i = 0; i < init.size(); i++) {
-				init.set(i, (Expression) init.get(i).accept(this, arg));
-			}
-			removeNulls(init);
-		}
-		if (n.getCompare() != null) {
-			n.setCompare((Expression) n.getCompare().accept(this, arg));
-		}
-		final List<Expression> update = n.getUpdate();
-		if (update != null) {
-			for (int i = 0; i < update.size(); i++) {
-				update.set(i, (Expression) update.get(i).accept(this, arg));
-			}
-			removeNulls(update);
-		}
-		n.setBody((Statement) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ForStmt n, final A arg) {
+        visitComment(n, arg);
+        final List<Expression> init = n.getInit();
+        if (init != null) {
+            for (int i = 0; i < init.size(); i++) {
+                init.set(i, (Expression) init.get(i).accept(this, arg));
+            }
+            removeNulls(init);
+        }
+        if (n.getCompare() != null) {
+            n.setCompare((Expression) n.getCompare().accept(this, arg));
+        }
+        final List<Expression> update = n.getUpdate();
+        if (update != null) {
+            for (int i = 0; i < update.size(); i++) {
+                update.set(i, (Expression) update.get(i).accept(this, arg));
+            }
+            removeNulls(update);
+        }
+        n.setBody((Statement) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final IfStmt n, final A arg) {
-		visitComment(n, arg);
-		final Expression condition = (Expression)
-			n.getCondition().accept(this, arg);
-		if (condition == null) {
-			return null;
-		}
-		n.setCondition(condition);
-		final Statement thenStmt = (Statement) n.getThenStmt().accept(this, arg);
-		if (thenStmt == null) {
-			// Remove the entire statement if the then-clause was removed.
-			// DumpVisitor, used for toString, has no null check for the
-			// then-clause.
-			return null;
-		}
-		n.setThenStmt(thenStmt);
-		if (n.getElseStmt() != null) {
-			n.setElseStmt((Statement) n.getElseStmt().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final IfStmt n, final A arg) {
+        visitComment(n, arg);
+        final Expression condition = (Expression)
+            n.getCondition().accept(this, arg);
+        if (condition == null) {
+            return null;
+        }
+        n.setCondition(condition);
+        final Statement thenStmt = (Statement) n.getThenStmt().accept(this, arg);
+        if (thenStmt == null) {
+            // Remove the entire statement if the then-clause was removed.
+            // DumpVisitor, used for toString, has no null check for the
+            // then-clause.
+            return null;
+        }
+        n.setThenStmt(thenStmt);
+        if (n.getElseStmt() != null) {
+            n.setElseStmt((Statement) n.getElseStmt().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ImportDeclaration n, final A arg) {
-		visitComment(n, arg);
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ImportDeclaration n, final A arg) {
+        visitComment(n, arg);
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final InitializerDeclaration n, final A arg) {
-		visitComment(n, arg);
-		n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final InitializerDeclaration n, final A arg) {
+        visitComment(n, arg);
+        n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final InstanceOfExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		n.setType((Type) n.getType().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final InstanceOfExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        n.setType((Type) n.getType().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final IntegerLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final IntegerLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final IntegerLiteralMinValueExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final IntegerLiteralMinValueExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final JavadocComment n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final JavadocComment n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final LabeledStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setStmt((Statement) n.getStmt().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final LabeledStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setStmt((Statement) n.getStmt().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final LongLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final LongLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final LongLiteralMinValueExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final LongLiteralMinValueExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final MarkerAnnotationExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final MarkerAnnotationExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final MemberValuePair n, final A arg) {
-		visitComment(n, arg);
-		n.setValue((Expression) n.getValue().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final MemberValuePair n, final A arg) {
+        visitComment(n, arg);
+        n.setValue((Expression) n.getValue().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final MethodCallExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getScope() != null) {
-			n.setScope((Expression) n.getScope().accept(this, arg));
-		}
+    @Override public Node visit(final MethodCallExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getScope() != null) {
+            n.setScope((Expression) n.getScope().accept(this, arg));
+        }
         final List<Type<?>> typeArguments = n.getTypeArguments();
         if (typeArguments != null) {
             for (int i = 0; i < typeArguments.size(); i++) {
@@ -704,81 +704,81 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
             }
             removeNulls(typeArguments);
         }
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
-		return n;
-	}
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final MethodDeclaration n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<TypeParameter> typeParameters = n.getTypeParameters();
-		if (typeParameters != null) {
-			for (int i = 0; i < typeParameters.size(); i++) {
-				typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
-			}
-			removeNulls(typeParameters);
-		}
-		n.setElementType((Type) n.getElementType().accept(this, arg));
-		final List<Parameter> parameters = n.getParameters();
-		if (parameters != null) {
-			for (int i = 0; i < parameters.size(); i++) {
-				parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
-			}
-			removeNulls(parameters);
-		}
-		final List<ReferenceType> throwz = n.getThrows();
-		if (throwz != null) {
-			for (int i = 0; i < throwz.size(); i++) {
-				throwz.set(i, (ReferenceType) throwz.get(i).accept(this, arg));
-			}
-			removeNulls(throwz);
-		}
-		if (n.getBody() != null) {
-			n.setBody((BlockStmt) n.getBody().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final MethodDeclaration n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<TypeParameter> typeParameters = n.getTypeParameters();
+        if (typeParameters != null) {
+            for (int i = 0; i < typeParameters.size(); i++) {
+                typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
+            }
+            removeNulls(typeParameters);
+        }
+        n.setElementType((Type) n.getElementType().accept(this, arg));
+        final List<Parameter> parameters = n.getParameters();
+        if (parameters != null) {
+            for (int i = 0; i < parameters.size(); i++) {
+                parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
+            }
+            removeNulls(parameters);
+        }
+        final List<ReferenceType> throwz = n.getThrows();
+        if (throwz != null) {
+            for (int i = 0; i < throwz.size(); i++) {
+                throwz.set(i, (ReferenceType) throwz.get(i).accept(this, arg));
+            }
+            removeNulls(throwz);
+        }
+        if (n.getBody() != null) {
+            n.setBody((BlockStmt) n.getBody().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final NameExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final NameExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final NormalAnnotationExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		final List<MemberValuePair> pairs = n.getPairs();
-		if (pairs != null) {
-			for (int i = 0; i < pairs.size(); i++) {
-				pairs.set(i, (MemberValuePair) pairs.get(i).accept(this, arg));
-			}
-			removeNulls(pairs);
-		}
-		return n;
-	}
+    @Override public Node visit(final NormalAnnotationExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        final List<MemberValuePair> pairs = n.getPairs();
+        if (pairs != null) {
+            for (int i = 0; i < pairs.size(); i++) {
+                pairs.set(i, (MemberValuePair) pairs.get(i).accept(this, arg));
+            }
+            removeNulls(pairs);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final NullLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final NullLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final ObjectCreationExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getScope() != null) {
-			n.setScope((Expression) n.getScope().accept(this, arg));
-		}
+    @Override public Node visit(final ObjectCreationExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getScope() != null) {
+            n.setScope((Expression) n.getScope().accept(this, arg));
+        }
         final List<Type<?>> typeArguments = n.getTypeArguments();
         if (typeArguments != null) {
             for (int i = 0; i < typeArguments.size(); i++) {
@@ -786,79 +786,79 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
             }
             removeNulls(typeArguments);
         }
-		n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
+        n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
         final List<BodyDeclaration<?>> anonymousClassBody = n.getAnonymousClassBody();
-		if (anonymousClassBody != null) {
-			for (int i = 0; i < anonymousClassBody.size(); i++) {
+        if (anonymousClassBody != null) {
+            for (int i = 0; i < anonymousClassBody.size(); i++) {
                 anonymousClassBody.set(i, (BodyDeclaration<?>) anonymousClassBody.get(i).accept(this, arg));
-			}
-			removeNulls(anonymousClassBody);
-		}
-		return n;
-	}
+            }
+            removeNulls(anonymousClassBody);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final PackageDeclaration n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		return n;
-	}
-	
-	@Override public Node visit(final Parameter n, final A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
-		n.setElementType((Type) n.getElementType().accept(this, arg));
-		return n;
-	}
-	
-	@Override public Node visit(final PrimitiveType n, final A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		return n;
-	}
+    @Override public Node visit(final PackageDeclaration n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        return n;
+    }
+    
+    @Override public Node visit(final Parameter n, final A arg) {
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
+        n.setElementType((Type) n.getElementType().accept(this, arg));
+        return n;
+    }
+    
+    @Override public Node visit(final PrimitiveType n, final A arg) {
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final QualifiedNameExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setQualifier((NameExpr) n.getQualifier().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final QualifiedNameExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setQualifier((NameExpr) n.getQualifier().accept(this, arg));
+        return n;
+    }
 
-	@Override
-	public Node visit(ArrayType n, A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		n.setComponentType((Type) n.getComponentType().accept(this, arg));
-		return n;
-	}
+    @Override
+    public Node visit(ArrayType n, A arg) {
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        n.setComponentType((Type) n.getComponentType().accept(this, arg));
+        return n;
+    }
 
-	@Override
-	public Node visit(ArrayCreationLevel n, A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		if(n.getDimension()!=null) {
-			n.setDimension((Expression) n.getDimension().accept(this, arg));
-		}
-		return n;
-	}
+    @Override
+    public Node visit(ArrayCreationLevel n, A arg) {
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        if(n.getDimension()!=null) {
+            n.setDimension((Expression) n.getDimension().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override
+    @Override
     public Node visit(final IntersectionType n, final A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
         final List<ReferenceType> elements = n.getElements();
         if (elements != null) {
             for (int i = 0; i < elements.size(); i++) {
@@ -871,9 +871,9 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 
     @Override
     public Node visit(final UnionType n, final A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		final List<ReferenceType> elements = n.getElements();
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        final List<ReferenceType> elements = n.getElements();
         if (elements != null) {
             for (int i = 0; i < elements.size(); i++) {
                 elements.set(i, (ReferenceType) elements.get(i).accept(this, arg));
@@ -883,267 +883,267 @@ public class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
         return n;
     }
 
-	@Override public Node visit(final ReturnStmt n, final A arg) {
-		visitComment(n, arg);
-		if (n.getExpr() != null) {
-			n.setExpr((Expression) n.getExpr().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final ReturnStmt n, final A arg) {
+        visitComment(n, arg);
+        if (n.getExpr() != null) {
+            n.setExpr((Expression) n.getExpr().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final SingleMemberAnnotationExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		n.setMemberValue((Expression) n.getMemberValue().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final SingleMemberAnnotationExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        n.setMemberValue((Expression) n.getMemberValue().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final StringLiteralExpr n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final StringLiteralExpr n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final SuperExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getClassExpr() != null) {
-			n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final SuperExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getClassExpr() != null) {
+            n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final SwitchEntryStmt n, final A arg) {
-		visitComment(n, arg);
-		if (n.getLabel() != null) {
-			n.setLabel((Expression) n.getLabel().accept(this, arg));
-		}
-		final List<Statement> stmts = n.getStmts();
-		if (stmts != null) {
-			for (int i = 0; i < stmts.size(); i++) {
-				stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
-			}
-			removeNulls(stmts);
-		}
-		return n;
-	}
+    @Override public Node visit(final SwitchEntryStmt n, final A arg) {
+        visitComment(n, arg);
+        if (n.getLabel() != null) {
+            n.setLabel((Expression) n.getLabel().accept(this, arg));
+        }
+        final List<Statement> stmts = n.getStmts();
+        if (stmts != null) {
+            for (int i = 0; i < stmts.size(); i++) {
+                stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
+            }
+            removeNulls(stmts);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final SwitchStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setSelector((Expression) n.getSelector().accept(this, arg));
-		final List<SwitchEntryStmt> entries = n.getEntries();
-		if (entries != null) {
-			for (int i = 0; i < entries.size(); i++) {
-				entries.set(i, (SwitchEntryStmt) entries.get(i).accept(this, arg));
-			}
-			removeNulls(entries);
-		}
-		return n;
+    @Override public Node visit(final SwitchStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setSelector((Expression) n.getSelector().accept(this, arg));
+        final List<SwitchEntryStmt> entries = n.getEntries();
+        if (entries != null) {
+            for (int i = 0; i < entries.size(); i++) {
+                entries.set(i, (SwitchEntryStmt) entries.get(i).accept(this, arg));
+            }
+            removeNulls(entries);
+        }
+        return n;
 
-	}
+    }
 
-	@Override public Node visit(final SynchronizedStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		n.setBody((BlockStmt) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final SynchronizedStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        n.setBody((BlockStmt) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ThisExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getClassExpr() != null) {
-			n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final ThisExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getClassExpr() != null) {
+            n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ThrowStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ThrowStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final TryStmt n, final A arg) {
-		visitComment(n, arg);
-		final List<VariableDeclarationExpr> types = n.getResources();
-		for (int i = 0; i < types.size(); i++) {
-			n.getResources().set(i,
-					(VariableDeclarationExpr) n.getResources().get(i).accept(this, arg));
-		}
-		n.setTryBlock((BlockStmt) n.getTryBlock().accept(this, arg));
-		final List<CatchClause> catchs = n.getCatchs();
-		if (catchs != null) {
-			for (int i = 0; i < catchs.size(); i++) {
-				catchs.set(i, (CatchClause) catchs.get(i).accept(this, arg));
-			}
-			removeNulls(catchs);
-		}
-		if (n.getFinallyBlock() != null) {
-			n.setFinallyBlock((BlockStmt) n.getFinallyBlock().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final TryStmt n, final A arg) {
+        visitComment(n, arg);
+        final List<VariableDeclarationExpr> types = n.getResources();
+        for (int i = 0; i < types.size(); i++) {
+            n.getResources().set(i,
+                    (VariableDeclarationExpr) n.getResources().get(i).accept(this, arg));
+        }
+        n.setTryBlock((BlockStmt) n.getTryBlock().accept(this, arg));
+        final List<CatchClause> catchs = n.getCatchs();
+        if (catchs != null) {
+            for (int i = 0; i < catchs.size(); i++) {
+                catchs.set(i, (CatchClause) catchs.get(i).accept(this, arg));
+            }
+            removeNulls(catchs);
+        }
+        if (n.getFinallyBlock() != null) {
+            n.setFinallyBlock((BlockStmt) n.getFinallyBlock().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final TypeDeclarationStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setTypeDeclaration((TypeDeclaration<?>) n.getTypeDeclaration().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final TypeDeclarationStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setTypeDeclaration((TypeDeclaration<?>) n.getTypeDeclaration().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final TypeParameter n, final A arg) {
-		visitComment(n, arg);
-		final List<ClassOrInterfaceType> typeBound = n.getTypeBound();
-		if (typeBound != null) {
-			for (int i = 0; i < typeBound.size(); i++) {
-				typeBound.set(i, (ClassOrInterfaceType) typeBound.get(i).accept(this, arg));
-			}
-			removeNulls(typeBound);
-		}
-		return n;
-	}
+    @Override public Node visit(final TypeParameter n, final A arg) {
+        visitComment(n, arg);
+        final List<ClassOrInterfaceType> typeBound = n.getTypeBound();
+        if (typeBound != null) {
+            for (int i = 0; i < typeBound.size(); i++) {
+                typeBound.set(i, (ClassOrInterfaceType) typeBound.get(i).accept(this, arg));
+            }
+            removeNulls(typeBound);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final UnaryExpr n, final A arg) {
-		visitComment(n, arg);
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final UnaryExpr n, final A arg) {
+        visitComment(n, arg);
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final UnknownType n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final UnknownType n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final VariableDeclarationExpr n, final A arg) {
-		visitComment(n, arg);
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
+    @Override public Node visit(final VariableDeclarationExpr n, final A arg) {
+        visitComment(n, arg);
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
 
-		final Type type = (Type) n.getElementType().accept(this, arg);
-		if (type == null) {
-			return null;
-		}
-		n.setElementType(type);
+        final Type type = (Type) n.getElementType().accept(this, arg);
+        if (type == null) {
+            return null;
+        }
+        n.setElementType(type);
 
-		final List<VariableDeclarator> vars = n.getVariables();
-		for (int i = 0; i < vars.size();) {
-			final VariableDeclarator decl = (VariableDeclarator)
-				vars.get(i).accept(this, arg);
-			if (decl == null) {
-				vars.remove(i);
-			} else {
-				vars.set(i++, decl);
-			}
-		}
-		if (vars.isEmpty()) {
-			return null;
-		}
+        final List<VariableDeclarator> vars = n.getVariables();
+        for (int i = 0; i < vars.size();) {
+            final VariableDeclarator decl = (VariableDeclarator)
+                vars.get(i).accept(this, arg);
+            if (decl == null) {
+                vars.remove(i);
+            } else {
+                vars.set(i++, decl);
+            }
+        }
+        if (vars.isEmpty()) {
+            return null;
+        }
 
-		return n;
-	}
+        return n;
+    }
 
-	@Override public Node visit(final VariableDeclarator n, final A arg) {
-		visitComment(n, arg);
-		final VariableDeclaratorId id = (VariableDeclaratorId)
-			n.getId().accept(this, arg);
-		if (id == null) {
-			return null;
-		}
-		n.setId(id);
-		if (n.getInit() != null) {
-			n.setInit((Expression) n.getInit().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final VariableDeclarator n, final A arg) {
+        visitComment(n, arg);
+        final VariableDeclaratorId id = (VariableDeclaratorId)
+            n.getId().accept(this, arg);
+        if (id == null) {
+            return null;
+        }
+        n.setId(id);
+        if (n.getInit() != null) {
+            n.setInit((Expression) n.getInit().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final VariableDeclaratorId n, final A arg) {
-		visitComment(n, arg);
-		return n;
-	}
+    @Override public Node visit(final VariableDeclaratorId n, final A arg) {
+        visitComment(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final VoidType n, final A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		return n;
-	}
+    @Override public Node visit(final VoidType n, final A arg) {
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        return n;
+    }
 
-	@Override public Node visit(final WhileStmt n, final A arg) {
-		visitComment(n, arg);
-		n.setCondition((Expression) n.getCondition().accept(this, arg));
-		n.setBody((Statement) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final WhileStmt n, final A arg) {
+        visitComment(n, arg);
+        n.setCondition((Expression) n.getCondition().accept(this, arg));
+        n.setBody((Statement) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final WildcardType n, final A arg) {
-		visitComment(n, arg);
-		visitAnnotations(n, arg);
-		if (n.getExtends() != null) {
-			n.setExtends((ReferenceType) n.getExtends().accept(this, arg));
-		}
-		if (n.getSuper() != null) {
-			n.setSuper((ReferenceType) n.getSuper().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final WildcardType n, final A arg) {
+        visitComment(n, arg);
+        visitAnnotations(n, arg);
+        if (n.getExtends() != null) {
+            n.setExtends((ReferenceType) n.getExtends().accept(this, arg));
+        }
+        if (n.getSuper() != null) {
+            n.setSuper((ReferenceType) n.getSuper().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override
-	public Node visit(final LambdaExpr n, final A arg) {
-		visitComment(n, arg);
-		final List<Parameter> parameters = n.getParameters();
-		for (int i = 0; i < parameters.size(); i++) {
-			parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
-		}
-		removeNulls(parameters);
-		if (n.getBody() != null) {
-			n.setBody((Statement) n.getBody().accept(this, arg));
-		}
-		return n;
-	}
+    @Override
+    public Node visit(final LambdaExpr n, final A arg) {
+        visitComment(n, arg);
+        final List<Parameter> parameters = n.getParameters();
+        for (int i = 0; i < parameters.size(); i++) {
+            parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
+        }
+        removeNulls(parameters);
+        if (n.getBody() != null) {
+            n.setBody((Statement) n.getBody().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override
-	public Node visit(final MethodReferenceExpr n, final A arg) {
-		visitComment(n, arg);
-		final List<Type<?>> types = n.getTypeArguments();
-		for (int i = 0; i < types.size(); i++) {
-			n.getTypeArguments().set(i,
-					(Type<?>) n.getTypeArguments().get(i).accept(this, arg));
-		}
-		if (n.getScope() != null) {
-			n.setScope((Expression)n.getScope().accept(this, arg));
-		}
-		return n;
-	}
+    @Override
+    public Node visit(final MethodReferenceExpr n, final A arg) {
+        visitComment(n, arg);
+        final List<Type<?>> types = n.getTypeArguments();
+        for (int i = 0; i < types.size(); i++) {
+            n.getTypeArguments().set(i,
+                    (Type<?>) n.getTypeArguments().get(i).accept(this, arg));
+        }
+        if (n.getScope() != null) {
+            n.setScope((Expression)n.getScope().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override
-	public Node visit(final TypeExpr n, final A arg) {
-		visitComment(n, arg);
-		if (n.getType() != null) {
+    @Override
+    public Node visit(final TypeExpr n, final A arg) {
+        visitComment(n, arg);
+        if (n.getType() != null) {
             n.setType((Type<?>) n.getType().accept(this, arg));
-		}
-		return n;
-	}
+        }
+        return n;
+    }
 
-	@Override
-	public Node visit(ArrayBracketPair n, A arg) {
-		visitAnnotations(n, arg);
-		return n;
-	}
+    @Override
+    public Node visit(ArrayBracketPair n, A arg) {
+        visitAnnotations(n, arg);
+        return n;
+    }
 
-	@Override
-	public Node visit(final BlockComment n, final A arg) {
-		return n;
-	}
+    @Override
+    public Node visit(final BlockComment n, final A arg) {
+        return n;
+    }
 
-	@Override
-	public Node visit(final LineComment n, final A arg) {
-		return n;
-	}
+    @Override
+    public Node visit(final LineComment n, final A arg) {
+        return n;
+    }
 
-	private void visitComment(Node n, final A arg) {
-		if (n != null && n.getComment() != null) {
-			n.setComment((Comment) n.getComment().accept(this, arg));
-		}
-	}
+    private void visitComment(Node n, final A arg) {
+        if (n != null && n.getComment() != null) {
+            n.setComment((Comment) n.getComment().accept(this, arg));
+        }
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/TreeVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/TreeVisitor.java
@@ -28,17 +28,17 @@ import com.github.javaparser.ast.Node;
  */
 public abstract class TreeVisitor {
 
-	/**
-	 * https://en.wikipedia.org/wiki/Depth-first_search
-	 *
-	 * @param node the start node, and the first one that is passed to process(node).
-	 */
-	public void visitDepthFirst(Node node) {
-		process(node);
-		for (Node child : node.getChildrenNodes()) {
-			visitDepthFirst(child);
-		}
-	}
+    /**
+     * https://en.wikipedia.org/wiki/Depth-first_search
+     *
+     * @param node the start node, and the first one that is passed to process(node).
+     */
+    public void visitDepthFirst(Node node) {
+        process(node);
+        for (Node child : node.getChildrenNodes()) {
+            visitDepthFirst(child);
+        }
+    }
 
-	public abstract void process(Node node);
+    public abstract void process(Node node);
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/VoidVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/VoidVisitor.java
@@ -71,181 +71,181 @@ import com.github.javaparser.ast.type.*;
  */
 public interface VoidVisitor<A> {
 
-	//- Compilation Unit ----------------------------------
+    //- Compilation Unit ----------------------------------
 
-	void visit(CompilationUnit n, A arg);
+    void visit(CompilationUnit n, A arg);
 
-	void visit(PackageDeclaration n, A arg);
+    void visit(PackageDeclaration n, A arg);
 
-	void visit(ImportDeclaration n, A arg);
+    void visit(ImportDeclaration n, A arg);
 
-	void visit(TypeParameter n, A arg);
+    void visit(TypeParameter n, A arg);
 
-	void visit(LineComment n, A arg);
+    void visit(LineComment n, A arg);
 
-	void visit(BlockComment n, A arg);
+    void visit(BlockComment n, A arg);
 
-	//- Body ----------------------------------------------
+    //- Body ----------------------------------------------
 
-	void visit(ClassOrInterfaceDeclaration n, A arg);
+    void visit(ClassOrInterfaceDeclaration n, A arg);
 
-	void visit(EnumDeclaration n, A arg);
+    void visit(EnumDeclaration n, A arg);
 
-	void visit(EmptyTypeDeclaration n, A arg);
+    void visit(EmptyTypeDeclaration n, A arg);
 
-	void visit(EnumConstantDeclaration n, A arg);
+    void visit(EnumConstantDeclaration n, A arg);
 
-	void visit(AnnotationDeclaration n, A arg);
+    void visit(AnnotationDeclaration n, A arg);
 
-	void visit(AnnotationMemberDeclaration n, A arg);
+    void visit(AnnotationMemberDeclaration n, A arg);
 
-	void visit(FieldDeclaration n, A arg);
+    void visit(FieldDeclaration n, A arg);
 
-	void visit(VariableDeclarator n, A arg);
+    void visit(VariableDeclarator n, A arg);
 
-	void visit(VariableDeclaratorId n, A arg);
+    void visit(VariableDeclaratorId n, A arg);
 
-	void visit(ConstructorDeclaration n, A arg);
+    void visit(ConstructorDeclaration n, A arg);
 
-	void visit(MethodDeclaration n, A arg);
+    void visit(MethodDeclaration n, A arg);
 
-	void visit(Parameter n, A arg);
-	
-	void visit(EmptyMemberDeclaration n, A arg);
+    void visit(Parameter n, A arg);
+    
+    void visit(EmptyMemberDeclaration n, A arg);
 
-	void visit(InitializerDeclaration n, A arg);
+    void visit(InitializerDeclaration n, A arg);
 
-	void visit(JavadocComment n, A arg);
+    void visit(JavadocComment n, A arg);
 
-	//- Type ----------------------------------------------
+    //- Type ----------------------------------------------
 
-	void visit(ClassOrInterfaceType n, A arg);
+    void visit(ClassOrInterfaceType n, A arg);
 
-	void visit(PrimitiveType n, A arg);
+    void visit(PrimitiveType n, A arg);
 
-	void visit(ArrayType n, A arg);
-	
-	void visit(ArrayCreationLevel n, A arg);
+    void visit(ArrayType n, A arg);
+    
+    void visit(ArrayCreationLevel n, A arg);
 
     void visit(IntersectionType n, A arg);
 
     void visit(UnionType n, A arg);
 
-	void visit(VoidType n, A arg);
+    void visit(VoidType n, A arg);
 
-	void visit(WildcardType n, A arg);
+    void visit(WildcardType n, A arg);
 
-	void visit(UnknownType n, A arg);
+    void visit(UnknownType n, A arg);
 
-	//- Expression ----------------------------------------
+    //- Expression ----------------------------------------
 
-	void visit(ArrayAccessExpr n, A arg);
+    void visit(ArrayAccessExpr n, A arg);
 
-	void visit(ArrayCreationExpr n, A arg);
+    void visit(ArrayCreationExpr n, A arg);
 
-	void visit(ArrayInitializerExpr n, A arg);
+    void visit(ArrayInitializerExpr n, A arg);
 
-	void visit(AssignExpr n, A arg);
+    void visit(AssignExpr n, A arg);
 
-	void visit(BinaryExpr n, A arg);
+    void visit(BinaryExpr n, A arg);
 
-	void visit(CastExpr n, A arg);
+    void visit(CastExpr n, A arg);
 
-	void visit(ClassExpr n, A arg);
+    void visit(ClassExpr n, A arg);
 
-	void visit(ConditionalExpr n, A arg);
+    void visit(ConditionalExpr n, A arg);
 
-	void visit(EnclosedExpr n, A arg);
+    void visit(EnclosedExpr n, A arg);
 
-	void visit(FieldAccessExpr n, A arg);
+    void visit(FieldAccessExpr n, A arg);
 
-	void visit(InstanceOfExpr n, A arg);
+    void visit(InstanceOfExpr n, A arg);
 
-	void visit(StringLiteralExpr n, A arg);
+    void visit(StringLiteralExpr n, A arg);
 
-	void visit(IntegerLiteralExpr n, A arg);
+    void visit(IntegerLiteralExpr n, A arg);
 
-	void visit(LongLiteralExpr n, A arg);
+    void visit(LongLiteralExpr n, A arg);
 
-	void visit(IntegerLiteralMinValueExpr n, A arg);
+    void visit(IntegerLiteralMinValueExpr n, A arg);
 
-	void visit(LongLiteralMinValueExpr n, A arg);
+    void visit(LongLiteralMinValueExpr n, A arg);
 
-	void visit(CharLiteralExpr n, A arg);
+    void visit(CharLiteralExpr n, A arg);
 
-	void visit(DoubleLiteralExpr n, A arg);
+    void visit(DoubleLiteralExpr n, A arg);
 
-	void visit(BooleanLiteralExpr n, A arg);
+    void visit(BooleanLiteralExpr n, A arg);
 
-	void visit(NullLiteralExpr n, A arg);
+    void visit(NullLiteralExpr n, A arg);
 
-	void visit(MethodCallExpr n, A arg);
+    void visit(MethodCallExpr n, A arg);
 
-	void visit(NameExpr n, A arg);
+    void visit(NameExpr n, A arg);
 
-	void visit(ObjectCreationExpr n, A arg);
+    void visit(ObjectCreationExpr n, A arg);
 
-	void visit(QualifiedNameExpr n, A arg);
+    void visit(QualifiedNameExpr n, A arg);
 
-	void visit(ThisExpr n, A arg);
+    void visit(ThisExpr n, A arg);
 
-	void visit(SuperExpr n, A arg);
+    void visit(SuperExpr n, A arg);
 
-	void visit(UnaryExpr n, A arg);
+    void visit(UnaryExpr n, A arg);
 
-	void visit(VariableDeclarationExpr n, A arg);
+    void visit(VariableDeclarationExpr n, A arg);
 
-	void visit(MarkerAnnotationExpr n, A arg);
+    void visit(MarkerAnnotationExpr n, A arg);
 
-	void visit(SingleMemberAnnotationExpr n, A arg);
+    void visit(SingleMemberAnnotationExpr n, A arg);
 
-	void visit(NormalAnnotationExpr n, A arg);
+    void visit(NormalAnnotationExpr n, A arg);
 
-	void visit(MemberValuePair n, A arg);
+    void visit(MemberValuePair n, A arg);
 
-	//- Statements ----------------------------------------
+    //- Statements ----------------------------------------
 
-	void visit(ExplicitConstructorInvocationStmt n, A arg);
+    void visit(ExplicitConstructorInvocationStmt n, A arg);
 
-	void visit(TypeDeclarationStmt n, A arg);
+    void visit(TypeDeclarationStmt n, A arg);
 
-	void visit(AssertStmt n, A arg);
+    void visit(AssertStmt n, A arg);
 
-	void visit(BlockStmt n, A arg);
+    void visit(BlockStmt n, A arg);
 
-	void visit(LabeledStmt n, A arg);
+    void visit(LabeledStmt n, A arg);
 
-	void visit(EmptyStmt n, A arg);
+    void visit(EmptyStmt n, A arg);
 
-	void visit(ExpressionStmt n, A arg);
+    void visit(ExpressionStmt n, A arg);
 
-	void visit(SwitchStmt n, A arg);
+    void visit(SwitchStmt n, A arg);
 
-	void visit(SwitchEntryStmt n, A arg);
+    void visit(SwitchEntryStmt n, A arg);
 
-	void visit(BreakStmt n, A arg);
+    void visit(BreakStmt n, A arg);
 
-	void visit(ReturnStmt n, A arg);
+    void visit(ReturnStmt n, A arg);
 
-	void visit(IfStmt n, A arg);
+    void visit(IfStmt n, A arg);
 
-	void visit(WhileStmt n, A arg);
+    void visit(WhileStmt n, A arg);
 
-	void visit(ContinueStmt n, A arg);
+    void visit(ContinueStmt n, A arg);
 
-	void visit(DoStmt n, A arg);
+    void visit(DoStmt n, A arg);
 
-	void visit(ForeachStmt n, A arg);
+    void visit(ForeachStmt n, A arg);
 
-	void visit(ForStmt n, A arg);
+    void visit(ForStmt n, A arg);
 
-	void visit(ThrowStmt n, A arg);
+    void visit(ThrowStmt n, A arg);
 
-	void visit(SynchronizedStmt n, A arg);
+    void visit(SynchronizedStmt n, A arg);
 
-	void visit(TryStmt n, A arg);
+    void visit(TryStmt n, A arg);
 
-	void visit(CatchClause n, A arg);
+    void visit(CatchClause n, A arg);
 
     void visit(LambdaExpr n, A arg);
 
@@ -253,5 +253,5 @@ public interface VoidVisitor<A> {
 
     void visit(TypeExpr n, A arg);
 
-	void visit(ArrayBracketPair arrayBracketPair, A arg);
+    void visit(ArrayBracketPair arrayBracketPair, A arg);
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -89,673 +89,673 @@ import com.github.javaparser.ast.type.*;
  */
 public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
-	@Override public void visit(final AnnotationDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getNameExpr().accept(this, arg);
-		if (n.getMembers() != null) {
-            for (final BodyDeclaration<?> member : n.getMembers()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final AnnotationMemberDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getType().accept(this, arg);
-		if (n.getDefaultValue() != null) {
-			n.getDefaultValue().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ArrayAccessExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		n.getIndex().accept(this, arg);
-	}
-
-	@Override public void visit(final ArrayCreationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-		for (ArrayCreationLevel level : n.getLevels()) {
-			level.accept(this, arg);
-		}
-		if (n.getInitializer() != null) {
-			n.getInitializer().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ArrayInitializerExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getValues() != null) {
-			for (final Expression expr : n.getValues()) {
-				expr.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final AssertStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCheck().accept(this, arg);
-		if (n.getMessage() != null) {
-			n.getMessage().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final AssignExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getTarget().accept(this, arg);
-		n.getValue().accept(this, arg);
-	}
-
-	@Override public void visit(final BinaryExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getLeft().accept(this, arg);
-		n.getRight().accept(this, arg);
-	}
-
-	@Override public void visit(final BlockComment n, final A arg) {
-	}
-
-	@Override public void visit(final BlockStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final BooleanLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final BreakStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final CastExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-		n.getExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final CatchClause n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getParam().accept(this, arg);
-		n.getBody().accept(this, arg);
-	}
-
-	@Override public void visit(final CharLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final ClassExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-	}
-
-	@Override public void visit(final ClassOrInterfaceDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getNameExpr().accept(this, arg);
-		for (final TypeParameter t : n.getTypeParameters()) {
-			t.accept(this, arg);
-		}
-		for (final ClassOrInterfaceType c : n.getExtends()) {
-			c.accept(this, arg);
-		}
-		for (final ClassOrInterfaceType c : n.getImplements()) {
-			c.accept(this, arg);
-		}
-        for (final BodyDeclaration<?> member : n.getMembers()) {
-			member.accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ClassOrInterfaceType n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-		}
-		if (n.getTypeArguments() != null) {
-			for (final Type t : n.getTypeArguments()) {
-				t.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final CompilationUnit n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getPackage() != null) {
-			n.getPackage().accept(this, arg);
-		}
-		if (n.getImports() != null) {
-			for (final ImportDeclaration i : n.getImports()) {
-				i.accept(this, arg);
-			}
-		}
-		if (n.getTypes() != null) {
-            for (final TypeDeclaration<?> typeDeclaration : n.getTypes()) {
-				typeDeclaration.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final ConditionalExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		n.getThenExpr().accept(this, arg);
-		n.getElseExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final ConstructorDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				t.accept(this, arg);
-			}
-		}
-		n.getNameExpr().accept(this, arg);
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				p.accept(this, arg);
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final ReferenceType name : n.getThrows()) {
-				name.accept(this, arg);
-			}
-		}
-		n.getBody().accept(this, arg);
-	}
-
-	@Override public void visit(final ContinueStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final DoStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getBody().accept(this, arg);
-		n.getCondition().accept(this, arg);
-	}
-
-	@Override public void visit(final DoubleLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final EmptyMemberDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final EmptyStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final EmptyTypeDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getNameExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final EnclosedExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getInner().accept(this, arg);
-	}
-
-	@Override public void visit(final EnumConstantDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getClassBody() != null) {
-            for (final BodyDeclaration<?> member : n.getClassBody()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final EnumDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getNameExpr().accept(this, arg);
-		if (n.getImplements() != null) {
-			for (final ClassOrInterfaceType c : n.getImplements()) {
-				c.accept(this, arg);
-			}
-		}
-		if (n.getEntries() != null) {
-			for (final EnumConstantDeclaration e : n.getEntries()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getMembers() != null) {
-            for (final BodyDeclaration<?> member : n.getMembers()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (!n.isThis() && n.getExpr() != null) {
-			n.getExpr().accept(this, arg);
-		}
-		if (n.getTypeArguments() != null) {
-			for (final Type t : n.getTypeArguments()) {
-				t.accept(this, arg);
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final ExpressionStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpression().accept(this, arg);
-	}
-
-	@Override public void visit(final FieldAccessExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getScope().accept(this, arg);
-		n.getFieldExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final FieldDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getElementType().accept(this, arg);
-		for (final VariableDeclarator var : n.getVariables()) {
-			var.accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ForeachStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getVariable().accept(this, arg);
-		n.getIterable().accept(this, arg);
-		n.getBody().accept(this, arg);
-	}
-
-	@Override public void visit(final ForStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getInit() != null) {
-			for (final Expression e : n.getInit()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getCompare() != null) {
-			n.getCompare().accept(this, arg);
-		}
-		if (n.getUpdate() != null) {
-			for (final Expression e : n.getUpdate()) {
-				e.accept(this, arg);
-			}
-		}
-		n.getBody().accept(this, arg);
-	}
-
-	@Override public void visit(final IfStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		n.getThenStmt().accept(this, arg);
-		if (n.getElseStmt() != null) {
-			n.getElseStmt().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ImportDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-	}
-
-	@Override public void visit(final InitializerDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getBlock().accept(this, arg);
-	}
-
-	@Override public void visit(final InstanceOfExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-		n.getType().accept(this, arg);
-	}
-
-	@Override public void visit(final IntegerLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final IntegerLiteralMinValueExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final JavadocComment n, final A arg) {
-	}
-
-	@Override public void visit(final LabeledStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getStmt().accept(this, arg);
-	}
-
-	@Override public void visit(final LineComment n, final A arg) {
-	}
-
-	@Override public void visit(final LongLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final LongLiteralMinValueExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final MarkerAnnotationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-	}
-
-	@Override public void visit(final MemberValuePair n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getValue().accept(this, arg);
-	}
-
-	@Override public void visit(final MethodCallExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-		}
-		if (n.getTypeArguments() != null) {
-			for (final Type t : n.getTypeArguments()) {
-				t.accept(this, arg);
-			}
-		}
-		n.getNameExpr().accept(this, arg);
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final MethodDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				t.accept(this, arg);
-			}
-		}
-		n.getElementType().accept(this, arg);
-		n.getNameExpr().accept(this, arg);
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				p.accept(this, arg);
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final ReferenceType name : n.getThrows()) {
-				name.accept(this, arg);
-			}
-		}
-		if (n.getBody() != null) {
-			n.getBody().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final NameExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final NormalAnnotationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		if (n.getPairs() != null) {
-			for (final MemberValuePair m : n.getPairs()) {
-				m.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final NullLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final ObjectCreationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-		}
-		if (n.getTypeArguments() != null) {
-			for (final Type t : n.getTypeArguments()) {
-				t.accept(this, arg);
-			}
-		}
-		n.getType().accept(this, arg);
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getAnonymousClassBody() != null) {
-            for (final BodyDeclaration<?> member : n.getAnonymousClassBody()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final PackageDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getName().accept(this, arg);
-	}
-
-	@Override public void visit(final Parameter n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getElementType().accept(this, arg);
-		n.getId().accept(this, arg);
-	}
-	
-	@Override public void visit(final PrimitiveType n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-	}
-
-	@Override public void visit(final QualifiedNameExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getQualifier().accept(this, arg);
-	}
-
-	@Override
-	public void visit(ArrayType n, A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getComponentType().accept(this, arg);
-	}
-
-	@Override
-	public void visit(ArrayCreationLevel n, A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		if(n.getDimension()!=null) {
-			n.getDimension().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final IntersectionType n, final A arg) {
+    @Override public void visit(final AnnotationDeclaration n, final A arg) {
         visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		for (ReferenceType element : n.getElements()) {
+        visitAnnotations(n, arg);
+        n.getNameExpr().accept(this, arg);
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration<?> member : n.getMembers()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final AnnotationMemberDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getType().accept(this, arg);
+        if (n.getDefaultValue() != null) {
+            n.getDefaultValue().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ArrayAccessExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        n.getIndex().accept(this, arg);
+    }
+
+    @Override public void visit(final ArrayCreationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+        for (ArrayCreationLevel level : n.getLevels()) {
+            level.accept(this, arg);
+        }
+        if (n.getInitializer() != null) {
+            n.getInitializer().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ArrayInitializerExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getValues() != null) {
+            for (final Expression expr : n.getValues()) {
+                expr.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final AssertStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCheck().accept(this, arg);
+        if (n.getMessage() != null) {
+            n.getMessage().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final AssignExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getTarget().accept(this, arg);
+        n.getValue().accept(this, arg);
+    }
+
+    @Override public void visit(final BinaryExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getLeft().accept(this, arg);
+        n.getRight().accept(this, arg);
+    }
+
+    @Override public void visit(final BlockComment n, final A arg) {
+    }
+
+    @Override public void visit(final BlockStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final BooleanLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final BreakStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final CastExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+        n.getExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final CatchClause n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getParam().accept(this, arg);
+        n.getBody().accept(this, arg);
+    }
+
+    @Override public void visit(final CharLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final ClassExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+    }
+
+    @Override public void visit(final ClassOrInterfaceDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getNameExpr().accept(this, arg);
+        for (final TypeParameter t : n.getTypeParameters()) {
+            t.accept(this, arg);
+        }
+        for (final ClassOrInterfaceType c : n.getExtends()) {
+            c.accept(this, arg);
+        }
+        for (final ClassOrInterfaceType c : n.getImplements()) {
+            c.accept(this, arg);
+        }
+        for (final BodyDeclaration<?> member : n.getMembers()) {
+            member.accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ClassOrInterfaceType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+        }
+        if (n.getTypeArguments() != null) {
+            for (final Type t : n.getTypeArguments()) {
+                t.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final CompilationUnit n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getPackage() != null) {
+            n.getPackage().accept(this, arg);
+        }
+        if (n.getImports() != null) {
+            for (final ImportDeclaration i : n.getImports()) {
+                i.accept(this, arg);
+            }
+        }
+        if (n.getTypes() != null) {
+            for (final TypeDeclaration<?> typeDeclaration : n.getTypes()) {
+                typeDeclaration.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final ConditionalExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        n.getThenExpr().accept(this, arg);
+        n.getElseExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final ConstructorDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                t.accept(this, arg);
+            }
+        }
+        n.getNameExpr().accept(this, arg);
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                p.accept(this, arg);
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final ReferenceType name : n.getThrows()) {
+                name.accept(this, arg);
+            }
+        }
+        n.getBody().accept(this, arg);
+    }
+
+    @Override public void visit(final ContinueStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final DoStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getBody().accept(this, arg);
+        n.getCondition().accept(this, arg);
+    }
+
+    @Override public void visit(final DoubleLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final EmptyMemberDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final EmptyStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final EmptyTypeDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getNameExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final EnclosedExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getInner().accept(this, arg);
+    }
+
+    @Override public void visit(final EnumConstantDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getClassBody() != null) {
+            for (final BodyDeclaration<?> member : n.getClassBody()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final EnumDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getNameExpr().accept(this, arg);
+        if (n.getImplements() != null) {
+            for (final ClassOrInterfaceType c : n.getImplements()) {
+                c.accept(this, arg);
+            }
+        }
+        if (n.getEntries() != null) {
+            for (final EnumConstantDeclaration e : n.getEntries()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration<?> member : n.getMembers()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final ExplicitConstructorInvocationStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (!n.isThis() && n.getExpr() != null) {
+            n.getExpr().accept(this, arg);
+        }
+        if (n.getTypeArguments() != null) {
+            for (final Type t : n.getTypeArguments()) {
+                t.accept(this, arg);
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final ExpressionStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpression().accept(this, arg);
+    }
+
+    @Override public void visit(final FieldAccessExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getScope().accept(this, arg);
+        n.getFieldExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final FieldDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getElementType().accept(this, arg);
+        for (final VariableDeclarator var : n.getVariables()) {
+            var.accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ForeachStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getVariable().accept(this, arg);
+        n.getIterable().accept(this, arg);
+        n.getBody().accept(this, arg);
+    }
+
+    @Override public void visit(final ForStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getInit() != null) {
+            for (final Expression e : n.getInit()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getCompare() != null) {
+            n.getCompare().accept(this, arg);
+        }
+        if (n.getUpdate() != null) {
+            for (final Expression e : n.getUpdate()) {
+                e.accept(this, arg);
+            }
+        }
+        n.getBody().accept(this, arg);
+    }
+
+    @Override public void visit(final IfStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        n.getThenStmt().accept(this, arg);
+        if (n.getElseStmt() != null) {
+            n.getElseStmt().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ImportDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+    }
+
+    @Override public void visit(final InitializerDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getBlock().accept(this, arg);
+    }
+
+    @Override public void visit(final InstanceOfExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+        n.getType().accept(this, arg);
+    }
+
+    @Override public void visit(final IntegerLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final IntegerLiteralMinValueExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final JavadocComment n, final A arg) {
+    }
+
+    @Override public void visit(final LabeledStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getStmt().accept(this, arg);
+    }
+
+    @Override public void visit(final LineComment n, final A arg) {
+    }
+
+    @Override public void visit(final LongLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final LongLiteralMinValueExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final MarkerAnnotationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+    }
+
+    @Override public void visit(final MemberValuePair n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getValue().accept(this, arg);
+    }
+
+    @Override public void visit(final MethodCallExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+        }
+        if (n.getTypeArguments() != null) {
+            for (final Type t : n.getTypeArguments()) {
+                t.accept(this, arg);
+            }
+        }
+        n.getNameExpr().accept(this, arg);
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final MethodDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                t.accept(this, arg);
+            }
+        }
+        n.getElementType().accept(this, arg);
+        n.getNameExpr().accept(this, arg);
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                p.accept(this, arg);
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final ReferenceType name : n.getThrows()) {
+                name.accept(this, arg);
+            }
+        }
+        if (n.getBody() != null) {
+            n.getBody().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final NameExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final NormalAnnotationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        if (n.getPairs() != null) {
+            for (final MemberValuePair m : n.getPairs()) {
+                m.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final NullLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final ObjectCreationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+        }
+        if (n.getTypeArguments() != null) {
+            for (final Type t : n.getTypeArguments()) {
+                t.accept(this, arg);
+            }
+        }
+        n.getType().accept(this, arg);
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getAnonymousClassBody() != null) {
+            for (final BodyDeclaration<?> member : n.getAnonymousClassBody()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final PackageDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getName().accept(this, arg);
+    }
+
+    @Override public void visit(final Parameter n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getElementType().accept(this, arg);
+        n.getId().accept(this, arg);
+    }
+    
+    @Override public void visit(final PrimitiveType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+    }
+
+    @Override public void visit(final QualifiedNameExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getQualifier().accept(this, arg);
+    }
+
+    @Override
+    public void visit(ArrayType n, A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getComponentType().accept(this, arg);
+    }
+
+    @Override
+    public void visit(ArrayCreationLevel n, A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        if(n.getDimension()!=null) {
+            n.getDimension().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final IntersectionType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        for (ReferenceType element : n.getElements()) {
             element.accept(this, arg);
         }
     }
 
     @Override public void visit(final UnionType n, final A arg) {
         visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		for (ReferenceType element : n.getElements()) {
+        visitAnnotations(n, arg);
+        for (ReferenceType element : n.getElements()) {
             element.accept(this, arg);
         }
     }
 
-	@Override public void visit(final ReturnStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getExpr() != null) {
-			n.getExpr().accept(this, arg);
-		}
-	}
+    @Override public void visit(final ReturnStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getExpr() != null) {
+            n.getExpr().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final SingleMemberAnnotationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		n.getMemberValue().accept(this, arg);
-	}
+    @Override public void visit(final SingleMemberAnnotationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        n.getMemberValue().accept(this, arg);
+    }
 
-	@Override public void visit(final StringLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
+    @Override public void visit(final StringLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
 
-	@Override public void visit(final SuperExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-		}
-	}
+    @Override public void visit(final SuperExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final SwitchEntryStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getLabel() != null) {
-			n.getLabel().accept(this, arg);
-		}
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-			}
-		}
-	}
+    @Override public void visit(final SwitchEntryStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getLabel() != null) {
+            n.getLabel().accept(this, arg);
+        }
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+            }
+        }
+    }
 
-	@Override public void visit(final SwitchStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getSelector().accept(this, arg);
-		if (n.getEntries() != null) {
-			for (final SwitchEntryStmt e : n.getEntries()) {
-				e.accept(this, arg);
-			}
-		}
-	}
+    @Override public void visit(final SwitchStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getSelector().accept(this, arg);
+        if (n.getEntries() != null) {
+            for (final SwitchEntryStmt e : n.getEntries()) {
+                e.accept(this, arg);
+            }
+        }
+    }
 
-	@Override public void visit(final SynchronizedStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-		n.getBody().accept(this, arg);
-	}
+    @Override public void visit(final SynchronizedStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+        n.getBody().accept(this, arg);
+    }
 
-	@Override public void visit(final ThisExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-		}
-	}
+    @Override public void visit(final ThisExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final ThrowStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-	}
+    @Override public void visit(final ThrowStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+    }
 
-	@Override public void visit(final TryStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getResources() != null) {
-			for (final VariableDeclarationExpr v : n.getResources()) {
-				v.accept(this, arg);
-			}
-		}
-		n.getTryBlock().accept(this, arg);
-		if (n.getCatchs() != null) {
-			for (final CatchClause c : n.getCatchs()) {
-				c.accept(this, arg);
-			}
-		}
-		if (n.getFinallyBlock() != null) {
-			n.getFinallyBlock().accept(this, arg);
-		}
-	}
+    @Override public void visit(final TryStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getResources() != null) {
+            for (final VariableDeclarationExpr v : n.getResources()) {
+                v.accept(this, arg);
+            }
+        }
+        n.getTryBlock().accept(this, arg);
+        if (n.getCatchs() != null) {
+            for (final CatchClause c : n.getCatchs()) {
+                c.accept(this, arg);
+            }
+        }
+        if (n.getFinallyBlock() != null) {
+            n.getFinallyBlock().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final TypeDeclarationStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getTypeDeclaration().accept(this, arg);
-	}
+    @Override public void visit(final TypeDeclarationStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getTypeDeclaration().accept(this, arg);
+    }
 
-	@Override public void visit(final TypeParameter n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getTypeBound() != null) {
-			for (final ClassOrInterfaceType c : n.getTypeBound()) {
-				c.accept(this, arg);
-			}
-		}
-	}
+    @Override public void visit(final TypeParameter n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getTypeBound() != null) {
+            for (final ClassOrInterfaceType c : n.getTypeBound()) {
+                c.accept(this, arg);
+            }
+        }
+    }
 
-	@Override public void visit(final UnaryExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-	}
+    @Override public void visit(final UnaryExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+    }
 
-	@Override public void visit(final UnknownType n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
+    @Override public void visit(final UnknownType n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
 
-	@Override public void visit(final VariableDeclarationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		n.getElementType().accept(this, arg);
-		for (final VariableDeclarator v : n.getVariables()) {
-			v.accept(this, arg);
-		}
-	}
+    @Override public void visit(final VariableDeclarationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        n.getElementType().accept(this, arg);
+        for (final VariableDeclarator v : n.getVariables()) {
+            v.accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final VariableDeclarator n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getId().accept(this, arg);
-		if (n.getInit() != null) {
-			n.getInit().accept(this, arg);
-		}
-	}
+    @Override public void visit(final VariableDeclarator n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getId().accept(this, arg);
+        if (n.getInit() != null) {
+            n.getInit().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final VariableDeclaratorId n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
+    @Override public void visit(final VariableDeclaratorId n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
 
-	@Override public void visit(final VoidType n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
+    @Override public void visit(final VoidType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
 
-	}
+    }
 
-	@Override public void visit(final WhileStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		n.getBody().accept(this, arg);
-	}
+    @Override public void visit(final WhileStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        n.getBody().accept(this, arg);
+    }
 
-	@Override public void visit(final WildcardType n, final A arg) {
-		visitComment(n.getComment(), arg);
-		visitAnnotations(n, arg);
-		if (n.getExtends() != null) {
-			n.getExtends().accept(this, arg);
-		}
-		if (n.getSuper() != null) {
-			n.getSuper().accept(this, arg);
-		}
-	}
+    @Override public void visit(final WildcardType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        visitAnnotations(n, arg);
+        if (n.getExtends() != null) {
+            n.getExtends().accept(this, arg);
+        }
+        if (n.getSuper() != null) {
+            n.getSuper().accept(this, arg);
+        }
+    }
 
     @Override
     public void visit(LambdaExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
+        visitComment(n.getComment(), arg);
         if (n.getParameters() != null) {
             for (final Parameter a : n.getParameters()) {
                 a.accept(this, arg);
@@ -768,12 +768,12 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(MethodReferenceExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getTypeArguments() != null) {
-			for (final Type t : n.getTypeArguments()) {
-				t.accept(this, arg);
-			}
-		}
+        visitComment(n.getComment(), arg);
+        if (n.getTypeArguments() != null) {
+            for (final Type t : n.getTypeArguments()) {
+                t.accept(this, arg);
+            }
+        }
         if (n.getScope() != null) {
             n.getScope().accept(this, arg);
         }
@@ -781,26 +781,26 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(TypeExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
+        visitComment(n.getComment(), arg);
         if (n.getType() != null) {
             n.getType().accept(this, arg);
         }
     }
 
-	@Override
-	public void visit(ArrayBracketPair n, A arg) {
-		visitAnnotations(n, arg);
-	}
+    @Override
+    public void visit(ArrayBracketPair n, A arg) {
+        visitAnnotations(n, arg);
+    }
 
-	private void visitComment(final Comment n, final A arg) {
-		if (n != null) {
-			n.accept(this, arg);
-		}
-	}
+    private void visitComment(final Comment n, final A arg) {
+        if (n != null) {
+            n.accept(this, arg);
+        }
+    }
 
-	private void visitAnnotations(NodeWithAnnotations<?> n, A arg) {
-		for (AnnotationExpr annotation : n.getAnnotations()) {
-			annotation.accept(this, arg);
-		}
-	}
+    private void visitAnnotations(NodeWithAnnotations<?> n, A arg) {
+        for (AnnotationExpr annotation : n.getAnnotations()) {
+            annotation.accept(this, arg);
+        }
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/utils/Pair.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/utils/Pair.java
@@ -6,11 +6,11 @@ package com.github.javaparser.utils;
  * @param <B> type of object b.
  */
 public class Pair<A, B> {
-	public final A a;
-	public final B b;
+    public final A a;
+    public final B b;
 
-	public Pair(A a, B b) {
-		this.a = a;
-		this.b = b;
-	}
+    public Pair(A a, B b) {
+        this.a = a;
+        this.b = b;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/utils/Utils.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-core/com/github/javaparser/utils/Utils.java
@@ -34,74 +34,74 @@ import java.util.*;
  * @author Federico Tomassetti
  */
 public class Utils {
-	public static final String EOL = System.getProperty("line.separator");
-	public static <T> List<T> ensureNotNull(List<T> list) {
-		return list == null ? new ArrayList<T>() : list;
-	}
+    public static final String EOL = System.getProperty("line.separator");
+    public static <T> List<T> ensureNotNull(List<T> list) {
+        return list == null ? new ArrayList<T>() : list;
+    }
 
-	public static <E> boolean isNullOrEmpty(Collection<E> collection) {
-		return collection == null || collection.isEmpty();
-	}
+    public static <E> boolean isNullOrEmpty(Collection<E> collection) {
+        return collection == null || collection.isEmpty();
+    }
 
-	public static <T> T assertNotNull(T o) {
-		if (o == null) {
-			throw new NullPointerException("Assertion failed.");
-		}
-		return o;
-	}
+    public static <T> T assertNotNull(T o) {
+        if (o == null) {
+            throw new NullPointerException("Assertion failed.");
+        }
+        return o;
+    }
 
-	/**
-	 * @return string with ASCII characters 10 and 13 replaced by the text "\n" and "\r".
-	 */
-	public static String escapeEndOfLines(String string) {
-		StringBuilder escapedString = new StringBuilder();
-		for (char c : string.toCharArray()) {
-			switch (c) {
-				case '\n':
-					escapedString.append("\\n");
-					break;
-				case '\r':
-					escapedString.append("\\r");
-					break;
-				default:
-					escapedString.append(c);
-			}
-		}
-		return escapedString.toString();
-	}
+    /**
+     * @return string with ASCII characters 10 and 13 replaced by the text "\n" and "\r".
+     */
+    public static String escapeEndOfLines(String string) {
+        StringBuilder escapedString = new StringBuilder();
+        for (char c : string.toCharArray()) {
+            switch (c) {
+                case '\n':
+                    escapedString.append("\\n");
+                    break;
+                case '\r':
+                    escapedString.append("\\r");
+                    break;
+                default:
+                    escapedString.append(c);
+            }
+        }
+        return escapedString.toString();
+    }
 
-	public static String readerToString(Reader reader) throws IOException {
-		final StringBuilder result = new StringBuilder();
-		final char[] buffer = new char[8 * 1024];
-		int numChars;
+    public static String readerToString(Reader reader) throws IOException {
+        final StringBuilder result = new StringBuilder();
+        final char[] buffer = new char[8 * 1024];
+        int numChars;
 
-		while ((numChars = reader.read(buffer, 0, buffer.length)) > 0) {
-			result.append(buffer, 0, numChars);
-		}
+        while ((numChars = reader.read(buffer, 0, buffer.length)) > 0) {
+            result.append(buffer, 0, numChars);
+        }
 
-		return result.toString();
-	}
+        return result.toString();
+    }
 
-	public static String providerToString(Provider provider) throws IOException {
-		final StringBuilder result = new StringBuilder();
-		final char[] buffer = new char[8 * 1024];
-		int numChars;
+    public static String providerToString(Provider provider) throws IOException {
+        final StringBuilder result = new StringBuilder();
+        final char[] buffer = new char[8 * 1024];
+        int numChars;
 
-		while ((numChars = provider.read(buffer, 0, buffer.length)) != -1) {
-			result.append(buffer, 0, numChars);
-		}
+        while ((numChars = provider.read(buffer, 0, buffer.length)) != -1) {
+            result.append(buffer, 0, numChars);
+        }
 
-		return result.toString();
-	}
+        return result.toString();
+    }
 
-	/**
-	 * Puts varargs in a mutable list.
+    /**
+     * Puts varargs in a mutable list.
      * This does not have the disadvantage of Arrays#asList that it has a static size. 
-	 */
-	public static <T> List<T> arrayToList(T[] array){
-		List<T> list = new LinkedList<>();
-		Collections.addAll(list, array);
-		return list;
-	}
+     */
+    public static <T> List<T> arrayToList(T[] array){
+        List<T> list = new LinkedList<>();
+        Collections.addAll(list, array);
+        return list;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/ASTParser.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/ASTParser.java
@@ -9022,7 +9022,7 @@ return ret;
   }
   /** Reinitialise. */
   public void ReInit(Provider stream) {
-	if (jj_input_stream == null) {
+    if (jj_input_stream == null) {
       jj_input_stream = new JavaCharStream(stream, 1, 1);
    } else {
       jj_input_stream.ReInit(stream, 1, 1);

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/ASTParserTokenManager.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/ASTParserTokenManager.java
@@ -2568,7 +2568,7 @@ private void jjCheckNAddStates(int start, int end)
   /** Reinitialise parser. */
   public void ReInit(JavaCharStream stream)
   {
-	
+    
     jjmatchedPos = jjnewStateCnt = 0;
     curLexState = defaultLexState;
     input_stream = stream;

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/JavaCharStream.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/JavaCharStream.java
@@ -317,7 +317,7 @@ class JavaCharStream
         }
         catch(java.io.IOException e)
         {
-	  // We are returning one backslash so we should only backup (count-1)
+      // We are returning one backslash so we should only backup (count-1)
           if (backSlashCnt > 1)
             backup(backSlashCnt-1);
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/ParseException.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/ParseException.java
@@ -44,9 +44,9 @@ public class ParseException extends Exception {
           int[][] expectedTokenSequencesVal,
           String[] tokenImageVal
          )
-	{
-	  this (currentTokenVal, expectedTokenSequencesVal, tokenImageVal, null);
-	}
+    {
+      this (currentTokenVal, expectedTokenSequencesVal, tokenImageVal, null);
+    }
   
   
   /**
@@ -119,7 +119,7 @@ public class ParseException extends Exception {
                            int[][] expectedTokenSequences,
                            String[] tokenImage,
                            String lexicalStateName) {
-	StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder();
     StringBuffer expected = new StringBuffer();
     
     int maxSize = 0;
@@ -129,7 +129,7 @@ public class ParseException extends Exception {
         maxSize = expectedTokenSequences[i].length;
       }
       for (int j = 0; j < expectedTokenSequences[i].length; j++) {
-    	  sortedOptions.add(tokenImage[expectedTokenSequences[i][j]]);
+          sortedOptions.add(tokenImage[expectedTokenSequences[i][j]]);
       }
     }
     
@@ -142,33 +142,33 @@ public class ParseException extends Exception {
     Token tok = currentToken.next;
     for (int i = 0; i < maxSize; i++) {
       String tokenText = tok.image;
-  	  String escapedTokenText = add_escapes(tokenText);
+        String escapedTokenText = add_escapes(tokenText);
       if (i != 0) {
-      	sb.append(" ");
+          sb.append(" ");
       }
       if (tok.kind == 0) {
-      	sb.append(tokenImage[0]);
+          sb.append(tokenImage[0]);
         break;
       }
       sb.append(" \"");
-	  sb.append(escapedTokenText);
+      sb.append(escapedTokenText);
       sb.append("\"");
       sb.append(" " + tokenImage[tok.kind]);
       tok = tok.next;
     }
-	sb.append(EOL).append(INDENT).append("at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn);
-	sb.append(".").append(EOL);
+    sb.append(EOL).append(INDENT).append("at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn);
+    sb.append(".").append(EOL);
     
     if (expectedTokenSequences.length == 0) {
         // Nothing to add here
     } else {
-    	int numExpectedTokens = expectedTokenSequences.length;
-    	sb.append(EOL).append("Was expecting"+ (numExpectedTokens == 1 ? ":" : " one of:") + EOL + EOL);
-    	sb.append(expected.toString());
+        int numExpectedTokens = expectedTokenSequences.length;
+        sb.append(EOL).append("Was expecting"+ (numExpectedTokens == 1 ? ":" : " one of:") + EOL + EOL);
+        sb.append(expected.toString());
     }
     // 2013/07/30 --> Seems to be inaccurate as represents the readahead state, not the lexical state BEFORE the unknown token
 //    if (lexicalStateName != null) {
-//    	sb.append(EOL).append("** Lexical State : ").append(lexicalStateName).append(EOL).append(EOL);
+//        sb.append(EOL).append("** Lexical State : ").append(lexicalStateName).append(EOL).append(EOL);
 //    }
     
     return sb.toString();

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/StreamProvider.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/StreamProvider.java
@@ -26,44 +26,44 @@ import java.io.Reader;
  */
 public class StreamProvider implements Provider {
 
-	Reader _reader;
+    Reader _reader;
 
-	public StreamProvider(Reader reader) {
-		_reader = reader;
-	}
-	
-	public StreamProvider(InputStream stream) throws IOException {
-		_reader = new BufferedReader(new InputStreamReader(stream));
-	}
-	
-	public StreamProvider(InputStream stream, String charsetName) throws IOException {
-		_reader = new BufferedReader(new InputStreamReader(stream, charsetName));
-	}
+    public StreamProvider(Reader reader) {
+        _reader = reader;
+    }
+    
+    public StreamProvider(InputStream stream) throws IOException {
+        _reader = new BufferedReader(new InputStreamReader(stream));
+    }
+    
+    public StreamProvider(InputStream stream, String charsetName) throws IOException {
+        _reader = new BufferedReader(new InputStreamReader(stream, charsetName));
+    }
 
-	@Override
-	public int read(char[] buffer, int off, int len) throws IOException {
-	   int result = _reader.read(buffer, off, len);
+    @Override
+    public int read(char[] buffer, int off, int len) throws IOException {
+       int result = _reader.read(buffer, off, len);
 
-	   /* CBA -- Added 2014/03/29 -- 
-	             This logic allows the generated Java code to be easily translated to C# (via sharpen) -
-	             as in C# 0 represents end of file, and in Java, -1 represents end of file
-	             See : http://msdn.microsoft.com/en-us/library/9kstw824(v=vs.110).aspx
-	             ** Technically, this is not required for java but the overhead is extremely low compared to the code generation benefits.
-	   */
-	   
-	   if (result == 0) {
-	      if (off < buffer.length && len > 0) {
-	        result = -1;
-	      }
-	   }
-	   
-		return result;
-	}
+       /* CBA -- Added 2014/03/29 -- 
+                 This logic allows the generated Java code to be easily translated to C# (via sharpen) -
+                 as in C# 0 represents end of file, and in Java, -1 represents end of file
+                 See : http://msdn.microsoft.com/en-us/library/9kstw824(v=vs.110).aspx
+                 ** Technically, this is not required for java but the overhead is extremely low compared to the code generation benefits.
+       */
+       
+       if (result == 0) {
+          if (off < buffer.length && len > 0) {
+            result = -1;
+          }
+       }
+       
+        return result;
+    }
 
-	@Override
-	public void close() throws IOException {
-		_reader.close();
-	}
+    @Override
+    public void close() throws IOException {
+        _reader.close();
+    }
 
 }
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/StringProvider.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_new_src/javaparser-generated-sources/com/github/javaparser/StringProvider.java
@@ -14,47 +14,47 @@
  */
 package com.github.javaparser;
 
-	
-	import java.io.IOException;
-	
-	public class StringProvider implements Provider {
+    
+    import java.io.IOException;
+    
+    public class StringProvider implements Provider {
 
-		String _string;
-		int _position = 0;
-		int _size;
-		
-		public StringProvider(String string) {
-			_string = string;
-			_size = string.length();
-		}
-		
-		@Override
-		public int read(char[] cbuf, int off, int len) throws IOException {
-			int numCharsOutstandingInString = _size - _position;
-			
-			if (numCharsOutstandingInString == 0) {
-				return -1;
-			}
-			
-			int numBytesInBuffer = cbuf.length;
-			int numBytesToRead = numBytesInBuffer -off;
-			numBytesToRead = numBytesToRead > len ? len : numBytesToRead;
-			
-			if (numBytesToRead > numCharsOutstandingInString) {
-				numBytesToRead = numCharsOutstandingInString;
-			}
-			
-			_string.getChars(_position, _position + numBytesToRead, cbuf, off);
-			
-			_position += numBytesToRead;
-			
-			return numBytesToRead;
-		}
+        String _string;
+        int _position = 0;
+        int _size;
+        
+        public StringProvider(String string) {
+            _string = string;
+            _size = string.length();
+        }
+        
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            int numCharsOutstandingInString = _size - _position;
+            
+            if (numCharsOutstandingInString == 0) {
+                return -1;
+            }
+            
+            int numBytesInBuffer = cbuf.length;
+            int numBytesToRead = numBytesInBuffer -off;
+            numBytesToRead = numBytesToRead > len ? len : numBytesToRead;
+            
+            if (numBytesToRead > numCharsOutstandingInString) {
+                numBytesToRead = numCharsOutstandingInString;
+            }
+            
+            _string.getChars(_position, _position + numBytesToRead, cbuf, off);
+            
+            _position += numBytesToRead;
+            
+            return numBytesToRead;
+        }
 
-		@Override
-		public void close() throws IOException {
-			_string = null;
-		}
-		
-	}
+        @Override
+        public void close() throws IOException {
+            _string = null;
+        }
+        
+    }
 /* JavaCC - OriginalChecksum=9873e92cad8666980a4c6d392c0c7ad4 (do not edit this line) */

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/generated/com/github/javaparser/JavaCharStream.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/generated/com/github/javaparser/JavaCharStream.java
@@ -314,7 +314,7 @@ class JavaCharStream
         }
         catch(java.io.IOException e)
         {
-	  // We are returning one backslash so we should only backup (count-1)
+      // We are returning one backslash so we should only backup (count-1)
           if (backSlashCnt > 1)
             backup(backSlashCnt-1);
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/CompilationUnit.java
@@ -152,7 +152,7 @@ public final class CompilationUnit extends Node {
      */
     public void setImports(List<ImportDeclaration> imports) {
         this.imports = imports;
-		setAsParentNodeOf(this.imports);
+        setAsParentNodeOf(this.imports);
     }
 
     /**
@@ -164,7 +164,7 @@ public final class CompilationUnit extends Node {
      */
     public void setPackage(PackageDeclaration pakage) {
         this.pakage = pakage;
-		setAsParentNodeOf(this.pakage);
+        setAsParentNodeOf(this.pakage);
     }
 
     /**
@@ -175,6 +175,6 @@ public final class CompilationUnit extends Node {
      */
     public void setTypes(List<TypeDeclaration> types) {
         this.types = types;
-		setAsParentNodeOf(this.types);
+        setAsParentNodeOf(this.types);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/TypeParameter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/TypeParameter.java
@@ -42,26 +42,26 @@ import java.util.List;
  */
 public final class TypeParameter extends Node implements NamedNode {
 
-	private String name;
+    private String name;
 
     private List<AnnotationExpr> annotations;
 
-	private List<ClassOrInterfaceType> typeBound;
+    private List<ClassOrInterfaceType> typeBound;
 
-	public TypeParameter() {
-	}
+    public TypeParameter() {
+    }
 
-	public TypeParameter(final String name, final List<ClassOrInterfaceType> typeBound) {
-		setName(name);
-		setTypeBound(typeBound);
-	}
+    public TypeParameter(final String name, final List<ClassOrInterfaceType> typeBound) {
+        setName(name);
+        setTypeBound(typeBound);
+    }
 
-	public TypeParameter(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String name, final List<ClassOrInterfaceType> typeBound) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setName(name);
-		setTypeBound(typeBound);
-	}
+    public TypeParameter(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String name, final List<ClassOrInterfaceType> typeBound) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setName(name);
+        setTypeBound(typeBound);
+    }
 
     public TypeParameter(int beginLine, int beginColumn, int endLine,
                          int endColumn, String name, List<ClassOrInterfaceType> typeBound, List<AnnotationExpr> annotations) {
@@ -71,53 +71,53 @@ public final class TypeParameter extends Node implements NamedNode {
         this.annotations = annotations;
     }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	/**
-	 * Return the name of the paramenter.
-	 * 
-	 * @return the name of the paramenter
-	 */
-	public String getName() {
-		return name;
-	}
+    /**
+     * Return the name of the paramenter.
+     * 
+     * @return the name of the paramenter
+     */
+    public String getName() {
+        return name;
+    }
 
-	/**
-	 * Return the list of {@link ClassOrInterfaceType} that this parameter
-	 * extends. Return <code>null</code> null if there are no type.
-	 * 
-	 * @return list of types that this paramente extends or <code>null</code>
-	 */
-	public List<ClassOrInterfaceType> getTypeBound() {
-		return typeBound;
-	}
+    /**
+     * Return the list of {@link ClassOrInterfaceType} that this parameter
+     * extends. Return <code>null</code> null if there are no type.
+     * 
+     * @return list of types that this paramente extends or <code>null</code>
+     */
+    public List<ClassOrInterfaceType> getTypeBound() {
+        return typeBound;
+    }
 
-	/**
-	 * Sets the name of this type parameter.
-	 * 
-	 * @param name
-	 *            the name to set
-	 */
-	public void setName(final String name) {
-		this.name = name;
-	}
+    /**
+     * Sets the name of this type parameter.
+     * 
+     * @param name
+     *            the name to set
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
 
-	/**
-	 * Sets the list o types.
-	 * 
-	 * @param typeBound
-	 *            the typeBound to set
-	 */
-	public void setTypeBound(final List<ClassOrInterfaceType> typeBound) {
-		this.typeBound = typeBound;
-		setAsParentNodeOf(typeBound);
-	}
+    /**
+     * Sets the list o types.
+     * 
+     * @param typeBound
+     *            the typeBound to set
+     */
+    public void setTypeBound(final List<ClassOrInterfaceType> typeBound) {
+        this.typeBound = typeBound;
+        setAsParentNodeOf(typeBound);
+    }
 
     public List<AnnotationExpr> getAnnotations() {
         return annotations;

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/BaseParameter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/BaseParameter.java
@@ -38,25 +38,25 @@ public abstract class BaseParameter extends Node {
     
     public BaseParameter(VariableDeclaratorId id) {
         setId(id);
-	}
+    }
 
-	public BaseParameter(int modifiers, VariableDeclaratorId id) {
+    public BaseParameter(int modifiers, VariableDeclaratorId id) {
         setModifiers(modifiers);
         setId(id);
-	}
-	
-	public BaseParameter(int modifiers, List<AnnotationExpr> annotations, VariableDeclaratorId id) {
+    }
+    
+    public BaseParameter(int modifiers, List<AnnotationExpr> annotations, VariableDeclaratorId id) {
         setModifiers(modifiers);
         setAnnotations(annotations);
         setId(id);
-	}
+    }
 
-	public BaseParameter(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, VariableDeclaratorId id) {
-	    super(beginLine, beginColumn, endLine, endColumn);
+    public BaseParameter(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, VariableDeclaratorId id) {
+        super(beginLine, beginColumn, endLine, endColumn);
         setModifiers(modifiers);
         setAnnotations(annotations);
         setId(id);
-	}
+    }
 
     public List<AnnotationExpr> getAnnotations() {
         return annotations;

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/BodyDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/BodyDeclaration.java
@@ -38,12 +38,12 @@ public abstract class BodyDeclaration extends Node implements AnnotableNode {
     }
 
     public BodyDeclaration(List<AnnotationExpr> annotations) {
-    	setAnnotations(annotations);
+        setAnnotations(annotations);
     }
 
     public BodyDeclaration(int beginLine, int beginColumn, int endLine, int endColumn, List<AnnotationExpr> annotations) {
         super(beginLine, beginColumn, endLine, endColumn);
-    	setAnnotations(annotations);
+        setAnnotations(annotations);
     }
 
     public final List<AnnotationExpr> getAnnotations() {
@@ -55,6 +55,6 @@ public abstract class BodyDeclaration extends Node implements AnnotableNode {
 
     public final void setAnnotations(List<AnnotationExpr> annotations) {
         this.annotations = annotations;
-		setAsParentNodeOf(this.annotations);
+        setAsParentNodeOf(this.annotations);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/ClassOrInterfaceDeclaration.java
@@ -36,88 +36,88 @@ import java.util.List;
  */
 public final class ClassOrInterfaceDeclaration extends TypeDeclaration implements DocumentableNode {
 
-	private boolean interface_;
+    private boolean interface_;
 
-	private List<TypeParameter> typeParameters;
+    private List<TypeParameter> typeParameters;
 
-	// Can contain more than one item if this is an interface
-	private List<ClassOrInterfaceType> extendsList;
+    // Can contain more than one item if this is an interface
+    private List<ClassOrInterfaceType> extendsList;
 
-	private List<ClassOrInterfaceType> implementsList;
+    private List<ClassOrInterfaceType> implementsList;
 
-	public ClassOrInterfaceDeclaration() {
-	}
+    public ClassOrInterfaceDeclaration() {
+    }
 
-	public ClassOrInterfaceDeclaration(final int modifiers, final boolean isInterface, final String name) {
-		super(modifiers, name);
-		setInterface(isInterface);
-	}
+    public ClassOrInterfaceDeclaration(final int modifiers, final boolean isInterface, final String name) {
+        super(modifiers, name);
+        setInterface(isInterface);
+    }
 
-	public ClassOrInterfaceDeclaration(final int modifiers,
-			final List<AnnotationExpr> annotations, final boolean isInterface, final String name,
-			final List<TypeParameter> typeParameters, final List<ClassOrInterfaceType> extendsList,
-			final List<ClassOrInterfaceType> implementsList, final List<BodyDeclaration> members) {
-		super(annotations, modifiers, name, members);
-		setInterface(isInterface);
-		setTypeParameters(typeParameters);
-		setExtends(extendsList);
-		setImplements(implementsList);
-	}
+    public ClassOrInterfaceDeclaration(final int modifiers,
+            final List<AnnotationExpr> annotations, final boolean isInterface, final String name,
+            final List<TypeParameter> typeParameters, final List<ClassOrInterfaceType> extendsList,
+            final List<ClassOrInterfaceType> implementsList, final List<BodyDeclaration> members) {
+        super(annotations, modifiers, name, members);
+        setInterface(isInterface);
+        setTypeParameters(typeParameters);
+        setExtends(extendsList);
+        setImplements(implementsList);
+    }
 
-	public ClassOrInterfaceDeclaration(final int beginLine, final int beginColumn, final int endLine,
-			final int endColumn, final int modifiers,
-			final List<AnnotationExpr> annotations, final boolean isInterface, final String name,
-			final List<TypeParameter> typeParameters, final List<ClassOrInterfaceType> extendsList,
-			final List<ClassOrInterfaceType> implementsList, final List<BodyDeclaration> members) {
-		super(beginLine, beginColumn, endLine, endColumn, annotations, modifiers, name, members);
-		setInterface(isInterface);
-		setTypeParameters(typeParameters);
-		setExtends(extendsList);
-		setImplements(implementsList);
-	}
+    public ClassOrInterfaceDeclaration(final int beginLine, final int beginColumn, final int endLine,
+            final int endColumn, final int modifiers,
+            final List<AnnotationExpr> annotations, final boolean isInterface, final String name,
+            final List<TypeParameter> typeParameters, final List<ClassOrInterfaceType> extendsList,
+            final List<ClassOrInterfaceType> implementsList, final List<BodyDeclaration> members) {
+        super(beginLine, beginColumn, endLine, endColumn, annotations, modifiers, name, members);
+        setInterface(isInterface);
+        setTypeParameters(typeParameters);
+        setExtends(extendsList);
+        setImplements(implementsList);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<ClassOrInterfaceType> getExtends() {
-		return extendsList;
-	}
+    public List<ClassOrInterfaceType> getExtends() {
+        return extendsList;
+    }
 
-	public List<ClassOrInterfaceType> getImplements() {
-		return implementsList;
-	}
+    public List<ClassOrInterfaceType> getImplements() {
+        return implementsList;
+    }
 
-	public List<TypeParameter> getTypeParameters() {
-		return typeParameters;
-	}
+    public List<TypeParameter> getTypeParameters() {
+        return typeParameters;
+    }
 
     public boolean isInterface() {
-		return interface_;
-	}
+        return interface_;
+    }
 
-	public void setExtends(final List<ClassOrInterfaceType> extendsList) {
-		this.extendsList = extendsList;
-		setAsParentNodeOf(this.extendsList);
-	}
+    public void setExtends(final List<ClassOrInterfaceType> extendsList) {
+        this.extendsList = extendsList;
+        setAsParentNodeOf(this.extendsList);
+    }
 
-	public void setImplements(final List<ClassOrInterfaceType> implementsList) {
-		this.implementsList = implementsList;
-		setAsParentNodeOf(this.implementsList);
-	}
+    public void setImplements(final List<ClassOrInterfaceType> implementsList) {
+        this.implementsList = implementsList;
+        setAsParentNodeOf(this.implementsList);
+    }
 
-	public void setInterface(final boolean interface_) {
-		this.interface_ = interface_;
-	}
+    public void setInterface(final boolean interface_) {
+        this.interface_ = interface_;
+    }
 
-	public void setTypeParameters(final List<TypeParameter> typeParameters) {
-		this.typeParameters = typeParameters;
-		setAsParentNodeOf(this.typeParameters);
-	}
+    public void setTypeParameters(final List<TypeParameter> typeParameters) {
+        this.typeParameters = typeParameters;
+        setAsParentNodeOf(this.typeParameters);
+    }
 
     @Override
     public void setJavaDoc(JavadocComment javadocComment) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/EnumConstantDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/EnumConstantDeclaration.java
@@ -87,12 +87,12 @@ public final class EnumConstantDeclaration extends BodyDeclaration implements Do
 
     public void setArgs(List<Expression> args) {
         this.args = args;
-		setAsParentNodeOf(this.args);
+        setAsParentNodeOf(this.args);
     }
 
     public void setClassBody(List<BodyDeclaration> classBody) {
         this.classBody = classBody;
-		setAsParentNodeOf(this.classBody);
+        setAsParentNodeOf(this.classBody);
     }
 
     public void setName(String name) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/EnumDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/EnumDeclaration.java
@@ -79,12 +79,12 @@ public final class EnumDeclaration extends TypeDeclaration implements Documentab
 
     public void setEntries(List<EnumConstantDeclaration> entries) {
         this.entries = entries;
-		setAsParentNodeOf(this.entries);
+        setAsParentNodeOf(this.entries);
     }
 
     public void setImplements(List<ClassOrInterfaceType> implementsList) {
         this.implementsList = implementsList;
-		setAsParentNodeOf(this.implementsList);
+        setAsParentNodeOf(this.implementsList);
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -46,31 +46,31 @@ public final class FieldDeclaration extends BodyDeclaration implements Documenta
     }
 
     public FieldDeclaration(int modifiers, Type type, VariableDeclarator variable) {
-    	setModifiers(modifiers);
-    	setType(type);
-    	List<VariableDeclarator> aux = new ArrayList<VariableDeclarator>();
-    	aux.add(variable);
-    	setVariables(aux);
+        setModifiers(modifiers);
+        setType(type);
+        List<VariableDeclarator> aux = new ArrayList<VariableDeclarator>();
+        aux.add(variable);
+        setVariables(aux);
     }
 
     public FieldDeclaration(int modifiers, Type type, List<VariableDeclarator> variables) {
-    	setModifiers(modifiers);
-    	setType(type);
-    	setVariables(variables);
+        setModifiers(modifiers);
+        setType(type);
+        setVariables(variables);
     }
 
     public FieldDeclaration(int modifiers, List<AnnotationExpr> annotations, Type type, List<VariableDeclarator> variables) {
         super(annotations);
         setModifiers(modifiers);
-    	setType(type);
-    	setVariables(variables);
+        setType(type);
+        setVariables(variables);
     }
 
     public FieldDeclaration(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, Type type, List<VariableDeclarator> variables) {
         super(beginLine, beginColumn, endLine, endColumn, annotations);
         setModifiers(modifiers);
-    	setType(type);
-    	setVariables(variables);
+        setType(type);
+        setVariables(variables);
     }
 
     @Override
@@ -107,12 +107,12 @@ public final class FieldDeclaration extends BodyDeclaration implements Documenta
 
     public void setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
     }
 
     public void setVariables(List<VariableDeclarator> variables) {
         this.variables = variables;
-		setAsParentNodeOf(this.variables);
+        setAsParentNodeOf(this.variables);
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/InitializerDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/InitializerDeclaration.java
@@ -71,7 +71,7 @@ public final class InitializerDeclaration extends BodyDeclaration implements Doc
 
     public void setBlock(BlockStmt block) {
         this.block = block;
-		setAsParentNodeOf(this.block);
+        setAsParentNodeOf(this.block);
     }
 
     public void setStatic(boolean isStatic) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -41,166 +41,166 @@ import java.util.ArrayList;
  */
 public final class MethodDeclaration extends BodyDeclaration implements DocumentableNode, WithDeclaration, NamedNode {
 
-	private int modifiers;
+    private int modifiers;
 
-	private List<TypeParameter> typeParameters;
+    private List<TypeParameter> typeParameters;
 
-	private Type type;
+    private Type type;
 
-	private NameExpr name;
+    private NameExpr name;
 
-	private List<Parameter> parameters;
+    private List<Parameter> parameters;
 
-	private int arrayCount;
+    private int arrayCount;
 
-	private List<NameExpr> throws_;
+    private List<NameExpr> throws_;
 
-	private BlockStmt body;
+    private BlockStmt body;
 
     private boolean isDefault = false;
 
     public MethodDeclaration() {
-	}
+    }
 
-	public MethodDeclaration(final int modifiers, final Type type, final String name) {
-		setModifiers(modifiers);
-		setType(type);
-		setName(name);
-	}
+    public MethodDeclaration(final int modifiers, final Type type, final String name) {
+        setModifiers(modifiers);
+        setType(type);
+        setName(name);
+    }
 
-	public MethodDeclaration(final int modifiers, final Type type, final String name, final List<Parameter> parameters) {
-		setModifiers(modifiers);
-		setType(type);
-		setName(name);
-		setParameters(parameters);
-	}
+    public MethodDeclaration(final int modifiers, final Type type, final String name, final List<Parameter> parameters) {
+        setModifiers(modifiers);
+        setType(type);
+        setName(name);
+        setParameters(parameters);
+    }
 
-	public MethodDeclaration(final int modifiers, final List<AnnotationExpr> annotations,
-			final List<TypeParameter> typeParameters, final Type type, final String name,
-			final List<Parameter> parameters, final int arrayCount, final List<NameExpr> throws_, final BlockStmt block) {
-		super(annotations);
-		setModifiers(modifiers);
-		setTypeParameters(typeParameters);
-		setType(type);
-		setName(name);
-		setParameters(parameters);
-		setArrayCount(arrayCount);
-		setThrows(throws_);
-		setBody(block);
-	}
+    public MethodDeclaration(final int modifiers, final List<AnnotationExpr> annotations,
+            final List<TypeParameter> typeParameters, final Type type, final String name,
+            final List<Parameter> parameters, final int arrayCount, final List<NameExpr> throws_, final BlockStmt block) {
+        super(annotations);
+        setModifiers(modifiers);
+        setTypeParameters(typeParameters);
+        setType(type);
+        setName(name);
+        setParameters(parameters);
+        setArrayCount(arrayCount);
+        setThrows(throws_);
+        setBody(block);
+    }
 
-	public MethodDeclaration(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final int modifiers, final List<AnnotationExpr> annotations,
-			final List<TypeParameter> typeParameters, final Type type, final String name,
-			final List<Parameter> parameters, final int arrayCount, final List<NameExpr> throws_, final BlockStmt block) {
-		super(beginLine, beginColumn, endLine, endColumn, annotations);
-		setModifiers(modifiers);
-		setTypeParameters(typeParameters);
-		setType(type);
-		setName(name);
-		setParameters(parameters);
-		setArrayCount(arrayCount);
-		setThrows(throws_);
-		setBody(block);
-	}
+    public MethodDeclaration(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final int modifiers, final List<AnnotationExpr> annotations,
+            final List<TypeParameter> typeParameters, final Type type, final String name,
+            final List<Parameter> parameters, final int arrayCount, final List<NameExpr> throws_, final BlockStmt block) {
+        super(beginLine, beginColumn, endLine, endColumn, annotations);
+        setModifiers(modifiers);
+        setTypeParameters(typeParameters);
+        setType(type);
+        setName(name);
+        setParameters(parameters);
+        setArrayCount(arrayCount);
+        setThrows(throws_);
+        setBody(block);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public int getArrayCount() {
-		return arrayCount;
-	}
+    public int getArrayCount() {
+        return arrayCount;
+    }
 
-	// FIXME this is called "Block" in the constructor. Pick one.
-	public BlockStmt getBody() {
-		return body;
-	}
+    // FIXME this is called "Block" in the constructor. Pick one.
+    public BlockStmt getBody() {
+        return body;
+    }
 
-	/**
-	 * Return the modifiers of this member declaration.
-	 * 
-	 * @see ModifierSet
-	 * @return modifiers
-	 */
-	public int getModifiers() {
-		return modifiers;
-	}
+    /**
+     * Return the modifiers of this member declaration.
+     * 
+     * @see ModifierSet
+     * @return modifiers
+     */
+    public int getModifiers() {
+        return modifiers;
+    }
 
-	public String getName() {
-		return name.getName();
-	}
+    public String getName() {
+        return name.getName();
+    }
 
     public NameExpr getNameExpr() {
         return name;
     }
 
-	public List<Parameter> getParameters() {
+    public List<Parameter> getParameters() {
         if (parameters == null) {
             parameters = new ArrayList<Parameter>();
         }
-		return parameters;
-	}
+        return parameters;
+    }
 
-	public List<NameExpr> getThrows() {
+    public List<NameExpr> getThrows() {
         if (throws_ == null) {
             throws_ = new ArrayList<NameExpr>();
         }
-		return throws_;
-	}
+        return throws_;
+    }
 
-	public Type getType() {
-		return type;
-	}
+    public Type getType() {
+        return type;
+    }
 
-	public List<TypeParameter> getTypeParameters() {
-		return typeParameters;
-	}
+    public List<TypeParameter> getTypeParameters() {
+        return typeParameters;
+    }
 
-	public void setArrayCount(final int arrayCount) {
-		this.arrayCount = arrayCount;
-	}
+    public void setArrayCount(final int arrayCount) {
+        this.arrayCount = arrayCount;
+    }
 
-	public void setBody(final BlockStmt body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
-	}
+    public void setBody(final BlockStmt body) {
+        this.body = body;
+        setAsParentNodeOf(this.body);
+    }
 
-	public void setModifiers(final int modifiers) {
-		this.modifiers = modifiers;
-	}
+    public void setModifiers(final int modifiers) {
+        this.modifiers = modifiers;
+    }
 
-	public void setName(final String name) {
-		this.name = new NameExpr(name);
-	}
+    public void setName(final String name) {
+        this.name = new NameExpr(name);
+    }
 
     public void setNameExpr(final NameExpr name) {
         this.name = name;
     }
 
     public void setParameters(final List<Parameter> parameters) {
-		this.parameters = parameters;
-		setAsParentNodeOf(this.parameters);
-	}
+        this.parameters = parameters;
+        setAsParentNodeOf(this.parameters);
+    }
 
-	public void setThrows(final List<NameExpr> throws_) {
-		this.throws_ = throws_;
-		setAsParentNodeOf(this.throws_);
-	}
+    public void setThrows(final List<NameExpr> throws_) {
+        this.throws_ = throws_;
+        setAsParentNodeOf(this.throws_);
+    }
 
-	public void setType(final Type type) {
-		this.type = type;
-		setAsParentNodeOf(this.type);
-	}
+    public void setType(final Type type) {
+        this.type = type;
+        setAsParentNodeOf(this.type);
+    }
 
-	public void setTypeParameters(final List<TypeParameter> typeParameters) {
-		this.typeParameters = typeParameters;
-		setAsParentNodeOf(typeParameters);
-	}
+    public void setTypeParameters(final List<TypeParameter> typeParameters) {
+        this.typeParameters = typeParameters;
+        setAsParentNodeOf(typeParameters);
+    }
 
 
     public boolean isDefault() {
@@ -271,7 +271,7 @@ public final class MethodDeclaration extends BodyDeclaration implements Document
             } else {
                 sb.append(param.getType().toStringWithoutComments());
                 if (param.isVarArgs()) {
-                	sb.append("...");
+                    sb.append("...");
                 }
             }
         }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/MultiTypeParameter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/MultiTypeParameter.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class MultiTypeParameter extends BaseParameter {
     private List<Type> types;
-	
+    
     public MultiTypeParameter() {}
 
     public MultiTypeParameter(int modifiers, List<AnnotationExpr> annotations, List<Type> types, VariableDeclaratorId id) {
@@ -41,7 +41,7 @@ public class MultiTypeParameter extends BaseParameter {
     public MultiTypeParameter(int beginLine, int beginColumn, int endLine, int endColumn, int modifiers, List<AnnotationExpr> annotations, List<Type> types, VariableDeclaratorId id) {
         super(beginLine, beginColumn, endLine, endColumn, modifiers, annotations, id);
         this.types = types;
-	}
+    }
 
     @Override
     public <R, A> R accept(GenericVisitor<R, A> v, A arg) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/Parameter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/Parameter.java
@@ -40,12 +40,12 @@ public final class Parameter extends BaseParameter {
     }
 
     public Parameter(Type type, VariableDeclaratorId id) {
-    	super(id);
+        super(id);
         setType(type);
     }
 
     public Parameter(int modifiers, Type type, VariableDeclaratorId id) {
-    	super(modifiers, id);
+        super(modifiers, id);
         setType(type);
     }
 
@@ -75,7 +75,7 @@ public final class Parameter extends BaseParameter {
 
     public void setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
     }
 
     public void setVarArgs(boolean isVarArgs) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/TypeDeclaration.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/TypeDeclaration.java
@@ -32,69 +32,69 @@ import java.util.List;
  */
 public abstract class TypeDeclaration extends BodyDeclaration implements NamedNode {
 
-	private NameExpr name;
+    private NameExpr name;
 
-	private int modifiers;
+    private int modifiers;
 
-	private List<BodyDeclaration> members;
+    private List<BodyDeclaration> members;
 
-	public TypeDeclaration() {
-	}
+    public TypeDeclaration() {
+    }
 
-	public TypeDeclaration(int modifiers, String name) {
-		setName(name);
-		setModifiers(modifiers);
-	}
+    public TypeDeclaration(int modifiers, String name) {
+        setName(name);
+        setModifiers(modifiers);
+    }
 
-	public TypeDeclaration(List<AnnotationExpr> annotations,
-			int modifiers, String name,
-			List<BodyDeclaration> members) {
-		super(annotations);
-		setName(name);
-		setModifiers(modifiers);
-		setMembers(members);
-	}
+    public TypeDeclaration(List<AnnotationExpr> annotations,
+            int modifiers, String name,
+            List<BodyDeclaration> members) {
+        super(annotations);
+        setName(name);
+        setModifiers(modifiers);
+        setMembers(members);
+    }
 
-	public TypeDeclaration(int beginLine, int beginColumn, int endLine,
-			int endColumn, List<AnnotationExpr> annotations,
-			int modifiers, String name,
-			List<BodyDeclaration> members) {
-		super(beginLine, beginColumn, endLine, endColumn, annotations);
-		setName(name);
-		setModifiers(modifiers);
-		setMembers(members);
-	}
+    public TypeDeclaration(int beginLine, int beginColumn, int endLine,
+            int endColumn, List<AnnotationExpr> annotations,
+            int modifiers, String name,
+            List<BodyDeclaration> members) {
+        super(beginLine, beginColumn, endLine, endColumn, annotations);
+        setName(name);
+        setModifiers(modifiers);
+        setMembers(members);
+    }
 
-	public final List<BodyDeclaration> getMembers() {
-		return members;
-	}
+    public final List<BodyDeclaration> getMembers() {
+        return members;
+    }
 
-	/**
-	 * Return the modifiers of this type declaration.
-	 * 
-	 * @see ModifierSet
-	 * @return modifiers
-	 */
-	public final int getModifiers() {
-		return modifiers;
-	}
+    /**
+     * Return the modifiers of this type declaration.
+     * 
+     * @see ModifierSet
+     * @return modifiers
+     */
+    public final int getModifiers() {
+        return modifiers;
+    }
 
-	public final String getName() {
-		return name.getName();
-	}
+    public final String getName() {
+        return name.getName();
+    }
 
-	public void setMembers(List<BodyDeclaration> members) {
-		this.members = members;
-		setAsParentNodeOf(this.members);
-	}
+    public void setMembers(List<BodyDeclaration> members) {
+        this.members = members;
+        setAsParentNodeOf(this.members);
+    }
 
-	public final void setModifiers(int modifiers) {
-		this.modifiers = modifiers;
-	}
+    public final void setModifiers(int modifiers) {
+        this.modifiers = modifiers;
+    }
 
-	public final void setName(String name) {
-		this.name = new NameExpr(name);
-	}
+    public final void setName(String name) {
+        this.name = new NameExpr(name);
+    }
 
     public final void setNameExpr(NameExpr nameExpr) {
       this.name = nameExpr;

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/VariableDeclarator.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/body/VariableDeclarator.java
@@ -43,8 +43,8 @@ public final class VariableDeclarator extends Node {
     }
 
     public VariableDeclarator(VariableDeclaratorId id, Expression init) {
-    	setId(id);
-    	setInit(init);
+        setId(id);
+        setInit(init);
     }
 
     public VariableDeclarator(int beginLine, int beginColumn, int endLine, int endColumn, VariableDeclaratorId id, Expression init) {
@@ -73,11 +73,11 @@ public final class VariableDeclarator extends Node {
 
     public void setId(VariableDeclaratorId id) {
         this.id = id;
-		setAsParentNodeOf(this.id);
+        setAsParentNodeOf(this.id);
     }
 
     public void setInit(Expression init) {
         this.init = init;
-		setAsParentNodeOf(this.init);
+        setAsParentNodeOf(this.init);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/AnnotationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/AnnotationExpr.java
@@ -26,21 +26,21 @@ package com.github.javaparser.ast.expr;
  */
 public abstract class AnnotationExpr extends Expression {
 
-	protected NameExpr name;
+    protected NameExpr name;
 
-	public AnnotationExpr() {}
+    public AnnotationExpr() {}
 
-	public AnnotationExpr(int beginLine, int beginColumn, int endLine,
-			int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn);
-	}
+    public AnnotationExpr(int beginLine, int beginColumn, int endLine,
+            int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn);
+    }
 
-	public NameExpr getName() {
-		return name;
-	}
+    public NameExpr getName() {
+        return name;
+    }
 
-	public void setName(NameExpr name) {
-		this.name = name;
-		setAsParentNodeOf(name);
-	}
+    public void setName(NameExpr name) {
+        this.name = name;
+        setAsParentNodeOf(name);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ArrayAccessExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ArrayAccessExpr.java
@@ -67,11 +67,11 @@ public final class ArrayAccessExpr extends Expression {
 
     public void setIndex(Expression index) {
         this.index = index;
-		setAsParentNodeOf(this.index);
+        setAsParentNodeOf(this.index);
     }
 
     public void setName(Expression name) {
         this.name = name;
-		setAsParentNodeOf(this.name);
+        setAsParentNodeOf(this.name);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ArrayCreationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ArrayCreationExpr.java
@@ -107,17 +107,17 @@ public final class ArrayCreationExpr extends Expression {
 
     public void setDimensions(List<Expression> dimensions) {
         this.dimensions = dimensions;
-		setAsParentNodeOf(this.dimensions);
+        setAsParentNodeOf(this.dimensions);
     }
 
     public void setInitializer(ArrayInitializerExpr initializer) {
         this.initializer = initializer;
-		setAsParentNodeOf(this.initializer);
+        setAsParentNodeOf(this.initializer);
     }
 
     public void setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
     }
 
     public List<List<AnnotationExpr>> getArraysAnnotations() {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ArrayInitializerExpr.java
@@ -61,6 +61,6 @@ public final class ArrayInitializerExpr extends Expression {
 
     public void setValues(List<Expression> values) {
         this.values = values;
-		setAsParentNodeOf(this.values);
+        setAsParentNodeOf(this.values);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/AssignExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/AssignExpr.java
@@ -94,11 +94,11 @@ public final class AssignExpr extends Expression {
 
     public void setTarget(Expression target) {
         this.target = target;
-		setAsParentNodeOf(this.target);
+        setAsParentNodeOf(this.target);
     }
 
     public void setValue(Expression value) {
         this.value = value;
-		setAsParentNodeOf(this.value);
+        setAsParentNodeOf(this.value);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/BinaryExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/BinaryExpr.java
@@ -61,16 +61,16 @@ public final class BinaryExpr extends Expression {
     }
 
     public BinaryExpr(Expression left, Expression right, Operator op) {
-    	setLeft(left);
-    	setRight(right);
-    	setOperator(op);
+        setLeft(left);
+        setRight(right);
+        setOperator(op);
     }
 
     public BinaryExpr(int beginLine, int beginColumn, int endLine, int endColumn, Expression left, Expression right, Operator op) {
         super(beginLine, beginColumn, endLine, endColumn);
-    	setLeft(left);
-    	setRight(right);
-    	setOperator(op);
+        setLeft(left);
+        setRight(right);
+        setOperator(op);
     }
 
     @Override
@@ -97,7 +97,7 @@ public final class BinaryExpr extends Expression {
 
     public void setLeft(Expression left) {
         this.left = left;
-		setAsParentNodeOf(this.left);
+        setAsParentNodeOf(this.left);
     }
 
     public void setOperator(Operator op) {
@@ -106,6 +106,6 @@ public final class BinaryExpr extends Expression {
 
     public void setRight(Expression right) {
         this.right = right;
-		setAsParentNodeOf(this.right);
+        setAsParentNodeOf(this.right);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/BooleanLiteralExpr.java
@@ -35,7 +35,7 @@ public final class BooleanLiteralExpr extends LiteralExpr {
     }
 
     public BooleanLiteralExpr(boolean value) {
-    	setValue(value);
+        setValue(value);
     }
 
     public BooleanLiteralExpr(int beginLine, int beginColumn, int endLine, int endColumn, boolean value) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/CastExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/CastExpr.java
@@ -38,14 +38,14 @@ public final class CastExpr extends Expression {
     }
 
     public CastExpr(Type type, Expression expr) {
-    	setType(type);
-    	setExpr(expr);
+        setType(type);
+        setExpr(expr);
     }
 
     public CastExpr(int beginLine, int beginColumn, int endLine, int endColumn, Type type, Expression expr) {
         super(beginLine, beginColumn, endLine, endColumn);
         setType(type);
-    	setExpr(expr);
+        setExpr(expr);
     }
 
     @Override
@@ -68,11 +68,11 @@ public final class CastExpr extends Expression {
 
     public void setExpr(Expression expr) {
         this.expr = expr;
-		setAsParentNodeOf(this.expr);
+        setAsParentNodeOf(this.expr);
     }
 
     public void setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ClassExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ClassExpr.java
@@ -60,6 +60,6 @@ public final class ClassExpr extends Expression {
 
     public void setType(Type type) {
         this.type = type;
-		setAsParentNodeOf(this.type);
+        setAsParentNodeOf(this.type);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ConditionalExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ConditionalExpr.java
@@ -75,16 +75,16 @@ public final class ConditionalExpr extends Expression {
 
     public void setCondition(Expression condition) {
         this.condition = condition;
-		setAsParentNodeOf(this.condition);
+        setAsParentNodeOf(this.condition);
     }
 
     public void setElseExpr(Expression elseExpr) {
         this.elseExpr = elseExpr;
-		setAsParentNodeOf(this.elseExpr);
+        setAsParentNodeOf(this.elseExpr);
     }
 
     public void setThenExpr(Expression thenExpr) {
         this.thenExpr = thenExpr;
-		setAsParentNodeOf(this.thenExpr);
+        setAsParentNodeOf(this.thenExpr);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/DoubleLiteralExpr.java
@@ -29,23 +29,23 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class DoubleLiteralExpr extends StringLiteralExpr {
 
-	public DoubleLiteralExpr() {
-	}
+    public DoubleLiteralExpr() {
+    }
 
-	public DoubleLiteralExpr(final String value) {
-		super(value);
-	}
+    public DoubleLiteralExpr(final String value) {
+        super(value);
+    }
 
-	public DoubleLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String value) {
-		super(beginLine, beginColumn, endLine, endColumn, value);
-	}
+    public DoubleLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String value) {
+        super(beginLine, beginColumn, endLine, endColumn, value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/EnclosedExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/EnclosedExpr.java
@@ -29,35 +29,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class EnclosedExpr extends Expression {
 
-	private Expression inner;
+    private Expression inner;
 
-	public EnclosedExpr() {
-	}
+    public EnclosedExpr() {
+    }
 
-	public EnclosedExpr(final Expression inner) {
-		setInner(inner);
-	}
+    public EnclosedExpr(final Expression inner) {
+        setInner(inner);
+    }
 
-	public EnclosedExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression inner) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setInner(inner);
-	}
+    public EnclosedExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression inner) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setInner(inner);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getInner() {
-		return inner;
-	}
+    public Expression getInner() {
+        return inner;
+    }
 
-	public void setInner(final Expression inner) {
-		this.inner = inner;
-		setAsParentNodeOf(this.inner);
-	}
+    public void setInner(final Expression inner) {
+        this.inner = inner;
+        setAsParentNodeOf(this.inner);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/Expression.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/Expression.java
@@ -28,11 +28,11 @@ import com.github.javaparser.ast.Node;
  */
 public abstract class Expression extends Node {
 
-	public Expression() {
-	}
+    public Expression() {
+    }
 
-	public Expression(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn);
-	}
+    public Expression(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/FieldAccessExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/FieldAccessExpr.java
@@ -32,67 +32,67 @@ import java.util.List;
  */
 public final class FieldAccessExpr extends Expression {
 
-	private Expression scope;
+    private Expression scope;
 
-	private List<Type> typeArgs;
+    private List<Type> typeArgs;
 
-	private NameExpr field;
+    private NameExpr field;
 
-	public FieldAccessExpr() {
-	}
+    public FieldAccessExpr() {
+    }
 
-	public FieldAccessExpr(final Expression scope, final String field) {
-		setScope(scope);
-		setField(field);
-	}
+    public FieldAccessExpr(final Expression scope, final String field) {
+        setScope(scope);
+        setField(field);
+    }
 
-	public FieldAccessExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression scope, final List<Type> typeArgs, final String field) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setScope(scope);
-		setTypeArgs(typeArgs);
-		setField(field);
-	}
+    public FieldAccessExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression scope, final List<Type> typeArgs, final String field) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setScope(scope);
+        setTypeArgs(typeArgs);
+        setField(field);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getField() {
-		return field.getName();
-	}
+    public String getField() {
+        return field.getName();
+    }
 
-	public NameExpr getFieldExpr() {
-		return field;
-	}
+    public NameExpr getFieldExpr() {
+        return field;
+    }
 
-	public Expression getScope() {
-		return scope;
-	}
+    public Expression getScope() {
+        return scope;
+    }
 
-	public List<Type> getTypeArgs() {
-		return typeArgs;
-	}
+    public List<Type> getTypeArgs() {
+        return typeArgs;
+    }
 
-	public void setField(final String field) {
-		this.field = new NameExpr(field);
-	}
+    public void setField(final String field) {
+        this.field = new NameExpr(field);
+    }
 
-	public void setFieldExpr(NameExpr field) {
-		this.field = field;
-	}
+    public void setFieldExpr(NameExpr field) {
+        this.field = field;
+    }
 
-	public void setScope(final Expression scope) {
-		this.scope = scope;
-		setAsParentNodeOf(this.scope);
-	}
+    public void setScope(final Expression scope) {
+        this.scope = scope;
+        setAsParentNodeOf(this.scope);
+    }
 
-	public void setTypeArgs(final List<Type> typeArgs) {
-		this.typeArgs = typeArgs;
-		setAsParentNodeOf(this.typeArgs);
-	}
+    public void setTypeArgs(final List<Type> typeArgs) {
+        this.typeArgs = typeArgs;
+        setAsParentNodeOf(this.typeArgs);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/InstanceOfExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/InstanceOfExpr.java
@@ -30,48 +30,48 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class InstanceOfExpr extends Expression {
 
-	private Expression expr;
+    private Expression expr;
 
-	private Type type;
+    private Type type;
 
-	public InstanceOfExpr() {
-	}
+    public InstanceOfExpr() {
+    }
 
-	public InstanceOfExpr(final Expression expr, final Type type) {
-		setExpr(expr);
-		setType(type);
-	}
+    public InstanceOfExpr(final Expression expr, final Type type) {
+        setExpr(expr);
+        setType(type);
+    }
 
-	public InstanceOfExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression expr, final Type type) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExpr(expr);
-		setType(type);
-	}
+    public InstanceOfExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression expr, final Type type) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExpr(expr);
+        setType(type);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public Type getType() {
-		return type;
-	}
+    public Type getType() {
+        return type;
+    }
 
-	public void setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-	}
+    public void setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+    }
 
-	public void setType(final Type type) {
-		this.type = type;
-		setAsParentNodeOf(this.type);
-	}
+    public void setType(final Type type) {
+        this.type = type;
+        setAsParentNodeOf(this.type);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/IntegerLiteralExpr.java
@@ -29,33 +29,33 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class IntegerLiteralExpr extends StringLiteralExpr {
 
-	private static final String UNSIGNED_MIN_VALUE = "2147483648";
+    private static final String UNSIGNED_MIN_VALUE = "2147483648";
 
-	protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE;
+    protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE;
 
-	public IntegerLiteralExpr() {
-	}
+    public IntegerLiteralExpr() {
+    }
 
-	public IntegerLiteralExpr(final String value) {
-		super(value);
-	}
+    public IntegerLiteralExpr(final String value) {
+        super(value);
+    }
 
-	public IntegerLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String value) {
-		super(beginLine, beginColumn, endLine, endColumn, value);
-	}
+    public IntegerLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String value) {
+        super(beginLine, beginColumn, endLine, endColumn, value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public final boolean isMinValue() {
-		return value != null && //
-				value.length() == 10 && //
-				value.equals(UNSIGNED_MIN_VALUE);
-	}
+    public final boolean isMinValue() {
+        return value != null && //
+                value.length() == 10 && //
+                value.equals(UNSIGNED_MIN_VALUE);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/IntegerLiteralMinValueExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/IntegerLiteralMinValueExpr.java
@@ -29,20 +29,20 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class IntegerLiteralMinValueExpr extends IntegerLiteralExpr {
 
-	public IntegerLiteralMinValueExpr() {
-		super(MIN_VALUE);
-	}
+    public IntegerLiteralMinValueExpr() {
+        super(MIN_VALUE);
+    }
 
-	public IntegerLiteralMinValueExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn, MIN_VALUE);
-	}
+    public IntegerLiteralMinValueExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn, MIN_VALUE);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LambdaExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LambdaExpr.java
@@ -36,59 +36,59 @@ import java.util.List;
  */
 public class LambdaExpr extends Expression {
 
-	private List<Parameter> parameters;
+    private List<Parameter> parameters;
 
-	private boolean parametersEnclosed;
+    private boolean parametersEnclosed;
 
-	private Statement body;
+    private Statement body;
 
-	public LambdaExpr() {
-	}
+    public LambdaExpr() {
+    }
 
-	public LambdaExpr(int beginLine, int beginColumn, int endLine,
+    public LambdaExpr(int beginLine, int beginColumn, int endLine,
                       int endColumn, List<Parameter> parameters, Statement body,
                       boolean parametersEnclosed) {
 
-		super(beginLine, beginColumn, endLine, endColumn);
-		setParameters(parameters);
-		setBody(body);
+        super(beginLine, beginColumn, endLine, endColumn);
+        setParameters(parameters);
+        setBody(body);
         setParametersEnclosed(parametersEnclosed);
-	}
+    }
 
-	public List<Parameter> getParameters() {
-		return parameters;
-	}
+    public List<Parameter> getParameters() {
+        return parameters;
+    }
 
-	public void setParameters(List<Parameter> parameters) {
-		this.parameters = parameters;
-		setAsParentNodeOf(this.parameters);
-	}
+    public void setParameters(List<Parameter> parameters) {
+        this.parameters = parameters;
+        setAsParentNodeOf(this.parameters);
+    }
 
-	public Statement getBody() {
-		return body;
-	}
+    public Statement getBody() {
+        return body;
+    }
 
-	public void setBody(Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
-	}
+    public void setBody(Statement body) {
+        this.body = body;
+        setAsParentNodeOf(this.body);
+    }
 
-	@Override
-	public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(VoidVisitor<A> v, A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
 
-	public boolean isParametersEnclosed() {
-		return parametersEnclosed;
-	}
+    public boolean isParametersEnclosed() {
+        return parametersEnclosed;
+    }
 
-	public void setParametersEnclosed(boolean parametersEnclosed) {
-		this.parametersEnclosed = parametersEnclosed;
-	}
+    public void setParametersEnclosed(boolean parametersEnclosed) {
+        this.parametersEnclosed = parametersEnclosed;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LiteralExpr.java
@@ -26,10 +26,10 @@ package com.github.javaparser.ast.expr;
  */
 public abstract class LiteralExpr extends Expression {
 
-	public LiteralExpr() {
-	}
+    public LiteralExpr() {
+    }
 
-	public LiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn);
-	}
+    public LiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LongLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LongLiteralExpr.java
@@ -29,34 +29,34 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class LongLiteralExpr extends StringLiteralExpr {
 
-	private static final String UNSIGNED_MIN_VALUE = "9223372036854775808";
+    private static final String UNSIGNED_MIN_VALUE = "9223372036854775808";
 
-	protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE + "L";
+    protected static final String MIN_VALUE = "-" + UNSIGNED_MIN_VALUE + "L";
 
-	public LongLiteralExpr() {
-	}
+    public LongLiteralExpr() {
+    }
 
-	public LongLiteralExpr(final String value) {
-		super(value);
-	}
+    public LongLiteralExpr(final String value) {
+        super(value);
+    }
 
-	public LongLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String value) {
-		super(beginLine, beginColumn, endLine, endColumn, value);
-	}
+    public LongLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String value) {
+        super(beginLine, beginColumn, endLine, endColumn, value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public final boolean isMinValue() {
-		return value != null && //
-				value.length() == 20 && //
-				value.startsWith(UNSIGNED_MIN_VALUE) && //
-				(value.charAt(19) == 'L' || value.charAt(19) == 'l');
-	}
+    public final boolean isMinValue() {
+        return value != null && //
+                value.length() == 20 && //
+                value.startsWith(UNSIGNED_MIN_VALUE) && //
+                (value.charAt(19) == 'L' || value.charAt(19) == 'l');
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LongLiteralMinValueExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/LongLiteralMinValueExpr.java
@@ -29,20 +29,20 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class LongLiteralMinValueExpr extends LongLiteralExpr {
 
-	public LongLiteralMinValueExpr() {
-		super(MIN_VALUE);
-	}
+    public LongLiteralMinValueExpr() {
+        super(MIN_VALUE);
+    }
 
-	public LongLiteralMinValueExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn, MIN_VALUE);
-	}
+    public LongLiteralMinValueExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn, MIN_VALUE);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/MarkerAnnotationExpr.java
@@ -29,25 +29,25 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class MarkerAnnotationExpr extends AnnotationExpr {
 
-	public MarkerAnnotationExpr() {
-	}
+    public MarkerAnnotationExpr() {
+    }
 
-	public MarkerAnnotationExpr(final NameExpr name) {
-		setName(name);
-	}
+    public MarkerAnnotationExpr(final NameExpr name) {
+        setName(name);
+    }
 
-	public MarkerAnnotationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final NameExpr name) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setName(name);
-	}
+    public MarkerAnnotationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final NameExpr name) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setName(name);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/MemberValuePair.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/MemberValuePair.java
@@ -31,47 +31,47 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class MemberValuePair extends Node implements NamedNode {
 
-	private String name;
+    private String name;
 
-	private Expression value;
+    private Expression value;
 
-	public MemberValuePair() {
-	}
+    public MemberValuePair() {
+    }
 
-	public MemberValuePair(final String name, final Expression value) {
-		setName(name);
-		setValue(value);
-	}
+    public MemberValuePair(final String name, final Expression value) {
+        setName(name);
+        setValue(value);
+    }
 
-	public MemberValuePair(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String name, final Expression value) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setName(name);
-		setValue(value);
-	}
+    public MemberValuePair(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String name, final Expression value) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setName(name);
+        setValue(value);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public Expression getValue() {
-		return value;
-	}
+    public Expression getValue() {
+        return value;
+    }
 
-	public void setName(final String name) {
-		this.name = name;
-	}
+    public void setName(final String name) {
+        this.name = name;
+    }
 
-	public void setValue(final Expression value) {
-		this.value = value;
-		setAsParentNodeOf(this.value);
-	}
+    public void setValue(final Expression value) {
+        this.value = value;
+        setAsParentNodeOf(this.value);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/MethodCallExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/MethodCallExpr.java
@@ -32,85 +32,85 @@ import java.util.List;
  */
 public final class MethodCallExpr extends Expression {
 
-	private Expression scope;
+    private Expression scope;
 
-	private List<Type> typeArgs;
+    private List<Type> typeArgs;
 
-	private NameExpr name;
+    private NameExpr name;
 
-	private List<Expression> args;
+    private List<Expression> args;
 
-	public MethodCallExpr() {
-	}
+    public MethodCallExpr() {
+    }
 
-	public MethodCallExpr(final Expression scope, final String name) {
-		setScope(scope);
-		setName(name);
-	}
+    public MethodCallExpr(final Expression scope, final String name) {
+        setScope(scope);
+        setName(name);
+    }
 
-	public MethodCallExpr(final Expression scope, final String name, final List<Expression> args) {
-		setScope(scope);
-		setName(name);
-		setArgs(args);
-	}
+    public MethodCallExpr(final Expression scope, final String name, final List<Expression> args) {
+        setScope(scope);
+        setName(name);
+        setArgs(args);
+    }
 
-	public MethodCallExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression scope, final List<Type> typeArgs, final String name, final List<Expression> args) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setScope(scope);
-		setTypeArgs(typeArgs);
-		setName(name);
-		setArgs(args);
-	}
+    public MethodCallExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression scope, final List<Type> typeArgs, final String name, final List<Expression> args) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setScope(scope);
+        setTypeArgs(typeArgs);
+        setName(name);
+        setArgs(args);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<Expression> getArgs() {
-		return args;
-	}
+    public List<Expression> getArgs() {
+        return args;
+    }
 
-	public String getName() {
-		return name.getName();
-	}
+    public String getName() {
+        return name.getName();
+    }
 
-	public NameExpr getNameExpr() {
-		return name;
-	}
+    public NameExpr getNameExpr() {
+        return name;
+    }
 
-	public Expression getScope() {
-		return scope;
-	}
+    public Expression getScope() {
+        return scope;
+    }
 
-	public List<Type> getTypeArgs() {
-		return typeArgs;
-	}
+    public List<Type> getTypeArgs() {
+        return typeArgs;
+    }
 
-	public void setArgs(final List<Expression> args) {
-		this.args = args;
-		setAsParentNodeOf(this.args);
-	}
+    public void setArgs(final List<Expression> args) {
+        this.args = args;
+        setAsParentNodeOf(this.args);
+    }
 
-	public void setName(final String name) {
-		this.name = new NameExpr(name);
-	}
+    public void setName(final String name) {
+        this.name = new NameExpr(name);
+    }
 
-	public void setNameExpr(NameExpr name) {
-		this.name = name;
-	}
+    public void setNameExpr(NameExpr name) {
+        this.name = name;
+    }
 
-	public void setScope(final Expression scope) {
-		this.scope = scope;
-		setAsParentNodeOf(this.scope);
-	}
+    public void setScope(final Expression scope) {
+        this.scope = scope;
+        setAsParentNodeOf(this.scope);
+    }
 
-	public void setTypeArgs(final List<Type> typeArgs) {
-		this.typeArgs = typeArgs;
-		setAsParentNodeOf(this.typeArgs);
-	}
+    public void setTypeArgs(final List<Type> typeArgs) {
+        this.typeArgs = typeArgs;
+        setAsParentNodeOf(this.typeArgs);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/NameExpr.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class NameExpr extends Expression implements NamedNode {
 
-	private String name;
+    private String name;
 
-	public NameExpr() {
-	}
+    public NameExpr() {
+    }
 
-	public NameExpr(final String name) {
-		this.name = name;
-	}
+    public NameExpr(final String name) {
+        this.name = name;
+    }
 
-	public NameExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String name) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		this.name = name;
-	}
+    public NameExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String name) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        this.name = name;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public final String getName() {
-		return name;
-	}
+    public final String getName() {
+        return name;
+    }
 
-	public final void setName(final String name) {
-		this.name = name;
-	}
+    public final void setName(final String name) {
+        this.name = name;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -31,37 +31,37 @@ import java.util.List;
  */
 public final class NormalAnnotationExpr extends AnnotationExpr {
 
-	private List<MemberValuePair> pairs;
+    private List<MemberValuePair> pairs;
 
-	public NormalAnnotationExpr() {
-	}
+    public NormalAnnotationExpr() {
+    }
 
-	public NormalAnnotationExpr(final NameExpr name, final List<MemberValuePair> pairs) {
-		setName(name);
-		setPairs(pairs);
-	}
+    public NormalAnnotationExpr(final NameExpr name, final List<MemberValuePair> pairs) {
+        setName(name);
+        setPairs(pairs);
+    }
 
-	public NormalAnnotationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final NameExpr name, final List<MemberValuePair> pairs) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setName(name);
-		setPairs(pairs);
-	}
+    public NormalAnnotationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final NameExpr name, final List<MemberValuePair> pairs) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setName(name);
+        setPairs(pairs);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<MemberValuePair> getPairs() {
-		return pairs;
-	}
+    public List<MemberValuePair> getPairs() {
+        return pairs;
+    }
 
-	public void setPairs(final List<MemberValuePair> pairs) {
-		this.pairs = pairs;
-		setAsParentNodeOf(this.pairs);
-	}
+    public void setPairs(final List<MemberValuePair> pairs) {
+        this.pairs = pairs;
+        setAsParentNodeOf(this.pairs);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/NullLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/NullLiteralExpr.java
@@ -29,18 +29,18 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class NullLiteralExpr extends LiteralExpr {
 
-	public NullLiteralExpr() {
-	}
+    public NullLiteralExpr() {
+    }
 
-	public NullLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn);
-	}
+    public NullLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ObjectCreationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ObjectCreationExpr.java
@@ -34,86 +34,86 @@ import java.util.List;
  */
 public final class ObjectCreationExpr extends Expression {
 
-	private Expression scope;
+    private Expression scope;
 
-	private ClassOrInterfaceType type;
+    private ClassOrInterfaceType type;
 
-	private List<Type> typeArgs;
+    private List<Type> typeArgs;
 
-	private List<Expression> args;
+    private List<Expression> args;
 
-	private List<BodyDeclaration> anonymousClassBody;
+    private List<BodyDeclaration> anonymousClassBody;
 
-	public ObjectCreationExpr() {
-	}
+    public ObjectCreationExpr() {
+    }
 
-	public ObjectCreationExpr(final Expression scope, final ClassOrInterfaceType type, final List<Expression> args) {
-		setScope(scope);
-		setType(type);
-		setArgs(args);
-	}
+    public ObjectCreationExpr(final Expression scope, final ClassOrInterfaceType type, final List<Expression> args) {
+        setScope(scope);
+        setType(type);
+        setArgs(args);
+    }
 
-	public ObjectCreationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression scope, final ClassOrInterfaceType type, final List<Type> typeArgs,
-			final List<Expression> args, final List<BodyDeclaration> anonymousBody) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setScope(scope);
-		setType(type);
-		setTypeArgs(typeArgs);
-		setArgs(args);
-		setAnonymousClassBody(anonymousBody);
-	}
+    public ObjectCreationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression scope, final ClassOrInterfaceType type, final List<Type> typeArgs,
+            final List<Expression> args, final List<BodyDeclaration> anonymousBody) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setScope(scope);
+        setType(type);
+        setTypeArgs(typeArgs);
+        setArgs(args);
+        setAnonymousClassBody(anonymousBody);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<BodyDeclaration> getAnonymousClassBody() {
-		return anonymousClassBody;
-	}
+    public List<BodyDeclaration> getAnonymousClassBody() {
+        return anonymousClassBody;
+    }
 
-	public List<Expression> getArgs() {
-		return args;
-	}
+    public List<Expression> getArgs() {
+        return args;
+    }
 
-	public Expression getScope() {
-		return scope;
-	}
+    public Expression getScope() {
+        return scope;
+    }
 
-	public ClassOrInterfaceType getType() {
-		return type;
-	}
+    public ClassOrInterfaceType getType() {
+        return type;
+    }
 
-	public List<Type> getTypeArgs() {
-		return typeArgs;
-	}
+    public List<Type> getTypeArgs() {
+        return typeArgs;
+    }
 
-	public void setAnonymousClassBody(final List<BodyDeclaration> anonymousClassBody) {
-		this.anonymousClassBody = anonymousClassBody;
-		setAsParentNodeOf(this.anonymousClassBody);
-	}
+    public void setAnonymousClassBody(final List<BodyDeclaration> anonymousClassBody) {
+        this.anonymousClassBody = anonymousClassBody;
+        setAsParentNodeOf(this.anonymousClassBody);
+    }
 
-	public void setArgs(final List<Expression> args) {
-		this.args = args;
-		setAsParentNodeOf(this.args);
-	}
+    public void setArgs(final List<Expression> args) {
+        this.args = args;
+        setAsParentNodeOf(this.args);
+    }
 
-	public void setScope(final Expression scope) {
-		this.scope = scope;
-		setAsParentNodeOf(this.scope);
-	}
+    public void setScope(final Expression scope) {
+        this.scope = scope;
+        setAsParentNodeOf(this.scope);
+    }
 
-	public void setType(final ClassOrInterfaceType type) {
-		this.type = type;
-		setAsParentNodeOf(this.type);
-	}
+    public void setType(final ClassOrInterfaceType type) {
+        this.type = type;
+        setAsParentNodeOf(this.type);
+    }
 
-	public void setTypeArgs(final List<Type> typeArgs) {
-		this.typeArgs = typeArgs;
-		setAsParentNodeOf(this.typeArgs);
-	}
+    public void setTypeArgs(final List<Type> typeArgs) {
+        this.typeArgs = typeArgs;
+        setAsParentNodeOf(this.typeArgs);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/QualifiedNameExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/QualifiedNameExpr.java
@@ -29,36 +29,36 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class QualifiedNameExpr extends NameExpr {
 
-	private NameExpr qualifier;
+    private NameExpr qualifier;
 
-	public QualifiedNameExpr() {
-	}
+    public QualifiedNameExpr() {
+    }
 
-	public QualifiedNameExpr(final NameExpr scope, final String name) {
-		super(name);
-		setQualifier(scope);
-	}
+    public QualifiedNameExpr(final NameExpr scope, final String name) {
+        super(name);
+        setQualifier(scope);
+    }
 
-	public QualifiedNameExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final NameExpr scope, final String name) {
-		super(beginLine, beginColumn, endLine, endColumn, name);
-		setQualifier(scope);
-	}
+    public QualifiedNameExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final NameExpr scope, final String name) {
+        super(beginLine, beginColumn, endLine, endColumn, name);
+        setQualifier(scope);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public NameExpr getQualifier() {
-		return qualifier;
-	}
+    public NameExpr getQualifier() {
+        return qualifier;
+    }
 
-	public void setQualifier(final NameExpr qualifier) {
-		this.qualifier = qualifier;
-		setAsParentNodeOf(this.qualifier);
-	}
+    public void setQualifier(final NameExpr qualifier) {
+        this.qualifier = qualifier;
+        setAsParentNodeOf(this.qualifier);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/SingleMemberAnnotationExpr.java
@@ -29,37 +29,37 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class SingleMemberAnnotationExpr extends AnnotationExpr {
 
-	private Expression memberValue;
+    private Expression memberValue;
 
-	public SingleMemberAnnotationExpr() {
-	}
+    public SingleMemberAnnotationExpr() {
+    }
 
-	public SingleMemberAnnotationExpr(final NameExpr name, final Expression memberValue) {
-		setName(name);
-		setMemberValue(memberValue);
-	}
+    public SingleMemberAnnotationExpr(final NameExpr name, final Expression memberValue) {
+        setName(name);
+        setMemberValue(memberValue);
+    }
 
-	public SingleMemberAnnotationExpr(final int beginLine, final int beginColumn, final int endLine,
-			final int endColumn, final NameExpr name, final Expression memberValue) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setName(name);
-		setMemberValue(memberValue);
-	}
+    public SingleMemberAnnotationExpr(final int beginLine, final int beginColumn, final int endLine,
+            final int endColumn, final NameExpr name, final Expression memberValue) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setName(name);
+        setMemberValue(memberValue);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getMemberValue() {
-		return memberValue;
-	}
+    public Expression getMemberValue() {
+        return memberValue;
+    }
 
-	public void setMemberValue(final Expression memberValue) {
-		this.memberValue = memberValue;
-		setAsParentNodeOf(this.memberValue);
-	}
+    public void setMemberValue(final Expression memberValue) {
+        this.memberValue = memberValue;
+        setAsParentNodeOf(this.memberValue);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/StringLiteralExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/StringLiteralExpr.java
@@ -29,34 +29,34 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public class StringLiteralExpr extends LiteralExpr {
 
-	protected String value;
+    protected String value;
 
-	public StringLiteralExpr() {
-	}
+    public StringLiteralExpr() {
+    }
 
-	public StringLiteralExpr(final String value) {
-		this.value = value;
-	}
+    public StringLiteralExpr(final String value) {
+        this.value = value;
+    }
 
-	public StringLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String value) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		this.value = value;
-	}
+    public StringLiteralExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String value) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        this.value = value;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public final String getValue() {
-		return value;
-	}
+    public final String getValue() {
+        return value;
+    }
 
-	public final void setValue(final String value) {
-		this.value = value;
-	}
+    public final void setValue(final String value) {
+        this.value = value;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/SuperExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/SuperExpr.java
@@ -29,35 +29,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class SuperExpr extends Expression {
 
-	private Expression classExpr;
+    private Expression classExpr;
 
-	public SuperExpr() {
-	}
+    public SuperExpr() {
+    }
 
-	public SuperExpr(final Expression classExpr) {
-		setClassExpr(classExpr);
-	}
+    public SuperExpr(final Expression classExpr) {
+        setClassExpr(classExpr);
+    }
 
-	public SuperExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression classExpr) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setClassExpr(classExpr);
-	}
+    public SuperExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression classExpr) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setClassExpr(classExpr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getClassExpr() {
-		return classExpr;
-	}
+    public Expression getClassExpr() {
+        return classExpr;
+    }
 
-	public void setClassExpr(final Expression classExpr) {
-		this.classExpr = classExpr;
-		setAsParentNodeOf(this.classExpr);
-	}
+    public void setClassExpr(final Expression classExpr) {
+        this.classExpr = classExpr;
+        setAsParentNodeOf(this.classExpr);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ThisExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/ThisExpr.java
@@ -29,35 +29,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ThisExpr extends Expression {
 
-	private Expression classExpr;
+    private Expression classExpr;
 
-	public ThisExpr() {
-	}
+    public ThisExpr() {
+    }
 
-	public ThisExpr(final Expression classExpr) {
-		setClassExpr(classExpr);
-	}
+    public ThisExpr(final Expression classExpr) {
+        setClassExpr(classExpr);
+    }
 
-	public ThisExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression classExpr) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setClassExpr(classExpr);
-	}
+    public ThisExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression classExpr) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setClassExpr(classExpr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getClassExpr() {
-		return classExpr;
-	}
+    public Expression getClassExpr() {
+        return classExpr;
+    }
 
-	public void setClassExpr(final Expression classExpr) {
-		this.classExpr = classExpr;
-		setAsParentNodeOf(this.classExpr);
-	}
+    public void setClassExpr(final Expression classExpr) {
+        this.classExpr = classExpr;
+        setAsParentNodeOf(this.classExpr);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/UnaryExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/UnaryExpr.java
@@ -29,58 +29,58 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class UnaryExpr extends Expression {
 
-	public static enum Operator {
-		positive, // +
-		negative, // -
-		preIncrement, // ++
-		preDecrement, // --
-		not, // !
-		inverse, // ~
-		posIncrement, // ++
-		posDecrement, // --
-	}
+    public static enum Operator {
+        positive, // +
+        negative, // -
+        preIncrement, // ++
+        preDecrement, // --
+        not, // !
+        inverse, // ~
+        posIncrement, // ++
+        posDecrement, // --
+    }
 
-	private Expression expr;
+    private Expression expr;
 
-	private Operator op;
+    private Operator op;
 
-	public UnaryExpr() {
-	}
+    public UnaryExpr() {
+    }
 
-	public UnaryExpr(final Expression expr, final Operator op) {
-		setExpr(expr);
-		setOperator(op);
-	}
+    public UnaryExpr(final Expression expr, final Operator op) {
+        setExpr(expr);
+        setOperator(op);
+    }
 
-	public UnaryExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression expr, final Operator op) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExpr(expr);
-		setOperator(op);
-	}
+    public UnaryExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression expr, final Operator op) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExpr(expr);
+        setOperator(op);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public Operator getOperator() {
-		return op;
-	}
+    public Operator getOperator() {
+        return op;
+    }
 
-	public void setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-	}
+    public void setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+    }
 
-	public void setOperator(final Operator op) {
-		this.op = op;
-	}
+    public void setOperator(final Operator op) {
+        this.op = op;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/expr/VariableDeclarationExpr.java
@@ -34,84 +34,84 @@ import java.util.List;
  */
 public final class VariableDeclarationExpr extends Expression {
 
-	private int modifiers;
+    private int modifiers;
 
-	private List<AnnotationExpr> annotations;
+    private List<AnnotationExpr> annotations;
 
-	private Type type;
+    private Type type;
 
-	private List<VariableDeclarator> vars;
+    private List<VariableDeclarator> vars;
 
-	public VariableDeclarationExpr() {
-	}
+    public VariableDeclarationExpr() {
+    }
 
-	public VariableDeclarationExpr(final Type type, final List<VariableDeclarator> vars) {
-		setType(type);
-		setVars(vars);
-	}
+    public VariableDeclarationExpr(final Type type, final List<VariableDeclarator> vars) {
+        setType(type);
+        setVars(vars);
+    }
 
-	public VariableDeclarationExpr(final int modifiers, final Type type, final List<VariableDeclarator> vars) {
-		setModifiers(modifiers);
-		setType(type);
-		setVars(vars);
-	}
+    public VariableDeclarationExpr(final int modifiers, final Type type, final List<VariableDeclarator> vars) {
+        setModifiers(modifiers);
+        setType(type);
+        setVars(vars);
+    }
 
-	public VariableDeclarationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final int modifiers, final List<AnnotationExpr> annotations, final Type type,
-			final List<VariableDeclarator> vars) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setModifiers(modifiers);
-		setAnnotations(annotations);
-		setType(type);
-		setVars(vars);
-	}
+    public VariableDeclarationExpr(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final int modifiers, final List<AnnotationExpr> annotations, final Type type,
+            final List<VariableDeclarator> vars) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setModifiers(modifiers);
+        setAnnotations(annotations);
+        setType(type);
+        setVars(vars);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<AnnotationExpr> getAnnotations() {
-		return annotations;
-	}
+    public List<AnnotationExpr> getAnnotations() {
+        return annotations;
+    }
 
-	/**
-	 * Return the modifiers of this variable declaration.
-	 * 
-	 * @see ModifierSet
-	 * @return modifiers
-	 */
-	public int getModifiers() {
-		return modifiers;
-	}
+    /**
+     * Return the modifiers of this variable declaration.
+     * 
+     * @see ModifierSet
+     * @return modifiers
+     */
+    public int getModifiers() {
+        return modifiers;
+    }
 
-	public Type getType() {
-		return type;
-	}
+    public Type getType() {
+        return type;
+    }
 
-	public List<VariableDeclarator> getVars() {
-		return vars;
-	}
+    public List<VariableDeclarator> getVars() {
+        return vars;
+    }
 
-	public void setAnnotations(final List<AnnotationExpr> annotations) {
-		this.annotations = annotations;
-		setAsParentNodeOf(this.annotations);
-	}
+    public void setAnnotations(final List<AnnotationExpr> annotations) {
+        this.annotations = annotations;
+        setAsParentNodeOf(this.annotations);
+    }
 
-	public void setModifiers(final int modifiers) {
-		this.modifiers = modifiers;
-	}
+    public void setModifiers(final int modifiers) {
+        this.modifiers = modifiers;
+    }
 
-	public void setType(final Type type) {
-		this.type = type;
-		setAsParentNodeOf(this.type);
-	}
+    public void setType(final Type type) {
+        this.type = type;
+        setAsParentNodeOf(this.type);
+    }
 
-	public void setVars(final List<VariableDeclarator> vars) {
-		this.vars = vars;
-		setAsParentNodeOf(this.vars);
-	}
+    public void setVars(final List<VariableDeclarator> vars) {
+        this.vars = vars;
+        setAsParentNodeOf(this.vars);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/AssertStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/AssertStmt.java
@@ -30,54 +30,54 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class AssertStmt extends Statement {
 
-	private Expression check;
+    private Expression check;
 
-	private Expression msg;
+    private Expression msg;
 
-	public AssertStmt() {
-	}
+    public AssertStmt() {
+    }
 
-	public AssertStmt(final Expression check) {
-		setCheck(check);
-	}
+    public AssertStmt(final Expression check) {
+        setCheck(check);
+    }
 
-	public AssertStmt(final Expression check, final Expression msg) {
-		setCheck(check);
-		setMessage(msg);
-	}
+    public AssertStmt(final Expression check, final Expression msg) {
+        setCheck(check);
+        setMessage(msg);
+    }
 
-	public AssertStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression check, final Expression msg) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		
-		setCheck(check);
-		setMessage(msg);
-		
-	}
+    public AssertStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression check, final Expression msg) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        
+        setCheck(check);
+        setMessage(msg);
+        
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getCheck() {
-		return check;
-	}
+    public Expression getCheck() {
+        return check;
+    }
 
-	public Expression getMessage() {
-		return msg;
-	}
+    public Expression getMessage() {
+        return msg;
+    }
 
-	public void setCheck(final Expression check) {
-		this.check = check;
-		setAsParentNodeOf(this.check);
-	}
+    public void setCheck(final Expression check) {
+        this.check = check;
+        setAsParentNodeOf(this.check);
+    }
 
-	public void setMessage(final Expression msg) {
-		this.msg = msg;
-		setAsParentNodeOf(this.msg);
-	}
+    public void setMessage(final Expression msg) {
+        this.msg = msg;
+        setAsParentNodeOf(this.msg);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/BlockStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/BlockStmt.java
@@ -31,37 +31,37 @@ import java.util.List;
  */
 public final class BlockStmt extends Statement {
 
-	private List<Statement> stmts;
+    private List<Statement> stmts;
 
-	public BlockStmt() {
-	}
+    public BlockStmt() {
+    }
 
-	public BlockStmt(final List<Statement> stmts) {
-		setStmts(stmts);
-	}
+    public BlockStmt(final List<Statement> stmts) {
+        setStmts(stmts);
+    }
 
-	public BlockStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn, final List<Statement> stmts) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setStmts(stmts);
-	}
+    public BlockStmt(final int beginLine, final int beginColumn,
+            final int endLine, final int endColumn, final List<Statement> stmts) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setStmts(stmts);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<Statement> getStmts() {
-		return stmts;
-	}
+    public List<Statement> getStmts() {
+        return stmts;
+    }
 
-	public void setStmts(final List<Statement> stmts) {
-		this.stmts = stmts;
-		setAsParentNodeOf(this.stmts);
-	}
+    public void setStmts(final List<Statement> stmts) {
+        this.stmts = stmts;
+        setAsParentNodeOf(this.stmts);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/BreakStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/BreakStmt.java
@@ -29,33 +29,33 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class BreakStmt extends Statement {
 
-	private String id;
+    private String id;
 
-	public BreakStmt() {
-	}
+    public BreakStmt() {
+    }
 
-	public BreakStmt(final String id) {
-		this.id = id;
-	}
+    public BreakStmt(final String id) {
+        this.id = id;
+    }
 
-	public BreakStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn, final String id) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		this.id = id;
-	}
+    public BreakStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn, final String id) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        this.id = id;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public void setId(final String id) {
-		this.id = id;
-	}
+    public void setId(final String id) {
+        this.id = id;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/CatchClause.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/CatchClause.java
@@ -47,42 +47,42 @@ public final class CatchClause extends Node {
         setExcept(except);
         setCatchBlock(catchBlock);
     }
-	
+    
     public CatchClause(int exceptModifier, List<AnnotationExpr> exceptAnnotations, List<Type> exceptTypes, VariableDeclaratorId exceptId, BlockStmt catchBlock) {
         this(new MultiTypeParameter(exceptModifier, exceptAnnotations, exceptTypes, exceptId), catchBlock);
     }
 
     public CatchClause(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-    	    final int exceptModifier, final List<AnnotationExpr> exceptAnnotations, final List<Type> exceptTypes, 
-    	    final VariableDeclaratorId exceptId, final BlockStmt catchBlock) {
+            final int exceptModifier, final List<AnnotationExpr> exceptAnnotations, final List<Type> exceptTypes, 
+            final VariableDeclaratorId exceptId, final BlockStmt catchBlock) {
         super(beginLine, beginColumn, endLine, endColumn);
         setExcept(new MultiTypeParameter(beginLine, beginColumn, endLine, endColumn, exceptModifier, exceptAnnotations, exceptTypes, exceptId));
         setCatchBlock(catchBlock);
     }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public BlockStmt getCatchBlock() {
-		return catchBlock;
-	}
+    public BlockStmt getCatchBlock() {
+        return catchBlock;
+    }
 
-	public MultiTypeParameter getExcept() {
-		return except;
-	}
+    public MultiTypeParameter getExcept() {
+        return except;
+    }
 
-	public void setCatchBlock(final BlockStmt catchBlock) {
-		this.catchBlock = catchBlock;
-		setAsParentNodeOf(this.catchBlock);
-	}
+    public void setCatchBlock(final BlockStmt catchBlock) {
+        this.catchBlock = catchBlock;
+        setAsParentNodeOf(this.catchBlock);
+    }
 
-	public void setExcept(final MultiTypeParameter except) {
-		this.except = except;
-		setAsParentNodeOf(this.except);
-	}
+    public void setExcept(final MultiTypeParameter except) {
+        this.except = except;
+        setAsParentNodeOf(this.except);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ContinueStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ContinueStmt.java
@@ -29,34 +29,34 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ContinueStmt extends Statement {
 
-	private String id;
+    private String id;
 
-	public ContinueStmt() {
-	}
+    public ContinueStmt() {
+    }
 
-	public ContinueStmt(final String id) {
-		this.id = id;
-	}
+    public ContinueStmt(final String id) {
+        this.id = id;
+    }
 
-	public ContinueStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String id) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		this.id = id;
-	}
+    public ContinueStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String id) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        this.id = id;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public void setId(final String id) {
-		this.id = id;
-	}
+    public void setId(final String id) {
+        this.id = id;
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/DoStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/DoStmt.java
@@ -30,48 +30,48 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class DoStmt extends Statement {
 
-	private Statement body;
+    private Statement body;
 
-	private Expression condition;
+    private Expression condition;
 
-	public DoStmt() {
-	}
+    public DoStmt() {
+    }
 
-	public DoStmt(final Statement body, final Expression condition) {
-		setBody(body);
-		setCondition(condition);
-	}
+    public DoStmt(final Statement body, final Expression condition) {
+        setBody(body);
+        setCondition(condition);
+    }
 
-	public DoStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Statement body, final Expression condition) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setBody(body);
-		setCondition(condition);
-	}
+    public DoStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Statement body, final Expression condition) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setBody(body);
+        setCondition(condition);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Statement getBody() {
-		return body;
-	}
+    public Statement getBody() {
+        return body;
+    }
 
-	public Expression getCondition() {
-		return condition;
-	}
+    public Expression getCondition() {
+        return condition;
+    }
 
-	public void setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
-	}
+    public void setBody(final Statement body) {
+        this.body = body;
+        setAsParentNodeOf(this.body);
+    }
 
-	public void setCondition(final Expression condition) {
-		this.condition = condition;
-		setAsParentNodeOf(this.condition);
-	}
+    public void setCondition(final Expression condition) {
+        this.condition = condition;
+        setAsParentNodeOf(this.condition);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/EmptyStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/EmptyStmt.java
@@ -29,18 +29,18 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class EmptyStmt extends Statement {
 
-	public EmptyStmt() {
-	}
+    public EmptyStmt() {
+    }
 
-	public EmptyStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn);
-	}
+    public EmptyStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ExplicitConstructorInvocationStmt.java
@@ -33,77 +33,77 @@ import java.util.List;
  */
 public final class ExplicitConstructorInvocationStmt extends Statement {
 
-	private List<Type> typeArgs;
+    private List<Type> typeArgs;
 
-	private boolean isThis;
+    private boolean isThis;
 
-	private Expression expr;
+    private Expression expr;
 
-	private List<Expression> args;
+    private List<Expression> args;
 
-	public ExplicitConstructorInvocationStmt() {
-	}
+    public ExplicitConstructorInvocationStmt() {
+    }
 
-	public ExplicitConstructorInvocationStmt(final boolean isThis,
-			final Expression expr, final List<Expression> args) {
-		setThis(isThis);
-		setExpr(expr);
-		setArgs(args);
-	}
+    public ExplicitConstructorInvocationStmt(final boolean isThis,
+            final Expression expr, final List<Expression> args) {
+        setThis(isThis);
+        setExpr(expr);
+        setArgs(args);
+    }
 
-	public ExplicitConstructorInvocationStmt(final int beginLine,
-			final int beginColumn, final int endLine, final int endColumn,
-			final List<Type> typeArgs, final boolean isThis,
-			final Expression expr, final List<Expression> args) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setTypeArgs(typeArgs);
-		setThis(isThis);
-		setExpr(expr);
-		setArgs(args);
-	}
+    public ExplicitConstructorInvocationStmt(final int beginLine,
+            final int beginColumn, final int endLine, final int endColumn,
+            final List<Type> typeArgs, final boolean isThis,
+            final Expression expr, final List<Expression> args) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setTypeArgs(typeArgs);
+        setThis(isThis);
+        setExpr(expr);
+        setArgs(args);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<Expression> getArgs() {
-		return args;
-	}
+    public List<Expression> getArgs() {
+        return args;
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public List<Type> getTypeArgs() {
-		return typeArgs;
-	}
+    public List<Type> getTypeArgs() {
+        return typeArgs;
+    }
 
-	public boolean isThis() {
-		return isThis;
-	}
+    public boolean isThis() {
+        return isThis;
+    }
 
-	public void setArgs(final List<Expression> args) {
-		this.args = args;
-		setAsParentNodeOf(this.args);
-	}
+    public void setArgs(final List<Expression> args) {
+        this.args = args;
+        setAsParentNodeOf(this.args);
+    }
 
-	public void setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-	}
+    public void setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+    }
 
-	public void setThis(final boolean isThis) {
-		this.isThis = isThis;
-	}
+    public void setThis(final boolean isThis) {
+        this.isThis = isThis;
+    }
 
-	public void setTypeArgs(final List<Type> typeArgs) {
-		this.typeArgs = typeArgs;
-		setAsParentNodeOf(this.typeArgs);
-	}
+    public void setTypeArgs(final List<Type> typeArgs) {
+        this.typeArgs = typeArgs;
+        setAsParentNodeOf(this.typeArgs);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ExpressionStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ExpressionStmt.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ExpressionStmt extends Statement {
 
-	private Expression expr;
+    private Expression expr;
 
-	public ExpressionStmt() {
-	}
+    public ExpressionStmt() {
+    }
 
-	public ExpressionStmt(final Expression expr) {
-		setExpression(expr);
-	}
+    public ExpressionStmt(final Expression expr) {
+        setExpression(expr);
+    }
 
-	public ExpressionStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression expr) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExpression(expr);
-	}
+    public ExpressionStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression expr) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExpression(expr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpression() {
-		return expr;
-	}
+    public Expression getExpression() {
+        return expr;
+    }
 
-	public void setExpression(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-	}
+    public void setExpression(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ForStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ForStmt.java
@@ -32,79 +32,79 @@ import java.util.List;
  */
 public final class ForStmt extends Statement {
 
-	private List<Expression> init;
+    private List<Expression> init;
 
-	private Expression compare;
+    private Expression compare;
 
-	private List<Expression> update;
+    private List<Expression> update;
 
-	private Statement body;
+    private Statement body;
 
-	public ForStmt() {
-	}
+    public ForStmt() {
+    }
 
-	public ForStmt(final List<Expression> init, final Expression compare,
-			final List<Expression> update, final Statement body) {
-		setCompare(compare);
-		setInit(init);
-		setUpdate(update);
-		setBody(body);
-	}
+    public ForStmt(final List<Expression> init, final Expression compare,
+            final List<Expression> update, final Statement body) {
+        setCompare(compare);
+        setInit(init);
+        setUpdate(update);
+        setBody(body);
+    }
 
-	public ForStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn,
-			final List<Expression> init, final Expression compare,
-			final List<Expression> update, final Statement body) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setCompare(compare);
-		setInit(init);
-		setUpdate(update);
-		setBody(body);
-	}
+    public ForStmt(final int beginLine, final int beginColumn,
+            final int endLine, final int endColumn,
+            final List<Expression> init, final Expression compare,
+            final List<Expression> update, final Statement body) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setCompare(compare);
+        setInit(init);
+        setUpdate(update);
+        setBody(body);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Statement getBody() {
-		return body;
-	}
+    public Statement getBody() {
+        return body;
+    }
 
-	public Expression getCompare() {
-		return compare;
-	}
+    public Expression getCompare() {
+        return compare;
+    }
 
-	public List<Expression> getInit() {
-		return init;
-	}
+    public List<Expression> getInit() {
+        return init;
+    }
 
-	public List<Expression> getUpdate() {
-		return update;
-	}
+    public List<Expression> getUpdate() {
+        return update;
+    }
 
-	public void setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
-	}
+    public void setBody(final Statement body) {
+        this.body = body;
+        setAsParentNodeOf(this.body);
+    }
 
-	public void setCompare(final Expression compare) {
-		this.compare = compare;
-		setAsParentNodeOf(this.compare);
-	}
+    public void setCompare(final Expression compare) {
+        this.compare = compare;
+        setAsParentNodeOf(this.compare);
+    }
 
-	public void setInit(final List<Expression> init) {
-		this.init = init;
-		setAsParentNodeOf(this.init);
-	}
+    public void setInit(final List<Expression> init) {
+        this.init = init;
+        setAsParentNodeOf(this.init);
+    }
 
-	public void setUpdate(final List<Expression> update) {
-		this.update = update;
-		setAsParentNodeOf(this.update);
-	}
+    public void setUpdate(final List<Expression> update) {
+        this.update = update;
+        setAsParentNodeOf(this.update);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ForeachStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ForeachStmt.java
@@ -31,66 +31,66 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ForeachStmt extends Statement {
 
-	private VariableDeclarationExpr var;
+    private VariableDeclarationExpr var;
 
-	private Expression iterable;
+    private Expression iterable;
 
-	private Statement body;
+    private Statement body;
 
-	public ForeachStmt() {
-	}
+    public ForeachStmt() {
+    }
 
-	public ForeachStmt(final VariableDeclarationExpr var,
-			final Expression iterable, final Statement body) {
-		setVariable(var);
-		setIterable(iterable);
-		setBody(body);
-	}
+    public ForeachStmt(final VariableDeclarationExpr var,
+            final Expression iterable, final Statement body) {
+        setVariable(var);
+        setIterable(iterable);
+        setBody(body);
+    }
 
-	public ForeachStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn,
-			final VariableDeclarationExpr var, final Expression iterable,
-			final Statement body) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setVariable(var);
-		setIterable(iterable);
-		setBody(body);
-	}
+    public ForeachStmt(final int beginLine, final int beginColumn,
+            final int endLine, final int endColumn,
+            final VariableDeclarationExpr var, final Expression iterable,
+            final Statement body) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setVariable(var);
+        setIterable(iterable);
+        setBody(body);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Statement getBody() {
-		return body;
-	}
+    public Statement getBody() {
+        return body;
+    }
 
-	public Expression getIterable() {
-		return iterable;
-	}
+    public Expression getIterable() {
+        return iterable;
+    }
 
-	public VariableDeclarationExpr getVariable() {
-		return var;
-	}
+    public VariableDeclarationExpr getVariable() {
+        return var;
+    }
 
-	public void setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
-	}
+    public void setBody(final Statement body) {
+        this.body = body;
+        setAsParentNodeOf(this.body);
+    }
 
-	public void setIterable(final Expression iterable) {
-		this.iterable = iterable;
-		setAsParentNodeOf(this.iterable);
-	}
+    public void setIterable(final Expression iterable) {
+        this.iterable = iterable;
+        setAsParentNodeOf(this.iterable);
+    }
 
-	public void setVariable(final VariableDeclarationExpr var) {
-		this.var = var;
-		setAsParentNodeOf(this.var);
-	}
+    public void setVariable(final VariableDeclarationExpr var) {
+        this.var = var;
+        setAsParentNodeOf(this.var);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/IfStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/IfStmt.java
@@ -30,61 +30,61 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class IfStmt extends Statement {
 
-	private Expression condition;
+    private Expression condition;
 
-	private Statement thenStmt;
+    private Statement thenStmt;
 
-	private Statement elseStmt;
+    private Statement elseStmt;
 
-	public IfStmt() {
-	}
+    public IfStmt() {
+    }
 
-	public IfStmt(final Expression condition, final Statement thenStmt, final Statement elseStmt) {
-		setCondition(condition);
-		setThenStmt(thenStmt);
-		setElseStmt(elseStmt);
-	}
+    public IfStmt(final Expression condition, final Statement thenStmt, final Statement elseStmt) {
+        setCondition(condition);
+        setThenStmt(thenStmt);
+        setElseStmt(elseStmt);
+    }
 
-	public IfStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression condition, final Statement thenStmt, final Statement elseStmt) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setCondition(condition);
-		setThenStmt(thenStmt);
-		setElseStmt(elseStmt);
-	}
+    public IfStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression condition, final Statement thenStmt, final Statement elseStmt) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setCondition(condition);
+        setThenStmt(thenStmt);
+        setElseStmt(elseStmt);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getCondition() {
-		return condition;
-	}
+    public Expression getCondition() {
+        return condition;
+    }
 
-	public Statement getElseStmt() {
-		return elseStmt;
-	}
+    public Statement getElseStmt() {
+        return elseStmt;
+    }
 
-	public Statement getThenStmt() {
-		return thenStmt;
-	}
+    public Statement getThenStmt() {
+        return thenStmt;
+    }
 
-	public void setCondition(final Expression condition) {
-		this.condition = condition;
-		setAsParentNodeOf(this.condition);
-	}
+    public void setCondition(final Expression condition) {
+        this.condition = condition;
+        setAsParentNodeOf(this.condition);
+    }
 
-	public void setElseStmt(final Statement elseStmt) {
-		this.elseStmt = elseStmt;
-		setAsParentNodeOf(this.elseStmt);
-	}
+    public void setElseStmt(final Statement elseStmt) {
+        this.elseStmt = elseStmt;
+        setAsParentNodeOf(this.elseStmt);
+    }
 
-	public void setThenStmt(final Statement thenStmt) {
-		this.thenStmt = thenStmt;
-		setAsParentNodeOf(this.thenStmt);
-	}
+    public void setThenStmt(final Statement thenStmt) {
+        this.thenStmt = thenStmt;
+        setAsParentNodeOf(this.thenStmt);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/LabeledStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/LabeledStmt.java
@@ -29,47 +29,47 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class LabeledStmt extends Statement {
 
-	private String label;
+    private String label;
 
-	private Statement stmt;
+    private Statement stmt;
 
-	public LabeledStmt() {
-	}
+    public LabeledStmt() {
+    }
 
-	public LabeledStmt(final String label, final Statement stmt) {
-		setLabel(label);
-		setStmt(stmt);
-	}
+    public LabeledStmt(final String label, final Statement stmt) {
+        setLabel(label);
+        setStmt(stmt);
+    }
 
-	public LabeledStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final String label, final Statement stmt) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setLabel(label);
-		setStmt(stmt);
-	}
+    public LabeledStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final String label, final Statement stmt) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setLabel(label);
+        setStmt(stmt);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public String getLabel() {
-		return label;
-	}
+    public String getLabel() {
+        return label;
+    }
 
-	public Statement getStmt() {
-		return stmt;
-	}
+    public Statement getStmt() {
+        return stmt;
+    }
 
-	public void setLabel(final String label) {
-		this.label = label;
-	}
+    public void setLabel(final String label) {
+        this.label = label;
+    }
 
-	public void setStmt(final Statement stmt) {
-		this.stmt = stmt;
-		setAsParentNodeOf(this.stmt);
-	}
+    public void setStmt(final Statement stmt) {
+        this.stmt = stmt;
+        setAsParentNodeOf(this.stmt);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ReturnStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ReturnStmt.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ReturnStmt extends Statement {
 
-	private Expression expr;
+    private Expression expr;
 
-	public ReturnStmt() {
-	}
+    public ReturnStmt() {
+    }
 
-	public ReturnStmt(final Expression expr) {
-		setExpr(expr);
-	}
+    public ReturnStmt(final Expression expr) {
+        setExpr(expr);
+    }
 
-	public ReturnStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression expr) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExpr(expr);
-	}
+    public ReturnStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression expr) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExpr(expr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public void setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-	}
+    public void setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/Statement.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/Statement.java
@@ -28,11 +28,11 @@ import com.github.javaparser.ast.Node;
  */
 public abstract class Statement extends Node {
 
-	public Statement() {
-	}
+    public Statement() {
+    }
 
-	public Statement(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn);
-	}
+    public Statement(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/SwitchEntryStmt.java
@@ -32,51 +32,51 @@ import java.util.List;
  */
 public final class SwitchEntryStmt extends Statement {
 
-	private Expression label;
+    private Expression label;
 
-	private List<Statement> stmts;
+    private List<Statement> stmts;
 
-	public SwitchEntryStmt() {
-	}
+    public SwitchEntryStmt() {
+    }
 
-	public SwitchEntryStmt(final Expression label, final List<Statement> stmts) {
-		setLabel(label);
-		setStmts(stmts);
-	}
+    public SwitchEntryStmt(final Expression label, final List<Statement> stmts) {
+        setLabel(label);
+        setStmts(stmts);
+    }
 
-	public SwitchEntryStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn, final Expression label,
-			final List<Statement> stmts) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setLabel(label);
-		setStmts(stmts);
-	}
+    public SwitchEntryStmt(final int beginLine, final int beginColumn,
+            final int endLine, final int endColumn, final Expression label,
+            final List<Statement> stmts) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setLabel(label);
+        setStmts(stmts);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getLabel() {
-		return label;
-	}
+    public Expression getLabel() {
+        return label;
+    }
 
-	public List<Statement> getStmts() {
-		return stmts;
-	}
+    public List<Statement> getStmts() {
+        return stmts;
+    }
 
-	public void setLabel(final Expression label) {
-		this.label = label;
-		setAsParentNodeOf(this.label);
-	}
+    public void setLabel(final Expression label) {
+        this.label = label;
+        setAsParentNodeOf(this.label);
+    }
 
-	public void setStmts(final List<Statement> stmts) {
-		this.stmts = stmts;
-		setAsParentNodeOf(this.stmts);
-	}
+    public void setStmts(final List<Statement> stmts) {
+        this.stmts = stmts;
+        setAsParentNodeOf(this.stmts);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/SwitchStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/SwitchStmt.java
@@ -32,52 +32,52 @@ import java.util.List;
  */
 public final class SwitchStmt extends Statement {
 
-	private Expression selector;
+    private Expression selector;
 
-	private List<SwitchEntryStmt> entries;
+    private List<SwitchEntryStmt> entries;
 
-	public SwitchStmt() {
-	}
+    public SwitchStmt() {
+    }
 
-	public SwitchStmt(final Expression selector,
-			final List<SwitchEntryStmt> entries) {
-		setSelector(selector);
-		setEntries(entries);
-	}
+    public SwitchStmt(final Expression selector,
+            final List<SwitchEntryStmt> entries) {
+        setSelector(selector);
+        setEntries(entries);
+    }
 
-	public SwitchStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn, final Expression selector,
-			final List<SwitchEntryStmt> entries) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setSelector(selector);
-		setEntries(entries);
-	}
+    public SwitchStmt(final int beginLine, final int beginColumn,
+            final int endLine, final int endColumn, final Expression selector,
+            final List<SwitchEntryStmt> entries) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setSelector(selector);
+        setEntries(entries);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<SwitchEntryStmt> getEntries() {
-		return entries;
-	}
+    public List<SwitchEntryStmt> getEntries() {
+        return entries;
+    }
 
-	public Expression getSelector() {
-		return selector;
-	}
+    public Expression getSelector() {
+        return selector;
+    }
 
-	public void setEntries(final List<SwitchEntryStmt> entries) {
-		this.entries = entries;
-		setAsParentNodeOf(this.entries);
-	}
+    public void setEntries(final List<SwitchEntryStmt> entries) {
+        this.entries = entries;
+        setAsParentNodeOf(this.entries);
+    }
 
-	public void setSelector(final Expression selector) {
-		this.selector = selector;
-		setAsParentNodeOf(this.selector);
-	}
+    public void setSelector(final Expression selector) {
+        this.selector = selector;
+        setAsParentNodeOf(this.selector);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/SynchronizedStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/SynchronizedStmt.java
@@ -30,51 +30,51 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class SynchronizedStmt extends Statement {
 
-	private Expression expr;
+    private Expression expr;
 
-	private BlockStmt block;
+    private BlockStmt block;
 
-	public SynchronizedStmt() {
-	}
+    public SynchronizedStmt() {
+    }
 
-	public SynchronizedStmt(final Expression expr, final BlockStmt block) {
-		setExpr(expr);
-		setBlock(block);
-	}
+    public SynchronizedStmt(final Expression expr, final BlockStmt block) {
+        setExpr(expr);
+        setBlock(block);
+    }
 
-	public SynchronizedStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn, final Expression expr,
-			final BlockStmt block) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExpr(expr);
-		setBlock(block);
-	}
+    public SynchronizedStmt(final int beginLine, final int beginColumn,
+            final int endLine, final int endColumn, final Expression expr,
+            final BlockStmt block) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExpr(expr);
+        setBlock(block);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public BlockStmt getBlock() {
-		return block;
-	}
+    public BlockStmt getBlock() {
+        return block;
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public void setBlock(final BlockStmt block) {
-		this.block = block;
-		setAsParentNodeOf(this.block);
-	}
+    public void setBlock(final BlockStmt block) {
+        this.block = block;
+        setAsParentNodeOf(this.block);
+    }
 
-	public void setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-	}
+    public void setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ThrowStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/ThrowStmt.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class ThrowStmt extends Statement {
 
-	private Expression expr;
+    private Expression expr;
 
-	public ThrowStmt() {
-	}
+    public ThrowStmt() {
+    }
 
-	public ThrowStmt(final Expression expr) {
-		setExpr(expr);
-	}
+    public ThrowStmt(final Expression expr) {
+        setExpr(expr);
+    }
 
-	public ThrowStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression expr) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExpr(expr);
-	}
+    public ThrowStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression expr) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExpr(expr);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Expression getExpr() {
-		return expr;
-	}
+    public Expression getExpr() {
+        return expr;
+    }
 
-	public void setExpr(final Expression expr) {
-		this.expr = expr;
-		setAsParentNodeOf(this.expr);
-	}
+    public void setExpr(final Expression expr) {
+        this.expr = expr;
+        setAsParentNodeOf(this.expr);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/TryStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/TryStmt.java
@@ -31,78 +31,78 @@ import java.util.List;
  * @author Julio Vilmar Gesser
  */
 public final class TryStmt extends Statement {
-	
-	private List<VariableDeclarationExpr> resources;
+    
+    private List<VariableDeclarationExpr> resources;
 
-	private BlockStmt tryBlock;
+    private BlockStmt tryBlock;
 
-	private List<CatchClause> catchs;
+    private List<CatchClause> catchs;
 
-	private BlockStmt finallyBlock;
+    private BlockStmt finallyBlock;
 
-	public TryStmt() {
-	}
+    public TryStmt() {
+    }
 
-	public TryStmt(final BlockStmt tryBlock, final List<CatchClause> catchs,
-			final BlockStmt finallyBlock) {
-		setTryBlock(tryBlock);
-		setCatchs(catchs);
-		setFinallyBlock(finallyBlock);
-	}
+    public TryStmt(final BlockStmt tryBlock, final List<CatchClause> catchs,
+            final BlockStmt finallyBlock) {
+        setTryBlock(tryBlock);
+        setCatchs(catchs);
+        setFinallyBlock(finallyBlock);
+    }
 
-	public TryStmt(final int beginLine, final int beginColumn,
-			final int endLine, final int endColumn, List<VariableDeclarationExpr> resources,
-			final BlockStmt tryBlock, final List<CatchClause> catchs, final BlockStmt finallyBlock) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setResources(resources);
-		setTryBlock(tryBlock);
-		setCatchs(catchs);
-		setFinallyBlock(finallyBlock);
-	}
+    public TryStmt(final int beginLine, final int beginColumn,
+            final int endLine, final int endColumn, List<VariableDeclarationExpr> resources,
+            final BlockStmt tryBlock, final List<CatchClause> catchs, final BlockStmt finallyBlock) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setResources(resources);
+        setTryBlock(tryBlock);
+        setCatchs(catchs);
+        setFinallyBlock(finallyBlock);
+    }
 
-	@Override
-	public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override
-	public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public List<CatchClause> getCatchs() {
-		return catchs;
-	}
+    public List<CatchClause> getCatchs() {
+        return catchs;
+    }
 
-	public BlockStmt getFinallyBlock() {
-		return finallyBlock;
-	}
+    public BlockStmt getFinallyBlock() {
+        return finallyBlock;
+    }
 
-	public BlockStmt getTryBlock() {
-		return tryBlock;
-	}
-	
-	public List<VariableDeclarationExpr> getResources() {
-		return resources;
-	}
+    public BlockStmt getTryBlock() {
+        return tryBlock;
+    }
+    
+    public List<VariableDeclarationExpr> getResources() {
+        return resources;
+    }
 
-	public void setCatchs(final List<CatchClause> catchs) {
-		this.catchs = catchs;
-		setAsParentNodeOf(this.catchs);
-	}
+    public void setCatchs(final List<CatchClause> catchs) {
+        this.catchs = catchs;
+        setAsParentNodeOf(this.catchs);
+    }
 
-	public void setFinallyBlock(final BlockStmt finallyBlock) {
-		this.finallyBlock = finallyBlock;
-		setAsParentNodeOf(this.finallyBlock);
-	}
+    public void setFinallyBlock(final BlockStmt finallyBlock) {
+        this.finallyBlock = finallyBlock;
+        setAsParentNodeOf(this.finallyBlock);
+    }
 
-	public void setTryBlock(final BlockStmt tryBlock) {
-		this.tryBlock = tryBlock;
-		setAsParentNodeOf(this.tryBlock);
-	}
-	
-	public void setResources(List<VariableDeclarationExpr> resources) {
-		this.resources = resources;
-		setAsParentNodeOf(this.resources);
-	}
+    public void setTryBlock(final BlockStmt tryBlock) {
+        this.tryBlock = tryBlock;
+        setAsParentNodeOf(this.tryBlock);
+    }
+    
+    public void setResources(List<VariableDeclarationExpr> resources) {
+        this.resources = resources;
+        setAsParentNodeOf(this.resources);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/TypeDeclarationStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/TypeDeclarationStmt.java
@@ -30,35 +30,35 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class TypeDeclarationStmt extends Statement {
 
-	private TypeDeclaration typeDecl;
+    private TypeDeclaration typeDecl;
 
-	public TypeDeclarationStmt() {
-	}
+    public TypeDeclarationStmt() {
+    }
 
-	public TypeDeclarationStmt(final TypeDeclaration typeDecl) {
-		setTypeDeclaration(typeDecl);
-	}
+    public TypeDeclarationStmt(final TypeDeclaration typeDecl) {
+        setTypeDeclaration(typeDecl);
+    }
 
-	public TypeDeclarationStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final TypeDeclaration typeDecl) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setTypeDeclaration(typeDecl);
-	}
+    public TypeDeclarationStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final TypeDeclaration typeDecl) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setTypeDeclaration(typeDecl);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public TypeDeclaration getTypeDeclaration() {
-		return typeDecl;
-	}
+    public TypeDeclaration getTypeDeclaration() {
+        return typeDecl;
+    }
 
-	public void setTypeDeclaration(final TypeDeclaration typeDecl) {
-		this.typeDecl = typeDecl;
-		setAsParentNodeOf(this.typeDecl);
-	}
+    public void setTypeDeclaration(final TypeDeclaration typeDecl) {
+        this.typeDecl = typeDecl;
+        setAsParentNodeOf(this.typeDecl);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/WhileStmt.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/stmt/WhileStmt.java
@@ -30,48 +30,48 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class WhileStmt extends Statement {
 
-	private Expression condition;
+    private Expression condition;
 
-	private Statement body;
+    private Statement body;
 
-	public WhileStmt() {
-	}
+    public WhileStmt() {
+    }
 
-	public WhileStmt(final Expression condition, final Statement body) {
-		setCondition(condition);
-		setBody(body);
-	}
+    public WhileStmt(final Expression condition, final Statement body) {
+        setCondition(condition);
+        setBody(body);
+    }
 
-	public WhileStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Expression condition, final Statement body) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setCondition(condition);
-		setBody(body);
-	}
+    public WhileStmt(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Expression condition, final Statement body) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setCondition(condition);
+        setBody(body);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Statement getBody() {
-		return body;
-	}
+    public Statement getBody() {
+        return body;
+    }
 
-	public Expression getCondition() {
-		return condition;
-	}
+    public Expression getCondition() {
+        return condition;
+    }
 
-	public void setBody(final Statement body) {
-		this.body = body;
-		setAsParentNodeOf(this.body);
-	}
+    public void setBody(final Statement body) {
+        this.body = body;
+        setAsParentNodeOf(this.body);
+    }
 
-	public void setCondition(final Expression condition) {
-		this.condition = condition;
-		setAsParentNodeOf(this.condition);
-	}
+    public void setCondition(final Expression condition) {
+        this.condition = condition;
+        setAsParentNodeOf(this.condition);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/PrimitiveType.java
@@ -31,67 +31,67 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class PrimitiveType extends Type {
 
-	public enum Primitive {
-		Boolean ("Boolean"),
-		Char    ("Character"),
-		Byte    ("Byte"),
-		Short   ("Short"),
-		Int     ("Integer"),
-		Long    ("Long"),
-		Float   ("Float"),
-		Double  ("Double");
+    public enum Primitive {
+        Boolean ("Boolean"),
+        Char    ("Character"),
+        Byte    ("Byte"),
+        Short   ("Short"),
+        Int     ("Integer"),
+        Long    ("Long"),
+        Float   ("Float"),
+        Double  ("Double");
 
-		final String nameOfBoxedType;
+        final String nameOfBoxedType;
 
-		public ClassOrInterfaceType toBoxedType() {
-			return new ClassOrInterfaceType(nameOfBoxedType);
-		}
+        public ClassOrInterfaceType toBoxedType() {
+            return new ClassOrInterfaceType(nameOfBoxedType);
+        }
 
-		private Primitive(String nameOfBoxedType) {
-			this.nameOfBoxedType = nameOfBoxedType;
-		}
-	}
+        private Primitive(String nameOfBoxedType) {
+            this.nameOfBoxedType = nameOfBoxedType;
+        }
+    }
 
-	static final HashMap<String, Primitive> unboxMap = new HashMap<String, Primitive>();
-	static {
-		for(Primitive unboxedType : Primitive.values()) {
-			unboxMap.put(unboxedType.nameOfBoxedType, unboxedType);
-		}
-	}
+    static final HashMap<String, Primitive> unboxMap = new HashMap<String, Primitive>();
+    static {
+        for(Primitive unboxedType : Primitive.values()) {
+            unboxMap.put(unboxedType.nameOfBoxedType, unboxedType);
+        }
+    }
 
-	private Primitive type;
+    private Primitive type;
 
-	public PrimitiveType() {
-	}
+    public PrimitiveType() {
+    }
 
-	public PrimitiveType(final Primitive type) {
-		this.type = type;
-	}
+    public PrimitiveType(final Primitive type) {
+        this.type = type;
+    }
 
-	public PrimitiveType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Primitive type) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		this.type = type;
-	}
+    public PrimitiveType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Primitive type) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        this.type = type;
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public Primitive getType() {
-		return type;
-	}
+    public Primitive getType() {
+        return type;
+    }
 
-	public ClassOrInterfaceType toBoxedType() {
-		return type.toBoxedType();
-	}
+    public ClassOrInterfaceType toBoxedType() {
+        return type.toBoxedType();
+    }
 
-	public void setType(final Primitive type) {
-		this.type = type;
-	}
+    public void setType(final Primitive type) {
+        this.type = type;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/ReferenceType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/ReferenceType.java
@@ -32,30 +32,30 @@ import java.util.List;
  */
 public final class ReferenceType extends Type {
 
-	private Type type;
+    private Type type;
 
-	private int arrayCount;
+    private int arrayCount;
 
     private List<List<AnnotationExpr>> arraysAnnotations;
 
     public ReferenceType() {
-	}
+    }
 
-	public ReferenceType(final Type type) {
-		setType(type);
-	}
+    public ReferenceType(final Type type) {
+        setType(type);
+    }
 
-	public ReferenceType(final Type type, final int arrayCount) {
-		setType(type);
-		setArrayCount(arrayCount);
-	}
+    public ReferenceType(final Type type, final int arrayCount) {
+        setType(type);
+        setArrayCount(arrayCount);
+    }
 
-	public ReferenceType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final Type type, final int arrayCount) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setType(type);
-		setArrayCount(arrayCount);
-	}
+    public ReferenceType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final Type type, final int arrayCount) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setType(type);
+        setArrayCount(arrayCount);
+    }
 
     public ReferenceType(int beginLine, int beginColumn, int endLine,
                          int endColumn, Type type, int arrayCount,
@@ -67,58 +67,58 @@ public final class ReferenceType extends Type {
         this.arraysAnnotations = arraysAnnotations;
     }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public int getArrayCount() {
-		return arrayCount;
-	}
+    public int getArrayCount() {
+        return arrayCount;
+    }
 
-	public Type getType() {
-		return type;
-	}
+    public Type getType() {
+        return type;
+    }
 
-	public void setArrayCount(final int arrayCount) {
-		this.arrayCount = arrayCount;
-	}
+    public void setArrayCount(final int arrayCount) {
+        this.arrayCount = arrayCount;
+    }
 
-	public void setType(final Type type) {
-		this.type = type;
-		setAsParentNodeOf(this.type);
-	}
+    public void setType(final Type type) {
+        this.type = type;
+        setAsParentNodeOf(this.type);
+    }
 
-	/**
-	 * <p>Arrays annotations are annotations on the arrays modifiers of the type.
-	 * Consider this example:</p>
-	 * 
-	 * <p><pre>
-	 * {@code
-	 * int @Ann1 [] @Ann2 [] array;
-	 * }</pre></p>
-	 * 
-	 * <p>in this method will return a list with the annotation expressions <pre>@Ann1</pre>
-	 * and <pre>@Ann2</pre></p>
-	 * 
-	 * <p>Note that the first list element of arraysAnnotations will refer to the first array modifier encountered.
-	 * Considering the example the first element will be a list containing just @Ann1 while the second element will
-	 * be a list containing just @Ann2.
-	 * </p>
-	 *
-	 * <p>This property is guaranteed to hold: <pre>{@code getArraysAnnotations().size() == getArrayCount()}</pre>
-	 * If a certain array modifier has no annotation the corresponding entry of arraysAnnotations will be null</p>
-	 */
+    /**
+     * <p>Arrays annotations are annotations on the arrays modifiers of the type.
+     * Consider this example:</p>
+     * 
+     * <p><pre>
+     * {@code
+     * int @Ann1 [] @Ann2 [] array;
+     * }</pre></p>
+     * 
+     * <p>in this method will return a list with the annotation expressions <pre>@Ann1</pre>
+     * and <pre>@Ann2</pre></p>
+     * 
+     * <p>Note that the first list element of arraysAnnotations will refer to the first array modifier encountered.
+     * Considering the example the first element will be a list containing just @Ann1 while the second element will
+     * be a list containing just @Ann2.
+     * </p>
+     *
+     * <p>This property is guaranteed to hold: <pre>{@code getArraysAnnotations().size() == getArrayCount()}</pre>
+     * If a certain array modifier has no annotation the corresponding entry of arraysAnnotations will be null</p>
+     */
     public List<List<AnnotationExpr>> getArraysAnnotations() {
         return arraysAnnotations;
     }
 
-	/**
-	 * For a description of the arrayAnnotations field refer to {@link #getArraysAnnotations()}
-	 */
+    /**
+     * For a description of the arrayAnnotations field refer to {@link #getArraysAnnotations()}
+     */
     public void setArraysAnnotations(List<List<AnnotationExpr>> arraysAnnotations) {
         this.arraysAnnotations = arraysAnnotations;
     }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/VoidType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/VoidType.java
@@ -29,19 +29,19 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class VoidType extends Type {
 
-	public VoidType() {
-	}
+    public VoidType() {
+    }
 
-	public VoidType(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
-		super(beginLine, beginColumn, endLine, endColumn);
-	}
+    public VoidType(final int beginLine, final int beginColumn, final int endLine, final int endColumn) {
+        super(beginLine, beginColumn, endLine, endColumn);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/WildcardType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/type/WildcardType.java
@@ -29,53 +29,53 @@ import com.github.javaparser.ast.visitor.VoidVisitor;
  */
 public final class WildcardType extends Type {
 
-	private ReferenceType ext;
+    private ReferenceType ext;
 
-	private ReferenceType sup;
+    private ReferenceType sup;
 
-	public WildcardType() {
-	}
+    public WildcardType() {
+    }
 
-	public WildcardType(final ReferenceType ext) {
-		setExtends(ext);
-	}
+    public WildcardType(final ReferenceType ext) {
+        setExtends(ext);
+    }
 
-	public WildcardType(final ReferenceType ext, final ReferenceType sup) {
-		setExtends(ext);
-		setSuper(sup);
-	}
+    public WildcardType(final ReferenceType ext, final ReferenceType sup) {
+        setExtends(ext);
+        setSuper(sup);
+    }
 
-	public WildcardType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
-			final ReferenceType ext, final ReferenceType sup) {
-		super(beginLine, beginColumn, endLine, endColumn);
-		setExtends(ext);
-		setSuper(sup);
-	}
+    public WildcardType(final int beginLine, final int beginColumn, final int endLine, final int endColumn,
+            final ReferenceType ext, final ReferenceType sup) {
+        super(beginLine, beginColumn, endLine, endColumn);
+        setExtends(ext);
+        setSuper(sup);
+    }
 
-	@Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-		return v.visit(this, arg);
-	}
+    @Override public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
 
-	@Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
-		v.visit(this, arg);
-	}
+    @Override public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
 
-	public ReferenceType getExtends() {
-		return ext;
-	}
+    public ReferenceType getExtends() {
+        return ext;
+    }
 
-	public ReferenceType getSuper() {
-		return sup;
-	}
+    public ReferenceType getSuper() {
+        return sup;
+    }
 
-	public void setExtends(final ReferenceType ext) {
-		this.ext = ext;
-		setAsParentNodeOf(this.ext);
-	}
+    public void setExtends(final ReferenceType ext) {
+        this.ext = ext;
+        setAsParentNodeOf(this.ext);
+    }
 
-	public void setSuper(final ReferenceType sup) {
-		this.sup = sup;
-		setAsParentNodeOf(this.sup);
-	}
+    public void setSuper(final ReferenceType sup) {
+        this.sup = sup;
+        setAsParentNodeOf(this.sup);
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -57,47 +57,47 @@ import com.github.javaparser.ast.type.*;
 
 public class CloneVisitor implements GenericVisitor<Node, Object> {
 
-	@Override
-	public Node visit(CompilationUnit _n, Object _arg) {
-		PackageDeclaration package_ = cloneNodes(_n.getPackage(), _arg);
-		List<ImportDeclaration> imports = visit(_n.getImports(), _arg);
-		List<TypeDeclaration> types = visit(_n.getTypes(), _arg);
+    @Override
+    public Node visit(CompilationUnit _n, Object _arg) {
+        PackageDeclaration package_ = cloneNodes(_n.getPackage(), _arg);
+        List<ImportDeclaration> imports = visit(_n.getImports(), _arg);
+        List<TypeDeclaration> types = visit(_n.getTypes(), _arg);
 
-		return new CompilationUnit(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				package_, imports, types
-		);
-	}
+        return new CompilationUnit(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                package_, imports, types
+        );
+    }
 
-	@Override
-	public Node visit(PackageDeclaration _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(PackageDeclaration _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		PackageDeclaration r = new PackageDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				annotations, name
-		);
-		r.setComment(comment);
-		return r;
-	}
+        PackageDeclaration r = new PackageDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                annotations, name
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ImportDeclaration _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ImportDeclaration _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ImportDeclaration r = new ImportDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				name, _n.isStatic(), _n.isAsterisk()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ImportDeclaration r = new ImportDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                name, _n.isStatic(), _n.isAsterisk()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(TypeParameter _n, Object _arg) {
+    @Override
+    public Node visit(TypeParameter _n, Object _arg) {
         List<ClassOrInterfaceType> typeBound = visit(_n.getTypeBound(), _arg);
 
         List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
@@ -107,1085 +107,1085 @@ public class CloneVisitor implements GenericVisitor<Node, Object> {
 
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
-		return r;
-	}
+        return r;
+    }
 
-	@Override
-	public Node visit(LineComment _n, Object _arg) {
-		return new LineComment(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), _n.getContent());
-	}
+    @Override
+    public Node visit(LineComment _n, Object _arg) {
+        return new LineComment(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), _n.getContent());
+    }
 
-	@Override
-	public Node visit(BlockComment _n, Object _arg) {
-		return new BlockComment(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), _n.getContent());
-	}
+    @Override
+    public Node visit(BlockComment _n, Object _arg) {
+        return new BlockComment(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), _n.getContent());
+    }
 
-	@Override
-	public Node visit(ClassOrInterfaceDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
-		List<ClassOrInterfaceType> extendsList = visit(_n.getExtends(), _arg);
-		List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
-		List<BodyDeclaration> members = visit(_n.getMembers(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ClassOrInterfaceDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
+        List<ClassOrInterfaceType> extendsList = visit(_n.getExtends(), _arg);
+        List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
+        List<BodyDeclaration> members = visit(_n.getMembers(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ClassOrInterfaceDeclaration r = new ClassOrInterfaceDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getModifiers(), annotations, _n.isInterface(), _n.getName(), typeParameters, extendsList, implementsList, members
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ClassOrInterfaceDeclaration r = new ClassOrInterfaceDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getModifiers(), annotations, _n.isInterface(), _n.getName(), typeParameters, extendsList, implementsList, members
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EnumDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
-		List<EnumConstantDeclaration> entries = visit(_n.getEntries(), _arg);
-		List<BodyDeclaration> members = visit(_n.getMembers(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(EnumDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<ClassOrInterfaceType> implementsList = visit(_n.getImplements(), _arg);
+        List<EnumConstantDeclaration> entries = visit(_n.getEntries(), _arg);
+        List<BodyDeclaration> members = visit(_n.getMembers(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EnumDeclaration r = new EnumDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 _n.getModifiers(), annotations, _n.getName(), implementsList, entries, members
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EnumDeclaration r = new EnumDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 _n.getModifiers(), annotations, _n.getName(), implementsList, entries, members
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EmptyTypeDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(EmptyTypeDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EmptyTypeDeclaration r = new EmptyTypeDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EmptyTypeDeclaration r = new EmptyTypeDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EnumConstantDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<Expression> args = visit(_n.getArgs(), _arg);
-		List<BodyDeclaration> classBody = visit(_n.getClassBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(EnumConstantDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<Expression> args = visit(_n.getArgs(), _arg);
+        List<BodyDeclaration> classBody = visit(_n.getClassBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EnumConstantDeclaration r = new EnumConstantDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 annotations, _n.getName(), args, classBody
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EnumConstantDeclaration r = new EnumConstantDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 annotations, _n.getName(), args, classBody
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(AnnotationDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<BodyDeclaration> members = visit(_n.getMembers(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(AnnotationDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<BodyDeclaration> members = visit(_n.getMembers(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		AnnotationDeclaration r = new AnnotationDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 _n.getModifiers(), annotations, _n.getName(), members
-		);
-		r.setComment(comment);
-		return r;
-	}
+        AnnotationDeclaration r = new AnnotationDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 _n.getModifiers(), annotations, _n.getName(), members
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(AnnotationMemberDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		Expression defaultValue = cloneNodes(_n.getDefaultValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(AnnotationMemberDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        Expression defaultValue = cloneNodes(_n.getDefaultValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		AnnotationMemberDeclaration r = new AnnotationMemberDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 _n.getModifiers(), annotations, type_, _n.getName(), defaultValue
-		);
-		r.setComment(comment);
-		return r;
-	}
+        AnnotationMemberDeclaration r = new AnnotationMemberDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 _n.getModifiers(), annotations, type_, _n.getName(), defaultValue
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(FieldDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		List<VariableDeclarator> variables = visit(_n.getVariables(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(FieldDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        List<VariableDeclarator> variables = visit(_n.getVariables(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		FieldDeclaration r = new FieldDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 _n.getModifiers(), annotations, type_, variables
-		);
-		r.setComment(comment);
-		return r;
-	}
+        FieldDeclaration r = new FieldDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 _n.getModifiers(), annotations, type_, variables
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(VariableDeclarator _n, Object _arg) {
-		VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
-		Expression init = cloneNodes(_n.getInit(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(VariableDeclarator _n, Object _arg) {
+        VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
+        Expression init = cloneNodes(_n.getInit(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		VariableDeclarator r = new VariableDeclarator(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				id, init
-		);
-		r.setComment(comment);
-		return r;
-	}
+        VariableDeclarator r = new VariableDeclarator(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                id, init
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(VariableDeclaratorId _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(VariableDeclaratorId _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		VariableDeclaratorId r = new VariableDeclaratorId(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getName(), _n.getArrayCount()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        VariableDeclaratorId r = new VariableDeclaratorId(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getName(), _n.getArrayCount()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ConstructorDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
-		List<Parameter> parameters = visit(_n.getParameters(), _arg);
-		List<NameExpr> throws_ = visit(_n.getThrows(), _arg);
-		BlockStmt block = cloneNodes(_n.getBlock(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ConstructorDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
+        List<Parameter> parameters = visit(_n.getParameters(), _arg);
+        List<NameExpr> throws_ = visit(_n.getThrows(), _arg);
+        BlockStmt block = cloneNodes(_n.getBlock(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ConstructorDeclaration r = new ConstructorDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 _n.getModifiers(), annotations, typeParameters, _n.getName(), parameters, throws_, block
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ConstructorDeclaration r = new ConstructorDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 _n.getModifiers(), annotations, typeParameters, _n.getName(), parameters, throws_, block
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(MethodDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		List<Parameter> parameters = visit(_n.getParameters(), _arg);
-		List<NameExpr> throws_ = visit(_n.getThrows(), _arg);
-		BlockStmt block = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(MethodDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<TypeParameter> typeParameters = visit(_n.getTypeParameters(), _arg);
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        List<Parameter> parameters = visit(_n.getParameters(), _arg);
+        List<NameExpr> throws_ = visit(_n.getThrows(), _arg);
+        BlockStmt block = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		MethodDeclaration r = new MethodDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 _n.getModifiers(), annotations, typeParameters, type_, _n.getName(), parameters, _n.getArrayCount(), throws_, block
-		);
-		r.setComment(comment);
-		return r;
-	}
+        MethodDeclaration r = new MethodDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 _n.getModifiers(), annotations, typeParameters, type_, _n.getName(), parameters, _n.getArrayCount(), throws_, block
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(Parameter _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(Parameter _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		Parameter r = new Parameter(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getModifiers(), annotations, type_, _n.isVarArgs(), id
-		);
-		r.setComment(comment);
-		return r;
-	}
-	
-	@Override
-	public Node visit(MultiTypeParameter _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		List<Type> types = visit(_n.getTypes(), _arg);
-		VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+        Parameter r = new Parameter(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getModifiers(), annotations, type_, _n.isVarArgs(), id
+        );
+        r.setComment(comment);
+        return r;
+    }
+    
+    @Override
+    public Node visit(MultiTypeParameter _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        List<Type> types = visit(_n.getTypes(), _arg);
+        VariableDeclaratorId id = cloneNodes(_n.getId(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		MultiTypeParameter r = new MultiTypeParameter(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getModifiers(), annotations, types, id
-		);
-		r.setComment(comment);
-		return r;
-	}
+        MultiTypeParameter r = new MultiTypeParameter(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getModifiers(), annotations, types, id
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(EmptyMemberDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(EmptyMemberDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		EmptyMemberDeclaration r = new EmptyMemberDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        EmptyMemberDeclaration r = new EmptyMemberDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(InitializerDeclaration _n, Object _arg) {
-		JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
-		BlockStmt block = cloneNodes(_n.getBlock(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(InitializerDeclaration _n, Object _arg) {
+        JavadocComment javaDoc = cloneNodes(_n.getJavaDoc(), _arg);
+        BlockStmt block = cloneNodes(_n.getBlock(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		InitializerDeclaration r = new InitializerDeclaration(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				 _n.isStatic(), block
-		);
-		r.setComment(comment);
-		return r;
-	}
+        InitializerDeclaration r = new InitializerDeclaration(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                 _n.isStatic(), block
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(JavadocComment _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		JavadocComment r = new JavadocComment(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getContent()
-		);
-		r.setComment(comment);
-		return r;
-	}
+    @Override
+    public Node visit(JavadocComment _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        JavadocComment r = new JavadocComment(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getContent()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ClassOrInterfaceType _n, Object _arg) {
-		ClassOrInterfaceType scope = cloneNodes(_n.getScope(), _arg);
-		List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ClassOrInterfaceType _n, Object _arg) {
+        ClassOrInterfaceType scope = cloneNodes(_n.getScope(), _arg);
+        List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ClassOrInterfaceType r = new ClassOrInterfaceType(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				scope, _n.getName(), typeArgs
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ClassOrInterfaceType r = new ClassOrInterfaceType(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                scope, _n.getName(), typeArgs
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(PrimitiveType _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(PrimitiveType _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		PrimitiveType r = new PrimitiveType(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getType()
-		);
-		r.setComment(comment);
-		return r;
-	}
+        PrimitiveType r = new PrimitiveType(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getType()
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ReferenceType _n, Object _arg) {
-		List<AnnotationExpr> ann = visit(_n.getAnnotations(), _arg);
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		List<List<AnnotationExpr>> arraysAnnotations = _n.getArraysAnnotations();
-		List<List<AnnotationExpr>> _arraysAnnotations = null;
-		if(arraysAnnotations != null){
-			_arraysAnnotations = new LinkedList<List<AnnotationExpr>>();
-			for(List<AnnotationExpr> aux: arraysAnnotations){
-				_arraysAnnotations.add(visit(aux, _arg));
-			}
-		}
+    @Override
+    public Node visit(ReferenceType _n, Object _arg) {
+        List<AnnotationExpr> ann = visit(_n.getAnnotations(), _arg);
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        List<List<AnnotationExpr>> arraysAnnotations = _n.getArraysAnnotations();
+        List<List<AnnotationExpr>> _arraysAnnotations = null;
+        if(arraysAnnotations != null){
+            _arraysAnnotations = new LinkedList<List<AnnotationExpr>>();
+            for(List<AnnotationExpr> aux: arraysAnnotations){
+                _arraysAnnotations.add(visit(aux, _arg));
+            }
+        }
 
         ReferenceType r = new ReferenceType(_n.getBeginLine(),
                 _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), type_,
                 _n.getArrayCount(), ann, _arraysAnnotations);
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
-		return r;
-	}
+        return r;
+    }
 
-	@Override
-	public Node visit(VoidType _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(VoidType _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		VoidType r = new VoidType(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
-		r.setComment(comment);
-		return r;
-	}
+        VoidType r = new VoidType(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(WildcardType _n, Object _arg) {
-		ReferenceType ext = cloneNodes(_n.getExtends(), _arg);
-		ReferenceType sup = cloneNodes(_n.getSuper(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(WildcardType _n, Object _arg) {
+        ReferenceType ext = cloneNodes(_n.getExtends(), _arg);
+        ReferenceType sup = cloneNodes(_n.getSuper(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		WildcardType r = new WildcardType(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				ext, sup
-		);
-		r.setComment(comment);
-		return r;
-	}
+        WildcardType r = new WildcardType(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                ext, sup
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(UnknownType _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(UnknownType _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		UnknownType r = new UnknownType();
-		r.setComment(comment);
-		return r;
-	}
+        UnknownType r = new UnknownType();
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ArrayAccessExpr _n, Object _arg) {
-		Expression name = cloneNodes(_n.getName(), _arg);
-		Expression index = cloneNodes(_n.getIndex(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
+    @Override
+    public Node visit(ArrayAccessExpr _n, Object _arg) {
+        Expression name = cloneNodes(_n.getName(), _arg);
+        Expression index = cloneNodes(_n.getIndex(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
 
-		ArrayAccessExpr r = new ArrayAccessExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				name, index
-		);
-		r.setComment(comment);
-		return r;
-	}
+        ArrayAccessExpr r = new ArrayAccessExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                name, index
+        );
+        r.setComment(comment);
+        return r;
+    }
 
-	@Override
-	public Node visit(ArrayCreationExpr _n, Object _arg) {
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		List<Expression> dimensions = visit(_n.getDimensions(), _arg);
-		ArrayCreationExpr r = new ArrayCreationExpr(_n.getBeginLine(),
-				_n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), type_,
-				dimensions, _n.getArrayCount());
-		if (_n.getInitializer() != null) {// ArrayCreationExpr has two mutually
-			// exclusive constructors
-			r.setInitializer(cloneNodes(_n.getInitializer(), _arg));
-		}
-		List<List<AnnotationExpr>> arraysAnnotations = _n.getArraysAnnotations();
-		List<List<AnnotationExpr>> _arraysAnnotations = null;
-		if(arraysAnnotations != null){
-			_arraysAnnotations = new LinkedList<List<AnnotationExpr>>();
-			for(List<AnnotationExpr> aux: arraysAnnotations){
-				_arraysAnnotations.add(visit(aux, _arg));
-			}
-		}
-		r.setArraysAnnotations(_arraysAnnotations);
+    @Override
+    public Node visit(ArrayCreationExpr _n, Object _arg) {
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        List<Expression> dimensions = visit(_n.getDimensions(), _arg);
+        ArrayCreationExpr r = new ArrayCreationExpr(_n.getBeginLine(),
+                _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), type_,
+                dimensions, _n.getArrayCount());
+        if (_n.getInitializer() != null) {// ArrayCreationExpr has two mutually
+            // exclusive constructors
+            r.setInitializer(cloneNodes(_n.getInitializer(), _arg));
+        }
+        List<List<AnnotationExpr>> arraysAnnotations = _n.getArraysAnnotations();
+        List<List<AnnotationExpr>> _arraysAnnotations = null;
+        if(arraysAnnotations != null){
+            _arraysAnnotations = new LinkedList<List<AnnotationExpr>>();
+            for(List<AnnotationExpr> aux: arraysAnnotations){
+                _arraysAnnotations.add(visit(aux, _arg));
+            }
+        }
+        r.setArraysAnnotations(_arraysAnnotations);
         Comment comment = cloneNodes(_n.getComment(), _arg);
         r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ArrayInitializerExpr _n, Object _arg) {
-		List<Expression> values = visit(_n.getValues(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ArrayInitializerExpr r = new ArrayInitializerExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				values
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(AssignExpr _n, Object _arg) {
-		Expression target = cloneNodes(_n.getTarget(), _arg);
-		Expression value = cloneNodes(_n.getValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		AssignExpr r = new AssignExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				target, value, _n.getOperator());
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(BinaryExpr _n, Object _arg) {
-		Expression left = cloneNodes(_n.getLeft(), _arg);
-		Expression right = cloneNodes(_n.getRight(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		BinaryExpr r = new BinaryExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				left, right, _n.getOperator()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(CastExpr _n, Object _arg) {
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		CastExpr r = new CastExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				type_, expr
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ClassExpr _n, Object _arg) {
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ClassExpr r = new ClassExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				type_
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ConditionalExpr _n, Object _arg) {
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Expression thenExpr = cloneNodes(_n.getThenExpr(), _arg);
-		Expression elseExpr = cloneNodes(_n.getElseExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ConditionalExpr r = new ConditionalExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				condition, thenExpr, elseExpr
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(EnclosedExpr _n, Object _arg) {
-		Expression inner = cloneNodes(_n.getInner(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		EnclosedExpr r = new EnclosedExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				inner
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(FieldAccessExpr _n, Object _arg) {
-		Expression scope = cloneNodes(_n.getScope(), _arg);
-		List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		FieldAccessExpr r = new FieldAccessExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				scope, typeArgs, _n.getField()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(InstanceOfExpr _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		InstanceOfExpr r = new InstanceOfExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				expr, type_
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(StringLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-		StringLiteralExpr r = new StringLiteralExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(IntegerLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		IntegerLiteralExpr r = new IntegerLiteralExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(LongLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		LongLiteralExpr r = new LongLiteralExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(IntegerLiteralMinValueExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		IntegerLiteralMinValueExpr r = new IntegerLiteralMinValueExpr(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(LongLiteralMinValueExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		LongLiteralMinValueExpr r = new LongLiteralMinValueExpr(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(CharLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		CharLiteralExpr r = new CharLiteralExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(DoubleLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		DoubleLiteralExpr r = new DoubleLiteralExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(BooleanLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		BooleanLiteralExpr r = new BooleanLiteralExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getValue()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(NullLiteralExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		NullLiteralExpr r = new NullLiteralExpr(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(MethodCallExpr _n, Object _arg) {
-		Expression scope = cloneNodes(_n.getScope(), _arg);
-		List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
-		List<Expression> args = visit(_n.getArgs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		MethodCallExpr r = new MethodCallExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				scope, typeArgs, _n.getName(), args
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(NameExpr _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		NameExpr r = new NameExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getName()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ObjectCreationExpr _n, Object _arg) {
-		Expression scope = cloneNodes(_n.getScope(), _arg);
-		ClassOrInterfaceType type_ = cloneNodes(_n.getType(), _arg);
-		List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
-		List<Expression> args = visit(_n.getArgs(), _arg);
-		List<BodyDeclaration> anonymousBody = visit(_n.getAnonymousClassBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ObjectCreationExpr r = new ObjectCreationExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				scope, type_, typeArgs, args, anonymousBody
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(QualifiedNameExpr _n, Object _arg) {
-		NameExpr scope = cloneNodes(_n.getQualifier(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		QualifiedNameExpr r = new QualifiedNameExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				scope, _n.getName()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ThisExpr _n, Object _arg) {
-		Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ThisExpr r = new ThisExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				classExpr
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(SuperExpr _n, Object _arg) {
-		Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		SuperExpr r = new SuperExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				classExpr
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(UnaryExpr _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		UnaryExpr r = new UnaryExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				expr, _n.getOperator()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(VariableDeclarationExpr _n, Object _arg) {
-		List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
-		Type type_ = cloneNodes(_n.getType(), _arg);
-		List<VariableDeclarator> vars = visit(_n.getVars(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		VariableDeclarationExpr r = new VariableDeclarationExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getModifiers(), annotations, type_, vars
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(MarkerAnnotationExpr _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		MarkerAnnotationExpr r = new MarkerAnnotationExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				name
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(SingleMemberAnnotationExpr _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		Expression memberValue = cloneNodes(_n.getMemberValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		SingleMemberAnnotationExpr r = new SingleMemberAnnotationExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				name, memberValue
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(NormalAnnotationExpr _n, Object _arg) {
-		NameExpr name = cloneNodes(_n.getName(), _arg);
-		List<MemberValuePair> pairs = visit(_n.getPairs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		NormalAnnotationExpr r = new NormalAnnotationExpr(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				name, pairs
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(MemberValuePair _n, Object _arg) {
-		Expression value = cloneNodes(_n.getValue(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		MemberValuePair r = new MemberValuePair(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getName(), value
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ExplicitConstructorInvocationStmt _n, Object _arg) {
-		List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		List<Expression> args = visit(_n.getArgs(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ExplicitConstructorInvocationStmt r = new ExplicitConstructorInvocationStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				typeArgs, _n.isThis(), expr, args
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(TypeDeclarationStmt _n, Object _arg) {
-		TypeDeclaration typeDecl = cloneNodes(_n.getTypeDeclaration(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		TypeDeclarationStmt r = new TypeDeclarationStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				typeDecl
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(AssertStmt _n, Object _arg) {
-		Expression check = cloneNodes(_n.getCheck(), _arg);
-		Expression message = cloneNodes(_n.getMessage(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		AssertStmt r = new AssertStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				check, message
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(BlockStmt _n, Object _arg) {
-		List<Statement> stmts = visit(_n.getStmts(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		BlockStmt r = new BlockStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				stmts
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(LabeledStmt _n, Object _arg) {
-		Statement stmt = cloneNodes(_n.getStmt(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		LabeledStmt r = new LabeledStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getLabel(), stmt
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(EmptyStmt _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		EmptyStmt r = new EmptyStmt(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ExpressionStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpression(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ExpressionStmt r = new ExpressionStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				expr
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(SwitchStmt _n, Object _arg) {
-		Expression selector = cloneNodes(_n.getSelector(), _arg);
-		List<SwitchEntryStmt> entries = visit(_n.getEntries(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		SwitchStmt r = new SwitchStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				selector, entries
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(SwitchEntryStmt _n, Object _arg) {
-		Expression label = cloneNodes(_n.getLabel(), _arg);
-		List<Statement> stmts = visit(_n.getStmts(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		SwitchEntryStmt r = new SwitchEntryStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				label, stmts
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(BreakStmt _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		BreakStmt r = new BreakStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getId()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ReturnStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ReturnStmt r = new ReturnStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				expr
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(IfStmt _n, Object _arg) {
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Statement thenStmt = cloneNodes(_n.getThenStmt(), _arg);
-		Statement elseStmt = cloneNodes(_n.getElseStmt(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		IfStmt r = new IfStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				condition, thenStmt, elseStmt
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(WhileStmt _n, Object _arg) {
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		WhileStmt r = new WhileStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				condition, body
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ContinueStmt _n, Object _arg) {
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ContinueStmt r = new ContinueStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				_n.getId()
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(DoStmt _n, Object _arg) {
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Expression condition = cloneNodes(_n.getCondition(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		DoStmt r = new DoStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				body, condition
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ForeachStmt _n, Object _arg) {
-		VariableDeclarationExpr var = cloneNodes(_n.getVariable(), _arg);
-		Expression iterable = cloneNodes(_n.getIterable(), _arg);
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ForeachStmt r = new ForeachStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				var, iterable, body
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ForStmt _n, Object _arg) {
-		List<Expression> init = visit(_n.getInit(), _arg);
-		Expression compare = cloneNodes(_n.getCompare(), _arg);
-		List<Expression> update = visit(_n.getUpdate(), _arg);
-		Statement body = cloneNodes(_n.getBody(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ForStmt r = new ForStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				init, compare, update, body
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(ThrowStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		ThrowStmt r = new ThrowStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				expr
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(SynchronizedStmt _n, Object _arg) {
-		Expression expr = cloneNodes(_n.getExpr(), _arg);
-		BlockStmt block = cloneNodes(_n.getBlock(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		SynchronizedStmt r = new SynchronizedStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				expr, block
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(TryStmt _n, Object _arg) {
-		List<VariableDeclarationExpr> resources = visit(_n.getResources(),_arg);
-		BlockStmt tryBlock = cloneNodes(_n.getTryBlock(), _arg);
-		List<CatchClause> catchs = visit(_n.getCatchs(), _arg);
-		BlockStmt finallyBlock = cloneNodes(_n.getFinallyBlock(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		TryStmt r = new TryStmt(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				resources, tryBlock, catchs, finallyBlock
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(CatchClause _n, Object _arg) {
-		MultiTypeParameter except = cloneNodes(_n.getExcept(), _arg);
-		BlockStmt catchBlock = cloneNodes(_n.getCatchBlock(), _arg);
-		Comment comment = cloneNodes(_n.getComment(), _arg);
-
-		CatchClause r = new CatchClause(
-				_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
-				except.getModifiers(), except.getAnnotations(), except.getTypes(), except.getId(), catchBlock
-		);
-		r.setComment(comment);
-		return r;
-	}
-
-	@Override
-	public Node visit(LambdaExpr _n, Object _arg) {
-
-		List<Parameter> lambdaParameters = visit(_n.getParameters(), _arg);
-
-		Statement body = cloneNodes(_n.getBody(), _arg);
-
-		LambdaExpr r = new LambdaExpr(_n.getBeginLine(), _n.getBeginColumn(),
-				_n.getEndLine(), _n.getEndColumn(), lambdaParameters, body,
-				_n.isParametersEnclosed());
-
-		return r;
-	}
-
-	@Override
-	public Node visit(MethodReferenceExpr _n, Object arg) {
-
-		List<TypeParameter> typeParams = visit(_n.getTypeParameters(), arg);
-		Expression scope = cloneNodes(_n.getScope(), arg);
-
-		MethodReferenceExpr r = new MethodReferenceExpr(_n.getBeginLine(),
-				_n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), scope,
-				typeParams, _n.getIdentifier());
-		return r;
-	}
-
-	@Override
-	public Node visit(TypeExpr n, Object arg) {
-
-		Type t = cloneNodes(n.getType(), arg);
-
-		TypeExpr r = new TypeExpr(n.getBeginLine(), n.getBeginColumn(),
-				n.getEndLine(), n.getEndColumn(), t);
-
-		return r;
-	}
+        return r;
+    }
+
+    @Override
+    public Node visit(ArrayInitializerExpr _n, Object _arg) {
+        List<Expression> values = visit(_n.getValues(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ArrayInitializerExpr r = new ArrayInitializerExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                values
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(AssignExpr _n, Object _arg) {
+        Expression target = cloneNodes(_n.getTarget(), _arg);
+        Expression value = cloneNodes(_n.getValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        AssignExpr r = new AssignExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                target, value, _n.getOperator());
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(BinaryExpr _n, Object _arg) {
+        Expression left = cloneNodes(_n.getLeft(), _arg);
+        Expression right = cloneNodes(_n.getRight(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        BinaryExpr r = new BinaryExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                left, right, _n.getOperator()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(CastExpr _n, Object _arg) {
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        CastExpr r = new CastExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                type_, expr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ClassExpr _n, Object _arg) {
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ClassExpr r = new ClassExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                type_
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ConditionalExpr _n, Object _arg) {
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Expression thenExpr = cloneNodes(_n.getThenExpr(), _arg);
+        Expression elseExpr = cloneNodes(_n.getElseExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ConditionalExpr r = new ConditionalExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                condition, thenExpr, elseExpr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(EnclosedExpr _n, Object _arg) {
+        Expression inner = cloneNodes(_n.getInner(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        EnclosedExpr r = new EnclosedExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                inner
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(FieldAccessExpr _n, Object _arg) {
+        Expression scope = cloneNodes(_n.getScope(), _arg);
+        List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        FieldAccessExpr r = new FieldAccessExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                scope, typeArgs, _n.getField()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(InstanceOfExpr _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        InstanceOfExpr r = new InstanceOfExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                expr, type_
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(StringLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+        StringLiteralExpr r = new StringLiteralExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(IntegerLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        IntegerLiteralExpr r = new IntegerLiteralExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(LongLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        LongLiteralExpr r = new LongLiteralExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(IntegerLiteralMinValueExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        IntegerLiteralMinValueExpr r = new IntegerLiteralMinValueExpr(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(LongLiteralMinValueExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        LongLiteralMinValueExpr r = new LongLiteralMinValueExpr(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(CharLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        CharLiteralExpr r = new CharLiteralExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(DoubleLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        DoubleLiteralExpr r = new DoubleLiteralExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(BooleanLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        BooleanLiteralExpr r = new BooleanLiteralExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getValue()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(NullLiteralExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        NullLiteralExpr r = new NullLiteralExpr(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(MethodCallExpr _n, Object _arg) {
+        Expression scope = cloneNodes(_n.getScope(), _arg);
+        List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
+        List<Expression> args = visit(_n.getArgs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        MethodCallExpr r = new MethodCallExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                scope, typeArgs, _n.getName(), args
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(NameExpr _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        NameExpr r = new NameExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getName()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ObjectCreationExpr _n, Object _arg) {
+        Expression scope = cloneNodes(_n.getScope(), _arg);
+        ClassOrInterfaceType type_ = cloneNodes(_n.getType(), _arg);
+        List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
+        List<Expression> args = visit(_n.getArgs(), _arg);
+        List<BodyDeclaration> anonymousBody = visit(_n.getAnonymousClassBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ObjectCreationExpr r = new ObjectCreationExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                scope, type_, typeArgs, args, anonymousBody
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(QualifiedNameExpr _n, Object _arg) {
+        NameExpr scope = cloneNodes(_n.getQualifier(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        QualifiedNameExpr r = new QualifiedNameExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                scope, _n.getName()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ThisExpr _n, Object _arg) {
+        Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ThisExpr r = new ThisExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                classExpr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(SuperExpr _n, Object _arg) {
+        Expression classExpr = cloneNodes(_n.getClassExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        SuperExpr r = new SuperExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                classExpr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(UnaryExpr _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        UnaryExpr r = new UnaryExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                expr, _n.getOperator()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(VariableDeclarationExpr _n, Object _arg) {
+        List<AnnotationExpr> annotations = visit(_n.getAnnotations(), _arg);
+        Type type_ = cloneNodes(_n.getType(), _arg);
+        List<VariableDeclarator> vars = visit(_n.getVars(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        VariableDeclarationExpr r = new VariableDeclarationExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getModifiers(), annotations, type_, vars
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(MarkerAnnotationExpr _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        MarkerAnnotationExpr r = new MarkerAnnotationExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                name
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(SingleMemberAnnotationExpr _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        Expression memberValue = cloneNodes(_n.getMemberValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        SingleMemberAnnotationExpr r = new SingleMemberAnnotationExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                name, memberValue
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(NormalAnnotationExpr _n, Object _arg) {
+        NameExpr name = cloneNodes(_n.getName(), _arg);
+        List<MemberValuePair> pairs = visit(_n.getPairs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        NormalAnnotationExpr r = new NormalAnnotationExpr(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                name, pairs
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(MemberValuePair _n, Object _arg) {
+        Expression value = cloneNodes(_n.getValue(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        MemberValuePair r = new MemberValuePair(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getName(), value
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ExplicitConstructorInvocationStmt _n, Object _arg) {
+        List<Type> typeArgs = visit(_n.getTypeArgs(), _arg);
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        List<Expression> args = visit(_n.getArgs(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ExplicitConstructorInvocationStmt r = new ExplicitConstructorInvocationStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                typeArgs, _n.isThis(), expr, args
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(TypeDeclarationStmt _n, Object _arg) {
+        TypeDeclaration typeDecl = cloneNodes(_n.getTypeDeclaration(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        TypeDeclarationStmt r = new TypeDeclarationStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                typeDecl
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(AssertStmt _n, Object _arg) {
+        Expression check = cloneNodes(_n.getCheck(), _arg);
+        Expression message = cloneNodes(_n.getMessage(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        AssertStmt r = new AssertStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                check, message
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(BlockStmt _n, Object _arg) {
+        List<Statement> stmts = visit(_n.getStmts(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        BlockStmt r = new BlockStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                stmts
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(LabeledStmt _n, Object _arg) {
+        Statement stmt = cloneNodes(_n.getStmt(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        LabeledStmt r = new LabeledStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getLabel(), stmt
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(EmptyStmt _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        EmptyStmt r = new EmptyStmt(_n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn());
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ExpressionStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpression(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ExpressionStmt r = new ExpressionStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                expr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(SwitchStmt _n, Object _arg) {
+        Expression selector = cloneNodes(_n.getSelector(), _arg);
+        List<SwitchEntryStmt> entries = visit(_n.getEntries(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        SwitchStmt r = new SwitchStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                selector, entries
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(SwitchEntryStmt _n, Object _arg) {
+        Expression label = cloneNodes(_n.getLabel(), _arg);
+        List<Statement> stmts = visit(_n.getStmts(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        SwitchEntryStmt r = new SwitchEntryStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                label, stmts
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(BreakStmt _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        BreakStmt r = new BreakStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getId()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ReturnStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ReturnStmt r = new ReturnStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                expr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(IfStmt _n, Object _arg) {
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Statement thenStmt = cloneNodes(_n.getThenStmt(), _arg);
+        Statement elseStmt = cloneNodes(_n.getElseStmt(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        IfStmt r = new IfStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                condition, thenStmt, elseStmt
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(WhileStmt _n, Object _arg) {
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        WhileStmt r = new WhileStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                condition, body
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ContinueStmt _n, Object _arg) {
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ContinueStmt r = new ContinueStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                _n.getId()
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(DoStmt _n, Object _arg) {
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Expression condition = cloneNodes(_n.getCondition(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        DoStmt r = new DoStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                body, condition
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ForeachStmt _n, Object _arg) {
+        VariableDeclarationExpr var = cloneNodes(_n.getVariable(), _arg);
+        Expression iterable = cloneNodes(_n.getIterable(), _arg);
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ForeachStmt r = new ForeachStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                var, iterable, body
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ForStmt _n, Object _arg) {
+        List<Expression> init = visit(_n.getInit(), _arg);
+        Expression compare = cloneNodes(_n.getCompare(), _arg);
+        List<Expression> update = visit(_n.getUpdate(), _arg);
+        Statement body = cloneNodes(_n.getBody(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ForStmt r = new ForStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                init, compare, update, body
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(ThrowStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        ThrowStmt r = new ThrowStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                expr
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(SynchronizedStmt _n, Object _arg) {
+        Expression expr = cloneNodes(_n.getExpr(), _arg);
+        BlockStmt block = cloneNodes(_n.getBlock(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        SynchronizedStmt r = new SynchronizedStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                expr, block
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(TryStmt _n, Object _arg) {
+        List<VariableDeclarationExpr> resources = visit(_n.getResources(),_arg);
+        BlockStmt tryBlock = cloneNodes(_n.getTryBlock(), _arg);
+        List<CatchClause> catchs = visit(_n.getCatchs(), _arg);
+        BlockStmt finallyBlock = cloneNodes(_n.getFinallyBlock(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        TryStmt r = new TryStmt(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                resources, tryBlock, catchs, finallyBlock
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(CatchClause _n, Object _arg) {
+        MultiTypeParameter except = cloneNodes(_n.getExcept(), _arg);
+        BlockStmt catchBlock = cloneNodes(_n.getCatchBlock(), _arg);
+        Comment comment = cloneNodes(_n.getComment(), _arg);
+
+        CatchClause r = new CatchClause(
+                _n.getBeginLine(), _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(),
+                except.getModifiers(), except.getAnnotations(), except.getTypes(), except.getId(), catchBlock
+        );
+        r.setComment(comment);
+        return r;
+    }
+
+    @Override
+    public Node visit(LambdaExpr _n, Object _arg) {
+
+        List<Parameter> lambdaParameters = visit(_n.getParameters(), _arg);
+
+        Statement body = cloneNodes(_n.getBody(), _arg);
+
+        LambdaExpr r = new LambdaExpr(_n.getBeginLine(), _n.getBeginColumn(),
+                _n.getEndLine(), _n.getEndColumn(), lambdaParameters, body,
+                _n.isParametersEnclosed());
+
+        return r;
+    }
+
+    @Override
+    public Node visit(MethodReferenceExpr _n, Object arg) {
+
+        List<TypeParameter> typeParams = visit(_n.getTypeParameters(), arg);
+        Expression scope = cloneNodes(_n.getScope(), arg);
+
+        MethodReferenceExpr r = new MethodReferenceExpr(_n.getBeginLine(),
+                _n.getBeginColumn(), _n.getEndLine(), _n.getEndColumn(), scope,
+                typeParams, _n.getIdentifier());
+        return r;
+    }
+
+    @Override
+    public Node visit(TypeExpr n, Object arg) {
+
+        Type t = cloneNodes(n.getType(), arg);
+
+        TypeExpr r = new TypeExpr(n.getBeginLine(), n.getBeginColumn(),
+                n.getEndLine(), n.getEndColumn(), t);
+
+        return r;
+    }
 
     public <T extends Node> List<T> visit(List<T> _nodes, Object _arg) {
         if (_nodes == null)

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/DumpVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/DumpVisitor.java
@@ -97,963 +97,963 @@ public final class DumpVisitor implements VoidVisitor<Object> {
         this.printComments = printComments;
     }
 
-	private static class SourcePrinter {
+    private static class SourcePrinter {
 
-		private int level = 0;
+        private int level = 0;
 
-		private boolean indented = false;
+        private boolean indented = false;
 
-		private final StringBuilder buf = new StringBuilder();
+        private final StringBuilder buf = new StringBuilder();
 
-		public void indent() {
-			level++;
-		}
+        public void indent() {
+            level++;
+        }
 
-		public void unindent() {
-			level--;
-		}
+        public void unindent() {
+            level--;
+        }
 
-		private void makeIndent() {
-			for (int i = 0; i < level; i++) {
-				buf.append("    ");
-			}
-		}
+        private void makeIndent() {
+            for (int i = 0; i < level; i++) {
+                buf.append("    ");
+            }
+        }
 
-		public void print(final String arg) {
-			if (!indented) {
-				makeIndent();
-				indented = true;
-			}
-			buf.append(arg);
-		}
+        public void print(final String arg) {
+            if (!indented) {
+                makeIndent();
+                indented = true;
+            }
+            buf.append(arg);
+        }
 
-		public void printLn(final String arg) {
-			print(arg);
-			printLn();
-		}
+        public void printLn(final String arg) {
+            print(arg);
+            printLn();
+        }
 
-		public void printLn() {
-			buf.append(System.getProperty("line.separator"));
-			indented = false;
-		}
+        public void printLn() {
+            buf.append(System.getProperty("line.separator"));
+            indented = false;
+        }
 
-		public String getSource() {
-			return buf.toString();
-		}
+        public String getSource() {
+            return buf.toString();
+        }
 
-		@Override public String toString() {
-			return getSource();
-		}
-	}
+        @Override public String toString() {
+            return getSource();
+        }
+    }
 
-	private final SourcePrinter printer = new SourcePrinter();
+    private final SourcePrinter printer = new SourcePrinter();
 
-	public String getSource() {
-		return printer.getSource();
-	}
+    public String getSource() {
+        return printer.getSource();
+    }
 
-	private void printModifiers(final int modifiers) {
-		if (ModifierSet.isPrivate(modifiers)) {
-			printer.print("private ");
-		}
-		if (ModifierSet.isProtected(modifiers)) {
-			printer.print("protected ");
-		}
-		if (ModifierSet.isPublic(modifiers)) {
-			printer.print("public ");
-		}
-		if (ModifierSet.isAbstract(modifiers)) {
-			printer.print("abstract ");
-		}
-		if (ModifierSet.isStatic(modifiers)) {
-			printer.print("static ");
-		}
-		if (ModifierSet.isFinal(modifiers)) {
-			printer.print("final ");
-		}
-		if (ModifierSet.isNative(modifiers)) {
-			printer.print("native ");
-		}
-		if (ModifierSet.isStrictfp(modifiers)) {
-			printer.print("strictfp ");
-		}
-		if (ModifierSet.isSynchronized(modifiers)) {
-			printer.print("synchronized ");
-		}
-		if (ModifierSet.isTransient(modifiers)) {
-			printer.print("transient ");
-		}
-		if (ModifierSet.isVolatile(modifiers)) {
-			printer.print("volatile ");
-		}
-	}
+    private void printModifiers(final int modifiers) {
+        if (ModifierSet.isPrivate(modifiers)) {
+            printer.print("private ");
+        }
+        if (ModifierSet.isProtected(modifiers)) {
+            printer.print("protected ");
+        }
+        if (ModifierSet.isPublic(modifiers)) {
+            printer.print("public ");
+        }
+        if (ModifierSet.isAbstract(modifiers)) {
+            printer.print("abstract ");
+        }
+        if (ModifierSet.isStatic(modifiers)) {
+            printer.print("static ");
+        }
+        if (ModifierSet.isFinal(modifiers)) {
+            printer.print("final ");
+        }
+        if (ModifierSet.isNative(modifiers)) {
+            printer.print("native ");
+        }
+        if (ModifierSet.isStrictfp(modifiers)) {
+            printer.print("strictfp ");
+        }
+        if (ModifierSet.isSynchronized(modifiers)) {
+            printer.print("synchronized ");
+        }
+        if (ModifierSet.isTransient(modifiers)) {
+            printer.print("transient ");
+        }
+        if (ModifierSet.isVolatile(modifiers)) {
+            printer.print("volatile ");
+        }
+    }
 
-	private void printMembers(final List<BodyDeclaration> members, final Object arg) {
-		for (final BodyDeclaration member : members) {
-			printer.printLn();
-			member.accept(this, arg);
-			printer.printLn();
-		}
-	}
+    private void printMembers(final List<BodyDeclaration> members, final Object arg) {
+        for (final BodyDeclaration member : members) {
+            printer.printLn();
+            member.accept(this, arg);
+            printer.printLn();
+        }
+    }
 
-	private void printMemberAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
-		if (!isNullOrEmpty(annotations)) {
-			for (final AnnotationExpr a : annotations) {
-				a.accept(this, arg);
-				printer.printLn();
-			}
-		}
-	}
+    private void printMemberAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
+        if (!isNullOrEmpty(annotations)) {
+            for (final AnnotationExpr a : annotations) {
+                a.accept(this, arg);
+                printer.printLn();
+            }
+        }
+    }
 
-	private void printAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
-		if (!isNullOrEmpty(annotations)) {
-			for (final AnnotationExpr a : annotations) {
-				a.accept(this, arg);
-				printer.print(" ");
-			}
-		}
-	}
+    private void printAnnotations(final List<AnnotationExpr> annotations, final Object arg) {
+        if (!isNullOrEmpty(annotations)) {
+            for (final AnnotationExpr a : annotations) {
+                a.accept(this, arg);
+                printer.print(" ");
+            }
+        }
+    }
 
-	private void printTypeArgs(final List<Type> args, final Object arg) {
+    private void printTypeArgs(final List<Type> args, final Object arg) {
         if (!isNullOrEmpty(args)) {
-			printer.print("<");
-			for (final Iterator<Type> i = args.iterator(); i.hasNext();) {
-				final Type t = i.next();
-				t.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-			printer.print(">");
-		}
-	}
+            printer.print("<");
+            for (final Iterator<Type> i = args.iterator(); i.hasNext();) {
+                final Type t = i.next();
+                t.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+            printer.print(">");
+        }
+    }
 
-	private void printTypeParameters(final List<TypeParameter> args, final Object arg) {
+    private void printTypeParameters(final List<TypeParameter> args, final Object arg) {
         if (!isNullOrEmpty(args)) {
-			printer.print("<");
-			for (final Iterator<TypeParameter> i = args.iterator(); i.hasNext();) {
-				final TypeParameter t = i.next();
-				t.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-			printer.print(">");
-		}
-	}
+            printer.print("<");
+            for (final Iterator<TypeParameter> i = args.iterator(); i.hasNext();) {
+                final TypeParameter t = i.next();
+                t.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+            printer.print(">");
+        }
+    }
 
-	private void printArguments(final List<Expression> args, final Object arg) {
-		printer.print("(");
+    private void printArguments(final List<Expression> args, final Object arg) {
+        printer.print("(");
         if (!isNullOrEmpty(args)) {
-			for (final Iterator<Expression> i = args.iterator(); i.hasNext();) {
-				final Expression e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
-	}
+            for (final Iterator<Expression> i = args.iterator(); i.hasNext();) {
+                final Expression e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
+    }
 
-	private void printJavadoc(final JavadocComment javadoc, final Object arg) {
-		if (javadoc != null) {
-			javadoc.accept(this, arg);
-		}
-	}
+    private void printJavadoc(final JavadocComment javadoc, final Object arg) {
+        if (javadoc != null) {
+            javadoc.accept(this, arg);
+        }
+    }
 
-	private void printJavaComment(final Comment javacomment, final Object arg) {
-		if (javacomment != null) {
-			javacomment.accept(this, arg);
-		}
-	}
+    private void printJavaComment(final Comment javacomment, final Object arg) {
+        if (javacomment != null) {
+            javacomment.accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final CompilationUnit n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
+    @Override public void visit(final CompilationUnit n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
 
-		if (n.getPackage() != null) {
-			n.getPackage().accept(this, arg);
-		}
+        if (n.getPackage() != null) {
+            n.getPackage().accept(this, arg);
+        }
 
-		if (n.getImports() != null) {
-			for (final ImportDeclaration i : n.getImports()) {
-				i.accept(this, arg);
-			}
-			printer.printLn();
-		}
+        if (n.getImports() != null) {
+            for (final ImportDeclaration i : n.getImports()) {
+                i.accept(this, arg);
+            }
+            printer.printLn();
+        }
 
-		if (n.getTypes() != null) {
-			for (final Iterator<TypeDeclaration> i = n.getTypes().iterator(); i.hasNext();) {
-				i.next().accept(this, arg);
-				printer.printLn();
-				if (i.hasNext()) {
-					printer.printLn();
-				}
-			}
-		}
-
-        printOrphanCommentsEnding(n);
-	}
-
-	@Override public void visit(final PackageDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), arg);
-		printer.print("package ");
-		n.getName().accept(this, arg);
-		printer.printLn(";");
-		printer.printLn();
+        if (n.getTypes() != null) {
+            for (final Iterator<TypeDeclaration> i = n.getTypes().iterator(); i.hasNext();) {
+                i.next().accept(this, arg);
+                printer.printLn();
+                if (i.hasNext()) {
+                    printer.printLn();
+                }
+            }
+        }
 
         printOrphanCommentsEnding(n);
-	}
+    }
 
-	@Override public void visit(final NameExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getName());
-
-        printOrphanCommentsEnding(n);
-	}
-
-	@Override public void visit(final QualifiedNameExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getQualifier().accept(this, arg);
-		printer.print(".");
-		printer.print(n.getName());
+    @Override public void visit(final PackageDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), arg);
+        printer.print("package ");
+        n.getName().accept(this, arg);
+        printer.printLn(";");
+        printer.printLn();
 
         printOrphanCommentsEnding(n);
-	}
+    }
 
-	@Override public void visit(final ImportDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("import ");
-		if (n.isStatic()) {
-			printer.print("static ");
-		}
-		n.getName().accept(this, arg);
-		if (n.isAsterisk()) {
-			printer.print(".*");
-		}
-		printer.printLn(";");
+    @Override public void visit(final NameExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getName());
 
         printOrphanCommentsEnding(n);
-	}
+    }
 
-	@Override public void visit(final ClassOrInterfaceDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
+    @Override public void visit(final QualifiedNameExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getQualifier().accept(this, arg);
+        printer.print(".");
+        printer.print(n.getName());
 
-		if (n.isInterface()) {
-			printer.print("interface ");
-		} else {
-			printer.print("class ");
-		}
+        printOrphanCommentsEnding(n);
+    }
 
-		printer.print(n.getName());
+    @Override public void visit(final ImportDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("import ");
+        if (n.isStatic()) {
+            printer.print("static ");
+        }
+        n.getName().accept(this, arg);
+        if (n.isAsterisk()) {
+            printer.print(".*");
+        }
+        printer.printLn(";");
 
-		printTypeParameters(n.getTypeParameters(), arg);
+        printOrphanCommentsEnding(n);
+    }
 
-		if (!isNullOrEmpty(n.getExtends())) {
-			printer.print(" extends ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getExtends().iterator(); i.hasNext();) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
+    @Override public void visit(final ClassOrInterfaceDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
 
-		if (!isNullOrEmpty(n.getImplements())) {
-			printer.print(" implements ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext();) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
+        if (n.isInterface()) {
+            printer.print("interface ");
+        } else {
+            printer.print("class ");
+        }
 
-		printer.printLn(" {");
-		printer.indent();
-		if (!isNullOrEmpty(n.getMembers())) {
-			printMembers(n.getMembers(), arg);
-		}
+        printer.print(n.getName());
+
+        printTypeParameters(n.getTypeParameters(), arg);
+
+        if (!isNullOrEmpty(n.getExtends())) {
+            printer.print(" extends ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getExtends().iterator(); i.hasNext();) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+
+        if (!isNullOrEmpty(n.getImplements())) {
+            printer.print(" implements ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext();) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+
+        printer.printLn(" {");
+        printer.indent();
+        if (!isNullOrEmpty(n.getMembers())) {
+            printMembers(n.getMembers(), arg);
+        }
 
         printOrphanCommentsEnding(n);
 
-		printer.unindent();
-		printer.print("}");
-	}
+        printer.unindent();
+        printer.print("}");
+    }
 
-	@Override public void visit(final EmptyTypeDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printer.print(";");
+    @Override public void visit(final EmptyTypeDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printer.print(";");
 
         printOrphanCommentsEnding(n);
-	}
+    }
 
-	@Override public void visit(final JavadocComment n, final Object arg) {
-		printer.print("/**");
-		printer.print(n.getContent());
-		printer.printLn("*/");
-	}
+    @Override public void visit(final JavadocComment n, final Object arg) {
+        printer.print("/**");
+        printer.print(n.getContent());
+        printer.printLn("*/");
+    }
 
-	@Override public void visit(final ClassOrInterfaceType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
+    @Override public void visit(final ClassOrInterfaceType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
 
-		if (n.getAnnotations() != null) {
-			for (AnnotationExpr ae : n.getAnnotations()) {
-				ae.accept(this, arg);
-				printer.print(" ");
-			}
-		}
+        if (n.getAnnotations() != null) {
+            for (AnnotationExpr ae : n.getAnnotations()) {
+                ae.accept(this, arg);
+                printer.print(" ");
+            }
+        }
 
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-			printer.print(".");
-		}
-		printer.print(n.getName());
-		printTypeArgs(n.getTypeArgs(), arg);
-	}
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+            printer.print(".");
+        }
+        printer.print(n.getName());
+        printTypeArgs(n.getTypeArgs(), arg);
+    }
 
-	@Override public void visit(final TypeParameter n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (AnnotationExpr ann : n.getAnnotations()) {
-				ann.accept(this, arg);
-				printer.print(" ");
-			}
-		}
-		printer.print(n.getName());
-		if (n.getTypeBound() != null) {
-			printer.print(" extends ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getTypeBound().iterator(); i.hasNext();) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(" & ");
-				}
-			}
-		}
-	}
+    @Override public void visit(final TypeParameter n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (AnnotationExpr ann : n.getAnnotations()) {
+                ann.accept(this, arg);
+                printer.print(" ");
+            }
+        }
+        printer.print(n.getName());
+        if (n.getTypeBound() != null) {
+            printer.print(" extends ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getTypeBound().iterator(); i.hasNext();) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(" & ");
+                }
+            }
+        }
+    }
 
-	@Override public void visit(final PrimitiveType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (AnnotationExpr ae : n.getAnnotations()) {
-				ae.accept(this, arg);
-				printer.print(" ");
-			}
-		}
-		switch (n.getType()) {
-		case Boolean:
-			printer.print("boolean");
-			break;
-		case Byte:
-			printer.print("byte");
-			break;
-		case Char:
-			printer.print("char");
-			break;
-		case Double:
-			printer.print("double");
-			break;
-		case Float:
-			printer.print("float");
-			break;
-		case Int:
-			printer.print("int");
-			break;
-		case Long:
-			printer.print("long");
-			break;
-		case Short:
-			printer.print("short");
-			break;
-		}
-	}
+    @Override public void visit(final PrimitiveType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (AnnotationExpr ae : n.getAnnotations()) {
+                ae.accept(this, arg);
+                printer.print(" ");
+            }
+        }
+        switch (n.getType()) {
+        case Boolean:
+            printer.print("boolean");
+            break;
+        case Byte:
+            printer.print("byte");
+            break;
+        case Char:
+            printer.print("char");
+            break;
+        case Double:
+            printer.print("double");
+            break;
+        case Float:
+            printer.print("float");
+            break;
+        case Int:
+            printer.print("int");
+            break;
+        case Long:
+            printer.print("long");
+            break;
+        case Short:
+            printer.print("short");
+            break;
+        }
+    }
 
-	@Override public void visit(final ReferenceType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (AnnotationExpr ae : n.getAnnotations()) {
-				ae.accept(this, arg);
-				printer.print(" ");
-			}
-		}
-		n.getType().accept(this, arg);
-		List<List<AnnotationExpr>> arraysAnnotations = n.getArraysAnnotations();
-		for (int i = 0; i < n.getArrayCount(); i++) {
-			if (arraysAnnotations != null && i < arraysAnnotations.size()) {
-				List<AnnotationExpr> annotations = arraysAnnotations.get(i);
-				if (annotations != null) {
-					for (AnnotationExpr ae : annotations) {
-						printer.print(" ");
-						ae.accept(this, arg);
+    @Override public void visit(final ReferenceType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (AnnotationExpr ae : n.getAnnotations()) {
+                ae.accept(this, arg);
+                printer.print(" ");
+            }
+        }
+        n.getType().accept(this, arg);
+        List<List<AnnotationExpr>> arraysAnnotations = n.getArraysAnnotations();
+        for (int i = 0; i < n.getArrayCount(); i++) {
+            if (arraysAnnotations != null && i < arraysAnnotations.size()) {
+                List<AnnotationExpr> annotations = arraysAnnotations.get(i);
+                if (annotations != null) {
+                    for (AnnotationExpr ae : annotations) {
+                        printer.print(" ");
+                        ae.accept(this, arg);
 
-					}
-				}
-			}
-			printer.print("[]");
-		}
-	}
+                    }
+                }
+            }
+            printer.print("[]");
+        }
+    }
 
-	@Override public void visit(final WildcardType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (AnnotationExpr ae : n.getAnnotations()) {
-				printer.print(" ");
-				ae.accept(this, arg);
-			}
-		}
-		printer.print("?");
-		if (n.getExtends() != null) {
-			printer.print(" extends ");
-			n.getExtends().accept(this, arg);
-		}
-		if (n.getSuper() != null) {
-			printer.print(" super ");
-			n.getSuper().accept(this, arg);
-		}
-	}
+    @Override public void visit(final WildcardType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (AnnotationExpr ae : n.getAnnotations()) {
+                printer.print(" ");
+                ae.accept(this, arg);
+            }
+        }
+        printer.print("?");
+        if (n.getExtends() != null) {
+            printer.print(" extends ");
+            n.getExtends().accept(this, arg);
+        }
+        if (n.getSuper() != null) {
+            printer.print(" super ");
+            n.getSuper().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final UnknownType n, final Object arg) {
-		// Nothing to dump
-	}
+    @Override public void visit(final UnknownType n, final Object arg) {
+        // Nothing to dump
+    }
 
-	@Override public void visit(final FieldDeclaration n, final Object arg) {
+    @Override public void visit(final FieldDeclaration n, final Object arg) {
         printOrphanCommentsBeforeThisChildNode(n);
 
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-		n.getType().accept(this, arg);
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+        n.getType().accept(this, arg);
 
-		printer.print(" ");
-		for (final Iterator<VariableDeclarator> i = n.getVariables().iterator(); i.hasNext();) {
-			final VariableDeclarator var = i.next();
-			var.accept(this, arg);
-			if (i.hasNext()) {
-				printer.print(", ");
-			}
-		}
+        printer.print(" ");
+        for (final Iterator<VariableDeclarator> i = n.getVariables().iterator(); i.hasNext();) {
+            final VariableDeclarator var = i.next();
+            var.accept(this, arg);
+            if (i.hasNext()) {
+                printer.print(", ");
+            }
+        }
 
-		printer.print(";");
-	}
+        printer.print(";");
+    }
 
-	@Override public void visit(final VariableDeclarator n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getId().accept(this, arg);
-		if (n.getInit() != null) {
-			printer.print(" = ");
-			n.getInit().accept(this, arg);
-		}
-	}
+    @Override public void visit(final VariableDeclarator n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getId().accept(this, arg);
+        if (n.getInit() != null) {
+            printer.print(" = ");
+            n.getInit().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final VariableDeclaratorId n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getName());
-		for (int i = 0; i < n.getArrayCount(); i++) {
-			printer.print("[]");
-		}
-	}
+    @Override public void visit(final VariableDeclaratorId n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getName());
+        for (int i = 0; i < n.getArrayCount(); i++) {
+            printer.print("[]");
+        }
+    }
 
-	@Override public void visit(final ArrayInitializerExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("{");
-		if (n.getValues() != null) {
-			printer.print(" ");
-			for (final Iterator<Expression> i = n.getValues().iterator(); i.hasNext();) {
-				final Expression expr = i.next();
-				expr.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-			printer.print(" ");
-		}
-		printer.print("}");
-	}
+    @Override public void visit(final ArrayInitializerExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("{");
+        if (n.getValues() != null) {
+            printer.print(" ");
+            for (final Iterator<Expression> i = n.getValues().iterator(); i.hasNext();) {
+                final Expression expr = i.next();
+                expr.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+            printer.print(" ");
+        }
+        printer.print("}");
+    }
 
-	@Override public void visit(final VoidType n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("void");
-	}
+    @Override public void visit(final VoidType n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("void");
+    }
 
-	@Override public void visit(final ArrayAccessExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		printer.print("[");
-		n.getIndex().accept(this, arg);
-		printer.print("]");
-	}
+    @Override public void visit(final ArrayAccessExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        printer.print("[");
+        n.getIndex().accept(this, arg);
+        printer.print("]");
+    }
 
-	@Override public void visit(final ArrayCreationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("new ");
-		n.getType().accept(this, arg);
-		List<List<AnnotationExpr>> arraysAnnotations = n.getArraysAnnotations();
-		if (n.getDimensions() != null) {
-			int j = 0;
-			for (final Expression dim : n.getDimensions()) {
+    @Override public void visit(final ArrayCreationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("new ");
+        n.getType().accept(this, arg);
+        List<List<AnnotationExpr>> arraysAnnotations = n.getArraysAnnotations();
+        if (n.getDimensions() != null) {
+            int j = 0;
+            for (final Expression dim : n.getDimensions()) {
 
-				if (arraysAnnotations != null && j < arraysAnnotations.size()) {
-					List<AnnotationExpr> annotations = arraysAnnotations.get(j);
-					if (annotations != null) {
-						for (AnnotationExpr ae : annotations) {
-							printer.print(" ");
-							ae.accept(this, arg);
-						}
-					}
-				}
-				printer.print("[");
-				dim.accept(this, arg);
-				printer.print("]");
-				j++;
-			}
-			for (int i = 0; i < n.getArrayCount(); i++) {
-				if (arraysAnnotations != null && i < arraysAnnotations.size()) {
+                if (arraysAnnotations != null && j < arraysAnnotations.size()) {
+                    List<AnnotationExpr> annotations = arraysAnnotations.get(j);
+                    if (annotations != null) {
+                        for (AnnotationExpr ae : annotations) {
+                            printer.print(" ");
+                            ae.accept(this, arg);
+                        }
+                    }
+                }
+                printer.print("[");
+                dim.accept(this, arg);
+                printer.print("]");
+                j++;
+            }
+            for (int i = 0; i < n.getArrayCount(); i++) {
+                if (arraysAnnotations != null && i < arraysAnnotations.size()) {
 
-					List<AnnotationExpr> annotations = arraysAnnotations.get(i);
-					if (annotations != null) {
-						for (AnnotationExpr ae : annotations) {
-							printer.print(" ");
-							ae.accept(this, arg);
+                    List<AnnotationExpr> annotations = arraysAnnotations.get(i);
+                    if (annotations != null) {
+                        for (AnnotationExpr ae : annotations) {
+                            printer.print(" ");
+                            ae.accept(this, arg);
 
-						}
-					}
-				}
-				printer.print("[]");
-			}
+                        }
+                    }
+                }
+                printer.print("[]");
+            }
 
-		} else {
-			for (int i = 0; i < n.getArrayCount(); i++) {
-				if (arraysAnnotations != null && i < arraysAnnotations.size()) {
-					List<AnnotationExpr> annotations = arraysAnnotations.get(i);
-					if (annotations != null) {
-						for (AnnotationExpr ae : annotations) {
-							ae.accept(this, arg);
-							printer.print(" ");
-						}
-					}
-				}
-				printer.print("[]");
-			}
-			printer.print(" ");
-			n.getInitializer().accept(this, arg);
-		}
-	}
+        } else {
+            for (int i = 0; i < n.getArrayCount(); i++) {
+                if (arraysAnnotations != null && i < arraysAnnotations.size()) {
+                    List<AnnotationExpr> annotations = arraysAnnotations.get(i);
+                    if (annotations != null) {
+                        for (AnnotationExpr ae : annotations) {
+                            ae.accept(this, arg);
+                            printer.print(" ");
+                        }
+                    }
+                }
+                printer.print("[]");
+            }
+            printer.print(" ");
+            n.getInitializer().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final AssignExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getTarget().accept(this, arg);
-		printer.print(" ");
-		switch (n.getOperator()) {
-		case assign:
-			printer.print("=");
-			break;
-		case and:
-			printer.print("&=");
-			break;
-		case or:
-			printer.print("|=");
-			break;
-		case xor:
-			printer.print("^=");
-			break;
-		case plus:
-			printer.print("+=");
-			break;
-		case minus:
-			printer.print("-=");
-			break;
-		case rem:
-			printer.print("%=");
-			break;
-		case slash:
-			printer.print("/=");
-			break;
-		case star:
-			printer.print("*=");
-			break;
-		case lShift:
-			printer.print("<<=");
-			break;
-		case rSignedShift:
-			printer.print(">>=");
-			break;
-		case rUnsignedShift:
-			printer.print(">>>=");
-			break;
-		}
-		printer.print(" ");
-		n.getValue().accept(this, arg);
-	}
+    @Override public void visit(final AssignExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getTarget().accept(this, arg);
+        printer.print(" ");
+        switch (n.getOperator()) {
+        case assign:
+            printer.print("=");
+            break;
+        case and:
+            printer.print("&=");
+            break;
+        case or:
+            printer.print("|=");
+            break;
+        case xor:
+            printer.print("^=");
+            break;
+        case plus:
+            printer.print("+=");
+            break;
+        case minus:
+            printer.print("-=");
+            break;
+        case rem:
+            printer.print("%=");
+            break;
+        case slash:
+            printer.print("/=");
+            break;
+        case star:
+            printer.print("*=");
+            break;
+        case lShift:
+            printer.print("<<=");
+            break;
+        case rSignedShift:
+            printer.print(">>=");
+            break;
+        case rUnsignedShift:
+            printer.print(">>>=");
+            break;
+        }
+        printer.print(" ");
+        n.getValue().accept(this, arg);
+    }
 
-	@Override public void visit(final BinaryExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getLeft().accept(this, arg);
-		printer.print(" ");
-		switch (n.getOperator()) {
-		case or:
-			printer.print("||");
-			break;
-		case and:
-			printer.print("&&");
-			break;
-		case binOr:
-			printer.print("|");
-			break;
-		case binAnd:
-			printer.print("&");
-			break;
-		case xor:
-			printer.print("^");
-			break;
-		case equals:
-			printer.print("==");
-			break;
-		case notEquals:
-			printer.print("!=");
-			break;
-		case less:
-			printer.print("<");
-			break;
-		case greater:
-			printer.print(">");
-			break;
-		case lessEquals:
-			printer.print("<=");
-			break;
-		case greaterEquals:
-			printer.print(">=");
-			break;
-		case lShift:
-			printer.print("<<");
-			break;
-		case rSignedShift:
-			printer.print(">>");
-			break;
-		case rUnsignedShift:
-			printer.print(">>>");
-			break;
-		case plus:
-			printer.print("+");
-			break;
-		case minus:
-			printer.print("-");
-			break;
-		case times:
-			printer.print("*");
-			break;
-		case divide:
-			printer.print("/");
-			break;
-		case remainder:
-			printer.print("%");
-			break;
-		}
-		printer.print(" ");
-		n.getRight().accept(this, arg);
-	}
+    @Override public void visit(final BinaryExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getLeft().accept(this, arg);
+        printer.print(" ");
+        switch (n.getOperator()) {
+        case or:
+            printer.print("||");
+            break;
+        case and:
+            printer.print("&&");
+            break;
+        case binOr:
+            printer.print("|");
+            break;
+        case binAnd:
+            printer.print("&");
+            break;
+        case xor:
+            printer.print("^");
+            break;
+        case equals:
+            printer.print("==");
+            break;
+        case notEquals:
+            printer.print("!=");
+            break;
+        case less:
+            printer.print("<");
+            break;
+        case greater:
+            printer.print(">");
+            break;
+        case lessEquals:
+            printer.print("<=");
+            break;
+        case greaterEquals:
+            printer.print(">=");
+            break;
+        case lShift:
+            printer.print("<<");
+            break;
+        case rSignedShift:
+            printer.print(">>");
+            break;
+        case rUnsignedShift:
+            printer.print(">>>");
+            break;
+        case plus:
+            printer.print("+");
+            break;
+        case minus:
+            printer.print("-");
+            break;
+        case times:
+            printer.print("*");
+            break;
+        case divide:
+            printer.print("/");
+            break;
+        case remainder:
+            printer.print("%");
+            break;
+        }
+        printer.print(" ");
+        n.getRight().accept(this, arg);
+    }
 
-	@Override public void visit(final CastExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("(");
-		n.getType().accept(this, arg);
-		printer.print(") ");
-		n.getExpr().accept(this, arg);
-	}
+    @Override public void visit(final CastExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("(");
+        n.getType().accept(this, arg);
+        printer.print(") ");
+        n.getExpr().accept(this, arg);
+    }
 
-	@Override public void visit(final ClassExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-		printer.print(".class");
-	}
+    @Override public void visit(final ClassExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+        printer.print(".class");
+    }
 
-	@Override public void visit(final ConditionalExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		printer.print(" ? ");
-		n.getThenExpr().accept(this, arg);
-		printer.print(" : ");
-		n.getElseExpr().accept(this, arg);
-	}
+    @Override public void visit(final ConditionalExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        printer.print(" ? ");
+        n.getThenExpr().accept(this, arg);
+        printer.print(" : ");
+        n.getElseExpr().accept(this, arg);
+    }
 
-	@Override public void visit(final EnclosedExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("(");
-		if (n.getInner() != null) {
-		n.getInner().accept(this, arg);
-		}
-		printer.print(")");
-	}
+    @Override public void visit(final EnclosedExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("(");
+        if (n.getInner() != null) {
+        n.getInner().accept(this, arg);
+        }
+        printer.print(")");
+    }
 
-	@Override public void visit(final FieldAccessExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getScope().accept(this, arg);
-		printer.print(".");
-		printer.print(n.getField());
-	}
+    @Override public void visit(final FieldAccessExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getScope().accept(this, arg);
+        printer.print(".");
+        printer.print(n.getField());
+    }
 
-	@Override public void visit(final InstanceOfExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-		printer.print(" instanceof ");
-		n.getType().accept(this, arg);
-	}
+    @Override public void visit(final InstanceOfExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+        printer.print(" instanceof ");
+        n.getType().accept(this, arg);
+    }
 
-	@Override public void visit(final CharLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("'");
-		printer.print(n.getValue());
-		printer.print("'");
-	}
+    @Override public void visit(final CharLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("'");
+        printer.print(n.getValue());
+        printer.print("'");
+    }
 
-	@Override public void visit(final DoubleLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
+    @Override public void visit(final DoubleLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
 
-	@Override public void visit(final IntegerLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
+    @Override public void visit(final IntegerLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
 
-	@Override public void visit(final LongLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
+    @Override public void visit(final LongLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
 
-	@Override public void visit(final IntegerLiteralMinValueExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
+    @Override public void visit(final IntegerLiteralMinValueExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
 
-	@Override public void visit(final LongLiteralMinValueExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getValue());
-	}
+    @Override public void visit(final LongLiteralMinValueExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getValue());
+    }
 
-	@Override public void visit(final StringLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("\"");
-		printer.print(n.getValue());
-		printer.print("\"");
-	}
+    @Override public void visit(final StringLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("\"");
+        printer.print(n.getValue());
+        printer.print("\"");
+    }
 
-	@Override public void visit(final BooleanLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(String.valueOf(n.getValue()));
-	}
+    @Override public void visit(final BooleanLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(String.valueOf(n.getValue()));
+    }
 
-	@Override public void visit(final NullLiteralExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("null");
-	}
+    @Override public void visit(final NullLiteralExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("null");
+    }
 
-	@Override public void visit(final ThisExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-			printer.print(".");
-		}
-		printer.print("this");
-	}
+    @Override public void visit(final ThisExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+            printer.print(".");
+        }
+        printer.print("this");
+    }
 
-	@Override public void visit(final SuperExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-			printer.print(".");
-		}
-		printer.print("super");
-	}
+    @Override public void visit(final SuperExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+            printer.print(".");
+        }
+        printer.print("super");
+    }
 
-	@Override public void visit(final MethodCallExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-			printer.print(".");
-		}
-		printTypeArgs(n.getTypeArgs(), arg);
-		printer.print(n.getName());
-		printArguments(n.getArgs(), arg);
-	}
+    @Override public void visit(final MethodCallExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+            printer.print(".");
+        }
+        printTypeArgs(n.getTypeArgs(), arg);
+        printer.print(n.getName());
+        printArguments(n.getArgs(), arg);
+    }
 
-	@Override public void visit(final ObjectCreationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-			printer.print(".");
-		}
+    @Override public void visit(final ObjectCreationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+            printer.print(".");
+        }
 
-		printer.print("new ");
+        printer.print("new ");
 
-		printTypeArgs(n.getTypeArgs(), arg);
-		if (!isNullOrEmpty(n.getTypeArgs())) {
-			printer.print(" ");
-		}
+        printTypeArgs(n.getTypeArgs(), arg);
+        if (!isNullOrEmpty(n.getTypeArgs())) {
+            printer.print(" ");
+        }
 
-		n.getType().accept(this, arg);
+        n.getType().accept(this, arg);
 
-		printArguments(n.getArgs(), arg);
+        printArguments(n.getArgs(), arg);
 
-		if (n.getAnonymousClassBody() != null) {
-			printer.printLn(" {");
-			printer.indent();
-			printMembers(n.getAnonymousClassBody(), arg);
-			printer.unindent();
-			printer.print("}");
-		}
-	}
+        if (n.getAnonymousClassBody() != null) {
+            printer.printLn(" {");
+            printer.indent();
+            printMembers(n.getAnonymousClassBody(), arg);
+            printer.unindent();
+            printer.print("}");
+        }
+    }
 
-	@Override public void visit(final UnaryExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		switch (n.getOperator()) {
-		case positive:
-			printer.print("+");
-			break;
-		case negative:
-			printer.print("-");
-			break;
-		case inverse:
-			printer.print("~");
-			break;
-		case not:
-			printer.print("!");
-			break;
-		case preIncrement:
-			printer.print("++");
-			break;
-		case preDecrement:
-			printer.print("--");
-			break;
-		default:
-		}
+    @Override public void visit(final UnaryExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        switch (n.getOperator()) {
+        case positive:
+            printer.print("+");
+            break;
+        case negative:
+            printer.print("-");
+            break;
+        case inverse:
+            printer.print("~");
+            break;
+        case not:
+            printer.print("!");
+            break;
+        case preIncrement:
+            printer.print("++");
+            break;
+        case preDecrement:
+            printer.print("--");
+            break;
+        default:
+        }
 
-		n.getExpr().accept(this, arg);
+        n.getExpr().accept(this, arg);
 
-		switch (n.getOperator()) {
-		case posIncrement:
-			printer.print("++");
-			break;
-		case posDecrement:
-			printer.print("--");
-			break;
-		default:
-		}
-	}
+        switch (n.getOperator()) {
+        case posIncrement:
+            printer.print("++");
+            break;
+        case posDecrement:
+            printer.print("--");
+            break;
+        default:
+        }
+    }
 
-	@Override public void visit(final ConstructorDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
+    @Override public void visit(final ConstructorDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
 
-		printTypeParameters(n.getTypeParameters(), arg);
-		if (n.getTypeParameters() != null) {
-			printer.print(" ");
-		}
-		printer.print(n.getName());
+        printTypeParameters(n.getTypeParameters(), arg);
+        if (n.getTypeParameters() != null) {
+            printer.print(" ");
+        }
+        printer.print(n.getName());
 
-		printer.print("(");
-		if (n.getParameters() != null) {
-			for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext();) {
-				final Parameter p = i.next();
-				p.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
+        printer.print("(");
+        if (n.getParameters() != null) {
+            for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext();) {
+                final Parameter p = i.next();
+                p.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
 
-		if (!isNullOrEmpty(n.getThrows())) {
-			printer.print(" throws ");
-			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
-				final NameExpr name = i.next();
-				name.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(" ");
-		n.getBlock().accept(this, arg);
-	}
+        if (!isNullOrEmpty(n.getThrows())) {
+            printer.print(" throws ");
+            for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
+                final NameExpr name = i.next();
+                name.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(" ");
+        n.getBlock().accept(this, arg);
+    }
 
-	@Override public void visit(final MethodDeclaration n, final Object arg) {
+    @Override public void visit(final MethodDeclaration n, final Object arg) {
         printOrphanCommentsBeforeThisChildNode(n);
 
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-		if (n.isDefault()) {
-			printer.print("default ");
-		}
-		printTypeParameters(n.getTypeParameters(), arg);
-		if (n.getTypeParameters() != null) {
-			printer.print(" ");
-		}
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+        if (n.isDefault()) {
+            printer.print("default ");
+        }
+        printTypeParameters(n.getTypeParameters(), arg);
+        if (n.getTypeParameters() != null) {
+            printer.print(" ");
+        }
 
-		n.getType().accept(this, arg);
-		printer.print(" ");
-		printer.print(n.getName());
+        n.getType().accept(this, arg);
+        printer.print(" ");
+        printer.print(n.getName());
 
-		printer.print("(");
-		if (n.getParameters() != null) {
-			for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext();) {
-				final Parameter p = i.next();
-				p.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
+        printer.print("(");
+        if (n.getParameters() != null) {
+            for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext();) {
+                final Parameter p = i.next();
+                p.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
 
-		for (int i = 0; i < n.getArrayCount(); i++) {
-			printer.print("[]");
-		}
+        for (int i = 0; i < n.getArrayCount(); i++) {
+            printer.print("[]");
+        }
 
-		if (!isNullOrEmpty(n.getThrows())) {
-			printer.print(" throws ");
-			for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
-				final NameExpr name = i.next();
-				name.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		if (n.getBody() == null) {
-			printer.print(";");
-		} else {
-			printer.print(" ");
-			n.getBody().accept(this, arg);
-		}
-	}
+        if (!isNullOrEmpty(n.getThrows())) {
+            printer.print(" throws ");
+            for (final Iterator<NameExpr> i = n.getThrows().iterator(); i.hasNext();) {
+                final NameExpr name = i.next();
+                name.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        if (n.getBody() == null) {
+            printer.print(";");
+        } else {
+            printer.print(" ");
+            n.getBody().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final Parameter n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
-		if (n.getType() != null) {
-			n.getType().accept(this, arg);
-		}
-		if (n.isVarArgs()) {
-			printer.print("...");
-		}
-		printer.print(" ");
-		n.getId().accept(this, arg);
-	}
-	
+    @Override public void visit(final Parameter n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
+        if (n.getType() != null) {
+            n.getType().accept(this, arg);
+        }
+        if (n.isVarArgs()) {
+            printer.print("...");
+        }
+        printer.print(" ");
+        n.getId().accept(this, arg);
+    }
+    
     @Override public void visit(MultiTypeParameter n, Object arg) {
         printAnnotations(n.getAnnotations(), arg);
         printModifiers(n.getModifiers());
@@ -1061,519 +1061,519 @@ public final class DumpVisitor implements VoidVisitor<Object> {
         Iterator<Type> types = n.getTypes().iterator();
         types.next().accept(this, arg);
         while (types.hasNext()) {
-        	printer.print(" | ");
-        	types.next().accept(this, arg);
+            printer.print(" | ");
+            types.next().accept(this, arg);
         }
         
         printer.print(" ");
         n.getId().accept(this, arg);
     }
 
-	@Override public void visit(final ExplicitConstructorInvocationStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.isThis()) {
-			printTypeArgs(n.getTypeArgs(), arg);
-			printer.print("this");
-		} else {
-			if (n.getExpr() != null) {
-				n.getExpr().accept(this, arg);
-				printer.print(".");
-			}
-			printTypeArgs(n.getTypeArgs(), arg);
-			printer.print("super");
-		}
-		printArguments(n.getArgs(), arg);
-		printer.print(";");
-	}
+    @Override public void visit(final ExplicitConstructorInvocationStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.isThis()) {
+            printTypeArgs(n.getTypeArgs(), arg);
+            printer.print("this");
+        } else {
+            if (n.getExpr() != null) {
+                n.getExpr().accept(this, arg);
+                printer.print(".");
+            }
+            printTypeArgs(n.getTypeArgs(), arg);
+            printer.print("super");
+        }
+        printArguments(n.getArgs(), arg);
+        printer.print(";");
+    }
 
-	@Override public void visit(final VariableDeclarationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
+    @Override public void visit(final VariableDeclarationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
 
-		n.getType().accept(this, arg);
-		printer.print(" ");
+        n.getType().accept(this, arg);
+        printer.print(" ");
 
-		for (final Iterator<VariableDeclarator> i = n.getVars().iterator(); i.hasNext();) {
-			final VariableDeclarator v = i.next();
-			v.accept(this, arg);
-			if (i.hasNext()) {
-				printer.print(", ");
-			}
-		}
-	}
+        for (final Iterator<VariableDeclarator> i = n.getVars().iterator(); i.hasNext();) {
+            final VariableDeclarator v = i.next();
+            v.accept(this, arg);
+            if (i.hasNext()) {
+                printer.print(", ");
+            }
+        }
+    }
 
-	@Override public void visit(final TypeDeclarationStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		n.getTypeDeclaration().accept(this, arg);
-	}
+    @Override public void visit(final TypeDeclarationStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        n.getTypeDeclaration().accept(this, arg);
+    }
 
-	@Override public void visit(final AssertStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("assert ");
-		n.getCheck().accept(this, arg);
-		if (n.getMessage() != null) {
-			printer.print(" : ");
-			n.getMessage().accept(this, arg);
-		}
-		printer.print(";");
-	}
+    @Override public void visit(final AssertStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("assert ");
+        n.getCheck().accept(this, arg);
+        if (n.getMessage() != null) {
+            printer.print(" : ");
+            n.getMessage().accept(this, arg);
+        }
+        printer.print(";");
+    }
 
-	@Override public void visit(final BlockStmt n, final Object arg) {
+    @Override public void visit(final BlockStmt n, final Object arg) {
         printOrphanCommentsBeforeThisChildNode(n);
-		printJavaComment(n.getComment(), arg);
-		printer.printLn("{");
-		if (n.getStmts() != null) {
-			printer.indent();
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-				printer.printLn();
-			}
-			printer.unindent();
-		}
-		printOrphanCommentsEnding(n);
-		printer.print("}");
+        printJavaComment(n.getComment(), arg);
+        printer.printLn("{");
+        if (n.getStmts() != null) {
+            printer.indent();
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+                printer.printLn();
+            }
+            printer.unindent();
+        }
+        printOrphanCommentsEnding(n);
+        printer.print("}");
 
-	}
+    }
 
-	@Override public void visit(final LabeledStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getLabel());
-		printer.print(": ");
-		n.getStmt().accept(this, arg);
-	}
+    @Override public void visit(final LabeledStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getLabel());
+        printer.print(": ");
+        n.getStmt().accept(this, arg);
+    }
 
-	@Override public void visit(final EmptyStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(";");
-	}
+    @Override public void visit(final EmptyStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(";");
+    }
 
-	@Override public void visit(final ExpressionStmt n, final Object arg) {
-		printOrphanCommentsBeforeThisChildNode(n);
-		printJavaComment(n.getComment(), arg);
-		n.getExpression().accept(this, arg);
-		printer.print(";");
-	}
+    @Override public void visit(final ExpressionStmt n, final Object arg) {
+        printOrphanCommentsBeforeThisChildNode(n);
+        printJavaComment(n.getComment(), arg);
+        n.getExpression().accept(this, arg);
+        printer.print(";");
+    }
 
-	@Override public void visit(final SwitchStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("switch(");
-		n.getSelector().accept(this, arg);
-		printer.printLn(") {");
-		if (n.getEntries() != null) {
-			printer.indent();
-			for (final SwitchEntryStmt e : n.getEntries()) {
-				e.accept(this, arg);
-			}
-			printer.unindent();
-		}
-		printer.print("}");
+    @Override public void visit(final SwitchStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("switch(");
+        n.getSelector().accept(this, arg);
+        printer.printLn(") {");
+        if (n.getEntries() != null) {
+            printer.indent();
+            for (final SwitchEntryStmt e : n.getEntries()) {
+                e.accept(this, arg);
+            }
+            printer.unindent();
+        }
+        printer.print("}");
 
-	}
+    }
 
-	@Override public void visit(final SwitchEntryStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		if (n.getLabel() != null) {
-			printer.print("case ");
-			n.getLabel().accept(this, arg);
-			printer.print(":");
-		} else {
-			printer.print("default:");
-		}
-		printer.printLn();
-		printer.indent();
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-				printer.printLn();
-			}
-		}
-		printer.unindent();
-	}
+    @Override public void visit(final SwitchEntryStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        if (n.getLabel() != null) {
+            printer.print("case ");
+            n.getLabel().accept(this, arg);
+            printer.print(":");
+        } else {
+            printer.print("default:");
+        }
+        printer.printLn();
+        printer.indent();
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+                printer.printLn();
+            }
+        }
+        printer.unindent();
+    }
 
-	@Override public void visit(final BreakStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("break");
-		if (n.getId() != null) {
-			printer.print(" ");
-			printer.print(n.getId());
-		}
-		printer.print(";");
-	}
+    @Override public void visit(final BreakStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("break");
+        if (n.getId() != null) {
+            printer.print(" ");
+            printer.print(n.getId());
+        }
+        printer.print(";");
+    }
 
-	@Override public void visit(final ReturnStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("return");
-		if (n.getExpr() != null) {
-			printer.print(" ");
-			n.getExpr().accept(this, arg);
-		}
-		printer.print(";");
-	}
+    @Override public void visit(final ReturnStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("return");
+        if (n.getExpr() != null) {
+            printer.print(" ");
+            n.getExpr().accept(this, arg);
+        }
+        printer.print(";");
+    }
 
-	@Override public void visit(final EnumDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
+    @Override public void visit(final EnumDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
 
-		printer.print("enum ");
-		printer.print(n.getName());
+        printer.print("enum ");
+        printer.print(n.getName());
 
-		if (n.getImplements() != null) {
-			printer.print(" implements ");
-			for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext();) {
-				final ClassOrInterfaceType c = i.next();
-				c.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
+        if (n.getImplements() != null) {
+            printer.print(" implements ");
+            for (final Iterator<ClassOrInterfaceType> i = n.getImplements().iterator(); i.hasNext();) {
+                final ClassOrInterfaceType c = i.next();
+                c.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
 
-		printer.printLn(" {");
-		printer.indent();
-		if (n.getEntries() != null) {
-			printer.printLn();
-			for (final Iterator<EnumConstantDeclaration> i = n.getEntries().iterator(); i.hasNext();) {
-				final EnumConstantDeclaration e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		if (n.getMembers() != null) {
-			printer.printLn(";");
-			printMembers(n.getMembers(), arg);
-		} else {
-			if (n.getEntries() != null) {
-				printer.printLn();
-			}
-		}
-		printer.unindent();
-		printer.print("}");
-	}
+        printer.printLn(" {");
+        printer.indent();
+        if (n.getEntries() != null) {
+            printer.printLn();
+            for (final Iterator<EnumConstantDeclaration> i = n.getEntries().iterator(); i.hasNext();) {
+                final EnumConstantDeclaration e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        if (n.getMembers() != null) {
+            printer.printLn(";");
+            printMembers(n.getMembers(), arg);
+        } else {
+            if (n.getEntries() != null) {
+                printer.printLn();
+            }
+        }
+        printer.unindent();
+        printer.print("}");
+    }
 
-	@Override public void visit(final EnumConstantDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printer.print(n.getName());
+    @Override public void visit(final EnumConstantDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printer.print(n.getName());
 
-		if (n.getArgs() != null) {
-			printArguments(n.getArgs(), arg);
-		}
+        if (n.getArgs() != null) {
+            printArguments(n.getArgs(), arg);
+        }
 
-		if (n.getClassBody() != null) {
-			printer.printLn(" {");
-			printer.indent();
-			printMembers(n.getClassBody(), arg);
-			printer.unindent();
-			printer.printLn("}");
-		}
-	}
+        if (n.getClassBody() != null) {
+            printer.printLn(" {");
+            printer.indent();
+            printMembers(n.getClassBody(), arg);
+            printer.unindent();
+            printer.printLn("}");
+        }
+    }
 
-	@Override public void visit(final EmptyMemberDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printer.print(";");
-	}
+    @Override public void visit(final EmptyMemberDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printer.print(";");
+    }
 
-	@Override public void visit(final InitializerDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		if (n.isStatic()) {
-			printer.print("static ");
-		}
-		n.getBlock().accept(this, arg);
-	}
+    @Override public void visit(final InitializerDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        if (n.isStatic()) {
+            printer.print("static ");
+        }
+        n.getBlock().accept(this, arg);
+    }
 
-	@Override public void visit(final IfStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("if (");
-		n.getCondition().accept(this, arg);
-		final boolean thenBlock = n.getThenStmt() instanceof BlockStmt;
-		if (thenBlock) // block statement should start on the same line
-			printer.print(") ");
-		else {
-			printer.printLn(")");
-			printer.indent();
-		}
-		n.getThenStmt().accept(this, arg);
-		if (!thenBlock)
-			printer.unindent();
-		if (n.getElseStmt() != null) {
-			if (thenBlock)
-				printer.print(" ");
-			else
-				printer.printLn();
-			final boolean elseIf = n.getElseStmt() instanceof IfStmt;
-			final boolean elseBlock = n.getElseStmt() instanceof BlockStmt;
-			if (elseIf || elseBlock) // put chained if and start of block statement on a same level
-				printer.print("else ");
-			else {
-				printer.printLn("else");
-				printer.indent();
-			}
-			n.getElseStmt().accept(this, arg);
-			if (!(elseIf || elseBlock))
-				printer.unindent();
-		}
-	}
+    @Override public void visit(final IfStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("if (");
+        n.getCondition().accept(this, arg);
+        final boolean thenBlock = n.getThenStmt() instanceof BlockStmt;
+        if (thenBlock) // block statement should start on the same line
+            printer.print(") ");
+        else {
+            printer.printLn(")");
+            printer.indent();
+        }
+        n.getThenStmt().accept(this, arg);
+        if (!thenBlock)
+            printer.unindent();
+        if (n.getElseStmt() != null) {
+            if (thenBlock)
+                printer.print(" ");
+            else
+                printer.printLn();
+            final boolean elseIf = n.getElseStmt() instanceof IfStmt;
+            final boolean elseBlock = n.getElseStmt() instanceof BlockStmt;
+            if (elseIf || elseBlock) // put chained if and start of block statement on a same level
+                printer.print("else ");
+            else {
+                printer.printLn("else");
+                printer.indent();
+            }
+            n.getElseStmt().accept(this, arg);
+            if (!(elseIf || elseBlock))
+                printer.unindent();
+        }
+    }
 
-	@Override public void visit(final WhileStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("while (");
-		n.getCondition().accept(this, arg);
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-	}
+    @Override public void visit(final WhileStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("while (");
+        n.getCondition().accept(this, arg);
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+    }
 
-	@Override public void visit(final ContinueStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("continue");
-		if (n.getId() != null) {
-			printer.print(" ");
-			printer.print(n.getId());
-		}
-		printer.print(";");
-	}
+    @Override public void visit(final ContinueStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("continue");
+        if (n.getId() != null) {
+            printer.print(" ");
+            printer.print(n.getId());
+        }
+        printer.print(";");
+    }
 
-	@Override public void visit(final DoStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("do ");
-		n.getBody().accept(this, arg);
-		printer.print(" while (");
-		n.getCondition().accept(this, arg);
-		printer.print(");");
-	}
+    @Override public void visit(final DoStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("do ");
+        n.getBody().accept(this, arg);
+        printer.print(" while (");
+        n.getCondition().accept(this, arg);
+        printer.print(");");
+    }
 
-	@Override public void visit(final ForeachStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("for (");
-		n.getVariable().accept(this, arg);
-		printer.print(" : ");
-		n.getIterable().accept(this, arg);
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-	}
+    @Override public void visit(final ForeachStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("for (");
+        n.getVariable().accept(this, arg);
+        printer.print(" : ");
+        n.getIterable().accept(this, arg);
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+    }
 
-	@Override public void visit(final ForStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("for (");
-		if (n.getInit() != null) {
-			for (final Iterator<Expression> i = n.getInit().iterator(); i.hasNext();) {
-				final Expression e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print("; ");
-		if (n.getCompare() != null) {
-			n.getCompare().accept(this, arg);
-		}
-		printer.print("; ");
-		if (n.getUpdate() != null) {
-			for (final Iterator<Expression> i = n.getUpdate().iterator(); i.hasNext();) {
-				final Expression e = i.next();
-				e.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(") ");
-		n.getBody().accept(this, arg);
-	}
+    @Override public void visit(final ForStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("for (");
+        if (n.getInit() != null) {
+            for (final Iterator<Expression> i = n.getInit().iterator(); i.hasNext();) {
+                final Expression e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print("; ");
+        if (n.getCompare() != null) {
+            n.getCompare().accept(this, arg);
+        }
+        printer.print("; ");
+        if (n.getUpdate() != null) {
+            for (final Iterator<Expression> i = n.getUpdate().iterator(); i.hasNext();) {
+                final Expression e = i.next();
+                e.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(") ");
+        n.getBody().accept(this, arg);
+    }
 
-	@Override public void visit(final ThrowStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("throw ");
-		n.getExpr().accept(this, arg);
-		printer.print(";");
-	}
+    @Override public void visit(final ThrowStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("throw ");
+        n.getExpr().accept(this, arg);
+        printer.print(";");
+    }
 
-	@Override public void visit(final SynchronizedStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("synchronized (");
-		n.getExpr().accept(this, arg);
-		printer.print(") ");
-		n.getBlock().accept(this, arg);
-	}
+    @Override public void visit(final SynchronizedStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("synchronized (");
+        n.getExpr().accept(this, arg);
+        printer.print(") ");
+        n.getBlock().accept(this, arg);
+    }
 
-	@Override public void visit(final TryStmt n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("try ");
-		if (!n.getResources().isEmpty()) {
-			printer.print("(");
-			Iterator<VariableDeclarationExpr> resources = n.getResources().iterator();
-			boolean first = true;
-			while (resources.hasNext()) {
-				visit(resources.next(), arg);
-				if (resources.hasNext()) {
-					printer.print(";");
-					printer.printLn();
-					if (first) {
-						printer.indent();
-					}
-				}
-				first = false;
-			}
-			if (n.getResources().size() > 1) {
-				printer.unindent();
-			}
-			printer.print(") ");
-		}
-		n.getTryBlock().accept(this, arg);
-		if (n.getCatchs() != null) {
-			for (final CatchClause c : n.getCatchs()) {
-				c.accept(this, arg);
-			}
-		}
-		if (n.getFinallyBlock() != null) {
-			printer.print(" finally ");
-			n.getFinallyBlock().accept(this, arg);
-		}
-	}
+    @Override public void visit(final TryStmt n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("try ");
+        if (!n.getResources().isEmpty()) {
+            printer.print("(");
+            Iterator<VariableDeclarationExpr> resources = n.getResources().iterator();
+            boolean first = true;
+            while (resources.hasNext()) {
+                visit(resources.next(), arg);
+                if (resources.hasNext()) {
+                    printer.print(";");
+                    printer.printLn();
+                    if (first) {
+                        printer.indent();
+                    }
+                }
+                first = false;
+            }
+            if (n.getResources().size() > 1) {
+                printer.unindent();
+            }
+            printer.print(") ");
+        }
+        n.getTryBlock().accept(this, arg);
+        if (n.getCatchs() != null) {
+            for (final CatchClause c : n.getCatchs()) {
+                c.accept(this, arg);
+            }
+        }
+        if (n.getFinallyBlock() != null) {
+            printer.print(" finally ");
+            n.getFinallyBlock().accept(this, arg);
+        }
+    }
 
-	@Override public void visit(final CatchClause n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(" catch (");
-		n.getExcept().accept(this, arg);
-		printer.print(") ");
-		n.getCatchBlock().accept(this, arg);
+    @Override public void visit(final CatchClause n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(" catch (");
+        n.getExcept().accept(this, arg);
+        printer.print(") ");
+        n.getCatchBlock().accept(this, arg);
 
-	}
+    }
 
-	@Override public void visit(final AnnotationDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
+    @Override public void visit(final AnnotationDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
 
-		printer.print("@interface ");
-		printer.print(n.getName());
-		printer.printLn(" {");
-		printer.indent();
-		if (n.getMembers() != null) {
-			printMembers(n.getMembers(), arg);
-		}
-		printer.unindent();
-		printer.print("}");
-	}
+        printer.print("@interface ");
+        printer.print(n.getName());
+        printer.printLn(" {");
+        printer.indent();
+        if (n.getMembers() != null) {
+            printMembers(n.getMembers(), arg);
+        }
+        printer.unindent();
+        printer.print("}");
+    }
 
-	@Override public void visit(final AnnotationMemberDeclaration n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printJavadoc(n.getJavaDoc(), arg);
-		printMemberAnnotations(n.getAnnotations(), arg);
-		printModifiers(n.getModifiers());
+    @Override public void visit(final AnnotationMemberDeclaration n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printJavadoc(n.getJavaDoc(), arg);
+        printMemberAnnotations(n.getAnnotations(), arg);
+        printModifiers(n.getModifiers());
 
-		n.getType().accept(this, arg);
-		printer.print(" ");
-		printer.print(n.getName());
-		printer.print("()");
-		if (n.getDefaultValue() != null) {
-			printer.print(" default ");
-			n.getDefaultValue().accept(this, arg);
-		}
-		printer.print(";");
-	}
+        n.getType().accept(this, arg);
+        printer.print(" ");
+        printer.print(n.getName());
+        printer.print("()");
+        if (n.getDefaultValue() != null) {
+            printer.print(" default ");
+            n.getDefaultValue().accept(this, arg);
+        }
+        printer.print(";");
+    }
 
-	@Override public void visit(final MarkerAnnotationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("@");
-		n.getName().accept(this, arg);
-	}
+    @Override public void visit(final MarkerAnnotationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("@");
+        n.getName().accept(this, arg);
+    }
 
-	@Override public void visit(final SingleMemberAnnotationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("@");
-		n.getName().accept(this, arg);
-		printer.print("(");
-		n.getMemberValue().accept(this, arg);
-		printer.print(")");
-	}
+    @Override public void visit(final SingleMemberAnnotationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("@");
+        n.getName().accept(this, arg);
+        printer.print("(");
+        n.getMemberValue().accept(this, arg);
+        printer.print(")");
+    }
 
-	@Override public void visit(final NormalAnnotationExpr n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print("@");
-		n.getName().accept(this, arg);
-		printer.print("(");
-		if (n.getPairs() != null) {
-			for (final Iterator<MemberValuePair> i = n.getPairs().iterator(); i.hasNext();) {
-				final MemberValuePair m = i.next();
-				m.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		printer.print(")");
-	}
+    @Override public void visit(final NormalAnnotationExpr n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print("@");
+        n.getName().accept(this, arg);
+        printer.print("(");
+        if (n.getPairs() != null) {
+            for (final Iterator<MemberValuePair> i = n.getPairs().iterator(); i.hasNext();) {
+                final MemberValuePair m = i.next();
+                m.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        printer.print(")");
+    }
 
-	@Override public void visit(final MemberValuePair n, final Object arg) {
-		printJavaComment(n.getComment(), arg);
-		printer.print(n.getName());
-		printer.print(" = ");
-		n.getValue().accept(this, arg);
-	}
+    @Override public void visit(final MemberValuePair n, final Object arg) {
+        printJavaComment(n.getComment(), arg);
+        printer.print(n.getName());
+        printer.print(" = ");
+        n.getValue().accept(this, arg);
+    }
 
-	@Override public void visit(final LineComment n, final Object arg) {
-		if (!this.printComments) {
+    @Override public void visit(final LineComment n, final Object arg) {
+        if (!this.printComments) {
             return;
         }
         printer.print("//");
-		String tmp = n.getContent();
-		tmp = tmp.replace('\r', ' ');
-		tmp = tmp.replace('\n', ' ');
-		printer.printLn(tmp);
-	}
+        String tmp = n.getContent();
+        tmp = tmp.replace('\r', ' ');
+        tmp = tmp.replace('\n', ' ');
+        printer.printLn(tmp);
+    }
 
-	@Override public void visit(final BlockComment n, final Object arg) {
+    @Override public void visit(final BlockComment n, final Object arg) {
         if (!this.printComments) {
             return;
         }
         printer.print("/*");
-		printer.print(n.getContent());
-		printer.printLn("*/");
-	}
+        printer.print(n.getContent());
+        printer.printLn("*/");
+    }
 
-	@Override
-	public void visit(LambdaExpr n, Object arg) {
+    @Override
+    public void visit(LambdaExpr n, Object arg) {
         printJavaComment(n.getComment(), arg);
 
         List<Parameter> parameters = n.getParameters();
-		boolean printPar = false;
-		printPar = n.isParametersEnclosed();
+        boolean printPar = false;
+        printPar = n.isParametersEnclosed();
 
-		if (printPar) {
-			printer.print("(");
-		}
-		if (parameters != null) {
-			for (Iterator<Parameter> i = parameters.iterator(); i.hasNext();) {
-				Parameter p = i.next();
-				p.accept(this, arg);
-				if (i.hasNext()) {
-					printer.print(", ");
-				}
-			}
-		}
-		if (printPar) {
-			printer.print(")");
-		}
+        if (printPar) {
+            printer.print("(");
+        }
+        if (parameters != null) {
+            for (Iterator<Parameter> i = parameters.iterator(); i.hasNext();) {
+                Parameter p = i.next();
+                p.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+        }
+        if (printPar) {
+            printer.print(")");
+        }
 
-		printer.print(" -> ");
-		Statement body = n.getBody();
-		if (body instanceof ExpressionStmt) {
-			// Print the expression directly
-			((ExpressionStmt) body).getExpression().accept(this, arg);
-		} else {
-			body.accept(this, arg);
-		}
-	}
+        printer.print(" -> ");
+        Statement body = n.getBody();
+        if (body instanceof ExpressionStmt) {
+            // Print the expression directly
+            ((ExpressionStmt) body).getExpression().accept(this, arg);
+        } else {
+            body.accept(this, arg);
+        }
+    }
 
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -77,15 +77,15 @@ import java.util.List;
  */
 public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
 
-	private static final EqualsVisitor SINGLETON = new EqualsVisitor();
+    private static final EqualsVisitor SINGLETON = new EqualsVisitor();
 
-	public static boolean equals(final Node n1, final Node n2) {
-		return SINGLETON.nodeEquals(n1, n2);
-	}
+    public static boolean equals(final Node n1, final Node n2) {
+        return SINGLETON.nodeEquals(n1, n2);
+    }
 
-	private EqualsVisitor() {
-		// hide constructor
-	}
+    private EqualsVisitor() {
+        // hide constructor
+    }
 
     /**
      * Check for equality that can be applied to each kind of node,
@@ -101,1331 +101,1331 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
         return true;
     }
 
-	private <T extends Node> boolean nodesEquals(final List<T> nodes1, final List<T> nodes2) {
-		if (nodes1 == null) {
-			if (nodes2 == null) {
-				return true;
-			}
-			return false;
-		} else if (nodes2 == null) {
-			return false;
-		}
-		if (nodes1.size() != nodes2.size()) {
-			return false;
-		}
-		for (int i = 0; i < nodes1.size(); i++) {
-			if (!nodeEquals(nodes1.get(i), nodes2.get(i))) {
-				return false;
-			}
-		}
-		return true;
-	}
+    private <T extends Node> boolean nodesEquals(final List<T> nodes1, final List<T> nodes2) {
+        if (nodes1 == null) {
+            if (nodes2 == null) {
+                return true;
+            }
+            return false;
+        } else if (nodes2 == null) {
+            return false;
+        }
+        if (nodes1.size() != nodes2.size()) {
+            return false;
+        }
+        for (int i = 0; i < nodes1.size(); i++) {
+            if (!nodeEquals(nodes1.get(i), nodes2.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-	private <T extends Node> boolean nodeEquals(final T n1, final T n2) {
-		if (n1 == n2) {
-			return true;
-		}
-		if (n1 == null) {
-			if (n2 == null) {
-				return true;
-			}
-			return false;
-		} else if (n2 == null) {
-			return false;
-		}
-		if (n1.getClass() != n2.getClass()) {
-			return false;
-		}
+    private <T extends Node> boolean nodeEquals(final T n1, final T n2) {
+        if (n1 == n2) {
+            return true;
+        }
+        if (n1 == null) {
+            if (n2 == null) {
+                return true;
+            }
+            return false;
+        } else if (n2 == null) {
+            return false;
+        }
+        if (n1.getClass() != n2.getClass()) {
+            return false;
+        }
         if (!commonNodeEquality(n1, n2)){
             return false;
         }
-		return n1.accept(this, n2).booleanValue();
-	}
+        return n1.accept(this, n2).booleanValue();
+    }
 
-	private boolean objEquals(final Object n1, final Object n2) {
-		if (n1 == n2) {
-			return true;
-		}
-		if (n1 == null) {
-			if (n2 == null) {
-				return true;
-			}
-			return false;
-		} else if (n2 == null) {
-			return false;
-		}
-		return n1.equals(n2);
-	}
+    private boolean objEquals(final Object n1, final Object n2) {
+        if (n1 == n2) {
+            return true;
+        }
+        if (n1 == null) {
+            if (n2 == null) {
+                return true;
+            }
+            return false;
+        } else if (n2 == null) {
+            return false;
+        }
+        return n1.equals(n2);
+    }
 
-	@Override public Boolean visit(final CompilationUnit n1, final Node arg) {
-		final CompilationUnit n2 = (CompilationUnit) arg;
+    @Override public Boolean visit(final CompilationUnit n1, final Node arg) {
+        final CompilationUnit n2 = (CompilationUnit) arg;
 
-		if (!nodeEquals(n1.getPackage(), n2.getPackage())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getPackage(), n2.getPackage())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getImports(), n2.getImports())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getImports(), n2.getImports())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getTypes(), n2.getTypes())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getTypes(), n2.getTypes())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getComments(), n2.getComments())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getComments(), n2.getComments())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final PackageDeclaration n1, final Node arg) {
-		final PackageDeclaration n2 = (PackageDeclaration) arg;
+    @Override public Boolean visit(final PackageDeclaration n1, final Node arg) {
+        final PackageDeclaration n2 = (PackageDeclaration) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final ImportDeclaration n1, final Node arg) {
-		final ImportDeclaration n2 = (ImportDeclaration) arg;
+    @Override public Boolean visit(final ImportDeclaration n1, final Node arg) {
+        final ImportDeclaration n2 = (ImportDeclaration) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final TypeParameter n1, final Node arg) {
-		final TypeParameter n2 = (TypeParameter) arg;
+    @Override public Boolean visit(final TypeParameter n1, final Node arg) {
+        final TypeParameter n2 = (TypeParameter) arg;
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getTypeBound(), n2.getTypeBound())) {
-			return Boolean.FALSE;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getTypeBound(), n2.getTypeBound())) {
+            return Boolean.FALSE;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final LineComment n1, final Node arg) {
-		final LineComment n2 = (LineComment) arg;
+    @Override public Boolean visit(final LineComment n1, final Node arg) {
+        final LineComment n2 = (LineComment) arg;
 
-		if (!objEquals(n1.getContent(), n2.getContent())) {
-			return Boolean.FALSE;
-		}
-
-        if (!objEquals(n1.getBeginLine(), n2.getBeginLine())) {
-      		return Boolean.FALSE;
-      	}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final BlockComment n1, final Node arg) {
-		final BlockComment n2 = (BlockComment) arg;
-
-		if (!objEquals(n1.getContent(), n2.getContent())) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getContent(), n2.getContent())) {
+            return Boolean.FALSE;
+        }
 
         if (!objEquals(n1.getBeginLine(), n2.getBeginLine())) {
-      			return Boolean.FALSE;
-      	}
+              return Boolean.FALSE;
+          }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final ClassOrInterfaceDeclaration n1, final Node arg) {
-		final ClassOrInterfaceDeclaration n2 = (ClassOrInterfaceDeclaration) arg;
+    @Override public Boolean visit(final BlockComment n1, final Node arg) {
+        final BlockComment n2 = (BlockComment) arg;
 
-		// javadoc are checked at CompilationUnit
+        if (!objEquals(n1.getContent(), n2.getContent())) {
+            return Boolean.FALSE;
+        }
 
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getBeginLine(), n2.getBeginLine())) {
+                  return Boolean.FALSE;
+          }
 
-		if (n1.isInterface() != n2.isInterface()) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final ClassOrInterfaceDeclaration n1, final Node arg) {
+        final ClassOrInterfaceDeclaration n2 = (ClassOrInterfaceDeclaration) arg;
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+        // javadoc are checked at CompilationUnit
 
-		if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
-			return Boolean.FALSE;
-		}
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getExtends(), n2.getExtends())) {
-			return Boolean.FALSE;
-		}
+        if (n1.isInterface() != n2.isInterface()) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final EnumDeclaration n1, final Node arg) {
-		final EnumDeclaration n2 = (EnumDeclaration) arg;
+        if (!nodesEquals(n1.getExtends(), n2.getExtends())) {
+            return Boolean.FALSE;
+        }
 
-		// javadoc are checked at CompilationUnit
+        if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
+            return Boolean.FALSE;
+        }
 
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
+            return Boolean.FALSE;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final EnumDeclaration n1, final Node arg) {
+        final EnumDeclaration n2 = (EnumDeclaration) arg;
 
-		if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
-			return Boolean.FALSE;
-		}
+        // javadoc are checked at CompilationUnit
 
-		if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
-			return Boolean.FALSE;
-		}
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final EmptyTypeDeclaration n1, final Node arg) {
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getImplements(), n2.getImplements())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final EnumConstantDeclaration n1, final Node arg) {
-		final EnumConstantDeclaration n2 = (EnumConstantDeclaration) arg;
+        if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
+            return Boolean.FALSE;
+        }
 
-		// javadoc are checked at CompilationUnit
+        if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
+            return Boolean.FALSE;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final EmptyTypeDeclaration n1, final Node arg) {
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final EnumConstantDeclaration n1, final Node arg) {
+        final EnumConstantDeclaration n2 = (EnumConstantDeclaration) arg;
 
-		if (!nodesEquals(n1.getClassBody(), n2.getClassBody())) {
-			return Boolean.FALSE;
-		}
+        // javadoc are checked at CompilationUnit
 
-		return Boolean.TRUE;
-	}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final AnnotationDeclaration n1, final Node arg) {
-		final AnnotationDeclaration n2 = (AnnotationDeclaration) arg;
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		// javadoc are checked at CompilationUnit
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return Boolean.FALSE;
+        }
 
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getClassBody(), n2.getClassBody())) {
+            return Boolean.FALSE;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final AnnotationDeclaration n1, final Node arg) {
+        final AnnotationDeclaration n2 = (AnnotationDeclaration) arg;
 
-		if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
-			return Boolean.FALSE;
-		}
+        // javadoc are checked at CompilationUnit
 
-		return Boolean.TRUE;
-	}
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final AnnotationMemberDeclaration n1, final Node arg) {
-		final AnnotationMemberDeclaration n2 = (AnnotationMemberDeclaration) arg;
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		// javadoc are checked at CompilationUnit
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getMembers(), n2.getMembers())) {
+            return Boolean.FALSE;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final AnnotationMemberDeclaration n1, final Node arg) {
+        final AnnotationMemberDeclaration n2 = (AnnotationMemberDeclaration) arg;
 
-		if (!nodeEquals(n1.getDefaultValue(), n2.getDefaultValue())) {
-			return Boolean.FALSE;
-		}
+        // javadoc are checked at CompilationUnit
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final FieldDeclaration n1, final Node arg) {
-		final FieldDeclaration n2 = (FieldDeclaration) arg;
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		// javadoc are checked at CompilationUnit
+        if (!nodeEquals(n1.getDefaultValue(), n2.getDefaultValue())) {
+            return Boolean.FALSE;
+        }
 
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final FieldDeclaration n1, final Node arg) {
+        final FieldDeclaration n2 = (FieldDeclaration) arg;
 
-		if (!nodesEquals(n1.getVariables(), n2.getVariables())) {
-			return Boolean.FALSE;
-		}
+        // javadoc are checked at CompilationUnit
 
-		return Boolean.TRUE;
-	}
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final VariableDeclarator n1, final Node arg) {
-		final VariableDeclarator n2 = (VariableDeclarator) arg;
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getId(), n2.getId())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getInit(), n2.getInit())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getVariables(), n2.getVariables())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final VariableDeclaratorId n1, final Node arg) {
-		final VariableDeclaratorId n2 = (VariableDeclaratorId) arg;
+    @Override public Boolean visit(final VariableDeclarator n1, final Node arg) {
+        final VariableDeclarator n2 = (VariableDeclarator) arg;
 
-		if (n1.getArrayCount() != n2.getArrayCount()) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getId(), n2.getId())) {
+            return Boolean.FALSE;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getInit(), n2.getInit())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ConstructorDeclaration n1, final Node arg) {
-		final ConstructorDeclaration n2 = (ConstructorDeclaration) arg;
-
-		// javadoc are checked at CompilationUnit
-
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
-
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final MethodDeclaration n1, final Node arg) {
-		final MethodDeclaration n2 = (MethodDeclaration) arg;
-
-		// javadoc are checked at CompilationUnit
-
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
-
-		if (n1.getArrayCount() != n2.getArrayCount()) {
-			return Boolean.FALSE;
-		}
-
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
-			return Boolean.FALSE;
-		}
-		if(n1.isDefault() != n2.isDefault()){
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-	
-	@Override public Boolean visit(final Parameter n1, final Node arg) {
-		final Parameter n2 = (Parameter) arg;
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-		return visit((BaseParameter) n1, arg);
-	}
-	
-	@Override public Boolean visit(MultiTypeParameter n1, Node arg) {
-		MultiTypeParameter n2 = (MultiTypeParameter) arg;
-		if (n1.getTypes().size() != n2.getTypes().size()) {
-			return Boolean.FALSE;
-		}
-		Iterator<Type> n1types = n1.getTypes().iterator();
-		Iterator<Type> n2types = n2.getTypes().iterator();
-		while (n1types.hasNext() && n2types.hasNext()) {
-			if (!nodeEquals(n1types.next(), n2types.next())) {
-				return Boolean.FALSE;
-			}
-		}
-		return visit((BaseParameter) n1, arg);
-	}
-
-	protected Boolean visit(final BaseParameter n1, final Node arg) {
-		final BaseParameter n2 = (BaseParameter) arg;
-
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getId(), n2.getId())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-	
-	@Override public Boolean visit(final EmptyMemberDeclaration n1, final Node arg) {
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final InitializerDeclaration n1, final Node arg) {
-		final InitializerDeclaration n2 = (InitializerDeclaration) arg;
-
-		if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final JavadocComment n1, final Node arg) {
-		final JavadocComment n2 = (JavadocComment) arg;
-
-		if (!objEquals(n1.getContent(), n2.getContent())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ClassOrInterfaceType n1, final Node arg) {
-		final ClassOrInterfaceType n2 = (ClassOrInterfaceType) arg;
-
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
-			return Boolean.FALSE;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final PrimitiveType n1, final Node arg) {
-		final PrimitiveType n2 = (PrimitiveType) arg;
-
-		if (n1.getType() != n2.getType()) {
-			return Boolean.FALSE;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ReferenceType n1, final Node arg) {
-		final ReferenceType n2 = (ReferenceType) arg;
-
-		if (n1.getArrayCount() != n2.getArrayCount()) {
-			return Boolean.FALSE;
-		}
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-		List<List<AnnotationExpr>> n1a = n1.getArraysAnnotations();
-		List<List<AnnotationExpr>> n2a = n2.getArraysAnnotations();
-
-		if (n1a !=null && n2a!= null) {
-			if(n1a.size() != n2a.size()){
-				return Boolean.FALSE;
-			}
-			else{
-				int i = 0;
-				for(List<AnnotationExpr> aux: n1a){
-					if(!nodesEquals(aux, n2a.get(i))){
-						return Boolean.FALSE;
-					}
-					i++;
-				}
-			}
-		}
-		else if (n1a != n2a){
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-
-	public Boolean visit(VoidType n1, Node arg) {
-		VoidType n2 = (VoidType) arg;
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final WildcardType n1, final Node arg) {
-		final WildcardType n2 = (WildcardType) arg;
-
-		if (!nodeEquals(n1.getExtends(), n2.getExtends())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getSuper(), n2.getSuper())) {
-			return Boolean.FALSE;
-		}
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final UnknownType n1, final Node arg) {
-		final WildcardType n2 = (WildcardType) arg;
-
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ArrayAccessExpr n1, final Node arg) {
-		final ArrayAccessExpr n2 = (ArrayAccessExpr) arg;
-
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getIndex(), n2.getIndex())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ArrayCreationExpr n1, final Node arg) {
-		final ArrayCreationExpr n2 = (ArrayCreationExpr) arg;
-
-		if (n1.getArrayCount() != n2.getArrayCount()) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getInitializer(), n2.getInitializer())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getDimensions(), n2.getDimensions())) {
-			return Boolean.FALSE;
-		}
-		List<List<AnnotationExpr>> n1a = n1.getArraysAnnotations();
-		List<List<AnnotationExpr>> n2a = n2.getArraysAnnotations();
-
-		if (n1a !=null && n2a!= null) {
-			if(n1a.size() != n2a.size()){
-				return Boolean.FALSE;
-			}
-			else{
-				int i = 0;
-				for(List<AnnotationExpr> aux: n1a){
-					if(!nodesEquals(aux, n2a.get(i))){
-						return Boolean.FALSE;
-					}
-					i++;
-				}
-			}
-		}
-		else if (n1a != n2a){
-			return Boolean.FALSE;
-		}
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ArrayInitializerExpr n1, final Node arg) {
-		final ArrayInitializerExpr n2 = (ArrayInitializerExpr) arg;
-
-		if (!nodesEquals(n1.getValues(), n2.getValues())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final AssignExpr n1, final Node arg) {
-		final AssignExpr n2 = (AssignExpr) arg;
-
-		if (n1.getOperator() != n2.getOperator()) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getTarget(), n2.getTarget())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final BinaryExpr n1, final Node arg) {
-		final BinaryExpr n2 = (BinaryExpr) arg;
-
-		if (n1.getOperator() != n2.getOperator()) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getLeft(), n2.getLeft())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getRight(), n2.getRight())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final CastExpr n1, final Node arg) {
-		final CastExpr n2 = (CastExpr) arg;
-
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ClassExpr n1, final Node arg) {
-		final ClassExpr n2 = (ClassExpr) arg;
-
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ConditionalExpr n1, final Node arg) {
-		final ConditionalExpr n2 = (ConditionalExpr) arg;
-
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getThenExpr(), n2.getThenExpr())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getElseExpr(), n2.getElseExpr())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final EnclosedExpr n1, final Node arg) {
-		final EnclosedExpr n2 = (EnclosedExpr) arg;
-
-		if (!nodeEquals(n1.getInner(), n2.getInner())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final FieldAccessExpr n1, final Node arg) {
-		final FieldAccessExpr n2 = (FieldAccessExpr) arg;
-
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return Boolean.FALSE;
-		}
-
-		if (!objEquals(n1.getField(), n2.getField())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final InstanceOfExpr n1, final Node arg) {
-		final InstanceOfExpr n2 = (InstanceOfExpr) arg;
-
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final StringLiteralExpr n1, final Node arg) {
-		final StringLiteralExpr n2 = (StringLiteralExpr) arg;
-
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final IntegerLiteralExpr n1, final Node arg) {
-		final IntegerLiteralExpr n2 = (IntegerLiteralExpr) arg;
-
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final LongLiteralExpr n1, final Node arg) {
-		final LongLiteralExpr n2 = (LongLiteralExpr) arg;
-
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final IntegerLiteralMinValueExpr n1, final Node arg) {
-		final IntegerLiteralMinValueExpr n2 = (IntegerLiteralMinValueExpr) arg;
-
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final LongLiteralMinValueExpr n1, final Node arg) {
-		final LongLiteralMinValueExpr n2 = (LongLiteralMinValueExpr) arg;
-
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final CharLiteralExpr n1, final Node arg) {
-		final CharLiteralExpr n2 = (CharLiteralExpr) arg;
-
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final DoubleLiteralExpr n1, final Node arg) {
-		final DoubleLiteralExpr n2 = (DoubleLiteralExpr) arg;
-
-		if (!objEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final BooleanLiteralExpr n1, final Node arg) {
-		final BooleanLiteralExpr n2 = (BooleanLiteralExpr) arg;
-
-		if (n1.getValue() != n2.getValue()) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final NullLiteralExpr n1, final Node arg) {
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final MethodCallExpr n1, final Node arg) {
-		final MethodCallExpr n2 = (MethodCallExpr) arg;
-
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return Boolean.FALSE;
-		}
-
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final NameExpr n1, final Node arg) {
-		final NameExpr n2 = (NameExpr) arg;
-
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ObjectCreationExpr n1, final Node arg) {
-		final ObjectCreationExpr n2 = (ObjectCreationExpr) arg;
-
-		if (!nodeEquals(n1.getScope(), n2.getScope())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getAnonymousClassBody(), n2.getAnonymousClassBody())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return Boolean.FALSE;
-		}
-
-		if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final QualifiedNameExpr n1, final Node arg) {
-		final QualifiedNameExpr n2 = (QualifiedNameExpr) arg;
-
-		if (!nodeEquals(n1.getQualifier(), n2.getQualifier())) {
-			return Boolean.FALSE;
-		}
-
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
-
-		return Boolean.TRUE;
-	}
-
-	@Override public Boolean visit(final ThisExpr n1, final Node arg) {
-		final ThisExpr n2 = (ThisExpr) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final VariableDeclaratorId n1, final Node arg) {
+        final VariableDeclaratorId n2 = (VariableDeclaratorId) arg;
 
-		return Boolean.TRUE;
-	}
+        if (n1.getArrayCount() != n2.getArrayCount()) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final SuperExpr n1, final Node arg) {
-		final SuperExpr n2 = (SuperExpr) arg;
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		return Boolean.TRUE;
-	}
+    @Override public Boolean visit(final ConstructorDeclaration n1, final Node arg) {
+        final ConstructorDeclaration n2 = (ConstructorDeclaration) arg;
+
+        // javadoc are checked at CompilationUnit
+
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final UnaryExpr n1, final Node arg) {
-		final UnaryExpr n2 = (UnaryExpr) arg;
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (n1.getOperator() != n2.getOperator()) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final MethodDeclaration n1, final Node arg) {
+        final MethodDeclaration n2 = (MethodDeclaration) arg;
+
+        // javadoc are checked at CompilationUnit
+
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final VariableDeclarationExpr n1, final Node arg) {
-		final VariableDeclarationExpr n2 = (VariableDeclarationExpr) arg;
+        if (n1.getArrayCount() != n2.getArrayCount()) {
+            return Boolean.FALSE;
+        }
 
-		if (n1.getModifiers() != n2.getModifiers()) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getType(), n2.getType())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getVars(), n2.getVars())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getParameters(), n2.getParameters())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getThrows(), n2.getThrows())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getTypeParameters(), n2.getTypeParameters())) {
+            return Boolean.FALSE;
+        }
+        if(n1.isDefault() != n2.isDefault()){
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+    
+    @Override public Boolean visit(final Parameter n1, final Node arg) {
+        final Parameter n2 = (Parameter) arg;
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
+        return visit((BaseParameter) n1, arg);
+    }
+    
+    @Override public Boolean visit(MultiTypeParameter n1, Node arg) {
+        MultiTypeParameter n2 = (MultiTypeParameter) arg;
+        if (n1.getTypes().size() != n2.getTypes().size()) {
+            return Boolean.FALSE;
+        }
+        Iterator<Type> n1types = n1.getTypes().iterator();
+        Iterator<Type> n2types = n2.getTypes().iterator();
+        while (n1types.hasNext() && n2types.hasNext()) {
+            if (!nodeEquals(n1types.next(), n2types.next())) {
+                return Boolean.FALSE;
+            }
+        }
+        return visit((BaseParameter) n1, arg);
+    }
+
+    protected Boolean visit(final BaseParameter n1, final Node arg) {
+        final BaseParameter n2 = (BaseParameter) arg;
+
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getId(), n2.getId())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+    
+    @Override public Boolean visit(final EmptyMemberDeclaration n1, final Node arg) {
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final InitializerDeclaration n1, final Node arg) {
+        final InitializerDeclaration n2 = (InitializerDeclaration) arg;
+
+        if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final JavadocComment n1, final Node arg) {
+        final JavadocComment n2 = (JavadocComment) arg;
+
+        if (!objEquals(n1.getContent(), n2.getContent())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ClassOrInterfaceType n1, final Node arg) {
+        final ClassOrInterfaceType n2 = (ClassOrInterfaceType) arg;
+
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
+            return Boolean.FALSE;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final PrimitiveType n1, final Node arg) {
+        final PrimitiveType n2 = (PrimitiveType) arg;
+
+        if (n1.getType() != n2.getType()) {
+            return Boolean.FALSE;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ReferenceType n1, final Node arg) {
+        final ReferenceType n2 = (ReferenceType) arg;
+
+        if (n1.getArrayCount() != n2.getArrayCount()) {
+            return Boolean.FALSE;
+        }
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+        List<List<AnnotationExpr>> n1a = n1.getArraysAnnotations();
+        List<List<AnnotationExpr>> n2a = n2.getArraysAnnotations();
+
+        if (n1a !=null && n2a!= null) {
+            if(n1a.size() != n2a.size()){
+                return Boolean.FALSE;
+            }
+            else{
+                int i = 0;
+                for(List<AnnotationExpr> aux: n1a){
+                    if(!nodesEquals(aux, n2a.get(i))){
+                        return Boolean.FALSE;
+                    }
+                    i++;
+                }
+            }
+        }
+        else if (n1a != n2a){
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    public Boolean visit(VoidType n1, Node arg) {
+        VoidType n2 = (VoidType) arg;
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final WildcardType n1, final Node arg) {
+        final WildcardType n2 = (WildcardType) arg;
+
+        if (!nodeEquals(n1.getExtends(), n2.getExtends())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getSuper(), n2.getSuper())) {
+            return Boolean.FALSE;
+        }
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final UnknownType n1, final Node arg) {
+        final WildcardType n2 = (WildcardType) arg;
+
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ArrayAccessExpr n1, final Node arg) {
+        final ArrayAccessExpr n2 = (ArrayAccessExpr) arg;
+
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getIndex(), n2.getIndex())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ArrayCreationExpr n1, final Node arg) {
+        final ArrayCreationExpr n2 = (ArrayCreationExpr) arg;
+
+        if (n1.getArrayCount() != n2.getArrayCount()) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getInitializer(), n2.getInitializer())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getDimensions(), n2.getDimensions())) {
+            return Boolean.FALSE;
+        }
+        List<List<AnnotationExpr>> n1a = n1.getArraysAnnotations();
+        List<List<AnnotationExpr>> n2a = n2.getArraysAnnotations();
+
+        if (n1a !=null && n2a!= null) {
+            if(n1a.size() != n2a.size()){
+                return Boolean.FALSE;
+            }
+            else{
+                int i = 0;
+                for(List<AnnotationExpr> aux: n1a){
+                    if(!nodesEquals(aux, n2a.get(i))){
+                        return Boolean.FALSE;
+                    }
+                    i++;
+                }
+            }
+        }
+        else if (n1a != n2a){
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ArrayInitializerExpr n1, final Node arg) {
+        final ArrayInitializerExpr n2 = (ArrayInitializerExpr) arg;
+
+        if (!nodesEquals(n1.getValues(), n2.getValues())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final AssignExpr n1, final Node arg) {
+        final AssignExpr n2 = (AssignExpr) arg;
+
+        if (n1.getOperator() != n2.getOperator()) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getTarget(), n2.getTarget())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final BinaryExpr n1, final Node arg) {
+        final BinaryExpr n2 = (BinaryExpr) arg;
+
+        if (n1.getOperator() != n2.getOperator()) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getLeft(), n2.getLeft())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getRight(), n2.getRight())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final CastExpr n1, final Node arg) {
+        final CastExpr n2 = (CastExpr) arg;
+
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ClassExpr n1, final Node arg) {
+        final ClassExpr n2 = (ClassExpr) arg;
+
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ConditionalExpr n1, final Node arg) {
+        final ConditionalExpr n2 = (ConditionalExpr) arg;
+
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getThenExpr(), n2.getThenExpr())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getElseExpr(), n2.getElseExpr())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final EnclosedExpr n1, final Node arg) {
+        final EnclosedExpr n2 = (EnclosedExpr) arg;
+
+        if (!nodeEquals(n1.getInner(), n2.getInner())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final FieldAccessExpr n1, final Node arg) {
+        final FieldAccessExpr n2 = (FieldAccessExpr) arg;
+
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return Boolean.FALSE;
+        }
+
+        if (!objEquals(n1.getField(), n2.getField())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final InstanceOfExpr n1, final Node arg) {
+        final InstanceOfExpr n2 = (InstanceOfExpr) arg;
+
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final StringLiteralExpr n1, final Node arg) {
+        final StringLiteralExpr n2 = (StringLiteralExpr) arg;
+
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final IntegerLiteralExpr n1, final Node arg) {
+        final IntegerLiteralExpr n2 = (IntegerLiteralExpr) arg;
+
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final LongLiteralExpr n1, final Node arg) {
+        final LongLiteralExpr n2 = (LongLiteralExpr) arg;
+
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final IntegerLiteralMinValueExpr n1, final Node arg) {
+        final IntegerLiteralMinValueExpr n2 = (IntegerLiteralMinValueExpr) arg;
+
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final LongLiteralMinValueExpr n1, final Node arg) {
+        final LongLiteralMinValueExpr n2 = (LongLiteralMinValueExpr) arg;
+
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final CharLiteralExpr n1, final Node arg) {
+        final CharLiteralExpr n2 = (CharLiteralExpr) arg;
+
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final DoubleLiteralExpr n1, final Node arg) {
+        final DoubleLiteralExpr n2 = (DoubleLiteralExpr) arg;
+
+        if (!objEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final BooleanLiteralExpr n1, final Node arg) {
+        final BooleanLiteralExpr n2 = (BooleanLiteralExpr) arg;
+
+        if (n1.getValue() != n2.getValue()) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final NullLiteralExpr n1, final Node arg) {
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final MethodCallExpr n1, final Node arg) {
+        final MethodCallExpr n2 = (MethodCallExpr) arg;
+
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return Boolean.FALSE;
+        }
+
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final NameExpr n1, final Node arg) {
+        final NameExpr n2 = (NameExpr) arg;
+
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ObjectCreationExpr n1, final Node arg) {
+        final ObjectCreationExpr n2 = (ObjectCreationExpr) arg;
+
+        if (!nodeEquals(n1.getScope(), n2.getScope())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getAnonymousClassBody(), n2.getAnonymousClassBody())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final QualifiedNameExpr n1, final Node arg) {
+        final QualifiedNameExpr n2 = (QualifiedNameExpr) arg;
 
-	@Override public Boolean visit(final MarkerAnnotationExpr n1, final Node arg) {
-		final MarkerAnnotationExpr n2 = (MarkerAnnotationExpr) arg;
+        if (!nodeEquals(n1.getQualifier(), n2.getQualifier())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final SingleMemberAnnotationExpr n1, final Node arg) {
-		final SingleMemberAnnotationExpr n2 = (SingleMemberAnnotationExpr) arg;
+    @Override public Boolean visit(final ThisExpr n1, final Node arg) {
+        final ThisExpr n2 = (ThisExpr) arg;
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getMemberValue(), n2.getMemberValue())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		return Boolean.TRUE;
-	}
+    @Override public Boolean visit(final SuperExpr n1, final Node arg) {
+        final SuperExpr n2 = (SuperExpr) arg;
 
-	@Override public Boolean visit(final NormalAnnotationExpr n1, final Node arg) {
-		final NormalAnnotationExpr n2 = (NormalAnnotationExpr) arg;
+        if (!nodeEquals(n1.getClassExpr(), n2.getClassExpr())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getPairs(), n2.getPairs())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final UnaryExpr n1, final Node arg) {
+        final UnaryExpr n2 = (UnaryExpr) arg;
 
-		return Boolean.TRUE;
-	}
+        if (n1.getOperator() != n2.getOperator()) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final MemberValuePair n1, final Node arg) {
-		final MemberValuePair n2 = (MemberValuePair) arg;
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return Boolean.FALSE;
+        }
 
-		if (!objEquals(n1.getName(), n2.getName())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getValue(), n2.getValue())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final VariableDeclarationExpr n1, final Node arg) {
+        final VariableDeclarationExpr n2 = (VariableDeclarationExpr) arg;
 
-		return Boolean.TRUE;
-	}
+        if (n1.getModifiers() != n2.getModifiers()) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final ExplicitConstructorInvocationStmt n1, final Node arg) {
-		final ExplicitConstructorInvocationStmt n2 = (ExplicitConstructorInvocationStmt) arg;
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getType(), n2.getType())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getVars(), n2.getVars())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		return Boolean.TRUE;
-	}
+    @Override public Boolean visit(final MarkerAnnotationExpr n1, final Node arg) {
+        final MarkerAnnotationExpr n2 = (MarkerAnnotationExpr) arg;
 
-	@Override public Boolean visit(final TypeDeclarationStmt n1, final Node arg) {
-		final TypeDeclarationStmt n2 = (TypeDeclarationStmt) arg;
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getTypeDeclaration(), n2.getTypeDeclaration())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		return Boolean.TRUE;
-	}
+    @Override public Boolean visit(final SingleMemberAnnotationExpr n1, final Node arg) {
+        final SingleMemberAnnotationExpr n2 = (SingleMemberAnnotationExpr) arg;
 
-	@Override public Boolean visit(final AssertStmt n1, final Node arg) {
-		final AssertStmt n2 = (AssertStmt) arg;
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getCheck(), n2.getCheck())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getMemberValue(), n2.getMemberValue())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getMessage(), n2.getMessage())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		return Boolean.TRUE;
-	}
+    @Override public Boolean visit(final NormalAnnotationExpr n1, final Node arg) {
+        final NormalAnnotationExpr n2 = (NormalAnnotationExpr) arg;
 
-	@Override public Boolean visit(final BlockStmt n1, final Node arg) {
-		final BlockStmt n2 = (BlockStmt) arg;
+        if (!nodeEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getPairs(), n2.getPairs())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final LabeledStmt n1, final Node arg) {
-		final LabeledStmt n2 = (LabeledStmt) arg;
+    @Override public Boolean visit(final MemberValuePair n1, final Node arg) {
+        final MemberValuePair n2 = (MemberValuePair) arg;
 
-		if (!nodeEquals(n1.getStmt(), n2.getStmt())) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getName(), n2.getName())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getValue(), n2.getValue())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final EmptyStmt n1, final Node arg) {
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final ExpressionStmt n1, final Node arg) {
-		final ExpressionStmt n2 = (ExpressionStmt) arg;
+    @Override public Boolean visit(final ExplicitConstructorInvocationStmt n1, final Node arg) {
+        final ExplicitConstructorInvocationStmt n2 = (ExplicitConstructorInvocationStmt) arg;
 
-		if (!nodeEquals(n1.getExpression(), n2.getExpression())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getArgs(), n2.getArgs())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final SwitchStmt n1, final Node arg) {
-		final SwitchStmt n2 = (SwitchStmt) arg;
+        if (!nodesEquals(n1.getTypeArgs(), n2.getTypeArgs())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getSelector(), n2.getSelector())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final TypeDeclarationStmt n1, final Node arg) {
+        final TypeDeclarationStmt n2 = (TypeDeclarationStmt) arg;
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getTypeDeclaration(), n2.getTypeDeclaration())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final SwitchEntryStmt n1, final Node arg) {
-		final SwitchEntryStmt n2 = (SwitchEntryStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getLabel(), n2.getLabel())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final AssertStmt n1, final Node arg) {
+        final AssertStmt n2 = (AssertStmt) arg;
 
-		if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getCheck(), n2.getCheck())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getMessage(), n2.getMessage())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final BreakStmt n1, final Node arg) {
-		final BreakStmt n2 = (BreakStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!objEquals(n1.getId(), n2.getId())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final BlockStmt n1, final Node arg) {
+        final BlockStmt n2 = (BlockStmt) arg;
 
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final ReturnStmt n1, final Node arg) {
-		final ReturnStmt n2 = (ReturnStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final LabeledStmt n1, final Node arg) {
+        final LabeledStmt n2 = (LabeledStmt) arg;
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getStmt(), n2.getStmt())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final IfStmt n1, final Node arg) {
-		final IfStmt n2 = (IfStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final EmptyStmt n1, final Node arg) {
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getThenStmt(), n2.getThenStmt())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final ExpressionStmt n1, final Node arg) {
+        final ExpressionStmt n2 = (ExpressionStmt) arg;
 
-		if (!nodeEquals(n1.getElseStmt(), n2.getElseStmt())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getExpression(), n2.getExpression())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final WhileStmt n1, final Node arg) {
-		final WhileStmt n2 = (WhileStmt) arg;
+    @Override public Boolean visit(final SwitchStmt n1, final Node arg) {
+        final SwitchStmt n2 = (SwitchStmt) arg;
 
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getSelector(), n2.getSelector())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getEntries(), n2.getEntries())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final ContinueStmt n1, final Node arg) {
-		final ContinueStmt n2 = (ContinueStmt) arg;
+    @Override public Boolean visit(final SwitchEntryStmt n1, final Node arg) {
+        final SwitchEntryStmt n2 = (SwitchEntryStmt) arg;
 
-		if (!objEquals(n1.getId(), n2.getId())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getLabel(), n2.getLabel())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodesEquals(n1.getStmts(), n2.getStmts())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final DoStmt n1, final Node arg) {
-		final DoStmt n2 = (DoStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final BreakStmt n1, final Node arg) {
+        final BreakStmt n2 = (BreakStmt) arg;
 
-		if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
-			return Boolean.FALSE;
-		}
+        if (!objEquals(n1.getId(), n2.getId())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        return Boolean.TRUE;
+    }
 
-	@Override public Boolean visit(final ForeachStmt n1, final Node arg) {
-		final ForeachStmt n2 = (ForeachStmt) arg;
+    @Override public Boolean visit(final ReturnStmt n1, final Node arg) {
+        final ReturnStmt n2 = (ReturnStmt) arg;
 
-		if (!nodeEquals(n1.getVariable(), n2.getVariable())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getIterable(), n2.getIterable())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final IfStmt n1, final Node arg) {
+        final IfStmt n2 = (IfStmt) arg;
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final ForStmt n1, final Node arg) {
-		final ForStmt n2 = (ForStmt) arg;
+        if (!nodeEquals(n1.getThenStmt(), n2.getThenStmt())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodesEquals(n1.getInit(), n2.getInit())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getElseStmt(), n2.getElseStmt())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getCompare(), n2.getCompare())) {
-			return Boolean.FALSE;
-		}
+        return Boolean.TRUE;
+    }
 
-		if (!nodesEquals(n1.getUpdate(), n2.getUpdate())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final WhileStmt n1, final Node arg) {
+        final WhileStmt n2 = (WhileStmt) arg;
 
-		if (!nodeEquals(n1.getBody(), n2.getBody())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final ThrowStmt n1, final Node arg) {
-		final ThrowStmt n2 = (ThrowStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final ContinueStmt n1, final Node arg) {
+        final ContinueStmt n2 = (ContinueStmt) arg;
 
-		return Boolean.TRUE;
-	}
+        if (!objEquals(n1.getId(), n2.getId())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final SynchronizedStmt n1, final Node arg) {
-		final SynchronizedStmt n2 = (SynchronizedStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final DoStmt n1, final Node arg) {
+        final DoStmt n2 = (DoStmt) arg;
 
-		if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getCondition(), n2.getCondition())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final TryStmt n1, final Node arg) {
-		final TryStmt n2 = (TryStmt) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getTryBlock(), n2.getTryBlock())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final ForeachStmt n1, final Node arg) {
+        final ForeachStmt n2 = (ForeachStmt) arg;
 
-		if (!nodesEquals(n1.getCatchs(), n2.getCatchs())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getVariable(), n2.getVariable())) {
+            return Boolean.FALSE;
+        }
 
-		if (!nodeEquals(n1.getFinallyBlock(), n2.getFinallyBlock())) {
-			return Boolean.FALSE;
-		}
+        if (!nodeEquals(n1.getIterable(), n2.getIterable())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return Boolean.FALSE;
+        }
 
-	@Override public Boolean visit(final CatchClause n1, final Node arg) {
-		final CatchClause n2 = (CatchClause) arg;
+        return Boolean.TRUE;
+    }
 
-		if (!nodeEquals(n1.getExcept(), n2.getExcept())) {
-			return Boolean.FALSE;
-		}
+    @Override public Boolean visit(final ForStmt n1, final Node arg) {
+        final ForStmt n2 = (ForStmt) arg;
 
-		if (!nodeEquals(n1.getCatchBlock(), n2.getCatchBlock())) {
-			return Boolean.FALSE;
-		}
+        if (!nodesEquals(n1.getInit(), n2.getInit())) {
+            return Boolean.FALSE;
+        }
 
-		return Boolean.TRUE;
-	}
+        if (!nodeEquals(n1.getCompare(), n2.getCompare())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getUpdate(), n2.getUpdate())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getBody(), n2.getBody())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final ThrowStmt n1, final Node arg) {
+        final ThrowStmt n2 = (ThrowStmt) arg;
+
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final SynchronizedStmt n1, final Node arg) {
+        final SynchronizedStmt n2 = (SynchronizedStmt) arg;
+
+        if (!nodeEquals(n1.getExpr(), n2.getExpr())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getBlock(), n2.getBlock())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final TryStmt n1, final Node arg) {
+        final TryStmt n2 = (TryStmt) arg;
+
+        if (!nodeEquals(n1.getTryBlock(), n2.getTryBlock())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodesEquals(n1.getCatchs(), n2.getCatchs())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getFinallyBlock(), n2.getFinallyBlock())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
+
+    @Override public Boolean visit(final CatchClause n1, final Node arg) {
+        final CatchClause n2 = (CatchClause) arg;
+
+        if (!nodeEquals(n1.getExcept(), n2.getExcept())) {
+            return Boolean.FALSE;
+        }
+
+        if (!nodeEquals(n1.getCatchBlock(), n2.getCatchBlock())) {
+            return Boolean.FALSE;
+        }
+
+        return Boolean.TRUE;
+    }
 
     @Override
     public Boolean visit(LambdaExpr n1, Node arg) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/GenericVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/GenericVisitor.java
@@ -74,177 +74,177 @@ import com.github.javaparser.ast.type.*;
  */
 public interface GenericVisitor<R, A> {
 
-	//- Compilation Unit ----------------------------------
+    //- Compilation Unit ----------------------------------
 
-	public R visit(CompilationUnit n, A arg);
+    public R visit(CompilationUnit n, A arg);
 
-	public R visit(PackageDeclaration n, A arg);
+    public R visit(PackageDeclaration n, A arg);
 
-	public R visit(ImportDeclaration n, A arg);
+    public R visit(ImportDeclaration n, A arg);
 
-	public R visit(TypeParameter n, A arg);
+    public R visit(TypeParameter n, A arg);
 
-	public R visit(LineComment n, A arg);
+    public R visit(LineComment n, A arg);
 
-	public R visit(BlockComment n, A arg);
+    public R visit(BlockComment n, A arg);
 
-	//- Body ----------------------------------------------
+    //- Body ----------------------------------------------
 
-	public R visit(ClassOrInterfaceDeclaration n, A arg);
+    public R visit(ClassOrInterfaceDeclaration n, A arg);
 
-	public R visit(EnumDeclaration n, A arg);
+    public R visit(EnumDeclaration n, A arg);
 
-	public R visit(EmptyTypeDeclaration n, A arg);
+    public R visit(EmptyTypeDeclaration n, A arg);
 
-	public R visit(EnumConstantDeclaration n, A arg);
+    public R visit(EnumConstantDeclaration n, A arg);
 
-	public R visit(AnnotationDeclaration n, A arg);
+    public R visit(AnnotationDeclaration n, A arg);
 
-	public R visit(AnnotationMemberDeclaration n, A arg);
+    public R visit(AnnotationMemberDeclaration n, A arg);
 
-	public R visit(FieldDeclaration n, A arg);
+    public R visit(FieldDeclaration n, A arg);
 
-	public R visit(VariableDeclarator n, A arg);
+    public R visit(VariableDeclarator n, A arg);
 
-	public R visit(VariableDeclaratorId n, A arg);
+    public R visit(VariableDeclaratorId n, A arg);
 
-	public R visit(ConstructorDeclaration n, A arg);
+    public R visit(ConstructorDeclaration n, A arg);
 
-	public R visit(MethodDeclaration n, A arg);
+    public R visit(MethodDeclaration n, A arg);
 
-	public R visit(Parameter n, A arg);
-	
-	public R visit(MultiTypeParameter n, A arg);
+    public R visit(Parameter n, A arg);
+    
+    public R visit(MultiTypeParameter n, A arg);
 
-	public R visit(EmptyMemberDeclaration n, A arg);
+    public R visit(EmptyMemberDeclaration n, A arg);
 
-	public R visit(InitializerDeclaration n, A arg);
+    public R visit(InitializerDeclaration n, A arg);
 
-	public R visit(JavadocComment n, A arg);
+    public R visit(JavadocComment n, A arg);
 
-	//- Type ----------------------------------------------
+    //- Type ----------------------------------------------
 
-	public R visit(ClassOrInterfaceType n, A arg);
+    public R visit(ClassOrInterfaceType n, A arg);
 
-	public R visit(PrimitiveType n, A arg);
+    public R visit(PrimitiveType n, A arg);
 
-	public R visit(ReferenceType n, A arg);
+    public R visit(ReferenceType n, A arg);
 
-	public R visit(VoidType n, A arg);
+    public R visit(VoidType n, A arg);
 
-	public R visit(WildcardType n, A arg);
+    public R visit(WildcardType n, A arg);
 
-	public R visit(UnknownType n, A arg);
+    public R visit(UnknownType n, A arg);
 
-	//- Expression ----------------------------------------
+    //- Expression ----------------------------------------
 
-	public R visit(ArrayAccessExpr n, A arg);
+    public R visit(ArrayAccessExpr n, A arg);
 
-	public R visit(ArrayCreationExpr n, A arg);
+    public R visit(ArrayCreationExpr n, A arg);
 
-	public R visit(ArrayInitializerExpr n, A arg);
+    public R visit(ArrayInitializerExpr n, A arg);
 
-	public R visit(AssignExpr n, A arg);
+    public R visit(AssignExpr n, A arg);
 
-	public R visit(BinaryExpr n, A arg);
+    public R visit(BinaryExpr n, A arg);
 
-	public R visit(CastExpr n, A arg);
+    public R visit(CastExpr n, A arg);
 
-	public R visit(ClassExpr n, A arg);
+    public R visit(ClassExpr n, A arg);
 
-	public R visit(ConditionalExpr n, A arg);
+    public R visit(ConditionalExpr n, A arg);
 
-	public R visit(EnclosedExpr n, A arg);
+    public R visit(EnclosedExpr n, A arg);
 
-	public R visit(FieldAccessExpr n, A arg);
+    public R visit(FieldAccessExpr n, A arg);
 
-	public R visit(InstanceOfExpr n, A arg);
+    public R visit(InstanceOfExpr n, A arg);
 
-	public R visit(StringLiteralExpr n, A arg);
+    public R visit(StringLiteralExpr n, A arg);
 
-	public R visit(IntegerLiteralExpr n, A arg);
+    public R visit(IntegerLiteralExpr n, A arg);
 
-	public R visit(LongLiteralExpr n, A arg);
+    public R visit(LongLiteralExpr n, A arg);
 
-	public R visit(IntegerLiteralMinValueExpr n, A arg);
+    public R visit(IntegerLiteralMinValueExpr n, A arg);
 
-	public R visit(LongLiteralMinValueExpr n, A arg);
+    public R visit(LongLiteralMinValueExpr n, A arg);
 
-	public R visit(CharLiteralExpr n, A arg);
+    public R visit(CharLiteralExpr n, A arg);
 
-	public R visit(DoubleLiteralExpr n, A arg);
+    public R visit(DoubleLiteralExpr n, A arg);
 
-	public R visit(BooleanLiteralExpr n, A arg);
+    public R visit(BooleanLiteralExpr n, A arg);
 
-	public R visit(NullLiteralExpr n, A arg);
+    public R visit(NullLiteralExpr n, A arg);
 
-	public R visit(MethodCallExpr n, A arg);
+    public R visit(MethodCallExpr n, A arg);
 
-	public R visit(NameExpr n, A arg);
+    public R visit(NameExpr n, A arg);
 
-	public R visit(ObjectCreationExpr n, A arg);
+    public R visit(ObjectCreationExpr n, A arg);
 
-	public R visit(QualifiedNameExpr n, A arg);
+    public R visit(QualifiedNameExpr n, A arg);
 
-	public R visit(ThisExpr n, A arg);
+    public R visit(ThisExpr n, A arg);
 
-	public R visit(SuperExpr n, A arg);
+    public R visit(SuperExpr n, A arg);
 
-	public R visit(UnaryExpr n, A arg);
+    public R visit(UnaryExpr n, A arg);
 
-	public R visit(VariableDeclarationExpr n, A arg);
+    public R visit(VariableDeclarationExpr n, A arg);
 
-	public R visit(MarkerAnnotationExpr n, A arg);
+    public R visit(MarkerAnnotationExpr n, A arg);
 
-	public R visit(SingleMemberAnnotationExpr n, A arg);
+    public R visit(SingleMemberAnnotationExpr n, A arg);
 
-	public R visit(NormalAnnotationExpr n, A arg);
+    public R visit(NormalAnnotationExpr n, A arg);
 
-	public R visit(MemberValuePair n, A arg);
+    public R visit(MemberValuePair n, A arg);
 
-	//- Statements ----------------------------------------
+    //- Statements ----------------------------------------
 
-	public R visit(ExplicitConstructorInvocationStmt n, A arg);
+    public R visit(ExplicitConstructorInvocationStmt n, A arg);
 
-	public R visit(TypeDeclarationStmt n, A arg);
+    public R visit(TypeDeclarationStmt n, A arg);
 
-	public R visit(AssertStmt n, A arg);
+    public R visit(AssertStmt n, A arg);
 
-	public R visit(BlockStmt n, A arg);
+    public R visit(BlockStmt n, A arg);
 
-	public R visit(LabeledStmt n, A arg);
+    public R visit(LabeledStmt n, A arg);
 
-	public R visit(EmptyStmt n, A arg);
+    public R visit(EmptyStmt n, A arg);
 
-	public R visit(ExpressionStmt n, A arg);
+    public R visit(ExpressionStmt n, A arg);
 
-	public R visit(SwitchStmt n, A arg);
+    public R visit(SwitchStmt n, A arg);
 
-	public R visit(SwitchEntryStmt n, A arg);
+    public R visit(SwitchEntryStmt n, A arg);
 
-	public R visit(BreakStmt n, A arg);
+    public R visit(BreakStmt n, A arg);
 
-	public R visit(ReturnStmt n, A arg);
+    public R visit(ReturnStmt n, A arg);
 
-	public R visit(IfStmt n, A arg);
+    public R visit(IfStmt n, A arg);
 
-	public R visit(WhileStmt n, A arg);
+    public R visit(WhileStmt n, A arg);
 
-	public R visit(ContinueStmt n, A arg);
+    public R visit(ContinueStmt n, A arg);
 
-	public R visit(DoStmt n, A arg);
+    public R visit(DoStmt n, A arg);
 
-	public R visit(ForeachStmt n, A arg);
+    public R visit(ForeachStmt n, A arg);
 
-	public R visit(ForStmt n, A arg);
+    public R visit(ForStmt n, A arg);
 
-	public R visit(ThrowStmt n, A arg);
+    public R visit(ThrowStmt n, A arg);
 
-	public R visit(SynchronizedStmt n, A arg);
+    public R visit(SynchronizedStmt n, A arg);
 
-	public R visit(TryStmt n, A arg);
+    public R visit(TryStmt n, A arg);
 
-	public R visit(CatchClause n, A arg);
+    public R visit(CatchClause n, A arg);
 
     public R visit(LambdaExpr n, A arg);
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -75,1515 +75,1515 @@ import com.github.javaparser.ast.type.*;
  */
 public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A> {
 
-	@Override
-	public R visit(final AnnotationDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getMembers() != null) {
-			for (final BodyDeclaration member : n.getMembers()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final AnnotationMemberDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getDefaultValue() != null) {
-			{
-				R result = n.getDefaultValue().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ArrayAccessExpr n, final A arg) {
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getIndex().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ArrayCreationExpr n, final A arg) {
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getDimensions() != null) {
-			for (final Expression dim : n.getDimensions()) {
-				{
-					R result = dim.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		} else {
-			{
-				R result = n.getInitializer().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ArrayInitializerExpr n, final A arg) {
-		if (n.getValues() != null) {
-			for (final Expression expr : n.getValues()) {
-				{
-					R result = expr.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final AssertStmt n, final A arg) {
-		{
-			R result = n.getCheck().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getMessage() != null) {
-			{
-				R result = n.getMessage().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final AssignExpr n, final A arg) {
-		{
-			R result = n.getTarget().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getValue().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final BinaryExpr n, final A arg) {
-		{
-			R result = n.getLeft().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getRight().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final BlockStmt n, final A arg) {
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				{
-					R result = s.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-
-	}
-
-	@Override
-	public R visit(final BooleanLiteralExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final BreakStmt n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final CastExpr n, final A arg) {
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final CatchClause n, final A arg) {
-		{
-			R result = n.getExcept().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getCatchBlock().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-
-	}
-
-	@Override
-	public R visit(final CharLiteralExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final ClassExpr n, final A arg) {
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ClassOrInterfaceDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getExtends() != null) {
-			for (final ClassOrInterfaceType c : n.getExtends()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-
-		if (n.getImplements() != null) {
-			for (final ClassOrInterfaceType c : n.getImplements()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getMembers() != null) {
-			for (final BodyDeclaration member : n.getMembers()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ClassOrInterfaceType n, final A arg) {
-		if (n.getScope() != null) {
-			{
-				R result = n.getScope().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final CompilationUnit n, final A arg) {
-		if (n.getPackage() != null) {
-			{
-				R result = n.getPackage().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getImports() != null) {
-			for (final ImportDeclaration i : n.getImports()) {
-				{
-					R result = i.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypes() != null) {
-			for (final TypeDeclaration typeDeclaration : n.getTypes()) {
-				{
-					R result = typeDeclaration.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ConditionalExpr n, final A arg) {
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getThenExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getElseExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ConstructorDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				{
-					R result = p.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
-				{
-					R result = name.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getBlock().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ContinueStmt n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final DoStmt n, final A arg) {
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final DoubleLiteralExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final EmptyMemberDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final EmptyStmt n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final EmptyTypeDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final EnclosedExpr n, final A arg) {
-		{
-			R result = n.getInner().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final EnumConstantDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getClassBody() != null) {
-			for (final BodyDeclaration member : n.getClassBody()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final EnumDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getImplements() != null) {
-			for (final ClassOrInterfaceType c : n.getImplements()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getEntries() != null) {
-			for (final EnumConstantDeclaration e : n.getEntries()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getMembers() != null) {
-			for (final BodyDeclaration member : n.getMembers()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-		if (!n.isThis()) {
-			if (n.getExpr() != null) {
-				{
-					R result = n.getExpr().accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ExpressionStmt n, final A arg) {
-		{
-			R result = n.getExpression().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final FieldAccessExpr n, final A arg) {
-		{
-			R result = n.getScope().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final FieldDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		for (final VariableDeclarator var : n.getVariables()) {
-			{
-				R result = var.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ForeachStmt n, final A arg) {
-		{
-			R result = n.getVariable().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getIterable().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ForStmt n, final A arg) {
-		if (n.getInit() != null) {
-			for (final Expression e : n.getInit()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getCompare() != null) {
-			{
-				R result = n.getCompare().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getUpdate() != null) {
-			for (final Expression e : n.getUpdate()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final IfStmt n, final A arg) {
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getThenStmt().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getElseStmt() != null) {
-			{
-				R result = n.getElseStmt().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ImportDeclaration n, final A arg) {
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final InitializerDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		{
-			R result = n.getBlock().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final InstanceOfExpr n, final A arg) {
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final IntegerLiteralExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final IntegerLiteralMinValueExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final JavadocComment n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final LabeledStmt n, final A arg) {
-		{
-			R result = n.getStmt().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final LongLiteralExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final LongLiteralMinValueExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final MarkerAnnotationExpr n, final A arg) {
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final MemberValuePair n, final A arg) {
-		{
-			R result = n.getValue().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final MethodCallExpr n, final A arg) {
-		if (n.getScope() != null) {
-			{
-				R result = n.getScope().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final MethodDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			{
-				R result = n.getJavaDoc().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				{
-					R result = p.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
-				{
-					R result = name.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getBody() != null) {
-			{
-				R result = n.getBody().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final NameExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final NormalAnnotationExpr n, final A arg) {
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getPairs() != null) {
-			for (final MemberValuePair m : n.getPairs()) {
-				{
-					R result = m.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final NullLiteralExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final ObjectCreationExpr n, final A arg) {
-		if (n.getScope() != null) {
-			{
-				R result = n.getScope().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				{
-					R result = t.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getAnonymousClassBody() != null) {
-			for (final BodyDeclaration member : n.getAnonymousClassBody()) {
-				{
-					R result = member.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final PackageDeclaration n, final A arg) {
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final Parameter n, final A arg) {
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getId().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-	
-	@Override
-	public R visit(final MultiTypeParameter n, final A arg) {
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			for (final Type type : n.getTypes()) {
-				R result = type.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		{
-			R result = n.getId().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final PrimitiveType n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final QualifiedNameExpr n, final A arg) {
-		{
-			R result = n.getQualifier().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ReferenceType n, final A arg) {
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ReturnStmt n, final A arg) {
-		if (n.getExpr() != null) {
-			{
-				R result = n.getExpr().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final SingleMemberAnnotationExpr n, final A arg) {
-		{
-			R result = n.getName().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getMemberValue().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final StringLiteralExpr n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final SuperExpr n, final A arg) {
-		if (n.getClassExpr() != null) {
-			{
-				R result = n.getClassExpr().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final SwitchEntryStmt n, final A arg) {
-		if (n.getLabel() != null) {
-			{
-				R result = n.getLabel().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				{
-					R result = s.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final SwitchStmt n, final A arg) {
-		{
-			R result = n.getSelector().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getEntries() != null) {
-			for (final SwitchEntryStmt e : n.getEntries()) {
-				{
-					R result = e.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-
-	}
-
-	@Override
-	public R visit(final SynchronizedStmt n, final A arg) {
-		{
-			if (n.getExpr() != null) {
-			    R result = n.getExpr().accept(this, arg);
-			    if (result != null) {
-				    return result;
-			    }
-			}
-		}
-		{
-			R result = n.getBlock().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ThisExpr n, final A arg) {
-		if (n.getClassExpr() != null) {
-			{
-				R result = n.getClassExpr().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final ThrowStmt n, final A arg) {
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final TryStmt n, final A arg) {
-		if (n.getResources() != null) {
-			for (final VariableDeclarationExpr v : n.getResources()) {
-				{
-					R result = v.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getTryBlock().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getCatchs() != null) {
-			for (final CatchClause c : n.getCatchs()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		if (n.getFinallyBlock() != null) {
-			{
-				R result = n.getFinallyBlock().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final TypeDeclarationStmt n, final A arg) {
-		{
-			R result = n.getTypeDeclaration().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final TypeParameter n, final A arg) {
-		if (n.getTypeBound() != null) {
-			for (final ClassOrInterfaceType c : n.getTypeBound()) {
-				{
-					R result = c.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final UnaryExpr n, final A arg) {
-		{
-			R result = n.getExpr().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final UnknownType n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final VariableDeclarationExpr n, final A arg) {
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				{
-					R result = a.accept(this, arg);
-					if (result != null) {
-						return result;
-					}
-				}
-			}
-		}
-		{
-			R result = n.getType().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		for (final VariableDeclarator v : n.getVars()) {
-			{
-				R result = v.accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final VariableDeclarator n, final A arg) {
-		{
-			R result = n.getId().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		if (n.getInit() != null) {
-			{
-				R result = n.getInit().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final VariableDeclaratorId n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final VoidType n, final A arg) {
-		return null;
-	}
-
-	@Override
-	public R visit(final WhileStmt n, final A arg) {
-		{
-			R result = n.getCondition().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		{
-			R result = n.getBody().accept(this, arg);
-			if (result != null) {
-				return result;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public R visit(final WildcardType n, final A arg) {
-		if (n.getExtends() != null) {
-			{
-				R result = n.getExtends().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		if (n.getSuper() != null) {
-			{
-				R result = n.getSuper().accept(this, arg);
-				if (result != null) {
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+    @Override
+    public R visit(final AnnotationDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration member : n.getMembers()) {
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final AnnotationMemberDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getDefaultValue() != null) {
+            {
+                R result = n.getDefaultValue().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ArrayAccessExpr n, final A arg) {
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getIndex().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ArrayCreationExpr n, final A arg) {
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getDimensions() != null) {
+            for (final Expression dim : n.getDimensions()) {
+                {
+                    R result = dim.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        } else {
+            {
+                R result = n.getInitializer().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ArrayInitializerExpr n, final A arg) {
+        if (n.getValues() != null) {
+            for (final Expression expr : n.getValues()) {
+                {
+                    R result = expr.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final AssertStmt n, final A arg) {
+        {
+            R result = n.getCheck().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getMessage() != null) {
+            {
+                R result = n.getMessage().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final AssignExpr n, final A arg) {
+        {
+            R result = n.getTarget().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getValue().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final BinaryExpr n, final A arg) {
+        {
+            R result = n.getLeft().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getRight().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final BlockStmt n, final A arg) {
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                {
+                    R result = s.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+
+    }
+
+    @Override
+    public R visit(final BooleanLiteralExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final BreakStmt n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final CastExpr n, final A arg) {
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final CatchClause n, final A arg) {
+        {
+            R result = n.getExcept().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getCatchBlock().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+
+    }
+
+    @Override
+    public R visit(final CharLiteralExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final ClassExpr n, final A arg) {
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ClassOrInterfaceDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getExtends() != null) {
+            for (final ClassOrInterfaceType c : n.getExtends()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+
+        if (n.getImplements() != null) {
+            for (final ClassOrInterfaceType c : n.getImplements()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration member : n.getMembers()) {
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ClassOrInterfaceType n, final A arg) {
+        if (n.getScope() != null) {
+            {
+                R result = n.getScope().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final CompilationUnit n, final A arg) {
+        if (n.getPackage() != null) {
+            {
+                R result = n.getPackage().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getImports() != null) {
+            for (final ImportDeclaration i : n.getImports()) {
+                {
+                    R result = i.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypes() != null) {
+            for (final TypeDeclaration typeDeclaration : n.getTypes()) {
+                {
+                    R result = typeDeclaration.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ConditionalExpr n, final A arg) {
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getThenExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getElseExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ConstructorDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                {
+                    R result = p.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final NameExpr name : n.getThrows()) {
+                {
+                    R result = name.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getBlock().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ContinueStmt n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final DoStmt n, final A arg) {
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final DoubleLiteralExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final EmptyMemberDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final EmptyStmt n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final EmptyTypeDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final EnclosedExpr n, final A arg) {
+        {
+            R result = n.getInner().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final EnumConstantDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getClassBody() != null) {
+            for (final BodyDeclaration member : n.getClassBody()) {
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final EnumDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getImplements() != null) {
+            for (final ClassOrInterfaceType c : n.getImplements()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getEntries() != null) {
+            for (final EnumConstantDeclaration e : n.getEntries()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration member : n.getMembers()) {
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ExplicitConstructorInvocationStmt n, final A arg) {
+        if (!n.isThis()) {
+            if (n.getExpr() != null) {
+                {
+                    R result = n.getExpr().accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ExpressionStmt n, final A arg) {
+        {
+            R result = n.getExpression().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final FieldAccessExpr n, final A arg) {
+        {
+            R result = n.getScope().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final FieldDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        for (final VariableDeclarator var : n.getVariables()) {
+            {
+                R result = var.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ForeachStmt n, final A arg) {
+        {
+            R result = n.getVariable().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getIterable().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ForStmt n, final A arg) {
+        if (n.getInit() != null) {
+            for (final Expression e : n.getInit()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getCompare() != null) {
+            {
+                R result = n.getCompare().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getUpdate() != null) {
+            for (final Expression e : n.getUpdate()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final IfStmt n, final A arg) {
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getThenStmt().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getElseStmt() != null) {
+            {
+                R result = n.getElseStmt().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ImportDeclaration n, final A arg) {
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final InitializerDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        {
+            R result = n.getBlock().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final InstanceOfExpr n, final A arg) {
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final IntegerLiteralExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final IntegerLiteralMinValueExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final JavadocComment n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final LabeledStmt n, final A arg) {
+        {
+            R result = n.getStmt().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final LongLiteralExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final LongLiteralMinValueExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final MarkerAnnotationExpr n, final A arg) {
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final MemberValuePair n, final A arg) {
+        {
+            R result = n.getValue().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final MethodCallExpr n, final A arg) {
+        if (n.getScope() != null) {
+            {
+                R result = n.getScope().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final MethodDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            {
+                R result = n.getJavaDoc().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                {
+                    R result = p.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final NameExpr name : n.getThrows()) {
+                {
+                    R result = name.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getBody() != null) {
+            {
+                R result = n.getBody().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final NameExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final NormalAnnotationExpr n, final A arg) {
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getPairs() != null) {
+            for (final MemberValuePair m : n.getPairs()) {
+                {
+                    R result = m.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final NullLiteralExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final ObjectCreationExpr n, final A arg) {
+        if (n.getScope() != null) {
+            {
+                R result = n.getScope().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                {
+                    R result = t.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getAnonymousClassBody() != null) {
+            for (final BodyDeclaration member : n.getAnonymousClassBody()) {
+                {
+                    R result = member.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final PackageDeclaration n, final A arg) {
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final Parameter n, final A arg) {
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getId().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+    
+    @Override
+    public R visit(final MultiTypeParameter n, final A arg) {
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            for (final Type type : n.getTypes()) {
+                R result = type.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        {
+            R result = n.getId().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final PrimitiveType n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final QualifiedNameExpr n, final A arg) {
+        {
+            R result = n.getQualifier().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ReferenceType n, final A arg) {
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ReturnStmt n, final A arg) {
+        if (n.getExpr() != null) {
+            {
+                R result = n.getExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final SingleMemberAnnotationExpr n, final A arg) {
+        {
+            R result = n.getName().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getMemberValue().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final StringLiteralExpr n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final SuperExpr n, final A arg) {
+        if (n.getClassExpr() != null) {
+            {
+                R result = n.getClassExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final SwitchEntryStmt n, final A arg) {
+        if (n.getLabel() != null) {
+            {
+                R result = n.getLabel().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                {
+                    R result = s.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final SwitchStmt n, final A arg) {
+        {
+            R result = n.getSelector().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getEntries() != null) {
+            for (final SwitchEntryStmt e : n.getEntries()) {
+                {
+                    R result = e.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+
+    }
+
+    @Override
+    public R visit(final SynchronizedStmt n, final A arg) {
+        {
+            if (n.getExpr() != null) {
+                R result = n.getExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        {
+            R result = n.getBlock().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ThisExpr n, final A arg) {
+        if (n.getClassExpr() != null) {
+            {
+                R result = n.getClassExpr().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final ThrowStmt n, final A arg) {
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final TryStmt n, final A arg) {
+        if (n.getResources() != null) {
+            for (final VariableDeclarationExpr v : n.getResources()) {
+                {
+                    R result = v.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getTryBlock().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getCatchs() != null) {
+            for (final CatchClause c : n.getCatchs()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        if (n.getFinallyBlock() != null) {
+            {
+                R result = n.getFinallyBlock().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final TypeDeclarationStmt n, final A arg) {
+        {
+            R result = n.getTypeDeclaration().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final TypeParameter n, final A arg) {
+        if (n.getTypeBound() != null) {
+            for (final ClassOrInterfaceType c : n.getTypeBound()) {
+                {
+                    R result = c.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final UnaryExpr n, final A arg) {
+        {
+            R result = n.getExpr().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final UnknownType n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final VariableDeclarationExpr n, final A arg) {
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                {
+                    R result = a.accept(this, arg);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+        }
+        {
+            R result = n.getType().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        for (final VariableDeclarator v : n.getVars()) {
+            {
+                R result = v.accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final VariableDeclarator n, final A arg) {
+        {
+            R result = n.getId().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        if (n.getInit() != null) {
+            {
+                R result = n.getInit().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final VariableDeclaratorId n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final VoidType n, final A arg) {
+        return null;
+    }
+
+    @Override
+    public R visit(final WhileStmt n, final A arg) {
+        {
+            R result = n.getCondition().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        {
+            R result = n.getBody().accept(this, arg);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final WildcardType n, final A arg) {
+        if (n.getExtends() != null) {
+            {
+                R result = n.getExtends().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        if (n.getSuper() != null) {
+            {
+                R result = n.getSuper().accept(this, arg);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
     @Override
     public R visit(LambdaExpr n, A arg) {
@@ -1600,14 +1600,14 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
         return null;
     }
 
-	@Override
-	public R visit(final BlockComment n, final A arg) {
-		return null;
-	}
+    @Override
+    public R visit(final BlockComment n, final A arg) {
+        return null;
+    }
 
-	@Override
-	public R visit(final LineComment n, final A arg) {
-		return null;
-	}
+    @Override
+    public R visit(final LineComment n, final A arg) {
+        return null;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/ModifierVisitorAdapter.java
@@ -120,854 +120,854 @@ import java.util.List;
  */
 public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, A> {
 
-	private void removeNulls(final List<?> list) {
-		for (int i = list.size() - 1; i >= 0; i--) {
-			if (list.get(i) == null) {
-				list.remove(i);
-			}
-		}
-	}
+    private void removeNulls(final List<?> list) {
+        for (int i = list.size() - 1; i >= 0; i--) {
+            if (list.get(i) == null) {
+                list.remove(i);
+            }
+        }
+    }
 
-	@Override public Node visit(final AnnotationDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<BodyDeclaration> members = n.getMembers();
-		if (members != null) {
-			for (int i = 0; i < members.size(); i++) {
-				members.set(i, (BodyDeclaration) members.get(i).accept(this, arg));
-			}
-			removeNulls(members);
-		}
-		return n;
-	}
+    @Override public Node visit(final AnnotationDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<BodyDeclaration> members = n.getMembers();
+        if (members != null) {
+            for (int i = 0; i < members.size(); i++) {
+                members.set(i, (BodyDeclaration) members.get(i).accept(this, arg));
+            }
+            removeNulls(members);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final AnnotationMemberDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		n.setType((Type) n.getType().accept(this, arg));
-		if (n.getDefaultValue() != null) {
-			n.setDefaultValue((Expression) n.getDefaultValue().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final AnnotationMemberDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        n.setType((Type) n.getType().accept(this, arg));
+        if (n.getDefaultValue() != null) {
+            n.setDefaultValue((Expression) n.getDefaultValue().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ArrayAccessExpr n, final A arg) {
-		n.setName((Expression) n.getName().accept(this, arg));
-		n.setIndex((Expression) n.getIndex().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ArrayAccessExpr n, final A arg) {
+        n.setName((Expression) n.getName().accept(this, arg));
+        n.setIndex((Expression) n.getIndex().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ArrayCreationExpr n, final A arg) {
-		n.setType((Type) n.getType().accept(this, arg));
-		if (n.getDimensions() != null) {
-			final List<Expression> dimensions = n.getDimensions();
-			if (dimensions != null) {
-				for (int i = 0; i < dimensions.size(); i++) {
-					dimensions.set(i, (Expression) dimensions.get(i).accept(this, arg));
-				}
-				removeNulls(dimensions);
-			}
-		} else {
-			n.setInitializer((ArrayInitializerExpr) n.getInitializer().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final ArrayCreationExpr n, final A arg) {
+        n.setType((Type) n.getType().accept(this, arg));
+        if (n.getDimensions() != null) {
+            final List<Expression> dimensions = n.getDimensions();
+            if (dimensions != null) {
+                for (int i = 0; i < dimensions.size(); i++) {
+                    dimensions.set(i, (Expression) dimensions.get(i).accept(this, arg));
+                }
+                removeNulls(dimensions);
+            }
+        } else {
+            n.setInitializer((ArrayInitializerExpr) n.getInitializer().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ArrayInitializerExpr n, final A arg) {
-		if (n.getValues() != null) {
-			final List<Expression> values = n.getValues();
-			if (values != null) {
-				for (int i = 0; i < values.size(); i++) {
-					values.set(i, (Expression) values.get(i).accept(this, arg));
-				}
-				removeNulls(values);
-			}
-		}
-		return n;
-	}
+    @Override public Node visit(final ArrayInitializerExpr n, final A arg) {
+        if (n.getValues() != null) {
+            final List<Expression> values = n.getValues();
+            if (values != null) {
+                for (int i = 0; i < values.size(); i++) {
+                    values.set(i, (Expression) values.get(i).accept(this, arg));
+                }
+                removeNulls(values);
+            }
+        }
+        return n;
+    }
 
-	@Override public Node visit(final AssertStmt n, final A arg) {
-		n.setCheck((Expression) n.getCheck().accept(this, arg));
-		if (n.getMessage() != null) {
-			n.setMessage((Expression) n.getMessage().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final AssertStmt n, final A arg) {
+        n.setCheck((Expression) n.getCheck().accept(this, arg));
+        if (n.getMessage() != null) {
+            n.setMessage((Expression) n.getMessage().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final AssignExpr n, final A arg) {
-		n.setTarget((Expression) n.getTarget().accept(this, arg));
-		n.setValue((Expression) n.getValue().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final AssignExpr n, final A arg) {
+        n.setTarget((Expression) n.getTarget().accept(this, arg));
+        n.setValue((Expression) n.getValue().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final BinaryExpr n, final A arg) {
-		n.setLeft((Expression) n.getLeft().accept(this, arg));
-		n.setRight((Expression) n.getRight().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final BinaryExpr n, final A arg) {
+        n.setLeft((Expression) n.getLeft().accept(this, arg));
+        n.setRight((Expression) n.getRight().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final BlockStmt n, final A arg) {
-		final List<Statement> stmts = n.getStmts();
-		if (stmts != null) {
-			for (int i = 0; i < stmts.size(); i++) {
-				stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
-			}
-			removeNulls(stmts);
-		}
-		return n;
-	}
+    @Override public Node visit(final BlockStmt n, final A arg) {
+        final List<Statement> stmts = n.getStmts();
+        if (stmts != null) {
+            for (int i = 0; i < stmts.size(); i++) {
+                stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
+            }
+            removeNulls(stmts);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final BooleanLiteralExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final BooleanLiteralExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final BreakStmt n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final BreakStmt n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final CastExpr n, final A arg) {
-		n.setType((Type) n.getType().accept(this, arg));
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final CastExpr n, final A arg) {
+        n.setType((Type) n.getType().accept(this, arg));
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final CatchClause n, final A arg) {
-		n.setExcept((MultiTypeParameter) n.getExcept().accept(this, arg));
-		n.setCatchBlock((BlockStmt) n.getCatchBlock().accept(this, arg));
-		return n;
+    @Override public Node visit(final CatchClause n, final A arg) {
+        n.setExcept((MultiTypeParameter) n.getExcept().accept(this, arg));
+        n.setCatchBlock((BlockStmt) n.getCatchBlock().accept(this, arg));
+        return n;
 
-	}
+    }
 
-	@Override public Node visit(final CharLiteralExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final CharLiteralExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final ClassExpr n, final A arg) {
-		n.setType((Type) n.getType().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ClassExpr n, final A arg) {
+        n.setType((Type) n.getType().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ClassOrInterfaceDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<TypeParameter> typeParameters = n.getTypeParameters();
-		if (typeParameters != null) {
-			for (int i = 0; i < typeParameters.size(); i++) {
-				typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
-			}
-			removeNulls(typeParameters);
-		}
-		final List<ClassOrInterfaceType> extendz = n.getExtends();
-		if (extendz != null) {
-			for (int i = 0; i < extendz.size(); i++) {
-				extendz.set(i, (ClassOrInterfaceType) extendz.get(i).accept(this, arg));
-			}
-			removeNulls(extendz);
-		}
-		final List<ClassOrInterfaceType> implementz = n.getImplements();
-		if (implementz != null) {
-			for (int i = 0; i < implementz.size(); i++) {
-				implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
-			}
-			removeNulls(implementz);
-		}
-		final List<BodyDeclaration> members = n.getMembers();
-		if (members != null) {
-			for (int i = 0; i < members.size(); i++) {
-				members.set(i, (BodyDeclaration) members.get(i).accept(this, arg));
-			}
-			removeNulls(members);
-		}
-		return n;
-	}
+    @Override public Node visit(final ClassOrInterfaceDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<TypeParameter> typeParameters = n.getTypeParameters();
+        if (typeParameters != null) {
+            for (int i = 0; i < typeParameters.size(); i++) {
+                typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
+            }
+            removeNulls(typeParameters);
+        }
+        final List<ClassOrInterfaceType> extendz = n.getExtends();
+        if (extendz != null) {
+            for (int i = 0; i < extendz.size(); i++) {
+                extendz.set(i, (ClassOrInterfaceType) extendz.get(i).accept(this, arg));
+            }
+            removeNulls(extendz);
+        }
+        final List<ClassOrInterfaceType> implementz = n.getImplements();
+        if (implementz != null) {
+            for (int i = 0; i < implementz.size(); i++) {
+                implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
+            }
+            removeNulls(implementz);
+        }
+        final List<BodyDeclaration> members = n.getMembers();
+        if (members != null) {
+            for (int i = 0; i < members.size(); i++) {
+                members.set(i, (BodyDeclaration) members.get(i).accept(this, arg));
+            }
+            removeNulls(members);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ClassOrInterfaceType n, final A arg) {
-		if (n.getScope() != null) {
-			n.setScope((ClassOrInterfaceType) n.getScope().accept(this, arg));
-		}
-		final List<Type> typeArgs = n.getTypeArgs();
-		if (typeArgs != null) {
-			for (int i = 0; i < typeArgs.size(); i++) {
-				typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
-			}
-			removeNulls(typeArgs);
-		}
-		return n;
-	}
+    @Override public Node visit(final ClassOrInterfaceType n, final A arg) {
+        if (n.getScope() != null) {
+            n.setScope((ClassOrInterfaceType) n.getScope().accept(this, arg));
+        }
+        final List<Type> typeArgs = n.getTypeArgs();
+        if (typeArgs != null) {
+            for (int i = 0; i < typeArgs.size(); i++) {
+                typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
+            }
+            removeNulls(typeArgs);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final CompilationUnit n, final A arg) {
-		if (n.getPackage() != null) {
-			n.setPackage((PackageDeclaration) n.getPackage().accept(this, arg));
-		}
-		final List<ImportDeclaration> imports = n.getImports();
-		if (imports != null) {
-			for (int i = 0; i < imports.size(); i++) {
-				imports.set(i, (ImportDeclaration) imports.get(i).accept(this, arg));
-			}
-			removeNulls(imports);
-		}
-		final List<TypeDeclaration> types = n.getTypes();
-		if (types != null) {
-			for (int i = 0; i < types.size(); i++) {
-				types.set(i, (TypeDeclaration) types.get(i).accept(this, arg));
-			}
-			removeNulls(types);
-		}
-		return n;
-	}
+    @Override public Node visit(final CompilationUnit n, final A arg) {
+        if (n.getPackage() != null) {
+            n.setPackage((PackageDeclaration) n.getPackage().accept(this, arg));
+        }
+        final List<ImportDeclaration> imports = n.getImports();
+        if (imports != null) {
+            for (int i = 0; i < imports.size(); i++) {
+                imports.set(i, (ImportDeclaration) imports.get(i).accept(this, arg));
+            }
+            removeNulls(imports);
+        }
+        final List<TypeDeclaration> types = n.getTypes();
+        if (types != null) {
+            for (int i = 0; i < types.size(); i++) {
+                types.set(i, (TypeDeclaration) types.get(i).accept(this, arg));
+            }
+            removeNulls(types);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ConditionalExpr n, final A arg) {
-		n.setCondition((Expression) n.getCondition().accept(this, arg));
-		n.setThenExpr((Expression) n.getThenExpr().accept(this, arg));
-		n.setElseExpr((Expression) n.getElseExpr().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ConditionalExpr n, final A arg) {
+        n.setCondition((Expression) n.getCondition().accept(this, arg));
+        n.setThenExpr((Expression) n.getThenExpr().accept(this, arg));
+        n.setElseExpr((Expression) n.getElseExpr().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ConstructorDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<TypeParameter> typeParameters = n.getTypeParameters();
-		if (typeParameters != null) {
-			for (int i = 0; i < typeParameters.size(); i++) {
-				typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
-			}
-			removeNulls(typeParameters);
-		}
-		final List<Parameter> parameters = n.getParameters();
-		if (parameters != null) {
-			for (int i = 0; i < parameters.size(); i++) {
-				parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
-			}
-			removeNulls(parameters);
-		}
-		final List<NameExpr> throwz = n.getThrows();
-		if (throwz != null) {
-			for (int i = 0; i < throwz.size(); i++) {
-				throwz.set(i, (NameExpr) throwz.get(i).accept(this, arg));
-			}
-			removeNulls(throwz);
-		}
-		n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ConstructorDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<TypeParameter> typeParameters = n.getTypeParameters();
+        if (typeParameters != null) {
+            for (int i = 0; i < typeParameters.size(); i++) {
+                typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
+            }
+            removeNulls(typeParameters);
+        }
+        final List<Parameter> parameters = n.getParameters();
+        if (parameters != null) {
+            for (int i = 0; i < parameters.size(); i++) {
+                parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
+            }
+            removeNulls(parameters);
+        }
+        final List<NameExpr> throwz = n.getThrows();
+        if (throwz != null) {
+            for (int i = 0; i < throwz.size(); i++) {
+                throwz.set(i, (NameExpr) throwz.get(i).accept(this, arg));
+            }
+            removeNulls(throwz);
+        }
+        n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ContinueStmt n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final ContinueStmt n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final DoStmt n, final A arg) {
-		n.setBody((Statement) n.getBody().accept(this, arg));
-		n.setCondition((Expression) n.getCondition().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final DoStmt n, final A arg) {
+        n.setBody((Statement) n.getBody().accept(this, arg));
+        n.setCondition((Expression) n.getCondition().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final DoubleLiteralExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final DoubleLiteralExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final EmptyMemberDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final EmptyMemberDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final EmptyStmt n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final EmptyStmt n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final EmptyTypeDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final EmptyTypeDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final EnclosedExpr n, final A arg) {
-		n.setInner((Expression) n.getInner().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final EnclosedExpr n, final A arg) {
+        n.setInner((Expression) n.getInner().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final EnumConstantDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
-		final List<BodyDeclaration> classBody = n.getClassBody();
-		if (classBody != null) {
-			for (int i = 0; i < classBody.size(); i++) {
-				classBody.set(i, (BodyDeclaration) classBody.get(i).accept(this, arg));
-			}
-			removeNulls(classBody);
-		}
-		return n;
-	}
+    @Override public Node visit(final EnumConstantDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
+        final List<BodyDeclaration> classBody = n.getClassBody();
+        if (classBody != null) {
+            for (int i = 0; i < classBody.size(); i++) {
+                classBody.set(i, (BodyDeclaration) classBody.get(i).accept(this, arg));
+            }
+            removeNulls(classBody);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final EnumDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<ClassOrInterfaceType> implementz = n.getImplements();
-		if (implementz != null) {
-			for (int i = 0; i < implementz.size(); i++) {
-				implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
-			}
-			removeNulls(implementz);
-		}
-		final List<EnumConstantDeclaration> entries = n.getEntries();
-		if (entries != null) {
-			for (int i = 0; i < entries.size(); i++) {
-				entries.set(i, (EnumConstantDeclaration) entries.get(i).accept(this, arg));
-			}
-			removeNulls(entries);
-		}
-		final List<BodyDeclaration> members = n.getMembers();
-		if (members != null) {
-			for (int i = 0; i < members.size(); i++) {
-				members.set(i, (BodyDeclaration) members.get(i).accept(this, arg));
-			}
-			removeNulls(members);
-		}
-		return n;
-	}
+    @Override public Node visit(final EnumDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<ClassOrInterfaceType> implementz = n.getImplements();
+        if (implementz != null) {
+            for (int i = 0; i < implementz.size(); i++) {
+                implementz.set(i, (ClassOrInterfaceType) implementz.get(i).accept(this, arg));
+            }
+            removeNulls(implementz);
+        }
+        final List<EnumConstantDeclaration> entries = n.getEntries();
+        if (entries != null) {
+            for (int i = 0; i < entries.size(); i++) {
+                entries.set(i, (EnumConstantDeclaration) entries.get(i).accept(this, arg));
+            }
+            removeNulls(entries);
+        }
+        final List<BodyDeclaration> members = n.getMembers();
+        if (members != null) {
+            for (int i = 0; i < members.size(); i++) {
+                members.set(i, (BodyDeclaration) members.get(i).accept(this, arg));
+            }
+            removeNulls(members);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-		if (!n.isThis()) {
-			if (n.getExpr() != null) {
-				n.setExpr((Expression) n.getExpr().accept(this, arg));
-			}
-		}
-		final List<Type> typeArgs = n.getTypeArgs();
-		if (typeArgs != null) {
-			for (int i = 0; i < typeArgs.size(); i++) {
-				typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
-			}
-			removeNulls(typeArgs);
-		}
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
-		return n;
-	}
+    @Override public Node visit(final ExplicitConstructorInvocationStmt n, final A arg) {
+        if (!n.isThis()) {
+            if (n.getExpr() != null) {
+                n.setExpr((Expression) n.getExpr().accept(this, arg));
+            }
+        }
+        final List<Type> typeArgs = n.getTypeArgs();
+        if (typeArgs != null) {
+            for (int i = 0; i < typeArgs.size(); i++) {
+                typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
+            }
+            removeNulls(typeArgs);
+        }
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ExpressionStmt n, final A arg) {
-		n.setExpression((Expression) n.getExpression().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ExpressionStmt n, final A arg) {
+        n.setExpression((Expression) n.getExpression().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final FieldAccessExpr n, final A arg) {
-		n.setScope((Expression) n.getScope().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final FieldAccessExpr n, final A arg) {
+        n.setScope((Expression) n.getScope().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final FieldDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		n.setType((Type) n.getType().accept(this, arg));
-		final List<VariableDeclarator> variables = n.getVariables();
-		for (int i = 0; i < variables.size(); i++) {
-			variables.set(i, (VariableDeclarator) variables.get(i).accept(this, arg));
-		}
-		removeNulls(variables);
-		return n;
-	}
+    @Override public Node visit(final FieldDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        n.setType((Type) n.getType().accept(this, arg));
+        final List<VariableDeclarator> variables = n.getVariables();
+        for (int i = 0; i < variables.size(); i++) {
+            variables.set(i, (VariableDeclarator) variables.get(i).accept(this, arg));
+        }
+        removeNulls(variables);
+        return n;
+    }
 
-	@Override public Node visit(final ForeachStmt n, final A arg) {
-		n.setVariable((VariableDeclarationExpr) n.getVariable().accept(this, arg));
-		n.setIterable((Expression) n.getIterable().accept(this, arg));
-		n.setBody((Statement) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ForeachStmt n, final A arg) {
+        n.setVariable((VariableDeclarationExpr) n.getVariable().accept(this, arg));
+        n.setIterable((Expression) n.getIterable().accept(this, arg));
+        n.setBody((Statement) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ForStmt n, final A arg) {
-		final List<Expression> init = n.getInit();
-		if (init != null) {
-			for (int i = 0; i < init.size(); i++) {
-				init.set(i, (Expression) init.get(i).accept(this, arg));
-			}
-			removeNulls(init);
-		}
-		if (n.getCompare() != null) {
-			n.setCompare((Expression) n.getCompare().accept(this, arg));
-		}
-		final List<Expression> update = n.getUpdate();
-		if (update != null) {
-			for (int i = 0; i < update.size(); i++) {
-				update.set(i, (Expression) update.get(i).accept(this, arg));
-			}
-			removeNulls(update);
-		}
-		n.setBody((Statement) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ForStmt n, final A arg) {
+        final List<Expression> init = n.getInit();
+        if (init != null) {
+            for (int i = 0; i < init.size(); i++) {
+                init.set(i, (Expression) init.get(i).accept(this, arg));
+            }
+            removeNulls(init);
+        }
+        if (n.getCompare() != null) {
+            n.setCompare((Expression) n.getCompare().accept(this, arg));
+        }
+        final List<Expression> update = n.getUpdate();
+        if (update != null) {
+            for (int i = 0; i < update.size(); i++) {
+                update.set(i, (Expression) update.get(i).accept(this, arg));
+            }
+            removeNulls(update);
+        }
+        n.setBody((Statement) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final IfStmt n, final A arg) {
-		n.setCondition((Expression) n.getCondition().accept(this, arg));
-		n.setThenStmt((Statement) n.getThenStmt().accept(this, arg));
-		if (n.getElseStmt() != null) {
-			n.setElseStmt((Statement) n.getElseStmt().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final IfStmt n, final A arg) {
+        n.setCondition((Expression) n.getCondition().accept(this, arg));
+        n.setThenStmt((Statement) n.getThenStmt().accept(this, arg));
+        if (n.getElseStmt() != null) {
+            n.setElseStmt((Statement) n.getElseStmt().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ImportDeclaration n, final A arg) {
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ImportDeclaration n, final A arg) {
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final InitializerDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final InitializerDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final InstanceOfExpr n, final A arg) {
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		n.setType((Type) n.getType().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final InstanceOfExpr n, final A arg) {
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        n.setType((Type) n.getType().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final IntegerLiteralExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final IntegerLiteralExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final IntegerLiteralMinValueExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final IntegerLiteralMinValueExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final JavadocComment n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final JavadocComment n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final LabeledStmt n, final A arg) {
-		n.setStmt((Statement) n.getStmt().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final LabeledStmt n, final A arg) {
+        n.setStmt((Statement) n.getStmt().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final LongLiteralExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final LongLiteralExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final LongLiteralMinValueExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final LongLiteralMinValueExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final MarkerAnnotationExpr n, final A arg) {
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final MarkerAnnotationExpr n, final A arg) {
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final MemberValuePair n, final A arg) {
-		n.setValue((Expression) n.getValue().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final MemberValuePair n, final A arg) {
+        n.setValue((Expression) n.getValue().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final MethodCallExpr n, final A arg) {
-		if (n.getScope() != null) {
-			n.setScope((Expression) n.getScope().accept(this, arg));
-		}
-		final List<Type> typeArgs = n.getTypeArgs();
-		if (typeArgs != null) {
-			for (int i = 0; i < typeArgs.size(); i++) {
-				typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
-			}
-			removeNulls(typeArgs);
-		}
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
-		return n;
-	}
+    @Override public Node visit(final MethodCallExpr n, final A arg) {
+        if (n.getScope() != null) {
+            n.setScope((Expression) n.getScope().accept(this, arg));
+        }
+        final List<Type> typeArgs = n.getTypeArgs();
+        if (typeArgs != null) {
+            for (int i = 0; i < typeArgs.size(); i++) {
+                typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
+            }
+            removeNulls(typeArgs);
+        }
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final MethodDeclaration n, final A arg) {
-		if (n.getJavaDoc() != null) {
-			n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
-		}
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		final List<TypeParameter> typeParameters = n.getTypeParameters();
-		if (typeParameters != null) {
-			for (int i = 0; i < typeParameters.size(); i++) {
-				typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
-			}
-			removeNulls(typeParameters);
-		}
-		n.setType((Type) n.getType().accept(this, arg));
-		final List<Parameter> parameters = n.getParameters();
-		if (parameters != null) {
-			for (int i = 0; i < parameters.size(); i++) {
-				parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
-			}
-			removeNulls(parameters);
-		}
-		final List<NameExpr> throwz = n.getThrows();
-		if (throwz != null) {
-			for (int i = 0; i < throwz.size(); i++) {
-				throwz.set(i, (NameExpr) throwz.get(i).accept(this, arg));
-			}
-			removeNulls(throwz);
-		}
-		if (n.getBody() != null) {
-			n.setBody((BlockStmt) n.getBody().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final MethodDeclaration n, final A arg) {
+        if (n.getJavaDoc() != null) {
+            n.setJavaDoc((JavadocComment) n.getJavaDoc().accept(this, arg));
+        }
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        final List<TypeParameter> typeParameters = n.getTypeParameters();
+        if (typeParameters != null) {
+            for (int i = 0; i < typeParameters.size(); i++) {
+                typeParameters.set(i, (TypeParameter) typeParameters.get(i).accept(this, arg));
+            }
+            removeNulls(typeParameters);
+        }
+        n.setType((Type) n.getType().accept(this, arg));
+        final List<Parameter> parameters = n.getParameters();
+        if (parameters != null) {
+            for (int i = 0; i < parameters.size(); i++) {
+                parameters.set(i, (Parameter) parameters.get(i).accept(this, arg));
+            }
+            removeNulls(parameters);
+        }
+        final List<NameExpr> throwz = n.getThrows();
+        if (throwz != null) {
+            for (int i = 0; i < throwz.size(); i++) {
+                throwz.set(i, (NameExpr) throwz.get(i).accept(this, arg));
+            }
+            removeNulls(throwz);
+        }
+        if (n.getBody() != null) {
+            n.setBody((BlockStmt) n.getBody().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final NameExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final NameExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final NormalAnnotationExpr n, final A arg) {
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		final List<MemberValuePair> pairs = n.getPairs();
-		if (pairs != null) {
-			for (int i = 0; i < pairs.size(); i++) {
-				pairs.set(i, (MemberValuePair) pairs.get(i).accept(this, arg));
-			}
-			removeNulls(pairs);
-		}
-		return n;
-	}
+    @Override public Node visit(final NormalAnnotationExpr n, final A arg) {
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        final List<MemberValuePair> pairs = n.getPairs();
+        if (pairs != null) {
+            for (int i = 0; i < pairs.size(); i++) {
+                pairs.set(i, (MemberValuePair) pairs.get(i).accept(this, arg));
+            }
+            removeNulls(pairs);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final NullLiteralExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final NullLiteralExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final ObjectCreationExpr n, final A arg) {
-		if (n.getScope() != null) {
-			n.setScope((Expression) n.getScope().accept(this, arg));
-		}
-		final List<Type> typeArgs = n.getTypeArgs();
-		if (typeArgs != null) {
-			for (int i = 0; i < typeArgs.size(); i++) {
-				typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
-			}
-			removeNulls(typeArgs);
-		}
-		n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
-		final List<Expression> args = n.getArgs();
-		if (args != null) {
-			for (int i = 0; i < args.size(); i++) {
-				args.set(i, (Expression) args.get(i).accept(this, arg));
-			}
-			removeNulls(args);
-		}
-		final List<BodyDeclaration> anonymousClassBody = n.getAnonymousClassBody();
-		if (anonymousClassBody != null) {
-			for (int i = 0; i < anonymousClassBody.size(); i++) {
-				anonymousClassBody.set(i, (BodyDeclaration) anonymousClassBody.get(i).accept(this, arg));
-			}
-			removeNulls(anonymousClassBody);
-		}
-		return n;
-	}
+    @Override public Node visit(final ObjectCreationExpr n, final A arg) {
+        if (n.getScope() != null) {
+            n.setScope((Expression) n.getScope().accept(this, arg));
+        }
+        final List<Type> typeArgs = n.getTypeArgs();
+        if (typeArgs != null) {
+            for (int i = 0; i < typeArgs.size(); i++) {
+                typeArgs.set(i, (Type) typeArgs.get(i).accept(this, arg));
+            }
+            removeNulls(typeArgs);
+        }
+        n.setType((ClassOrInterfaceType) n.getType().accept(this, arg));
+        final List<Expression> args = n.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); i++) {
+                args.set(i, (Expression) args.get(i).accept(this, arg));
+            }
+            removeNulls(args);
+        }
+        final List<BodyDeclaration> anonymousClassBody = n.getAnonymousClassBody();
+        if (anonymousClassBody != null) {
+            for (int i = 0; i < anonymousClassBody.size(); i++) {
+                anonymousClassBody.set(i, (BodyDeclaration) anonymousClassBody.get(i).accept(this, arg));
+            }
+            removeNulls(anonymousClassBody);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final PackageDeclaration n, final A arg) {
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		return n;
-	}
-	
-	@Override public Node visit(final Parameter n, final A arg) {
-		visit((BaseParameter) n, arg);
-		n.setType((Type) n.getType().accept(this, arg));
-		return n;
-	}
-	
-	@Override public Node visit(MultiTypeParameter n, A arg) {
-    	visit((BaseParameter) n, arg);
-    	List<Type> types = new LinkedList<Type>();
-    	for (Type type : n.getTypes()) {
-    		types.add((Type) type.accept(this, arg));
-    	}
+    @Override public Node visit(final PackageDeclaration n, final A arg) {
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        return n;
+    }
+    
+    @Override public Node visit(final Parameter n, final A arg) {
+        visit((BaseParameter) n, arg);
+        n.setType((Type) n.getType().accept(this, arg));
+        return n;
+    }
+    
+    @Override public Node visit(MultiTypeParameter n, A arg) {
+        visit((BaseParameter) n, arg);
+        List<Type> types = new LinkedList<Type>();
+        for (Type type : n.getTypes()) {
+            types.add((Type) type.accept(this, arg));
+        }
         n.setTypes(types);
         return n;
     }
 
-	protected Node visit(final BaseParameter n, final A arg) {
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		
-		n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
-		return n;
-	}
+    protected Node visit(final BaseParameter n, final A arg) {
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        
+        n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final PrimitiveType n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final PrimitiveType n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final QualifiedNameExpr n, final A arg) {
-		n.setQualifier((NameExpr) n.getQualifier().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final QualifiedNameExpr n, final A arg) {
+        n.setQualifier((NameExpr) n.getQualifier().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ReferenceType n, final A arg) {
-		n.setType((Type) n.getType().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ReferenceType n, final A arg) {
+        n.setType((Type) n.getType().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ReturnStmt n, final A arg) {
-		if (n.getExpr() != null) {
-			n.setExpr((Expression) n.getExpr().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final ReturnStmt n, final A arg) {
+        if (n.getExpr() != null) {
+            n.setExpr((Expression) n.getExpr().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final SingleMemberAnnotationExpr n, final A arg) {
-		n.setName((NameExpr) n.getName().accept(this, arg));
-		n.setMemberValue((Expression) n.getMemberValue().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final SingleMemberAnnotationExpr n, final A arg) {
+        n.setName((NameExpr) n.getName().accept(this, arg));
+        n.setMemberValue((Expression) n.getMemberValue().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final StringLiteralExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final StringLiteralExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final SuperExpr n, final A arg) {
-		if (n.getClassExpr() != null) {
-			n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final SuperExpr n, final A arg) {
+        if (n.getClassExpr() != null) {
+            n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final SwitchEntryStmt n, final A arg) {
-		if (n.getLabel() != null) {
-			n.setLabel((Expression) n.getLabel().accept(this, arg));
-		}
-		final List<Statement> stmts = n.getStmts();
-		if (stmts != null) {
-			for (int i = 0; i < stmts.size(); i++) {
-				stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
-			}
-			removeNulls(stmts);
-		}
-		return n;
-	}
+    @Override public Node visit(final SwitchEntryStmt n, final A arg) {
+        if (n.getLabel() != null) {
+            n.setLabel((Expression) n.getLabel().accept(this, arg));
+        }
+        final List<Statement> stmts = n.getStmts();
+        if (stmts != null) {
+            for (int i = 0; i < stmts.size(); i++) {
+                stmts.set(i, (Statement) stmts.get(i).accept(this, arg));
+            }
+            removeNulls(stmts);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final SwitchStmt n, final A arg) {
-		n.setSelector((Expression) n.getSelector().accept(this, arg));
-		final List<SwitchEntryStmt> entries = n.getEntries();
-		if (entries != null) {
-			for (int i = 0; i < entries.size(); i++) {
-				entries.set(i, (SwitchEntryStmt) entries.get(i).accept(this, arg));
-			}
-			removeNulls(entries);
-		}
-		return n;
+    @Override public Node visit(final SwitchStmt n, final A arg) {
+        n.setSelector((Expression) n.getSelector().accept(this, arg));
+        final List<SwitchEntryStmt> entries = n.getEntries();
+        if (entries != null) {
+            for (int i = 0; i < entries.size(); i++) {
+                entries.set(i, (SwitchEntryStmt) entries.get(i).accept(this, arg));
+            }
+            removeNulls(entries);
+        }
+        return n;
 
-	}
+    }
 
-	@Override public Node visit(final SynchronizedStmt n, final A arg) {
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final SynchronizedStmt n, final A arg) {
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        n.setBlock((BlockStmt) n.getBlock().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final ThisExpr n, final A arg) {
-		if (n.getClassExpr() != null) {
-			n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final ThisExpr n, final A arg) {
+        if (n.getClassExpr() != null) {
+            n.setClassExpr((Expression) n.getClassExpr().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final ThrowStmt n, final A arg) {
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final ThrowStmt n, final A arg) {
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final TryStmt n, final A arg) {
-		n.setTryBlock((BlockStmt) n.getTryBlock().accept(this, arg));
-		final List<CatchClause> catchs = n.getCatchs();
-		if (catchs != null) {
-			for (int i = 0; i < catchs.size(); i++) {
-				catchs.set(i, (CatchClause) catchs.get(i).accept(this, arg));
-			}
-			removeNulls(catchs);
-		}
-		if (n.getFinallyBlock() != null) {
-			n.setFinallyBlock((BlockStmt) n.getFinallyBlock().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final TryStmt n, final A arg) {
+        n.setTryBlock((BlockStmt) n.getTryBlock().accept(this, arg));
+        final List<CatchClause> catchs = n.getCatchs();
+        if (catchs != null) {
+            for (int i = 0; i < catchs.size(); i++) {
+                catchs.set(i, (CatchClause) catchs.get(i).accept(this, arg));
+            }
+            removeNulls(catchs);
+        }
+        if (n.getFinallyBlock() != null) {
+            n.setFinallyBlock((BlockStmt) n.getFinallyBlock().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final TypeDeclarationStmt n, final A arg) {
-		n.setTypeDeclaration((TypeDeclaration) n.getTypeDeclaration().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final TypeDeclarationStmt n, final A arg) {
+        n.setTypeDeclaration((TypeDeclaration) n.getTypeDeclaration().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final TypeParameter n, final A arg) {
-		final List<ClassOrInterfaceType> typeBound = n.getTypeBound();
-		if (typeBound != null) {
-			for (int i = 0; i < typeBound.size(); i++) {
-				typeBound.set(i, (ClassOrInterfaceType) typeBound.get(i).accept(this, arg));
-			}
-			removeNulls(typeBound);
-		}
-		return n;
-	}
+    @Override public Node visit(final TypeParameter n, final A arg) {
+        final List<ClassOrInterfaceType> typeBound = n.getTypeBound();
+        if (typeBound != null) {
+            for (int i = 0; i < typeBound.size(); i++) {
+                typeBound.set(i, (ClassOrInterfaceType) typeBound.get(i).accept(this, arg));
+            }
+            removeNulls(typeBound);
+        }
+        return n;
+    }
 
-	@Override public Node visit(final UnaryExpr n, final A arg) {
-		n.setExpr((Expression) n.getExpr().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final UnaryExpr n, final A arg) {
+        n.setExpr((Expression) n.getExpr().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final UnknownType n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final UnknownType n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final VariableDeclarationExpr n, final A arg) {
-		final List<AnnotationExpr> annotations = n.getAnnotations();
-		if (annotations != null) {
-			for (int i = 0; i < annotations.size(); i++) {
-				annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
-			}
-			removeNulls(annotations);
-		}
-		n.setType((Type) n.getType().accept(this, arg));
-		final List<VariableDeclarator> vars = n.getVars();
-		for (int i = 0; i < vars.size(); i++) {
-			vars.set(i, (VariableDeclarator) vars.get(i).accept(this, arg));
-		}
-		removeNulls(vars);
-		return n;
-	}
+    @Override public Node visit(final VariableDeclarationExpr n, final A arg) {
+        final List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
+        n.setType((Type) n.getType().accept(this, arg));
+        final List<VariableDeclarator> vars = n.getVars();
+        for (int i = 0; i < vars.size(); i++) {
+            vars.set(i, (VariableDeclarator) vars.get(i).accept(this, arg));
+        }
+        removeNulls(vars);
+        return n;
+    }
 
-	@Override public Node visit(final VariableDeclarator n, final A arg) {
-		n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
-		if (n.getInit() != null) {
-			n.setInit((Expression) n.getInit().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final VariableDeclarator n, final A arg) {
+        n.setId((VariableDeclaratorId) n.getId().accept(this, arg));
+        if (n.getInit() != null) {
+            n.setInit((Expression) n.getInit().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final VariableDeclaratorId n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final VariableDeclaratorId n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final VoidType n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final VoidType n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final WhileStmt n, final A arg) {
-		n.setCondition((Expression) n.getCondition().accept(this, arg));
-		n.setBody((Statement) n.getBody().accept(this, arg));
-		return n;
-	}
+    @Override public Node visit(final WhileStmt n, final A arg) {
+        n.setCondition((Expression) n.getCondition().accept(this, arg));
+        n.setBody((Statement) n.getBody().accept(this, arg));
+        return n;
+    }
 
-	@Override public Node visit(final WildcardType n, final A arg) {
-		if (n.getExtends() != null) {
-			n.setExtends((ReferenceType) n.getExtends().accept(this, arg));
-		}
-		if (n.getSuper() != null) {
-			n.setSuper((ReferenceType) n.getSuper().accept(this, arg));
-		}
-		return n;
-	}
+    @Override public Node visit(final WildcardType n, final A arg) {
+        if (n.getExtends() != null) {
+            n.setExtends((ReferenceType) n.getExtends().accept(this, arg));
+        }
+        if (n.getSuper() != null) {
+            n.setSuper((ReferenceType) n.getSuper().accept(this, arg));
+        }
+        return n;
+    }
 
-	@Override public Node visit(final LambdaExpr n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final LambdaExpr n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final MethodReferenceExpr n, final A arg){
-		return n;
-	}
+    @Override public Node visit(final MethodReferenceExpr n, final A arg){
+        return n;
+    }
 
-	@Override public Node visit(final TypeExpr n, final A arg){
-		return n;
-	}
+    @Override public Node visit(final TypeExpr n, final A arg){
+        return n;
+    }
 
-	@Override public Node visit(final BlockComment n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final BlockComment n, final A arg) {
+        return n;
+    }
 
-	@Override public Node visit(final LineComment n, final A arg) {
-		return n;
-	}
+    @Override public Node visit(final LineComment n, final A arg) {
+        return n;
+    }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/VoidVisitor.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/VoidVisitor.java
@@ -74,177 +74,177 @@ import com.github.javaparser.ast.type.*;
  */
 public interface VoidVisitor<A> {
 
-	//- Compilation Unit ----------------------------------
+    //- Compilation Unit ----------------------------------
 
-	void visit(CompilationUnit n, A arg);
+    void visit(CompilationUnit n, A arg);
 
-	void visit(PackageDeclaration n, A arg);
+    void visit(PackageDeclaration n, A arg);
 
-	void visit(ImportDeclaration n, A arg);
+    void visit(ImportDeclaration n, A arg);
 
-	void visit(TypeParameter n, A arg);
+    void visit(TypeParameter n, A arg);
 
-	void visit(LineComment n, A arg);
+    void visit(LineComment n, A arg);
 
-	void visit(BlockComment n, A arg);
+    void visit(BlockComment n, A arg);
 
-	//- Body ----------------------------------------------
+    //- Body ----------------------------------------------
 
-	void visit(ClassOrInterfaceDeclaration n, A arg);
+    void visit(ClassOrInterfaceDeclaration n, A arg);
 
-	void visit(EnumDeclaration n, A arg);
+    void visit(EnumDeclaration n, A arg);
 
-	void visit(EmptyTypeDeclaration n, A arg);
+    void visit(EmptyTypeDeclaration n, A arg);
 
-	void visit(EnumConstantDeclaration n, A arg);
+    void visit(EnumConstantDeclaration n, A arg);
 
-	void visit(AnnotationDeclaration n, A arg);
+    void visit(AnnotationDeclaration n, A arg);
 
-	void visit(AnnotationMemberDeclaration n, A arg);
+    void visit(AnnotationMemberDeclaration n, A arg);
 
-	void visit(FieldDeclaration n, A arg);
+    void visit(FieldDeclaration n, A arg);
 
-	void visit(VariableDeclarator n, A arg);
+    void visit(VariableDeclarator n, A arg);
 
-	void visit(VariableDeclaratorId n, A arg);
+    void visit(VariableDeclaratorId n, A arg);
 
-	void visit(ConstructorDeclaration n, A arg);
+    void visit(ConstructorDeclaration n, A arg);
 
-	void visit(MethodDeclaration n, A arg);
+    void visit(MethodDeclaration n, A arg);
 
-	void visit(Parameter n, A arg);
-	
-	void visit(MultiTypeParameter n, A arg);
+    void visit(Parameter n, A arg);
+    
+    void visit(MultiTypeParameter n, A arg);
 
-	void visit(EmptyMemberDeclaration n, A arg);
+    void visit(EmptyMemberDeclaration n, A arg);
 
-	void visit(InitializerDeclaration n, A arg);
+    void visit(InitializerDeclaration n, A arg);
 
-	void visit(JavadocComment n, A arg);
+    void visit(JavadocComment n, A arg);
 
-	//- Type ----------------------------------------------
+    //- Type ----------------------------------------------
 
-	void visit(ClassOrInterfaceType n, A arg);
+    void visit(ClassOrInterfaceType n, A arg);
 
-	void visit(PrimitiveType n, A arg);
+    void visit(PrimitiveType n, A arg);
 
-	void visit(ReferenceType n, A arg);
+    void visit(ReferenceType n, A arg);
 
-	void visit(VoidType n, A arg);
+    void visit(VoidType n, A arg);
 
-	void visit(WildcardType n, A arg);
+    void visit(WildcardType n, A arg);
 
-	void visit(UnknownType n, A arg);
+    void visit(UnknownType n, A arg);
 
-	//- Expression ----------------------------------------
+    //- Expression ----------------------------------------
 
-	void visit(ArrayAccessExpr n, A arg);
+    void visit(ArrayAccessExpr n, A arg);
 
-	void visit(ArrayCreationExpr n, A arg);
+    void visit(ArrayCreationExpr n, A arg);
 
-	void visit(ArrayInitializerExpr n, A arg);
+    void visit(ArrayInitializerExpr n, A arg);
 
-	void visit(AssignExpr n, A arg);
+    void visit(AssignExpr n, A arg);
 
-	void visit(BinaryExpr n, A arg);
+    void visit(BinaryExpr n, A arg);
 
-	void visit(CastExpr n, A arg);
+    void visit(CastExpr n, A arg);
 
-	void visit(ClassExpr n, A arg);
+    void visit(ClassExpr n, A arg);
 
-	void visit(ConditionalExpr n, A arg);
+    void visit(ConditionalExpr n, A arg);
 
-	void visit(EnclosedExpr n, A arg);
+    void visit(EnclosedExpr n, A arg);
 
-	void visit(FieldAccessExpr n, A arg);
+    void visit(FieldAccessExpr n, A arg);
 
-	void visit(InstanceOfExpr n, A arg);
+    void visit(InstanceOfExpr n, A arg);
 
-	void visit(StringLiteralExpr n, A arg);
+    void visit(StringLiteralExpr n, A arg);
 
-	void visit(IntegerLiteralExpr n, A arg);
+    void visit(IntegerLiteralExpr n, A arg);
 
-	void visit(LongLiteralExpr n, A arg);
+    void visit(LongLiteralExpr n, A arg);
 
-	void visit(IntegerLiteralMinValueExpr n, A arg);
+    void visit(IntegerLiteralMinValueExpr n, A arg);
 
-	void visit(LongLiteralMinValueExpr n, A arg);
+    void visit(LongLiteralMinValueExpr n, A arg);
 
-	void visit(CharLiteralExpr n, A arg);
+    void visit(CharLiteralExpr n, A arg);
 
-	void visit(DoubleLiteralExpr n, A arg);
+    void visit(DoubleLiteralExpr n, A arg);
 
-	void visit(BooleanLiteralExpr n, A arg);
+    void visit(BooleanLiteralExpr n, A arg);
 
-	void visit(NullLiteralExpr n, A arg);
+    void visit(NullLiteralExpr n, A arg);
 
-	void visit(MethodCallExpr n, A arg);
+    void visit(MethodCallExpr n, A arg);
 
-	void visit(NameExpr n, A arg);
+    void visit(NameExpr n, A arg);
 
-	void visit(ObjectCreationExpr n, A arg);
+    void visit(ObjectCreationExpr n, A arg);
 
-	void visit(QualifiedNameExpr n, A arg);
+    void visit(QualifiedNameExpr n, A arg);
 
-	void visit(ThisExpr n, A arg);
+    void visit(ThisExpr n, A arg);
 
-	void visit(SuperExpr n, A arg);
+    void visit(SuperExpr n, A arg);
 
-	void visit(UnaryExpr n, A arg);
+    void visit(UnaryExpr n, A arg);
 
-	void visit(VariableDeclarationExpr n, A arg);
+    void visit(VariableDeclarationExpr n, A arg);
 
-	void visit(MarkerAnnotationExpr n, A arg);
+    void visit(MarkerAnnotationExpr n, A arg);
 
-	void visit(SingleMemberAnnotationExpr n, A arg);
+    void visit(SingleMemberAnnotationExpr n, A arg);
 
-	void visit(NormalAnnotationExpr n, A arg);
+    void visit(NormalAnnotationExpr n, A arg);
 
-	void visit(MemberValuePair n, A arg);
+    void visit(MemberValuePair n, A arg);
 
-	//- Statements ----------------------------------------
+    //- Statements ----------------------------------------
 
-	void visit(ExplicitConstructorInvocationStmt n, A arg);
+    void visit(ExplicitConstructorInvocationStmt n, A arg);
 
-	void visit(TypeDeclarationStmt n, A arg);
+    void visit(TypeDeclarationStmt n, A arg);
 
-	void visit(AssertStmt n, A arg);
+    void visit(AssertStmt n, A arg);
 
-	void visit(BlockStmt n, A arg);
+    void visit(BlockStmt n, A arg);
 
-	void visit(LabeledStmt n, A arg);
+    void visit(LabeledStmt n, A arg);
 
-	void visit(EmptyStmt n, A arg);
+    void visit(EmptyStmt n, A arg);
 
-	void visit(ExpressionStmt n, A arg);
+    void visit(ExpressionStmt n, A arg);
 
-	void visit(SwitchStmt n, A arg);
+    void visit(SwitchStmt n, A arg);
 
-	void visit(SwitchEntryStmt n, A arg);
+    void visit(SwitchEntryStmt n, A arg);
 
-	void visit(BreakStmt n, A arg);
+    void visit(BreakStmt n, A arg);
 
-	void visit(ReturnStmt n, A arg);
+    void visit(ReturnStmt n, A arg);
 
-	void visit(IfStmt n, A arg);
+    void visit(IfStmt n, A arg);
 
-	void visit(WhileStmt n, A arg);
+    void visit(WhileStmt n, A arg);
 
-	void visit(ContinueStmt n, A arg);
+    void visit(ContinueStmt n, A arg);
 
-	void visit(DoStmt n, A arg);
+    void visit(DoStmt n, A arg);
 
-	void visit(ForeachStmt n, A arg);
+    void visit(ForeachStmt n, A arg);
 
-	void visit(ForStmt n, A arg);
+    void visit(ForStmt n, A arg);
 
-	void visit(ThrowStmt n, A arg);
+    void visit(ThrowStmt n, A arg);
 
-	void visit(SynchronizedStmt n, A arg);
+    void visit(SynchronizedStmt n, A arg);
 
-	void visit(TryStmt n, A arg);
+    void visit(TryStmt n, A arg);
 
-	void visit(CatchClause n, A arg);
+    void visit(CatchClause n, A arg);
 
     void visit(LambdaExpr n, A arg);
 

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javaparser_src/proper_source/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -78,734 +78,734 @@ import static com.github.javaparser.ast.internal.Utils.isNullOrEmpty;
  */
 public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
-	@Override public void visit(final AnnotationDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		if (n.getMembers() != null) {
-			for (final BodyDeclaration member : n.getMembers()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final AnnotationMemberDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		n.getType().accept(this, arg);
-		if (n.getDefaultValue() != null) {
-			n.getDefaultValue().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ArrayAccessExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		n.getIndex().accept(this, arg);
-	}
-
-	@Override public void visit(final ArrayCreationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-		if (!isNullOrEmpty(n.getDimensions())) {
-			for (final Expression dim : n.getDimensions()) {
-				dim.accept(this, arg);
-			}
-		} else {
-			n.getInitializer().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ArrayInitializerExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getValues() != null) {
-			for (final Expression expr : n.getValues()) {
-				expr.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final AssertStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCheck().accept(this, arg);
-		if (n.getMessage() != null) {
-			n.getMessage().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final AssignExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getTarget().accept(this, arg);
-		n.getValue().accept(this, arg);
-	}
-
-	@Override public void visit(final BinaryExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getLeft().accept(this, arg);
-		n.getRight().accept(this, arg);
-	}
-
-	@Override public void visit(final BlockComment n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final BlockStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final BooleanLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final BreakStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final CastExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-		n.getExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final CatchClause n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExcept().accept(this, arg);
-		n.getCatchBlock().accept(this, arg);
-	}
-
-	@Override public void visit(final CharLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final ClassExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-	}
-
-	@Override public void visit(final ClassOrInterfaceDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				t.accept(this, arg);
-			}
-		}
-		if (n.getExtends() != null) {
-			for (final ClassOrInterfaceType c : n.getExtends()) {
-				c.accept(this, arg);
-			}
-		}
-
-		if (n.getImplements() != null) {
-			for (final ClassOrInterfaceType c : n.getImplements()) {
-				c.accept(this, arg);
-			}
-		}
-		if (n.getMembers() != null) {
-			for (final BodyDeclaration member : n.getMembers()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final ClassOrInterfaceType n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				t.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final CompilationUnit n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getPackage() != null) {
-			n.getPackage().accept(this, arg);
-		}
-		if (n.getImports() != null) {
-			for (final ImportDeclaration i : n.getImports()) {
-				i.accept(this, arg);
-			}
-		}
-		if (n.getTypes() != null) {
-			for (final TypeDeclaration typeDeclaration : n.getTypes()) {
-				typeDeclaration.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final ConditionalExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		n.getThenExpr().accept(this, arg);
-		n.getElseExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final ConstructorDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				t.accept(this, arg);
-			}
-		}
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				p.accept(this, arg);
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
-				name.accept(this, arg);
-			}
-		}
-		n.getBlock().accept(this, arg);
-	}
-
-	@Override public void visit(final ContinueStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final DoStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getBody().accept(this, arg);
-		n.getCondition().accept(this, arg);
-	}
-
-	@Override public void visit(final DoubleLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final EmptyMemberDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final EmptyStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final EmptyTypeDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final EnclosedExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getInner().accept(this, arg);
-	}
-
-	@Override public void visit(final EnumConstantDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getClassBody() != null) {
-			for (final BodyDeclaration member : n.getClassBody()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final EnumDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		if (n.getImplements() != null) {
-			for (final ClassOrInterfaceType c : n.getImplements()) {
-				c.accept(this, arg);
-			}
-		}
-		if (n.getEntries() != null) {
-			for (final EnumConstantDeclaration e : n.getEntries()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getMembers() != null) {
-			for (final BodyDeclaration member : n.getMembers()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final ExplicitConstructorInvocationStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (!n.isThis()) {
-			if (n.getExpr() != null) {
-				n.getExpr().accept(this, arg);
-			}
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				t.accept(this, arg);
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final ExpressionStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpression().accept(this, arg);
-	}
-
-	@Override public void visit(final FieldAccessExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getScope().accept(this, arg);
-	}
-
-	@Override public void visit(final FieldDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		n.getType().accept(this, arg);
-		for (final VariableDeclarator var : n.getVariables()) {
-			var.accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ForeachStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getVariable().accept(this, arg);
-		n.getIterable().accept(this, arg);
-		n.getBody().accept(this, arg);
-	}
-
-	@Override public void visit(final ForStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getInit() != null) {
-			for (final Expression e : n.getInit()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getCompare() != null) {
-			n.getCompare().accept(this, arg);
-		}
-		if (n.getUpdate() != null) {
-			for (final Expression e : n.getUpdate()) {
-				e.accept(this, arg);
-			}
-		}
-		n.getBody().accept(this, arg);
-	}
-
-	@Override public void visit(final IfStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		n.getThenStmt().accept(this, arg);
-		if (n.getElseStmt() != null) {
-			n.getElseStmt().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ImportDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-	}
-
-	@Override public void visit(final InitializerDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		n.getBlock().accept(this, arg);
-	}
-
-	@Override public void visit(final InstanceOfExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-		n.getType().accept(this, arg);
-	}
-
-	@Override public void visit(final IntegerLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final IntegerLiteralMinValueExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final JavadocComment n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final LabeledStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getStmt().accept(this, arg);
-	}
-
-	@Override public void visit(final LineComment n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final LongLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final LongLiteralMinValueExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final MarkerAnnotationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-	}
-
-	@Override public void visit(final MemberValuePair n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getValue().accept(this, arg);
-	}
-
-	@Override public void visit(final MethodCallExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				t.accept(this, arg);
-			}
-		}
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final MethodDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getJavaDoc() != null) {
-			n.getJavaDoc().accept(this, arg);
-		}
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		if (n.getTypeParameters() != null) {
-			for (final TypeParameter t : n.getTypeParameters()) {
-				t.accept(this, arg);
-			}
-		}
-		n.getType().accept(this, arg);
-		if (n.getParameters() != null) {
-			for (final Parameter p : n.getParameters()) {
-				p.accept(this, arg);
-			}
-		}
-		if (n.getThrows() != null) {
-			for (final NameExpr name : n.getThrows()) {
-				name.accept(this, arg);
-			}
-		}
-		if (n.getBody() != null) {
-			n.getBody().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final NameExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final NormalAnnotationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		if (n.getPairs() != null) {
-			for (final MemberValuePair m : n.getPairs()) {
-				m.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final NullLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final ObjectCreationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getScope() != null) {
-			n.getScope().accept(this, arg);
-		}
-		if (n.getTypeArgs() != null) {
-			for (final Type t : n.getTypeArgs()) {
-				t.accept(this, arg);
-			}
-		}
-		n.getType().accept(this, arg);
-		if (n.getArgs() != null) {
-			for (final Expression e : n.getArgs()) {
-				e.accept(this, arg);
-			}
-		}
-		if (n.getAnonymousClassBody() != null) {
-			for (final BodyDeclaration member : n.getAnonymousClassBody()) {
-				member.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final PackageDeclaration n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		n.getName().accept(this, arg);
-	}
-
-	@Override public void visit(final Parameter n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		n.getType().accept(this, arg);
-		n.getId().accept(this, arg);
-	}
-	
-	@Override public void visit(final MultiTypeParameter n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		for (final Type type : n.getTypes()) {
-			type.accept(this, arg);
-		}
-		n.getId().accept(this, arg);
-	}
-
-	@Override public void visit(final PrimitiveType n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final QualifiedNameExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getQualifier().accept(this, arg);
-	}
-
-	@Override public void visit(final ReferenceType n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getType().accept(this, arg);
-	}
-
-	@Override public void visit(final ReturnStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getExpr() != null) {
-			n.getExpr().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final SingleMemberAnnotationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getName().accept(this, arg);
-		n.getMemberValue().accept(this, arg);
-	}
-
-	@Override public void visit(final StringLiteralExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final SuperExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final SwitchEntryStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getLabel() != null) {
-			n.getLabel().accept(this, arg);
-		}
-		if (n.getStmts() != null) {
-			for (final Statement s : n.getStmts()) {
-				s.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final SwitchStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getSelector().accept(this, arg);
-		if (n.getEntries() != null) {
-			for (final SwitchEntryStmt e : n.getEntries()) {
-				e.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final SynchronizedStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-		n.getBlock().accept(this, arg);
-	}
-
-	@Override public void visit(final ThisExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getClassExpr() != null) {
-			n.getClassExpr().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final ThrowStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final TryStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getResources() != null) {
-			for (final VariableDeclarationExpr v : n.getResources()) {
-				v.accept(this, arg);
-			}
-		}
-		n.getTryBlock().accept(this, arg);
-		if (n.getCatchs() != null) {
-			for (final CatchClause c : n.getCatchs()) {
-				c.accept(this, arg);
-			}
-		}
-		if (n.getFinallyBlock() != null) {
-			n.getFinallyBlock().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final TypeDeclarationStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getTypeDeclaration().accept(this, arg);
-	}
-
-	@Override public void visit(final TypeParameter n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getTypeBound() != null) {
-			for (final ClassOrInterfaceType c : n.getTypeBound()) {
-				c.accept(this, arg);
-			}
-		}
-	}
-
-	@Override public void visit(final UnaryExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getExpr().accept(this, arg);
-	}
-
-	@Override public void visit(final UnknownType n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final VariableDeclarationExpr n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getAnnotations() != null) {
-			for (final AnnotationExpr a : n.getAnnotations()) {
-				a.accept(this, arg);
-			}
-		}
-		n.getType().accept(this, arg);
-		for (final VariableDeclarator v : n.getVars()) {
-			v.accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final VariableDeclarator n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getId().accept(this, arg);
-		if (n.getInit() != null) {
-			n.getInit().accept(this, arg);
-		}
-	}
-
-	@Override public void visit(final VariableDeclaratorId n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final VoidType n, final A arg) {
-		visitComment(n.getComment(), arg);
-	}
-
-	@Override public void visit(final WhileStmt n, final A arg) {
-		visitComment(n.getComment(), arg);
-		n.getCondition().accept(this, arg);
-		n.getBody().accept(this, arg);
-	}
-
-	@Override public void visit(final WildcardType n, final A arg) {
-		visitComment(n.getComment(), arg);
-		if (n.getExtends() != null) {
-			n.getExtends().accept(this, arg);
-		}
-		if (n.getSuper() != null) {
-			n.getSuper().accept(this, arg);
-		}
-	}
+    @Override public void visit(final AnnotationDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration member : n.getMembers()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final AnnotationMemberDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        n.getType().accept(this, arg);
+        if (n.getDefaultValue() != null) {
+            n.getDefaultValue().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ArrayAccessExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        n.getIndex().accept(this, arg);
+    }
+
+    @Override public void visit(final ArrayCreationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+        if (!isNullOrEmpty(n.getDimensions())) {
+            for (final Expression dim : n.getDimensions()) {
+                dim.accept(this, arg);
+            }
+        } else {
+            n.getInitializer().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ArrayInitializerExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getValues() != null) {
+            for (final Expression expr : n.getValues()) {
+                expr.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final AssertStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCheck().accept(this, arg);
+        if (n.getMessage() != null) {
+            n.getMessage().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final AssignExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getTarget().accept(this, arg);
+        n.getValue().accept(this, arg);
+    }
+
+    @Override public void visit(final BinaryExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getLeft().accept(this, arg);
+        n.getRight().accept(this, arg);
+    }
+
+    @Override public void visit(final BlockComment n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final BlockStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final BooleanLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final BreakStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final CastExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+        n.getExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final CatchClause n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExcept().accept(this, arg);
+        n.getCatchBlock().accept(this, arg);
+    }
+
+    @Override public void visit(final CharLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final ClassExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+    }
+
+    @Override public void visit(final ClassOrInterfaceDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                t.accept(this, arg);
+            }
+        }
+        if (n.getExtends() != null) {
+            for (final ClassOrInterfaceType c : n.getExtends()) {
+                c.accept(this, arg);
+            }
+        }
+
+        if (n.getImplements() != null) {
+            for (final ClassOrInterfaceType c : n.getImplements()) {
+                c.accept(this, arg);
+            }
+        }
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration member : n.getMembers()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final ClassOrInterfaceType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                t.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final CompilationUnit n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getPackage() != null) {
+            n.getPackage().accept(this, arg);
+        }
+        if (n.getImports() != null) {
+            for (final ImportDeclaration i : n.getImports()) {
+                i.accept(this, arg);
+            }
+        }
+        if (n.getTypes() != null) {
+            for (final TypeDeclaration typeDeclaration : n.getTypes()) {
+                typeDeclaration.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final ConditionalExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        n.getThenExpr().accept(this, arg);
+        n.getElseExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final ConstructorDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                t.accept(this, arg);
+            }
+        }
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                p.accept(this, arg);
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final NameExpr name : n.getThrows()) {
+                name.accept(this, arg);
+            }
+        }
+        n.getBlock().accept(this, arg);
+    }
+
+    @Override public void visit(final ContinueStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final DoStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getBody().accept(this, arg);
+        n.getCondition().accept(this, arg);
+    }
+
+    @Override public void visit(final DoubleLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final EmptyMemberDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final EmptyStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final EmptyTypeDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final EnclosedExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getInner().accept(this, arg);
+    }
+
+    @Override public void visit(final EnumConstantDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getClassBody() != null) {
+            for (final BodyDeclaration member : n.getClassBody()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final EnumDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        if (n.getImplements() != null) {
+            for (final ClassOrInterfaceType c : n.getImplements()) {
+                c.accept(this, arg);
+            }
+        }
+        if (n.getEntries() != null) {
+            for (final EnumConstantDeclaration e : n.getEntries()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getMembers() != null) {
+            for (final BodyDeclaration member : n.getMembers()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final ExplicitConstructorInvocationStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (!n.isThis()) {
+            if (n.getExpr() != null) {
+                n.getExpr().accept(this, arg);
+            }
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                t.accept(this, arg);
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final ExpressionStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpression().accept(this, arg);
+    }
+
+    @Override public void visit(final FieldAccessExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getScope().accept(this, arg);
+    }
+
+    @Override public void visit(final FieldDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        n.getType().accept(this, arg);
+        for (final VariableDeclarator var : n.getVariables()) {
+            var.accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ForeachStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getVariable().accept(this, arg);
+        n.getIterable().accept(this, arg);
+        n.getBody().accept(this, arg);
+    }
+
+    @Override public void visit(final ForStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getInit() != null) {
+            for (final Expression e : n.getInit()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getCompare() != null) {
+            n.getCompare().accept(this, arg);
+        }
+        if (n.getUpdate() != null) {
+            for (final Expression e : n.getUpdate()) {
+                e.accept(this, arg);
+            }
+        }
+        n.getBody().accept(this, arg);
+    }
+
+    @Override public void visit(final IfStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        n.getThenStmt().accept(this, arg);
+        if (n.getElseStmt() != null) {
+            n.getElseStmt().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ImportDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+    }
+
+    @Override public void visit(final InitializerDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        n.getBlock().accept(this, arg);
+    }
+
+    @Override public void visit(final InstanceOfExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+        n.getType().accept(this, arg);
+    }
+
+    @Override public void visit(final IntegerLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final IntegerLiteralMinValueExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final JavadocComment n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final LabeledStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getStmt().accept(this, arg);
+    }
+
+    @Override public void visit(final LineComment n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final LongLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final LongLiteralMinValueExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final MarkerAnnotationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+    }
+
+    @Override public void visit(final MemberValuePair n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getValue().accept(this, arg);
+    }
+
+    @Override public void visit(final MethodCallExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                t.accept(this, arg);
+            }
+        }
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final MethodDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getJavaDoc() != null) {
+            n.getJavaDoc().accept(this, arg);
+        }
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        if (n.getTypeParameters() != null) {
+            for (final TypeParameter t : n.getTypeParameters()) {
+                t.accept(this, arg);
+            }
+        }
+        n.getType().accept(this, arg);
+        if (n.getParameters() != null) {
+            for (final Parameter p : n.getParameters()) {
+                p.accept(this, arg);
+            }
+        }
+        if (n.getThrows() != null) {
+            for (final NameExpr name : n.getThrows()) {
+                name.accept(this, arg);
+            }
+        }
+        if (n.getBody() != null) {
+            n.getBody().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final NameExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final NormalAnnotationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        if (n.getPairs() != null) {
+            for (final MemberValuePair m : n.getPairs()) {
+                m.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final NullLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final ObjectCreationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+        }
+        if (n.getTypeArgs() != null) {
+            for (final Type t : n.getTypeArgs()) {
+                t.accept(this, arg);
+            }
+        }
+        n.getType().accept(this, arg);
+        if (n.getArgs() != null) {
+            for (final Expression e : n.getArgs()) {
+                e.accept(this, arg);
+            }
+        }
+        if (n.getAnonymousClassBody() != null) {
+            for (final BodyDeclaration member : n.getAnonymousClassBody()) {
+                member.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final PackageDeclaration n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        n.getName().accept(this, arg);
+    }
+
+    @Override public void visit(final Parameter n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        n.getType().accept(this, arg);
+        n.getId().accept(this, arg);
+    }
+    
+    @Override public void visit(final MultiTypeParameter n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        for (final Type type : n.getTypes()) {
+            type.accept(this, arg);
+        }
+        n.getId().accept(this, arg);
+    }
+
+    @Override public void visit(final PrimitiveType n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final QualifiedNameExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getQualifier().accept(this, arg);
+    }
+
+    @Override public void visit(final ReferenceType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getType().accept(this, arg);
+    }
+
+    @Override public void visit(final ReturnStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getExpr() != null) {
+            n.getExpr().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final SingleMemberAnnotationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getName().accept(this, arg);
+        n.getMemberValue().accept(this, arg);
+    }
+
+    @Override public void visit(final StringLiteralExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final SuperExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final SwitchEntryStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getLabel() != null) {
+            n.getLabel().accept(this, arg);
+        }
+        if (n.getStmts() != null) {
+            for (final Statement s : n.getStmts()) {
+                s.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final SwitchStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getSelector().accept(this, arg);
+        if (n.getEntries() != null) {
+            for (final SwitchEntryStmt e : n.getEntries()) {
+                e.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final SynchronizedStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+        n.getBlock().accept(this, arg);
+    }
+
+    @Override public void visit(final ThisExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getClassExpr() != null) {
+            n.getClassExpr().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final ThrowStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final TryStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getResources() != null) {
+            for (final VariableDeclarationExpr v : n.getResources()) {
+                v.accept(this, arg);
+            }
+        }
+        n.getTryBlock().accept(this, arg);
+        if (n.getCatchs() != null) {
+            for (final CatchClause c : n.getCatchs()) {
+                c.accept(this, arg);
+            }
+        }
+        if (n.getFinallyBlock() != null) {
+            n.getFinallyBlock().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final TypeDeclarationStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getTypeDeclaration().accept(this, arg);
+    }
+
+    @Override public void visit(final TypeParameter n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getTypeBound() != null) {
+            for (final ClassOrInterfaceType c : n.getTypeBound()) {
+                c.accept(this, arg);
+            }
+        }
+    }
+
+    @Override public void visit(final UnaryExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getExpr().accept(this, arg);
+    }
+
+    @Override public void visit(final UnknownType n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final VariableDeclarationExpr n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getAnnotations() != null) {
+            for (final AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
+        n.getType().accept(this, arg);
+        for (final VariableDeclarator v : n.getVars()) {
+            v.accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final VariableDeclarator n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getId().accept(this, arg);
+        if (n.getInit() != null) {
+            n.getInit().accept(this, arg);
+        }
+    }
+
+    @Override public void visit(final VariableDeclaratorId n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final VoidType n, final A arg) {
+        visitComment(n.getComment(), arg);
+    }
+
+    @Override public void visit(final WhileStmt n, final A arg) {
+        visitComment(n.getComment(), arg);
+        n.getCondition().accept(this, arg);
+        n.getBody().accept(this, arg);
+    }
+
+    @Override public void visit(final WildcardType n, final A arg) {
+        visitComment(n.getComment(), arg);
+        if (n.getExtends() != null) {
+            n.getExtends().accept(this, arg);
+        }
+        if (n.getSuper() != null) {
+            n.getSuper().accept(this, arg);
+        }
+    }
 
     @Override
     public void visit(LambdaExpr n, final A arg) {
@@ -839,8 +839,8 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     }
 
     private void visitComment(final Comment n, final A arg) {
-		if (n != null) {
-			n.accept(this, arg);
-		}
-	}
+        if (n != null) {
+            n.accept(this, arg);
+        }
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-core/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-core/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -69,14 +69,14 @@ public class JavaParserTypeDeclarationAdapter {
 
         // Look into extended classes and implemented interfaces
         for (ReferenceType ancestor : this.typeDeclaration.getAncestors()) {
-        	try {
-	            for (TypeDeclaration internalTypeDeclaration : ancestor.getTypeDeclaration().internalTypes()) {
-	                if (internalTypeDeclaration.getName().equals(name)) {
-	                    return SymbolReference.solved(internalTypeDeclaration);
-	                }
-	            }
-        	} catch (UnsupportedOperationException e) {
-	            // just continue using the next ancestor
+            try {
+                for (TypeDeclaration internalTypeDeclaration : ancestor.getTypeDeclaration().internalTypes()) {
+                    if (internalTypeDeclaration.getName().equals(name)) {
+                        return SymbolReference.solved(internalTypeDeclaration);
+                    }
+                }
+            } catch (UnsupportedOperationException e) {
+                // just continue using the next ancestor
             }
         }
 
@@ -91,7 +91,7 @@ public class JavaParserTypeDeclarationAdapter {
         // We want to avoid infinite recursion in case of Object having Object as ancestor
         if (!Object.class.getCanonicalName().equals(typeDeclaration.getQualifiedName())) {
             for (ReferenceType ancestor : typeDeclaration.getAncestors()) {
-		// Avoid recursion on self
+        // Avoid recursion on self
                 if (typeDeclaration != ancestor.getTypeDeclaration()) {
                     SymbolReference<MethodDeclaration> res = MethodResolutionLogic
                             .solveMethodInType(ancestor.getTypeDeclaration(), name, argumentsTypes, staticOnly, typeSolver);
@@ -101,7 +101,7 @@ public class JavaParserTypeDeclarationAdapter {
                     if (res.isSolved()) {
                         candidateMethods.add(res.getCorrespondingDeclaration());
                     }
-		}
+        }
             }
         }
         // We want to avoid infinite recursion when a class is using its own method

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-core/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-core/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -237,7 +237,7 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
                 ParameterDeclaration parameter = methodUsage.getDeclaration().getParam(i);
                 Type parameterType = parameter.getType();
                 if (parameter.isVariadic()) {
-                	parameterType = parameterType.asArrayType().getComponentType();
+                    parameterType = parameterType.asArrayType().getComponentType();
                 }
                 inferTypes(argumentsTypes.get(i), parameterType, derivedValues);
             }
@@ -265,14 +265,14 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             return;
         }
         if (source.isReferenceType() && target.isReferenceType()) {
-        	ReferenceType sourceRefType = source.asReferenceType();
-        	ReferenceType targetRefType = target.asReferenceType();
+            ReferenceType sourceRefType = source.asReferenceType();
+            ReferenceType targetRefType = target.asReferenceType();
             if (sourceRefType.getQualifiedName().equals(targetRefType.getQualifiedName())) {
-            	if (!sourceRefType.isRawType() && !targetRefType.isRawType()) {
-	                for (int i = 0; i < sourceRefType.typeParametersValues().size(); i++) {
-	                    inferTypes(sourceRefType.typeParametersValues().get(i), targetRefType.typeParametersValues().get(i), mappings);
-	                }
-            	}
+                if (!sourceRefType.isRawType() && !targetRefType.isRawType()) {
+                    for (int i = 0; i < sourceRefType.typeParametersValues().size(); i++) {
+                        inferTypes(sourceRefType.typeParametersValues().get(i), targetRefType.typeParametersValues().get(i), mappings);
+                    }
+                }
             }
             return;
         }

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-core/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-core/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
@@ -100,7 +100,7 @@ public class JavaParserTypeSolver implements TypeSolver {
         // TODO support enums
         // TODO support interfaces
         if (foundTypes.containsKey(name))
-        	return SymbolReference.solved(foundTypes.get(name));
+            return SymbolReference.solved(foundTypes.get(name));
 
         SymbolReference<ReferenceTypeDeclaration> result = tryToSolveTypeUncached(name);
         if (result.isSolved()) {

--- a/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-model/com/github/javaparser/symbolsolver/model/typesystem/ReferenceType.java
+++ b/javaparser-symbol-solver-testing/src/test/test_sourcecode/javasymbolsolver_0_6_0/src/java-symbol-solver-model/com/github/javaparser/symbolsolver/model/typesystem/ReferenceType.java
@@ -288,9 +288,9 @@ public abstract class ReferenceType implements Type, TypeParametrized, TypeParam
     public List<Tuple2<TypeParameterDeclaration, Type>> getTypeParametersMap() {
         List<Tuple2<TypeParameterDeclaration, Type>> typeParametersMap = new ArrayList<>();
         if (!isRawType()) {
-	        for (int i = 0; i < typeDeclaration.getTypeParameters().size(); i++) {
-	            typeParametersMap.add(new Tuple2<>(typeDeclaration.getTypeParameters().get(0), typeParametersValues().get(i)));
-	        }
+            for (int i = 0; i < typeDeclaration.getTypeParameters().size(); i++) {
+                typeParametersMap.add(new Tuple2<>(typeDeclaration.getTypeParameters().get(0), typeParametersValues().get(i)));
+            }
         }
         return typeParametersMap;
     }


### PR DESCRIPTION
The JavaParser codebase mainly uses spaces for indentation.  However, in a few places it inconsistently uses tabs.  This pull request changes tabs to spaces in `.java` files.
