### PR TITLE
fix: issue 4311 IllegalStateException when removing all comments with LexicalPreservingPrinter

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -26,7 +26,10 @@ import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -1699,6 +1702,24 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 		    	"  }\n" +
 		    	"}";
     	cu.getAllContainedComments().get(0).remove();
+    	assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
+
+    // issue 4311  IllegalStateException when removing all comments with LexicalPreservingPrinter
+    @Test
+    void removedLineCommentsWithSameContent() {
+		considerCode("public class Foo {\n" +
+    			"  //line 1 \n" +
+    			"  //line 1 \n" +
+    			"  void mymethod() {\n" +
+    			"  }\n" +
+    			"}");
+		String expected =
+				"public class Foo {\n" +
+		    	"  void mymethod() {\n" +
+		    	"  }\n" +
+		    	"}";
+    	cu.getAllContainedComments().stream().forEach(c -> c.remove());
     	assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -349,11 +349,12 @@ public class LexicalPreservingPrinter {
 						.filter(t -> t.getText().trim().equals((oldValue.asString()).trim()))
 						.collect(toList());
 			}
-			// To check that a comment matches in the list of tokens, the range must be always checked,
+			// To check that a comment matches in the list of tokens, if exists the range must be always checked,
 			// as comments with the same content may exist on different lines.
             return matchingTokens.stream()
-                		.filter(t -> t.getToken().hasRange() && oldValue.hasRange())
-                		.filter(t -> t.getToken().getRange().get().equals(oldValue.getRange().get()))
+                		.filter(t -> (!t.getToken().hasRange() && !oldValue.hasRange())
+                				|| (t.getToken().hasRange() && oldValue.hasRange()
+                						&& t.getToken().getRange().get().equals(oldValue.getRange().get())))
                 		.collect(toList());
         }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -175,9 +175,6 @@ public class LexicalPreservingPrinter {
                         } else {
                         	removeAllExtraCharactersStartingFrom(nodeText.getElements().listIterator(index));
                         }
-//                        if (nodeText.getElements().get(index).isNewline()) {
-//                            nodeText.removeElement(index);
-//                        }
                     } else {
                         throw new UnsupportedOperationException("Trying to remove something that is not a comment!");
                     }
@@ -285,12 +282,21 @@ public class LexicalPreservingPrinter {
             return nodeText.findElement(matchingChild.and(matchingChild.matchByRange()));
         }
 
+        /*
+         * Comment
+         */
         private List<ChildTextElement> findChildTextElementForComment(Comment oldValue, NodeText nodeText) {
             List<ChildTextElement> matchingChildElements;
 			matchingChildElements = selectMatchingChildElements(oldValue, nodeText);
             if (matchingChildElements.size() > 1) {
                 // Duplicate child nodes found, refine the result
-                matchingChildElements = matchingChildElements.stream().filter(t -> isEqualRange(t.getChild().getRange(), oldValue.getRange())).collect(toList());
+				matchingChildElements = matchingChildElements.stream()
+						.filter(t -> t.getChild().hasRange() && oldValue.hasRange())
+						.filter(t -> t.getChild().getRange().get().equals(oldValue.getRange().get())
+								|| (t.getChild().getComment().isPresent()
+										&& t.getChild().getComment().get().hasRange()
+										&& t.getChild().getComment().get().getRange().get().equals(oldValue.getRange().get())))
+						.collect(toList());
             }
             if (matchingChildElements.size() != 1) {
                 throw new IllegalStateException("The matching child text element for the comment to be removed could not be found.");
@@ -324,25 +330,31 @@ public class LexicalPreservingPrinter {
 
         private List<TokenTextElement> findTokenTextElementForComment(Comment oldValue, NodeText nodeText) {
             List<TokenTextElement> matchingTokens;
-            if (oldValue instanceof JavadocComment) {
-                matchingTokens = nodeText.getElements().stream().filter(e -> e.isToken(JAVADOC_COMMENT)).map(e -> (TokenTextElement) e).filter(t -> t.getText().equals(oldValue.getHeader() + oldValue.getContent() + oldValue.getFooter())).collect(toList());
-            } else if (oldValue instanceof BlockComment) {
-                matchingTokens = nodeText.getElements().stream().filter(e -> e.isToken(MULTI_LINE_COMMENT)).map(e -> (TokenTextElement) e).filter(t -> t.getText().equals(oldValue.getHeader() + oldValue.getContent() + oldValue.getFooter())).collect(toList());
-            } else {
-                matchingTokens = nodeText.getElements().stream().filter(e -> e.isToken(SINGLE_LINE_COMMENT)).map(e -> (TokenTextElement) e).filter(t -> t.getText().trim().equals((oldValue.getHeader() + oldValue.getContent()).trim())).collect(toList());
-            }
-            if (matchingTokens.size() > 1) {
-                // Duplicate comments found, refine the result
-                matchingTokens = matchingTokens.stream().filter(t -> isEqualRange(t.getToken().getRange(), oldValue.getRange())).collect(toList());
-            }
-            return matchingTokens;
-        }
-
-        private boolean isEqualRange(Optional<Range> range1, Optional<Range> range2) {
-            if (range1.isPresent() && range2.isPresent()) {
-                return range1.get().equals(range2.get());
-            }
-            return false;
+			if (oldValue instanceof JavadocComment) {
+				matchingTokens = nodeText.getElements().stream()
+						.filter(e -> e.isToken(JAVADOC_COMMENT))
+						.map(e -> (TokenTextElement) e)
+						.filter(t -> t.getText().equals(oldValue.asString()))
+						.collect(toList());
+			} else if (oldValue instanceof BlockComment) {
+				matchingTokens = nodeText.getElements().stream()
+						.filter(e -> e.isToken(MULTI_LINE_COMMENT))
+						.map(e -> (TokenTextElement) e)
+						.filter(t -> t.getText().equals(oldValue.asString()))
+						.collect(toList());
+			} else {
+				matchingTokens = nodeText.getElements().stream()
+						.filter(e -> e.isToken(SINGLE_LINE_COMMENT))
+						.map(e -> (TokenTextElement) e)
+						.filter(t -> t.getText().trim().equals((oldValue.asString()).trim()))
+						.collect(toList());
+			}
+			// To check that a comment matches in the list of tokens, the range must be always checked,
+			// as comments with the same content may exist on different lines.
+            return matchingTokens.stream()
+                		.filter(t -> t.getToken().hasRange() && oldValue.hasRange())
+                		.filter(t -> t.getToken().getRange().get().equals(oldValue.getRange().get()))
+                		.collect(toList());
         }
 
 		/**


### PR DESCRIPTION
This bug is highlighted by the presence of 2 comments with the same content. To check that a comment matches in the list of tokens, the range must be always checked, as comments with the same content may exist on different lines.

Fixes #4311 .
