### PR TITLE
Fix: issue #4047 Symbol Solver mixes name with type

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -181,15 +181,6 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
         if (optScope.isPresent()) {
             Expression scope = optScope.get();
 
-            // consider static methods
-            if (scope instanceof NameExpr) {
-                NameExpr scopeAsName = scope.asNameExpr();
-                SymbolReference<ResolvedTypeDeclaration> symbolReference = this.solveType(scopeAsName.getName().getId());
-                if (symbolReference.isSolved() && symbolReference.getCorrespondingDeclaration().isType()) {
-                    return singletonList(symbolReference.getCorrespondingDeclaration().asReferenceType());
-                }
-            }
-
             ResolvedType typeOfScope;
             try {
                 typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
@@ -216,11 +207,11 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                 }
                 return singletonList(typeSolver.getSolvedJavaLangObject());
             }
-                    if (typeOfScope.isArray()) {
+            if (typeOfScope.isArray()) {
                 // method call on array are Object methods
                 return singletonList(typeSolver.getSolvedJavaLangObject());
             }
-                    if (typeOfScope.isTypeVariable()) {
+            if (typeOfScope.isTypeVariable()) {
                 Collection<ResolvedReferenceTypeDeclaration> result = new ArrayList<>();
                 for (ResolvedTypeParameterDeclaration.Bound bound : typeOfScope.asTypeParameter().getBounds()) {
                     // TODO: Figure out if it is appropriate to remove the orElseThrow() -- if so, how...
@@ -233,7 +224,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                 }
                 return result;
             }
-                    if (typeOfScope.isConstraint()) {
+            if (typeOfScope.isConstraint()) {
                 // TODO: Figure out if it is appropriate to remove the orElseThrow() -- if so, how...
             	ResolvedType type = typeOfScope.asConstraintType().getBound();
             	if (type.isReferenceType()) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4047Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4047Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue4047Test extends AbstractResolutionTest {
+
+	@Test
+	void test() {
+
+		String code =
+				"import static java.lang.String.valueOf;\n"
+				+ "public class MyClass { \n"
+				+ "  void f() { \n"
+				+ "    Long Integer = null; \n"
+				+ "    Integer.intValue(); \n"
+				+ "    valueOf(Integer); \n"
+				+ "  } \n"
+				+ "} \n";
+
+		JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+		CompilationUnit cu = parser.parse(code);
+
+		List<MethodCallExpr> exprs = cu.findAll(MethodCallExpr .class);
+
+		assertEquals("java.lang.Long.intValue()", exprs.get(0).resolve().getQualifiedSignature());
+		assertEquals("java.lang.String.valueOf(java.lang.Object)", exprs.get(1).resolve().getQualifiedSignature());
+	}
+}


### PR DESCRIPTION
Fixes #4047 .

When the scope of the method invocation is a NameExpr there was a specific type resolution that appears to take static methods into account. However, static methods are already taken into consideration. This code snippet that was removed has been there since the start of the project but may no longer be useful now. Still, this snippet raises a problem in certain cases where the scope is a variable declared in the method block and if the name of the variable also corresponds to a type. In this case it is the type of the variable which should make it possible to determine the declaration of the method.