### PR TITLE
Fix: issue 3972 StackOverflowError when resolving type of scope of a MethodCall

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/parametrization/ResolvedTypeParameterValueProvider.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/parametrization/ResolvedTypeParameterValueProvider.java
@@ -47,7 +47,14 @@ public interface ResolvedTypeParameterValueProvider {
             if (typeParameter.declaredOnType()) {
                 Optional<ResolvedType> typeParam = typeParamValue(typeParameter);
                 if (typeParam.isPresent()) {
-                    type = typeParam.get();
+                	ResolvedType resolvedTypeParam = typeParam.get();
+                	// Try to avoid an infinite loop when the type is a wildcard type bounded by a type variable like "? super T" 
+                	if (resolvedTypeParam.isWildcard() && 
+                			( !resolvedTypeParam.asWildcard().equals(ResolvedWildcard.UNBOUNDED)
+                					&& type.equals(resolvedTypeParam.asWildcard().getBoundedType()))) {
+                		return type;
+                	}
+                    type = resolvedTypeParam;
                 }
             }
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3972Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3972Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class Issue3972Test extends AbstractResolutionTest {
+
+    @Test
+    void test() {
+    	JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+
+        CompilationUnit cu = parser.parse(
+                "class C {\n" +
+                        "    void f() throws NoSuchMethodException {\n" +
+                        "        Class cls = getClass();\n" +
+                        "        cls.getSuperclass().getSuperclass().toString();\n" +
+                        "    }\n" +
+                        "}"
+        );
+
+        for (MethodCallExpr methodCallExpr : cu.findAll(MethodCallExpr.class)) {
+            methodCallExpr.getScope().ifPresent(s -> {
+				String type = s.calculateResolvedType().describe();
+				assertNotNull(type);
+            });
+        }
+    }
+
+}


### PR DESCRIPTION

Fixes #3972 .

The issue related to the parameterized type bounded with by a type variable.
