### PR TITLE
fix: Dead stores should be removed (sonar rule)

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/UtilsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/UtilsTest.java
@@ -21,7 +21,11 @@
 
 package com.github.javaparser.utils;
 
-import org.junit.jupiter.api.Test;
+import static com.github.javaparser.utils.Utils.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -30,9 +34,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 
-import static com.github.javaparser.utils.Utils.assertNotNull;
-import static com.github.javaparser.utils.Utils.*;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class UtilsTest {
 
@@ -182,8 +184,11 @@ class UtilsTest {
                 Optional.empty()));
 
         assertFalse(valueIsNullOrEmptyStringOrOptional("foo"));
+        assertFalse(valueIsNullOrEmptyStringOrOptional(""));
         assertFalse(valueIsNullOrEmptyStringOrOptional(
                 Optional.ofNullable("foo")));
+        assertFalse(valueIsNullOrEmptyStringOrOptional(
+                Optional.ofNullable("")));
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -20,6 +20,8 @@
  */
 package com.github.javaparser.ast.visitor;
 
+import java.util.Optional;
+
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
@@ -30,8 +32,6 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
-
-import java.util.Optional;
 
 /**
  * A visitor that clones (copies) a node and all its children.
@@ -258,7 +258,6 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(final InitializerDeclaration n, final Object arg) {
         BlockStmt body = cloneNode(n.getBody(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         InitializerDeclaration r = new InitializerDeclaration(n.getTokenRange().orElse(null), n.isStatic(), body);
         r.setComment(comment);
@@ -329,7 +328,6 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(final IntersectionType n, final Object arg) {
         NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         IntersectionType r = new IntersectionType(n.getTokenRange().orElse(null), elements);
         r.setComment(comment);
@@ -341,7 +339,6 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     @Override
     public Visitable visit(final UnionType n, final Object arg) {
         NodeList<ReferenceType> elements = cloneList(n.getElements(), arg);
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         UnionType r = new UnionType(n.getTokenRange().orElse(null), elements);
         r.setComment(comment);
@@ -352,7 +349,6 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final VoidType n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         VoidType r = new VoidType(n.getTokenRange().orElse(null));
         r.setComment(comment);
@@ -376,7 +372,6 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final UnknownType n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         UnknownType r = new UnknownType(n.getTokenRange().orElse(null));
         r.setComment(comment);
@@ -1189,7 +1184,6 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
 
     @Override
     public Visitable visit(final VarType n, final Object arg) {
-        NodeList<AnnotationExpr> annotations = cloneList(n.getAnnotations(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         VarType r = new VarType(n.getTokenRange().orElse(null));
         r.setComment(comment);

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -130,7 +130,6 @@ public class MethodResolutionLogic {
 
         // The index of the final argument passed (on the method usage).
         int countOfNeedleArgumentsPassedAfterGrouping = needleArgumentTypes.size();
-        int lastNeedleArgumentIndexAfterGrouping = getLastParameterIndex(countOfNeedleArgumentsPassed);
 
         // If variadic parameters are possible then they will have been "grouped" into a single argument.
         // At this point, therefore, the number of arguments must be equal -- if they're not, then there is no match.
@@ -428,7 +427,6 @@ public class MethodResolutionLogic {
 
         // The index of the final argument passed (on the method usage).
         int needleParameterCount = needleParameterTypes.size();
-        int lastNeedleParameterIndex = getLastParameterIndex(needleParameterCount);
 
         // TODO: Does the method usage have a declaration at this point..?
         boolean methodIsDeclaredWithVariadicParameter = methodUsage.getDeclaration().hasVariadicParameter();

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -20,15 +20,15 @@
  */
 package com.github.javaparser.utils;
 
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.expr.UnaryExpr;
+import static java.util.Arrays.asList;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.util.*;
 import java.util.function.Function;
 
-import static java.util.Arrays.asList;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.UnaryExpr;
 
 /**
  * Any kind of utility.
@@ -220,17 +220,20 @@ public class Utils {
     }
 
     public static boolean valueIsNullOrEmptyStringOrOptional(Object value) {
+    	// is null?
         if (value == null) {
             return true;
         }
-        if (value instanceof Optional) {
-            if (((Optional) value).isPresent()) {
-                value = ((Optional) value).get();
-            } else {
-                return true;
-            }
-        }
-        return false;
+//        // is not Optional?
+//        if (!(value instanceof Optional)) {
+//        	return false;
+//        }
+//        // is an empty Optional?
+//		if (!((Optional) value).isPresent()) {
+//			return true;
+//		}
+//        return false;
+        return value instanceof Optional ? !((Optional) value).isPresent() : false;
     }
 
     /**


### PR DESCRIPTION
A dead store happens when a local variable is assigned a value that is not read by any subsequent instruction. Calculating or retrieving a value only to then overwrite it or throw it away, could indicate a serious error in the code. Even if it's not an error, it is at best a waste of resources. Therefore all calculated values should be used.
