### PR TITLE
✏️ make mvnw command runnable by copy-pasting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,12 +101,12 @@ implementation 'com.github.javaparser:javaparser-core-serialization:3.25.10'
 
 If you checked out the project's source code from GitHub, you can build the project with maven using:
 ```
-mvnw clean install
+./mvnw clean install
 ```
 
 If you want to generate the packaged jar files from the source files, you run the following maven command:
 ```
-mvnw package
+./mvnw package
 ```
 
 **NOTE** the jar files for the two modules can be found in:
@@ -114,10 +114,10 @@ mvnw package
 - `javaparser-symbol-solver-core/target/javaparser-symbol-solver-core-\<version\>.jar`
 
 If you checkout the sources and want to view the project in an IDE, it is best to first generate some of the source files;
-otherwise you will get many compilation complaints in the IDE. (`mvnw clean install` already does this for you.)
+otherwise you will get many compilation complaints in the IDE. (`./mvnw clean install` already does this for you.)
 
 ```
-mvnw javacc:javacc
+./mvnw javacc:javacc
 ```
 
 If you modify the code of the AST nodes, specifically if you add or remove fields or node classes,


### PR DESCRIPTION
Hi,
this is a small change regarding the readme file. When following the instruction, the mvnw command will not run because the executable is in the local directory, so `./` is needed to run correctly if you copy-paste the command.
I didn't create a issue for such small change but if you think is better to document it I will create one and link this PR.

Thank you and have a nice day!

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)