### PR TITLE
fix: Replace this if-then-else statement by a single return statement (sonar rule)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -132,10 +132,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
         if (otherName.equals(JAVA_IO_SERIALIZABLE)) {
             return true;
         }
-        if (other.isJavaLangObject()) {
-            return true;
-        }
-        return false;
+        return other.isJavaLangObject();
     }
 
     @Override
@@ -185,9 +182,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
 
         JavaParserEnumDeclaration that = (JavaParserEnumDeclaration) o;
 
-        if (!wrappedNode.equals(that.wrappedNode)) return false;
-
-        return true;
+        return wrappedNode.equals(that.wrappedNode);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -93,9 +93,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
 
         JavaParserInterfaceDeclaration that = (JavaParserInterfaceDeclaration) o;
 
-        if (!wrappedNode.equals(that.wrappedNode)) return false;
-
-        return true;
+        return wrappedNode.equals(that.wrappedNode);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
@@ -21,6 +21,11 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
+import static com.github.javaparser.resolution.Navigator.demandParentNode;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -33,11 +38,6 @@ import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static com.github.javaparser.resolution.Navigator.demandParentNode;
 
 
 /**
@@ -69,9 +69,7 @@ public class JavaParserTypeParameter extends AbstractTypeDeclaration implements 
 
         JavaParserTypeParameter that = (JavaParserTypeParameter) o;
 
-        if (wrappedNode != null ? !wrappedNode.equals(that.wrappedNode) : that.wrappedNode != null) return false;
-
-        return true;
+        return wrappedNode != null && wrappedNode.equals(that.wrappedNode);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -137,10 +137,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
         if (otherName.equals(JAVA_IO_SERIALIZABLE)) {
             return true;
         }
-        if (other.isJavaLangObject()) {
-            return true;
-        }
-        return false;
+        return other.isJavaLangObject();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeParameter.java
@@ -21,6 +21,11 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
@@ -28,12 +33,8 @@ import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclar
 import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
-import javassist.bytecode.SignatureAttribute;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import javassist.bytecode.SignatureAttribute;
 
 /**
  * @author Federico Tomassetti
@@ -60,14 +61,11 @@ public class JavassistTypeParameter implements ResolvedTypeParameterDeclaration 
         if (!getQualifiedName().equals(that.getQualifiedName())) {
             return false;
         }
-        if (declaredOnType() != that.declaredOnType()) {
-            return false;
-        }
-        if (declaredOnMethod() != that.declaredOnMethod()) {
-            return false;
+        if (declaredOnType() == that.declaredOnType()) {
+            return true;
         }
         // TODO check bounds
-        return true;
+        return declaredOnMethod() == that.declaredOnMethod();
     }
 
     @Override
@@ -128,7 +126,7 @@ public class JavassistTypeParameter implements ResolvedTypeParameterDeclaration 
         }
         return Optional.empty();
     }
-    
+
     @Override
     public ResolvedReferenceType object() {
         return new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -21,6 +21,13 @@
 
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.resolution.Context;
@@ -38,13 +45,6 @@ import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapabi
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ContextHelper;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.reflectionmodel.comparators.MethodComparator;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -108,9 +108,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
 
         ReflectionClassDeclaration that = (ReflectionClassDeclaration) o;
 
-        if (!clazz.getCanonicalName().equals(that.clazz.getCanonicalName())) return false;
-
-        return true;
+        return clazz.getCanonicalName().equals(that.clazz.getCanonicalName());
     }
 
     @Override
@@ -190,8 +188,8 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
         }
 
         // When empty there is no sense in trying to find the most applicable.
-        // This is useful for debugging. Performance is not affected as 
-        // MethodResolutionLogic.findMostApplicable method returns very early 
+        // This is useful for debugging. Performance is not affected as
+        // MethodResolutionLogic.findMostApplicable method returns very early
         // when candidateSolvedMethods is empty.
         if (candidateSolvedMethods.isEmpty()) {
             return SymbolReference.unsolved();
@@ -211,7 +209,8 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
         return new ReferenceTypeImpl(this);
     }
 
-    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes, Context invokationContext, List<ResolvedType> typeParameterValues) {
+    @Override
+	public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes, Context invokationContext, List<ResolvedType> typeParameterValues) {
         List<MethodUsage> methodUsages = new ArrayList<>();
 
         List<Method> allMethods = Arrays.stream(clazz.getDeclaredMethods())

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -161,10 +161,7 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration
       if (otherName.equals(JAVA_IO_SERIALIZABLE)) {
           return true;
       }
-      if (other.isJavaLangObject()) {
-          return true;
-      }
-      return false;
+      return other.isJavaLangObject();
   }
 
   @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -21,6 +21,10 @@
 
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
+
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.resolution.Context;
@@ -39,10 +43,6 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionCapability;
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
-
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -131,11 +131,7 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
 
         if (!clazz.getCanonicalName().equals(that.clazz.getCanonicalName())) return false;
 
-        if (!getTypeParameters().equals(that.getTypeParameters())) {
-            return false;
-        }
-
-        return true;
+        return getTypeParameters().equals(that.getTypeParameters());
     }
 
     @Override
@@ -143,7 +139,8 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
         return clazz.hashCode();
     }
 
-    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> parameterTypes,
+    @Override
+	public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> parameterTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameterValues) {
         Optional<MethodUsage> res = ReflectionMethodResolutionLogic.solveMethodAsUsage(name, parameterTypes, typeSolver, invokationContext,
                 typeParameterValues, this, clazz);
@@ -193,12 +190,8 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
             }
         }
 
-        if (other.isJavaLangObject()) {
-            // Everything can be assigned to {@code java.lang.Object}
-            return true;
-        }
-
-        return false;
+        // Everything can be assigned to {@code java.lang.Object}
+        return other.isJavaLangObject();
     }
 
     @Override
@@ -288,7 +281,7 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
         }
         return res;
     }
-    
+
     @Override
     public Optional<ResolvedReferenceTypeDeclaration> containerType() {
         return reflectionClassAdapter.containerType();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
@@ -21,14 +21,6 @@
 
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
-import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
-import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
-import com.github.javaparser.resolution.types.ResolvedReferenceType;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.Method;
@@ -37,6 +29,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParametrizable;
+import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
 
 /**
  * @author Federico Tomassetti
@@ -70,14 +70,11 @@ public class ReflectionTypeParameter implements ResolvedTypeParameterDeclaration
         if (!getQualifiedName().equals(that.getQualifiedName())) {
             return false;
         }
-        if (declaredOnType() != that.declaredOnType()) {
-            return false;
-        }
-        if (declaredOnMethod() != that.declaredOnMethod()) {
-            return false;
+        if (declaredOnType() == that.declaredOnType()) {
+            return true;
         }
         // TODO check bounds
-        return true;
+        return declaredOnMethod() == that.declaredOnMethod();
     }
 
     @Override
@@ -107,7 +104,7 @@ public class ReflectionTypeParameter implements ResolvedTypeParameterDeclaration
         }
         return ((ResolvedMethodLikeDeclaration) container).getQualifiedSignature();
     }
-    
+
     @Override
     public ResolvedTypeParametrizable getContainer() {
         return this.container;
@@ -132,7 +129,7 @@ public class ReflectionTypeParameter implements ResolvedTypeParameterDeclaration
         }
         return Optional.empty();
     }
-    
+
     @Override
     public ResolvedReferenceType object() {
         return new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/naming/NameLogic.java
@@ -592,12 +592,8 @@ public class NameLogic {
 
         // 2. In a type-import-on-demand declaration (§7.5.2)
 
-        if (whenParentIs(ImportDeclaration.class, name, (p, c) ->
-                !p.isStatic() && p.isAsterisk() && p.getName() == name)) {
-            return true;
-        }
-
-        return false;
+        return whenParentIs(ImportDeclaration.class, name, (p, c) ->
+                !p.isStatic() && p.isAsterisk() && p.getName() == name);
     }
 
     private static boolean isSyntacticallyAMethodName(Node name) {
@@ -605,11 +601,7 @@ public class NameLogic {
         //
         // 1. Before the "(" in a method invocation expression (§15.12)
 
-        if (whenParentIs(MethodCallExpr.class, name, (p, c) -> p.getName() == c)) {
-            return true;
-        }
-
-        return false;
+        return whenParentIs(MethodCallExpr.class, name, (p, c) -> p.getName() == c);
     }
 
     private static boolean isSyntacticallyAModuleName(Node name) {
@@ -626,11 +618,8 @@ public class NameLogic {
         if (whenParentIs(ModuleExportsDirective.class, name, (p, c) -> p.getModuleNames().contains(name))) {
             return true;
         }
-        if (whenParentIs(ModuleOpensDirective.class, name, (p, c) -> p.getModuleNames().contains(name))) {
-            return true;
-        }
 
-        return false;
+        return whenParentIs(ModuleOpensDirective.class, name, (p, c) -> p.getModuleNames().contains(name));
     }
 
     private static boolean isSyntacticallyAPackageName(Node name) {
@@ -644,12 +633,9 @@ public class NameLogic {
             return true;
         }
         // 2. To the left of the "." in a qualified PackageName
-        if (whenParentIs(Name.class, name, (p, c) -> p.getQualifier().isPresent()
+        return whenParentIs(Name.class, name, (p, c) -> p.getQualifier().isPresent()
                 && p.getQualifier().get() == name
-                && isSyntacticallyAPackageName(p))) {
-            return true;
-        }
-        return false;
+                && isSyntacticallyAPackageName(p));
     }
 
     private static boolean isSyntacticallyATypeName(Node name) {


### PR DESCRIPTION

Return of boolean literal statements wrapped into if-then-else ones should be simplified.

Similarly, method invocations wrapped into if-then-else differing only from boolean literals should be simplified into a single invocation.
