### PR TITLE
feat: Add parseArrayInitializerExpr to JavaParser API

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -163,6 +163,14 @@ class JavaParserTest {
     }
 
     @Test
+    void parseArrayInitialization() {
+        String code = "{1,2,3}";
+        ArrayInitializerExpr expression = parseArrayInitializerExpr(code);
+
+        assertEquals(3, expression.getValues().size());
+    }
+
+    @Test
     void rangeOfIntersectionType() {
         String code = "class A {" + SYSTEM_EOL
                 + "  Object f() {" + SYSTEM_EOL

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -537,4 +537,16 @@ public final class JavaParser {
     public ParseResult<MethodDeclaration> parseMethodDeclaration(String methodDeclaration) {
         return parse(METHOD_DECLARATION, provider(methodDeclaration));
     }
+
+    /**
+     * Parses an array initializer expression and returns it as ArrayInitializerExpr.
+     *
+     * @param arrayInitializerExpr an array initializer like "{1,2,3}"
+     * @return the AST for the array initializer expression
+     * @throws ParseProblemException if the source code has parser errors
+     * @see ArrayInitializerExpr
+     */
+    public ParseResult<ArrayInitializerExpr> parseArrayInitializerExpr(String arrayInitializerExpr) {
+        return parse(ARRAY_INITIALIZER_EXPR, provider(arrayInitializerExpr));
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParserAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParserAdapter.java
@@ -195,4 +195,7 @@ public class JavaParserAdapter {
         return handleResult(getParser().parseMethodDeclaration(methodDeclaration));
     }
 
+    public ArrayInitializerExpr parseArrayInitializerExpr(String arrayInitializerExpr) {
+        return handleResult(getParser().parseArrayInitializerExpr(arrayInitializerExpr));
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseStart.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseStart.java
@@ -91,5 +91,7 @@ public interface ParseStart<R> {
 
     ParseStart<MethodDeclaration> METHOD_DECLARATION = GeneratedJavaParser::MethodDeclarationParseStart;
 
+    ParseStart<ArrayInitializerExpr> ARRAY_INITIALIZER_EXPR = GeneratedJavaParser::ArrayInitializer;
+
     R parse(GeneratedJavaParser parser) throws ParseException;
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -517,6 +517,19 @@ public final class StaticJavaParser {
         return newParserAdapted().parseMethodDeclaration(methodDeclaration);
     }
 
+    /**
+     * Parses an array initializer expression and returns it as ArrayInitializerExpr.
+     *
+     * @param arrayInitializerExpr an array initializer like "{1,2,3}"
+     * @return the AST for the array initializer expression
+     * @throws ParseProblemException if the source code has parser errors
+     * @see ArrayInitializerExpr
+     */
+    public static ArrayInitializerExpr parseArrayInitializerExpr(@NotNull String arrayInitializerExpr) {
+        Preconditions.checkNotNull(arrayInitializerExpr, "Parameter arrayInitializerExpr can't be null.");
+        return newParserAdapted().parseArrayInitializerExpr(arrayInitializerExpr);
+    }
+
     // Private methods
 
     private static JavaParser newParser() {


### PR DESCRIPTION
I encountered a problem when did some work with java code generation: there was no API to parse array initializer expression into `Expression`, which is required for `AnnotationMemberDeclaration::setDefaultValue` method

So I simply added that API