### PR TITLE
Optimize find ancestor

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
@@ -92,13 +92,14 @@ public interface HasParentNode<T> extends Observable {
         if (!hasParentNode())
             return Optional.empty();
         Node parent = getParentNode().get();
-        Optional<Class<N>> oType = Arrays.stream(types).filter(type -> type.isAssignableFrom(parent.getClass()) && predicate.test(type.cast(parent))).findFirst();
-        if (oType.isPresent()) {
-            return Optional.of(oType.get().cast(parent));
+        for (Class<N> type : types) {
+            if (type.isAssignableFrom(parent.getClass()) && predicate.test(type.cast(parent))) {
+                return Optional.of(type.cast(parent));
+            }
         }
         return parent.findAncestor(predicate, types);
     }
-
+    
     /**
      * Determines whether this {@code HasParentNode} node is a descendant of the given node. A node is <i>not</i> a
      * descendant of itself.

--- a/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
@@ -99,7 +99,7 @@ public interface HasParentNode<T> extends Observable {
         }
         return parent.findAncestor(predicate, types);
     }
-    
+
     /**
      * Determines whether this {@code HasParentNode} node is a descendant of the given node. A node is <i>not</i> a
      * descendant of itself.


### PR DESCRIPTION
HasParentNode.findAncestor() uses Arrays.stream() to handle the varargs types parameters.
This may be convenient, but is both inefficient in terms of performance and memory consumption.
The proposed new implementation uses the good old iteration which improves numbers by factor 2, see JMH benchmark below.

```
Eval_FindAncestor.testImproved                     thrpt    2  34631766.865           ops/s
Eval_FindAncestor.testImproved:gc.alloc.rate       thrpt    2     10830.080          MB/sec
Eval_FindAncestor.testImproved:gc.alloc.rate.norm  thrpt    2       328.000            B/op
Eval_FindAncestor.testImproved:gc.count            thrpt    2        34.000          counts
Eval_FindAncestor.testImproved:gc.time             thrpt    2        24.000              ms

Eval_FindAncestor.testCurrent                      thrpt    2  18087357.962           ops/s
Eval_FindAncestor.testCurrent:gc.alloc.rate        thrpt    2      9795.026          MB/sec
Eval_FindAncestor.testCurrent:gc.alloc.rate.norm   thrpt    2       568.000            B/op
Eval_FindAncestor.testCurrent:gc.count             thrpt    2        36.000          counts
Eval_FindAncestor.testCurrent:gc.time              thrpt    2        22.000              ms
```
