### PR TITLE
Cleanup poms, use jakarta provided (javax namespace), hamcrest follow up, and switch coveralls plugin - Fixes #4111

### DIFF
--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -56,14 +56,14 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.json</groupId>
-			<artifactId>javax.json-api</artifactId>
-			<version>1.1.4</version>
+			<groupId>jakarta.json</groupId>
+			<artifactId>jakarta.json-api</artifactId>
+			<version>1.1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<version>1.1.4</version>
+			<artifactId>jakarta.json</artifactId>
+			<version>1.1.6</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -125,7 +125,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -104,7 +104,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>templating-maven-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>filter-src</id>

--- a/pom.xml
+++ b/pom.xml
@@ -374,12 +374,6 @@
                 <version>32.1.3-jre</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>2.2</version>
@@ -402,6 +396,12 @@
                 <artifactId>junit-vintage-engine</artifactId>
                 <version>5.10.1</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -256,16 +256,9 @@
                     <version>3.3.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.eluder.coveralls</groupId>
+                    <groupId>com.github.hazendaz.maven</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
-                    <version>4.3.0</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
-                            <version>2.3.1</version>
-                        </dependency>
-                    </dependencies>
+                    <version>4.5.0-M2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -282,12 +282,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.12.1</version>
-                    <configuration>
-                        <!-- TODO/FIXME: Is this still the way to disable doclint during release/site? -->
-                        <additionalOptions>
-                            <additionalOption>-Xdoclint:none</additionalOption>
-                        </additionalOptions>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>


### PR DESCRIPTION
Fixes #4111

- Jakarta was the original transition from javax but was still javax namespace.  Its still supported and thus should be used.  Do note if using a dependency bot to update that you will not want subsequent items yet depending on usage as the namespace changes after these revisions.
- Removed already defined versions as flagged by m2e in Eclipse
- Removed invalid setup on site plugin that has no influence on anything as not supported there (was for javadocs but not correct).  This was also flagged by m2e as invalid configuration.
- Cleanup junit 4 usage, it was already set by having junit vintage engine.  Cleaned up transient on hamcrest core.
- Switched coveralls plugin to a hard fork I'm not supporting (I support some half a dozen or more maven plugins including spotbugs).  New version no longer has bind-api concerns.  Added some links on the commit to follow out to the original repo(s) as its been difficult to get releases in years even though changes.  We started using this on MyBatis in last week or so and it works perfect while picking up a lot of newer changes.