### PR TITLE
Fixes #4410

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <byte-buddy.version>1.14.14</byte-buddy.version>
-        <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar</argLine>
+        <argLine>-javaagent:'${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar'</argLine>
         <build.timestamp>2024-04-04T00:00:00Z</build.timestamp>
         <!-- Maven Plugins -->
     </properties>


### PR DESCRIPTION
settings.localRepository might contains spaces, which splits the arguments once passed to the commande line in Maven. We use single quotes to keep them together as one single argument.

Notice that double quotes did not fix the issue, although many resources on the Web suggest to use double quotes for similar issues.