### PR TITLE
Fix: issue #3251 Unable to get types for NameExpr which refer to ClassNames

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
@@ -34,7 +34,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.NameExprMetaModel;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -47,7 +47,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
  *
  * @author Julio Vilmar Gesser
  */
-public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>, Resolvable<ResolvedValueDeclaration> {
+public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>, Resolvable<ResolvedDeclaration> {
 
     private SimpleName name;
 
@@ -151,10 +151,10 @@ public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>
 
     /**
      * Attempts to resolve the declaration corresponding to the accessed name. If successful, a
-     * {@link ResolvedValueDeclaration} representing the declaration of the value accessed by this {@code NameExpr} is
+     * {@link ResolvedDeclaration} representing the declaration of the value accessed by this {@code NameExpr} is
      * returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
      *
-     * @return a {@link ResolvedValueDeclaration} representing the declaration of the accessed value.
+     * @return a {@link ResolvedDeclaration} representing the declaration of the accessed value.
      * @throws UnsolvedSymbolException if the declaration corresponding to the name expression could not be resolved.
      * @see FieldAccessExpr#resolve()
      * @see MethodCallExpr#resolve()
@@ -162,8 +162,8 @@ public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>
      * @see ExplicitConstructorInvocationStmt#resolve()
      */
     @Override
-    public ResolvedValueDeclaration resolve() {
-        return getSymbolResolver().resolveDeclaration(this, ResolvedValueDeclaration.class);
+    public ResolvedDeclaration resolve() {
+        return getSymbolResolver().resolveDeclaration(this, ResolvedDeclaration.class);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -189,7 +189,10 @@ public class JavaSymbolSolver implements SymbolResolver {
             }
         }
         if (node instanceof NameExpr) {
-            SymbolReference<? extends ResolvedValueDeclaration> result = JavaParserFacade.get(typeSolver).solve((NameExpr) node);
+            SymbolReference<? extends ResolvedDeclaration> result = JavaParserFacade.get(typeSolver).solve((NameExpr) node);
+            if (!result.isSolved()) {
+                result = JavaParserFactory.getContext(node, typeSolver).solveType(((NameExpr) node).getNameAsString());
+            }
             if (result.isSolved()) {
                 if (resultClass.isInstance(result.getCorrespondingDeclaration())) {
                     return resultClass.cast(result.getCorrespondingDeclaration());
@@ -302,7 +305,7 @@ public class JavaSymbolSolver implements SymbolResolver {
             }
         }
         if (node instanceof PatternExpr) {
-            SymbolReference<? extends ResolvedValueDeclaration> result = JavaParserFacade.get(typeSolver).solve((PatternExpr) node);
+            SymbolReference<? extends ResolvedDeclaration> result = JavaParserFacade.get(typeSolver).solve((PatternExpr) node);
             if (result.isSolved()) {
                 if (resultClass.isInstance(result.getCorrespondingDeclaration())) {
                     return resultClass.cast(result.getCorrespondingDeclaration());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -118,15 +118,15 @@ public class JavaParserFacade {
         return symbolSolver;
     }
 
-    public SymbolReference<? extends ResolvedValueDeclaration> solve(NameExpr nameExpr) {
+    public SymbolReference<? extends ResolvedDeclaration> solve(NameExpr nameExpr) {
         return symbolSolver.solveSymbol(nameExpr.getName().getId(), nameExpr);
     }
 
-    public SymbolReference<? extends ResolvedValueDeclaration> solve(SimpleName nameExpr) {
+    public SymbolReference<? extends ResolvedDeclaration> solve(SimpleName nameExpr) {
         return symbolSolver.solveSymbol(nameExpr.getId(), nameExpr);
     }
 
-    public SymbolReference<? extends ResolvedValueDeclaration> solve(Expression expr) {
+    public SymbolReference<? extends ResolvedDeclaration> solve(Expression expr) {
         return expr.toNameExpr().map(this::solve).orElseThrow(() -> new IllegalArgumentException(expr.getClass().getCanonicalName()));
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2367Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2367Test.java
@@ -55,7 +55,7 @@ class Issue2367Test extends AbstractSymbolResolutionTest {
                 new StreamProvider(Files.newInputStream(file), StandardCharsets.UTF_8.name())).getResult().get();
 
         NameExpr nameExpr = unit.findFirst(NameExpr.class, m -> m.getName().getIdentifier().equals("privateField")).get();
-        ResolvedValueDeclaration resolvedValueDeclaration = nameExpr.resolve();
+        ResolvedValueDeclaration resolvedValueDeclaration = (ResolvedValueDeclaration) nameExpr.resolve();
         assertEquals("double", resolvedValueDeclaration.getType().describe());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2764Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2764Test.java
@@ -59,7 +59,7 @@ public class Issue2764Test {
 
         CompilationUnit cu = parseResult.getResult().get();
         NameExpr name = (NameExpr) cu.findFirst(UnaryExpr.class).get().getExpression();
-        ResolvedValueDeclaration resolve = name.resolve();
+        ResolvedValueDeclaration resolve = (ResolvedValueDeclaration) name.resolve();
 
         assertTrue("int".contentEquals(resolve.getType().describe()));
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue314Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue314Test.java
@@ -26,7 +26,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
@@ -67,7 +67,7 @@ class Issue314Test extends AbstractResolutionTest{
                 "    }";
         CompilationUnit cu = parse(code);
         NameExpr refToA = Navigator.findNameExpression(Navigator.demandClass(cu, "B"), "a").get();
-        SymbolReference<? extends ResolvedValueDeclaration> symbolReference = javaParserFacade.solve(refToA);
+        SymbolReference<? extends ResolvedDeclaration> symbolReference = javaParserFacade.solve(refToA);
         assertEquals(true, symbolReference.isSolved());
         assertEquals(true, symbolReference.getCorrespondingDeclaration().isField());
         assertEquals("a", symbolReference.getCorrespondingDeclaration().getName());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserVariableDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserVariableDeclarationTest.java
@@ -84,7 +84,7 @@ class JavaParserVariableDeclarationTest  extends AbstractResolutionTest  impleme
                 createParserWithResolver(defaultTypeSolver())).parse(code);
 
         List<NameExpr> names = cu.findAll(NameExpr.class);
-        ResolvedValueDeclaration rvd = names.get(3).resolve();
+        ResolvedValueDeclaration rvd = (ResolvedValueDeclaration) names.get(3).resolve();
 
         String decl = rvd.asField().toAst().get().toString();
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseNewJavaParserHelpersTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnalyseNewJavaParserHelpersTest.java
@@ -25,7 +25,10 @@ import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
@@ -87,7 +90,8 @@ class AnalyseNewJavaParserHelpersTest extends AbstractResolutionTest {
     void nodesTypeIsCorrect() throws IOException {
         CompilationUnit cu = parse("com/github/javaparser/utils/PositionUtils");
         NameExpr nodes = cu.findAll(NameExpr.class).stream().filter(it -> it.getName() != null && it.getName().getId().equals("nodes")).findFirst().get();
-        ResolvedType type = JavaParserFacade.get(TYPESOLVER).solve(nodes).getCorrespondingDeclaration().getType();
+        SymbolReference<? extends ResolvedDeclaration> resolved = JavaParserFacade.get(TYPESOLVER).solve(nodes);
+        ResolvedType type = ((ResolvedValueDeclaration) resolved.getCorrespondingDeclaration()).getType();
         assertEquals("java.util.List<T>", type.describe());
         assertEquals(1, type.asReferenceType().typeParametersValues().size());
         assertEquals(true, type.asReferenceType().typeParametersValues().get(0).isTypeVariable());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/CompilationUnitContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/CompilationUnitContextResolutionTest.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.Navigator;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
@@ -96,7 +97,7 @@ class CompilationUnitContextResolutionTest extends AbstractResolutionTest {
 
         CompilationUnit cu = StaticJavaParser.parse(adaptPath("src/test/resources/CompilationUnitContextResolutionTest/03_symbol/main/Main.java"));
         NameExpr ne = Navigator.findNameExpression(cu, "A").get();
-        String actual = ne.resolve().getType().describe();
+        String actual = ((ResolvedValueDeclaration) ne.resolve()).getType().describe();
         assertEquals("main.Clazz.MyEnum", actual);
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.SwitchStmt;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedEnumConstantDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -58,9 +59,10 @@ class EnumResolutionTest extends AbstractResolutionTest {
         SwitchStmt switchStmt = Navigator.demandSwitch(method);
         Expression expression = switchStmt.getEntries().get(0).getLabels().get(0);
 
-        SymbolReference<? extends ResolvedValueDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(expression);
+        SymbolReference<? extends ResolvedDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(expression);
         assertTrue(ref.isSolved());
-        assertEquals("SwitchOnEnum.MyEnum", ref.getCorrespondingDeclaration().getType().asReferenceType().getQualifiedName());
+        ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) ref.getCorrespondingDeclaration();
+        assertEquals("SwitchOnEnum.MyEnum", valueDecl.getType().asReferenceType().getQualifiedName());
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
@@ -182,7 +182,7 @@ class FieldsResolutionTest extends AbstractResolutionTest {
         NameExpr expression = returnStmt.getExpression().get().asNameExpr();
 
         // resolve field access expression
-        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
+        ResolvedValueDeclaration resolvedValueDeclaration = (ResolvedValueDeclaration) expression.resolve();
 
         // get expected field declaration
         VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "foo");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InstanceOfTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InstanceOfTest.java
@@ -29,8 +29,8 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -374,7 +374,7 @@ public class InstanceOfTest {
                 assertEquals(1, nameExprs.size());
 
                 NameExpr nameExpr = nameExprs.get(0);
-                ResolvedValueDeclaration resolvedNameExpr = nameExpr.resolve();
+                ResolvedDeclaration resolvedNameExpr = nameExpr.resolve();
             }
 
 
@@ -564,7 +564,7 @@ public class InstanceOfTest {
             assertEquals(2, nameExprs.size());
 
             NameExpr nameExpr = nameExprs.get(0);
-            ResolvedValueDeclaration resolvedNameExpr = nameExpr.resolve();
+            ResolvedDeclaration resolvedNameExpr = nameExpr.resolve();
             ResolvedType resolvedNameExprType = nameExpr.calculateResolvedType();
 
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/JavaParserFacadeResolutionTest.java
@@ -24,6 +24,7 @@ package com.github.javaparser.symbolsolver.resolution;
 import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.JavaParser;
@@ -45,7 +46,6 @@ import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.Solver;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -107,7 +107,7 @@ class JavaParserFacadeResolutionTest extends AbstractResolutionTest {
                 "}";
         MethodCallExpr methodCallExpr = Navigator.demandNodeOfGivenClass(parse(code), MethodCallExpr.class);
         NameExpr nameE = (NameExpr) methodCallExpr.getScope().get();
-        SymbolReference<? extends ResolvedValueDeclaration> symbolReference = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameE);
+        SymbolReference<? extends ResolvedDeclaration> symbolReference = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameE);
         assertTrue(symbolReference.isSolved());
         assertTrue(symbolReference.getCorrespondingDeclaration().isParameter());
         assertEquals("e", symbolReference.getCorrespondingDeclaration().asParameter().getName());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/QualifiedNameResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/QualifiedNameResolutionTest.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.Navigator;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
@@ -43,9 +44,10 @@ class QualifiedNameResolutionTest extends AbstractResolutionTest {
         MethodDeclaration method = Navigator.demandMethod(referencesToField, "foo1");
         NameExpr nameExpr = Navigator.findNameExpression(method, "s").get();
 
-        SymbolReference<? extends ResolvedValueDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
+        SymbolReference<? extends ResolvedDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
         assertTrue(ref.isSolved());
-        assertEquals("java.util.Scanner", ref.getCorrespondingDeclaration().getType().asReferenceType().getQualifiedName());
+        ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) ref.getCorrespondingDeclaration();
+        assertEquals("java.util.Scanner", valueDecl.getType().asReferenceType().getQualifiedName());
     }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/StatementContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/StatementContextResolutionTest.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
@@ -46,9 +47,10 @@ class StatementContextResolutionTest extends AbstractResolutionTest {
         MethodDeclaration method = Navigator.demandMethod(referencesToField, "foo1");
         NameExpr nameExpr = Navigator.findNameExpression(method, "s").get();
 
-        SymbolReference<? extends ResolvedValueDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
+        SymbolReference<? extends ResolvedDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
         assertTrue(ref.isSolved());
-        assertEquals("java.lang.String", ref.getCorrespondingDeclaration().getType().asReferenceType().getQualifiedName());
+        ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) ref.getCorrespondingDeclaration();
+        assertEquals("java.lang.String", valueDecl.getType().asReferenceType().getQualifiedName());
     }
 
     @Test
@@ -58,9 +60,10 @@ class StatementContextResolutionTest extends AbstractResolutionTest {
         MethodDeclaration method = Navigator.demandMethod(referencesToField, "foo3");
         NameExpr nameExpr = Navigator.findNameExpression(method, "s").get();
 
-        SymbolReference<? extends ResolvedValueDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
+        SymbolReference<? extends ResolvedDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
         assertTrue(ref.isSolved());
-        assertEquals("java.lang.String", ref.getCorrespondingDeclaration().getType().asReferenceType().getQualifiedName());
+        ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) ref.getCorrespondingDeclaration();
+        assertEquals("java.lang.String", valueDecl.getType().asReferenceType().getQualifiedName());
     }
 
     @Test
@@ -70,9 +73,10 @@ class StatementContextResolutionTest extends AbstractResolutionTest {
         MethodDeclaration method = Navigator.demandMethod(referencesToField, "foo2");
         NameExpr nameExpr = Navigator.findNameExpression(method, "s").get();
 
-        SymbolReference<? extends ResolvedValueDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
+        SymbolReference<? extends ResolvedDeclaration> ref = JavaParserFacade.get(new ReflectionTypeSolver()).solve(nameExpr);
         assertTrue(ref.isSolved());
-        assertEquals("java.lang.String", ref.getCorrespondingDeclaration().getType().asReferenceType().getQualifiedName());
+        ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) ref.getCorrespondingDeclaration();
+        assertEquals("java.lang.String", valueDecl.getType().asReferenceType().getQualifiedName());
     }
 
     @Test
@@ -84,9 +88,10 @@ class StatementContextResolutionTest extends AbstractResolutionTest {
 
         TypeSolver typeSolver = new ReflectionTypeSolver();
 
-        SymbolReference<? extends ResolvedValueDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope().get());
+        SymbolReference<? extends ResolvedDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope().get());
         assertTrue(ref.isSolved());
-        assertEquals("java.util.List<Comment>", ref.getCorrespondingDeclaration().getType().describe());
+        ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) ref.getCorrespondingDeclaration();
+        assertEquals("java.util.List<Comment>", valueDecl.getType().describe());
 
         MethodUsage methodUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(call);
         assertEquals("add", methodUsage.getName());
@@ -101,9 +106,10 @@ class StatementContextResolutionTest extends AbstractResolutionTest {
 
         TypeSolver typeSolver = new ReflectionTypeSolver();
 
-        SymbolReference<? extends ResolvedValueDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope().get());
+        SymbolReference<? extends ResolvedDeclaration> ref = JavaParserFacade.get(typeSolver).solve(call.getScope().get());
         assertTrue(ref.isSolved());
-        assertEquals("java.util.List<Comment>", ref.getCorrespondingDeclaration().getType().describe());
+        ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) ref.getCorrespondingDeclaration();
+        assertEquals("java.util.List<Comment>", valueDecl.getType().describe());
 
         MethodUsage methodUsage = JavaParserFacade.get(typeSolver).solveMethodAsUsage(call);
         assertEquals("add", methodUsage.getName());


### PR DESCRIPTION
Fixes #3251 

on solveSymbol() failure, try solveType(); also change some API methods' return type from ResolvedValueDeclaration to ResolvedDeclaration.