### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/VisitorGenerator.java
@@ -79,7 +79,7 @@ public abstract class VisitorGenerator extends Generator {
 
     private void generateVisitMethodForNode(BaseNodeMetaModel node, ClassOrInterfaceDeclaration visitorClass, CompilationUnit compilationUnit) {
         final Optional<MethodDeclaration> existingVisitMethod = visitorClass.getMethods().stream()
-                .filter(m -> m.getNameAsString().equals("visit"))
+                .filter(m -> "visit".equals(m.getNameAsString()))
                 .filter(m -> m.getParameter(0).getType().toString().equals(node.getTypeName()))
                 .findFirst();
 

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/other/TokenKindGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/other/TokenKindGenerator.java
@@ -53,7 +53,7 @@ public class TokenKindGenerator extends Generator {
         
         final CompilationUnit javaTokenCu = sourceRoot.parse("com.github.javaparser", "JavaToken.java");
         final ClassOrInterfaceDeclaration javaToken = javaTokenCu.getClassByName("JavaToken").orElseThrow(() -> new AssertionError("Can't find class in java file."));
-        final EnumDeclaration kindEnum = javaToken.findFirst(EnumDeclaration.class, e -> e.getNameAsString().equals("Kind")).orElseThrow(() -> new AssertionError("Can't find class in java file."));
+        final EnumDeclaration kindEnum = javaToken.findFirst(EnumDeclaration.class, e -> "Kind".equals(e.getNameAsString())).orElseThrow(() -> new AssertionError("Can't find class in java file."));
 
         kindEnum.getEntries().clear();
         annotateGenerated(kindEnum);

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/CloneVisitorGenerator.java
@@ -64,7 +64,7 @@ public class CloneVisitorGenerator extends VisitorGenerator {
         SeparatedItemStringBuilder builder = new SeparatedItemStringBuilder(f("%s r = new %s(", node.getTypeNameGenerified(), node.getTypeNameGenerified()), ",", ");");
         builder.append("n.getTokenRange().orElse(null)");
         for (PropertyMetaModel field : node.getConstructorParameters()) {
-            if (field.getName().equals("comment")) {
+            if ("comment".equals(field.getName())) {
                 continue;
             }
             if (field.getNodeReference().isPresent()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/RecordAsTypeIdentifierNotAllowed.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/RecordAsTypeIdentifierNotAllowed.java
@@ -39,7 +39,7 @@ public class RecordAsTypeIdentifierNotAllowed extends VisitorValidator {
 
     @Override
     public void visit(Name n, ProblemReporter arg) {
-        if (n.getIdentifier().equals("record") && !validUsage(n)) {
+        if ("record".equals(n.getIdentifier()) && !validUsage(n)) {
             arg.report(n, error);
         }
         super.visit(n, arg);
@@ -47,7 +47,7 @@ public class RecordAsTypeIdentifierNotAllowed extends VisitorValidator {
 
     @Override
     public void visit(SimpleName n, ProblemReporter arg) {
-        if (n.getIdentifier().equals("record") && !validUsage(n)) {
+        if ("record".equals(n.getIdentifier()) && !validUsage(n)) {
             arg.report(n, error);
         }
         super.visit(n, arg);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/UnderscoreKeywordValidator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/UnderscoreKeywordValidator.java
@@ -41,7 +41,7 @@ public class UnderscoreKeywordValidator extends VisitorValidator {
     }
 
     private static void validateIdentifier(Node n, String id, ProblemReporter arg) {
-        if (id.equals("_")) {
+        if ("_".equals(id)) {
             arg.report(n, "'_' is a reserved keyword.");
         }
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java10PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java10PostProcessor.java
@@ -51,7 +51,7 @@ public class Java10PostProcessor extends PostProcessors {
             result.getResult().ifPresent(node -> {
                 node.findAll(ClassOrInterfaceType.class)
                     .forEach(n -> {
-                        if (n.getNameAsString().equals("var")
+                        if ("var".equals(n.getNameAsString())
                                 && !matchForbiddenContext(n)) {
                             n.replace(new VarType(n.getTokenRange().orElse(null)));
                         }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -786,7 +786,7 @@ public class Difference {
             if (part.equals(token.asString())) {
                 // get 'dot' token
                 token = token.getNextToken().get();
-                if (!token.asString().equals("."))
+                if (!".".equals(token.asString()))
                     break;
                 // get the next part
                 token = token.getNextToken().get();

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
@@ -360,7 +360,7 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      */
     default boolean isJavaLangObject() {
         return this.isClass() && !isAnonymousClass() && // Consider anonymous classes
-        hasName() && getQualifiedName().equals(JAVA_LANG_OBJECT);
+        hasName() && JAVA_LANG_OBJECT.equals(getQualifiedName());
     }
 
     /**
@@ -368,6 +368,6 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      * @see ResolvedReferenceType#isJavaLangEnum()
      */
     default boolean isJavaLangEnum() {
-        return this.isEnum() && getQualifiedName().equals(JAVA_LANG_ENUM);
+        return this.isEnum() && JAVA_LANG_ENUM.equals(getQualifiedName());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/CollectionStrategy.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/CollectionStrategy.java
@@ -50,7 +50,7 @@ public interface CollectionStrategy {
                 if (parseResult.getResult().isPresent()) {
                     final Optional<CompilationUnit.Storage> storage = parseResult.getResult().flatMap(CompilationUnit::getStorage);
                     if (storage.isPresent()) {
-                        if (storage.get().getFileName().equals("module-info.java")) {
+                        if ("module-info.java".equals(storage.get().getFileName())) {
                             // module-info.java is useless for finding the source root, since it can be placed in any directory.
                             return Optional.empty();
                         }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/ParserCollectionStrategy.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/ParserCollectionStrategy.java
@@ -66,7 +66,7 @@ public class ParserCollectionStrategy implements CollectionStrategy {
 
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (file.getFileName().toString().equals("module-info.java")) {
+                    if ("module-info.java".equals(file.getFileName().toString())) {
                         // module-info.java is useless for finding the source root, since it can be placed within any directory.
                         return CONTINUE;
                     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -215,7 +215,7 @@ public class JavaSymbolSolver implements SymbolResolver {
                     return resultClass.cast(result.getCorrespondingDeclaration());
                 }
             } else {
-                if (((FieldAccessExpr) node).getName().getId().equals("length")) {
+                if ("length".equals(((FieldAccessExpr) node).getName().getId())) {
                     ResolvedType scopeType = ((FieldAccessExpr) node).getScope().calculateResolvedType();
                     if (scopeType.isArray()) {
                         if (resultClass.isInstance(ArrayLengthValueDeclaration.INSTANCE)) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
@@ -83,7 +83,7 @@ public class FieldAccessContext extends AbstractJavaParserContext<FieldAccessExp
         Expression scope = wrappedNode.getScope();
         if (wrappedNode.getName().toString().equals(name)) {
             ResolvedType typeOfScope = JavaParserFacade.get(typeSolver).getType(scope);
-            if (typeOfScope.isArray() && name.equals(ARRAY_LENGTH_FIELD_NAME)) {
+            if (typeOfScope.isArray() && ARRAY_LENGTH_FIELD_NAME.equals(name)) {
                 return Optional.of(new Value(ResolvedPrimitiveType.INT, ARRAY_LENGTH_FIELD_NAME));
             }
             if (typeOfScope.isReferenceType()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -122,7 +122,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
         if (otherName.equals(this.getQualifiedName())) {
             return true;
         }
-        if (otherName.equals(JAVA_LANG_ENUM)) {
+        if (JAVA_LANG_ENUM.equals(otherName)) {
             return true;
         }
         // Enum implements Comparable and Serializable
@@ -204,10 +204,10 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> argumentsTypes,
                                                                   boolean staticOnly) {
-        if (name.equals("values") && argumentsTypes.isEmpty()) {
+        if ("values".equals(name) && argumentsTypes.isEmpty()) {
             return SymbolReference.solved(new JavaParserEnumDeclaration.ValuesMethod(this, typeSolver));
         }
-        if (name.equals("valueOf") && argumentsTypes.size() == 1) {
+        if ("valueOf".equals(name) && argumentsTypes.size() == 1) {
             ResolvedType argument = argumentsTypes.get(0);
             if (argument.isReferenceType() && "java.lang.String".equals(argument.asReferenceType().getQualifiedName())) {
                 return SymbolReference.solved(new JavaParserEnumDeclaration.ValueOfMethod(this, typeSolver));

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -127,7 +127,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
         if (otherName.equals(this.getQualifiedName())) {
             return true;
         }
-        if (otherName.equals(JAVA_LANG_ENUM)) {
+        if (JAVA_LANG_ENUM.equals(otherName)) {
             return true;
         }
         // Enum implements Comparable and Serializable

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -151,7 +151,7 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration
       if (otherName.equals(this.getQualifiedName())) {
           return true;
       }
-      if (otherName.equals(JAVA_LANG_ENUM)) {
+      if (JAVA_LANG_ENUM.equals(otherName)) {
           return true;
       }
       // Enum implements Comparable and Serializable


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2Fjavaparser%7C600a82f95e99b5a134d72c6fb3c3a60442b4f113)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->