### PR TITLE
Further improve correction of whitespace during difference application

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/remove/NodeRemovalTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/remove/NodeRemovalTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.remove;
 
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,6 +37,7 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 
 class NodeRemovalTest extends  AbstractLexicalPreservingTest{
 
@@ -90,6 +92,27 @@ class NodeRemovalTest extends  AbstractLexicalPreservingTest{
 		assertTrue(children.size() == 1);
 		assertTrue(children.stream().allMatch(n -> n.getParentNode() != null));
 	}
+
+	@Test
+	// issue 1638
+    public void removingAnnotationsFormattedWithAdditionalSpaces() {
+        considerCode(
+                "class X {\n" +
+                "   @Override\n" +
+                "  public void testCase() {\n" +
+                "  }\n" +
+                "}"
+        );
+
+        cu.getType(0).getMethods().get(0).getAnnotationByName("Override").get().remove();
+
+        String result = LexicalPreservingPrinter.print(cu.findCompilationUnit().get());
+        assertEqualsStringIgnoringEol(
+                "class X {\n" +
+                        "  public void testCase() {\n" +
+                        "  }\n" +
+                        "}", result);
+    }
 
 	// remove the node and parent's node until response is true
 	boolean remove(Node node) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/remove/NodeRemovalTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/remove/NodeRemovalTest.java
@@ -21,6 +21,13 @@
 
 package com.github.javaparser.remove;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -29,15 +36,9 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NodeRemovalTest extends  AbstractLexicalPreservingTest{
-	
+
 	private final CompilationUnit compilationUnit = new CompilationUnit();
 
 	@Test
@@ -75,9 +76,12 @@ class NodeRemovalTest extends  AbstractLexicalPreservingTest{
 
 	@Test
 	void testRemoveStatementFromMethodBodyWithLexicalPreservingPrinter() {
-		considerStatement("{\r\n" + "    log.error(\"context\", e);\r\n" +
+		considerStatement(
+				"{\r\n" +
 				"    log.error(\"context\", e);\r\n" +
-				"    throw new ApplicationException(e);\r\n" + "}\r\n");
+				"    log.error(\"context\", e);\r\n" +
+				"    throw new ApplicationException(e);\r\n" +
+				"}\r\n");
 		BlockStmt bstmt = statement.asBlockStmt();
 		List<Node> children = bstmt.getChildNodes();
 		remove(children.get(0));


### PR DESCRIPTION
Fixes #1638 .

Lexical preservation is based on decomposing AST nodes into tokens. Spaces, tabs and end-of-line characters are also represented in the form of tokens. When lexical preservation is enabled, each operation on the AST updates this list of tokens, which are then printed to restore the lines of code.

The list of tokens analysed is defined from the parent node of the node on which the operation is performed. In the example provided, this is the list of tokens representing the declaration of the method on which the annotation is removed.

The problem you describe arises when you try to delete the first element in the list, as the prior indentation is generally carried by the parent node of the element in consideration (in this case, the annotation). Here, the tokens representing the method declaration are not sufficient as they do not contain the indentation information because they start with the element representing the annotation. We therefore need to analyse the parent node of the method declaration, then search the list of tokens for the element corresponding to the method declaration and finally determine whether an indentation is present and delete it if necessary.
