### PR TITLE
Fix: issue 3833 No enum constant com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_18

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java18ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java18ValidatorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+
+import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_18;
+
+class Java18ValidatorTest {
+
+    private final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_18));
+
+
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -166,8 +166,12 @@ public class ParserConfiguration {
          * Java 17 -- including incubator/preview/second preview features.
          * Note that preview features, unless otherwise specified, follow the grammar and behaviour of the latest released JEP for that feature.
          */
-        JAVA_17_PREVIEW(new Java17PreviewValidator(), new Java17PostProcessor());
-
+        JAVA_17_PREVIEW(new Java17PreviewValidator(), new Java17PostProcessor()),
+    	/**
+         * Java 18
+         */
+        JAVA_18(new Java18Validator(), new Java18PostProcessor());
+    	
         /**
          * Does no post processing or validation. Only for people wanting the fastest parsing.
          */

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java18Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java18Validator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.ast.validator.language_level_validations;
+
+/**
+ * This validator validates according to Java 18 syntax rules.
+ *
+ * @see <a href="https://openjdk.java.net/projects/jdk/18/">https://openjdk.java.net/projects/jdk/18/</a>
+ */
+public class Java18Validator extends Java17Validator {
+
+    public Java18Validator() {
+        super();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java18PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java18PostProcessor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Processes the generic AST into a Java 18 AST and validates it.
+ */
+public class Java18PostProcessor extends Java16PostProcessor {
+}


### PR DESCRIPTION

Fixes #3833 .

Note that this PR does not provide support for pattern matching for switch which is a preview feature.
