### PR TITLE
Fix: issue 3650 unreproducible MAVEN_BUILD_TIMESTAMP

### DIFF
--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -25,7 +25,6 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<build.timestamp>${maven.build.timestamp}</build.timestamp>
 	</properties>
 
 	<build>

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -26,7 +26,6 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <build.timestamp>${maven.build.timestamp}</build.timestamp>
     </properties>
     
     <dependencies>

--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -27,7 +27,6 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <build.timestamp>${maven.build.timestamp}</build.timestamp>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -147,10 +147,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+<<<<<<< Updated upstream
 
         <byte-buddy.version>1.14.10</byte-buddy.version>
         <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar</argLine>
 
+=======
+		<build.timestamp>2023-12-03T00:00:00Z</build.timestamp>
+        <!-- Maven Plugins -->
+>>>>>>> Stashed changes
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -147,15 +147,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-<<<<<<< Updated upstream
-
         <byte-buddy.version>1.14.10</byte-buddy.version>
         <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar</argLine>
-
-=======
 		<build.timestamp>2023-12-03T00:00:00Z</build.timestamp>
         <!-- Maven Plugins -->
->>>>>>> Stashed changes
     </properties>
 
     <scm>


### PR DESCRIPTION
Fixes #3650 .

According to the following documentation (https://maven.apache.org/guides/mini/guide-reproducible-builds.html) we will integrate the build date into the maven scripts.
