### PR TITLE
Fix issue 4345 Strange error when trying to find erasure of generic t…

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -20,6 +20,10 @@
  */
 package com.github.javaparser.resolution.types;
 
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
@@ -32,10 +36,6 @@ import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParame
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap;
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametrized;
 import com.github.javaparser.utils.Pair;
-
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * A ReferenceType like a class, an interface or an enum. Note that this type can contain also the values
@@ -575,18 +575,7 @@ public abstract class ResolvedReferenceType implements ResolvedType, ResolvedTyp
     }
 
     private List<ResolvedType> erasureOfParamaters(ResolvedTypeParametersMap typeParametersMap) {
-        List<ResolvedType> erasedParameters = new ArrayList<ResolvedType>();
-        if (!typeParametersMap.isEmpty()) {
-            // add erased type except java.lang.object
-        	List<ResolvedType> parameters = typeParametersMap.getTypes().stream()
-        			.filter(type -> !type.isReferenceType())
-        			.map(type -> type.erasure())
-        			.filter(erasedType -> !(isJavaObject(erasedType)))
-        			.filter(erasedType -> erasedType != null)
-        			.collect(Collectors.toList());
-            erasedParameters.addAll(parameters);
-        }
-        return erasedParameters;
+        return new ArrayList<ResolvedType>();
     }
 
     private boolean isJavaObject(ResolvedType rt) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.JavaParser;
-import com.github.javaparser.ParseStart;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -819,7 +818,7 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
         parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver));
 
         CompilationUnit cu = new JavaParser(parserConfiguration)
-                .parse(ParseStart.COMPILATION_UNIT, new StringProvider(code)).getResult().get();
+                .parse(code).getResult().get();
 
         ClassOrInterfaceDeclaration classA = cu.getClassByName("A").get();
         ClassOrInterfaceDeclaration classB = cu.getClassByName("B").get();
@@ -845,7 +844,7 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
         parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver));
 
         CompilationUnit cu = new JavaParser(parserConfiguration)
-                .parse(ParseStart.COMPILATION_UNIT, new StringProvider(code)).getResult().get();
+                .parse(code).getResult().get();
 
         ClassOrInterfaceDeclaration classA = cu.getClassByName("A").get();
         ClassOrInterfaceDeclaration classB = cu.getClassByName("B").get();


### PR DESCRIPTION
…ype where one of two type parameters is an array

Fixes #4345.

https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html


Type erasure is a mapping from types (possibly including parameterized types and type variables) to types (that are never parameterized types or type variables). We write |T| for the erasure of type T. The erasure mapping is defined as follows:

The erasure of a parameterized type ([§4.5](https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.5)) G<T1,...,Tn> is |G|.

The erasure of a nested type T.C is |T|.C.

The erasure of an array type T[] is |T|[].

The erasure of a type variable ([§4.4](https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4)) is the erasure of its leftmost bound.

The erasure of every other type is the type itself.
