### PR TITLE
Added methods for including children at a given index.

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/BlockStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/BlockStmtTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.stmt;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.github.javaparser.utils.TestParser.parseStatement;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BlockStmtTest {
+    @Test
+    void addStatementChildAtCorrectPosition() {
+        BlockStmt block = parseStatement("{\nint b = 1;\nint c = 2;\n}").asBlockStmt();
+        ExpressionStmt newStatement = parseStatement("int a = 0;").asExpressionStmt();
+        block.addStatement(0, newStatement);
+
+        NodeList<Statement> statements =  block.getStatements();
+        List<Node> children =  block.getChildNodes();
+
+        assertEquals(statements.size(), children.size());
+        for (int i=0; i < statements.size(); i++) {
+            assertEquals(statements.get(i), children.get(i));
+        }
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/HasParentNode.java
@@ -52,6 +52,15 @@ public interface HasParentNode<T> extends Observable {
     T setParentNode(Node parentNode);
 
     /**
+     * Sets the parent node.
+     *
+     * @param parentNode the parent node, or {@code null} to set no parent.
+     * @param index the index this node will be inserted at the child list of parentNode.
+     * @return {@code this}
+     */
+    T setParentNode(Node parentNode, int index);
+
+    /**
      * Returns the parent node from the perspective of the children of this node.
      * <p>
      * That is, this method returns {@code this} for everything except {@code NodeList}. A {@code NodeList} returns its

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -433,6 +433,35 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
         if (newParentNode == parentNode) {
             return this;
         }
+        setParentNodeButDontAddToChildren(newParentNode);
+        // add to new parent, if any
+        if (parentNode != null) {
+            parentNode.childNodes.add(this);
+        }
+        return this;
+    }
+
+    /**
+     * Assign a new parent to this node, removing it
+     * from the list of children of the previous parent, if any.
+     *
+     * @param newParentNode node to be set as parent
+     * @param index         the index this node will be added at the parent's child list
+     */
+    @Override
+    public Node setParentNode(Node newParentNode, int index) {
+        if (newParentNode == parentNode) {
+            return this;
+        }
+        setParentNodeButDontAddToChildren(newParentNode);
+        // add to new parent, if any
+        if (parentNode != null) {
+            parentNode.childNodes.add(index, this);
+        }
+        return this;
+    }
+
+    protected void setParentNodeButDontAddToChildren(Node newParentNode) {
         observers.forEach(o -> o.parentChange(this, parentNode, newParentNode));
         // remove from old parent, if any
         if (parentNode != null) {
@@ -445,11 +474,6 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
             parentChildNodes.trimToSize();
         }
         parentNode = newParentNode;
-        // add to new parent, if any
-        if (parentNode != null) {
-            parentNode.childNodes.add(this);
-        }
-        return this;
     }
 
     protected void setAsParentNodeOf(Node childNode) {
@@ -638,6 +662,12 @@ public abstract class Node implements Cloneable, HasParentNode<Node>, Visitable,
     protected void setAsParentNodeOf(NodeList<? extends Node> list) {
         if (list != null) {
             list.setParentNode(getParentNodeForChildren());
+        }
+    }
+
+    protected void addListToChildrenAtIndexButDontSetParent(NodeList<? extends Node> list, int index) {
+        if (list != null) {
+            this.childNodes.addAll(index, list);
         }
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
@@ -81,6 +81,13 @@ public class NodeList<N extends Node> implements List<N>, Iterable<N>, HasParent
         setAsParentNodeOf(node);
     }
 
+    private void own(N node, int index) {
+        if (node == null) {
+            return;
+        }
+        setAsParentNodeOf(node, index);
+    }
+
     public boolean remove(Node node) {
         int index = innerList.indexOf(node);
         if (index != -1) {
@@ -179,7 +186,7 @@ public class NodeList<N extends Node> implements List<N>, Iterable<N>, HasParent
     @Override
     public void add(int index, N node) {
         notifyElementAdded(index, node);
-        own(node);
+        own(node, index);
         innerList.add(index, node);
     }
 
@@ -262,6 +269,20 @@ public class NodeList<N extends Node> implements List<N>, Iterable<N>, HasParent
     public NodeList<N> setParentNode(Node parentNode) {
         this.parentNode = parentNode;
         setAsParentNodeOf(innerList);
+        return this;
+    }
+
+    /**
+     * Sets the parentNode
+     *
+     * @param parentNode the parentNode
+     * @return this, the NodeList
+     */
+    @Override
+    public NodeList<N> setParentNode(Node parentNode, int index) {
+        this.parentNode = parentNode;
+        setAsParentNodeOfButDontAddToChildren(innerList);
+        parentNode.addListToChildrenAtIndexButDontSetParent(this, index);
         return this;
     }
 
@@ -547,8 +568,16 @@ public class NodeList<N extends Node> implements List<N>, Iterable<N>, HasParent
 
     private void setAsParentNodeOf(List<? extends Node> childNodes) {
         if (childNodes != null) {
-            for (HasParentNode current : childNodes) {
+            for (HasParentNode<Node> current : childNodes) {
                 current.setParentNode(getParentNodeForChildren());
+            }
+        }
+    }
+
+    private void setAsParentNodeOfButDontAddToChildren(List<? extends Node> childNodes) {
+        if (childNodes != null) {
+            for (Node current : childNodes) {
+                current.setParentNodeButDontAddToChildren(getParentNodeForChildren());
             }
         }
     }
@@ -556,6 +585,12 @@ public class NodeList<N extends Node> implements List<N>, Iterable<N>, HasParent
     private void setAsParentNodeOf(Node childNode) {
         if (childNode != null) {
             childNode.setParentNode(getParentNodeForChildren());
+        }
+    }
+
+    private void setAsParentNodeOf(Node childNode, int index) {
+        if (childNode != null) {
+            childNode.setParentNode(getParentNodeForChildren(), index);
         }
     }
 


### PR DESCRIPTION
This PR adds some new methods to include children at a given index. It also modifies `addStatements(index, node)` to use those methods.

Fixes #4370.
