### PR TITLE
fix: issue 4331 Cannot be 'abstract' and also 'private'. for a private method in an interface

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
@@ -125,25 +125,38 @@ class MethodDeclarationTest {
         assertTrue(method2.isFixedArityMethod());
     }
 
+    /*
+	 * A method in the body of an interface may be declared public or private
+	 * (§6.6). If no access modifier is given, the method is implicitly public.
+	 * https://docs.oracle.com/javase/specs/jls/se9/html/jls-9.html#jls-9.4
+	 */
     @Test
-    void isInterfaceImplictlyPublic() {
+    void isMethodInterfaceImplictlyPublic() {
         CompilationUnit cu = parse("interface Foo { void m(); }");
+        assertTrue(cu.findFirst(MethodDeclaration.class).get().isPublic());
+        cu = parse("interface Foo { public void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isPublic());
         cu = parse("interface Foo { abstract void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isPublic());
-        cu = parse("interface Foo { protected void m(); }");
+        cu = parse("interface Foo { private void m(); }");
         assertFalse(cu.findFirst(MethodDeclaration.class).get().isPublic());
     }
 
+    /*
+     * An interface method lacking a private, default, or static modifier is implicitly abstract.
+     * https://docs.oracle.com/javase/specs/jls/se9/html/jls-9.html#jls-9.4
+     */
     @Test
-    void isInterfaceImplictlyAbstract() {
+    void isMethodInterfaceImplictlyAbstract() {
         CompilationUnit cu = parse("interface Foo { void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isAbstract());
         cu = parse("interface Foo { abstract void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isAbstract());
-        cu = parse("interface Foo { protected void m(); }");
-        assertTrue(cu.findFirst(MethodDeclaration.class).get().isAbstract());
+        cu = parse("interface Foo { private void m(); }");
+        assertFalse(cu.findFirst(MethodDeclaration.class).get().isAbstract());
         cu = parse("interface Foo { static void m(); }");
+        assertFalse(cu.findFirst(MethodDeclaration.class).get().isAbstract());
+        cu = parse("interface Foo { default void m(){} }");
         assertFalse(cu.findFirst(MethodDeclaration.class).get().isAbstract());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -254,9 +254,11 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
         return sb.toString();
     }
 
-    /*
-     * Interface methods are implicitly public
-     */
+	/*
+	 * A method in the body of an interface may be declared public or private
+	 * (§6.6). If no access modifier is given, the method is implicitly public.
+	 * https://docs.oracle.com/javase/specs/jls/se9/html/jls-9.html#jls-9.4
+	 */
     @Override
     public boolean isPublic() {
         return hasModifier(PUBLIC) || isImplicitlyPublic();
@@ -270,22 +272,20 @@ public class MethodDeclaration extends CallableDeclaration<MethodDeclaration> im
     }
 
     /*
-     * Every interface is implicitly abstract but
-     * only one of abstract, default, or static modifier is permitted
-     * https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.1.1
+     * An interface method lacking a private, default, or static modifier is implicitly abstract.
+     * https://docs.oracle.com/javase/specs/jls/se9/html/jls-9.html#jls-9.4
      */
     @Override
 	public boolean isAbstract() {
-		return hasModifier(Keyword.ABSTRACT) || (isImplicitlyAbstract() && Arrays
-				.asList(Keyword.STATIC, Keyword.DEFAULT).stream()
-					.noneMatch(modifier -> hasModifier(modifier)));
+		return super.isAbstract() || isImplicitlyAbstract();
 	}
 
-    private boolean isImplicitlyAbstract() {
-    	return hasParentNode()
-    			&& getParentNode().get() instanceof ClassOrInterfaceDeclaration
-    			&& ((ClassOrInterfaceDeclaration)getParentNode().get()).isInterface();
-    }
+	private boolean isImplicitlyAbstract() {
+		return hasParentNode() && getParentNode().get() instanceof ClassOrInterfaceDeclaration
+				&& ((ClassOrInterfaceDeclaration) getParentNode().get()).isInterface()
+				&& Arrays.asList(Keyword.STATIC, Keyword.DEFAULT, Keyword.PRIVATE).stream()
+						.noneMatch(modifier -> hasModifier(modifier));
+	}
 
 
 


### PR DESCRIPTION
https://docs.oracle.com/javase/specs/jls/se9/html/jls-9.html#jls-9.4

Fixes #4331 
