### PR TITLE
fix: issue 4358 prevent infinite cycles with static imports

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -265,7 +265,8 @@ public class JavaParserTypeDeclarationAdapter {
         // If we haven't located any candidates that are declared on this type or its ancestors, consider the parent context.
         // This is relevant e.g. with nested classes.
         // Note that we want to avoid infinite recursion when a class is using its own method - see issue #75
-        if (candidateMethods.isEmpty()) {
+        // We also want to avoid infinite recursion when handling static imports - see issue #4358
+        if (candidateMethods.isEmpty() && !staticOnly) {
             SymbolReference<ResolvedMethodDeclaration> parentSolution = context.getParent()
                     .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
                     .solveMethod(name, argumentsTypes, staticOnly);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4358Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4358Test.java
@@ -1,0 +1,38 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+public class Issue4358Test extends AbstractSymbolResolutionTest {
+  @Test
+  public void testIssue4358() throws IOException {
+    Path issueResourcesPath = adaptPath("src/test/resources/issue4358");
+    ReflectionTypeSolver rts = new ReflectionTypeSolver();
+    JavaParserTypeSolver jpts = new JavaParserTypeSolver(issueResourcesPath);
+    CombinedTypeSolver cts = new CombinedTypeSolver();
+    cts.add(rts);
+    cts.add(jpts);
+    ParserConfiguration pc = new ParserConfiguration()
+        .setSymbolResolver(new JavaSymbolSolver(cts));
+    StaticJavaParser.setConfiguration(pc);
+    CompilationUnit cu = StaticJavaParser.parse(issueResourcesPath.resolve("foo/A.java"));
+
+    // There's only one method call in this compilation unit
+    ResolvedMethodDeclaration actual = cu.findAll(MethodCallExpr.class).stream()
+        .map(MethodCallExpr::resolve)
+        .findAny().get();
+
+    assertEquals("foo.B.d()", actual.getQualifiedSignature());
+  }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4358/foo/A.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4358/foo/A.java
@@ -1,0 +1,9 @@
+package foo;
+
+import static foo.B.d;
+
+class A {
+  void c() {
+    d();
+  }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4358/foo/B.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4358/foo/B.java
@@ -1,0 +1,6 @@
+package foo;
+
+class B extends A {
+  static void d() {
+  }
+}


### PR DESCRIPTION
Fixes #4358 (infinite loop when `import static` is used between an ancestor and parent class).
