### PR TITLE
Fixes SYSTEM_EOL warnings

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
@@ -23,6 +23,7 @@ package com.github.javaparser;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.comments.CommentsCollection;
+import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.utils.TestParser;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,6 @@ import java.io.IOException;
 
 import static com.github.javaparser.utils.TestUtils.assertEqualToTextResourceNoEol;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CommentsInserterTest {
@@ -66,11 +66,11 @@ class CommentsInserterTest {
 
     @Test
     void issue200EnumConstantsWithCommentsForceVerticalAlignment() {
-        CompilationUnit cu = TestParser.parseCompilationUnit("public enum X {" + SYSTEM_EOL +
-                "    /** const1 javadoc */" + SYSTEM_EOL +
-                "    BORDER_CONSTANT," + SYSTEM_EOL +
-                "    /** const2 javadoc */" + SYSTEM_EOL +
-                "    ANOTHER_CONSTANT" + SYSTEM_EOL +
+        CompilationUnit cu = TestParser.parseCompilationUnit("public enum X {" + LineSeparator.SYSTEM +
+                "    /** const1 javadoc */" + LineSeparator.SYSTEM +
+                "    BORDER_CONSTANT," + LineSeparator.SYSTEM +
+                "    /** const2 javadoc */" + LineSeparator.SYSTEM +
+                "    ANOTHER_CONSTANT" + LineSeparator.SYSTEM +
                 "}");
         assertEqualsStringIgnoringEol("public enum X {\n" +
                 "\n" +
@@ -87,13 +87,13 @@ class CommentsInserterTest {
 
     @Test
     void issue234LosingCommentsInArrayInitializerExpr() {
-        CompilationUnit cu = TestParser.parseCompilationUnit("@Anno(stuff={" + SYSTEM_EOL +
-                "    // Just," + SYSTEM_EOL +
-                "    // an," + SYSTEM_EOL +
-                "    // example" + SYSTEM_EOL +
-                "})" + SYSTEM_EOL +
-                "class ABC {" + SYSTEM_EOL +
-                "" + SYSTEM_EOL +
+        CompilationUnit cu = TestParser.parseCompilationUnit("@Anno(stuff={" + LineSeparator.SYSTEM +
+                "    // Just," + LineSeparator.SYSTEM +
+                "    // an," + LineSeparator.SYSTEM +
+                "    // example" + LineSeparator.SYSTEM +
+                "})" + LineSeparator.SYSTEM +
+                "class ABC {" + LineSeparator.SYSTEM +
+                "" + LineSeparator.SYSTEM +
                 "}");
 
         assertEqualsStringIgnoringEol("@Anno(stuff = {// Just,\n" +

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -28,7 +28,6 @@ import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.Range.range;
 import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.TestUtils.assertInstanceOf;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
@@ -50,6 +49,7 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.IntersectionType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.printer.YamlPrinter;
+import com.github.javaparser.utils.LineSeparator;
 
 class JavaParserTest {
 
@@ -172,9 +172,9 @@ class JavaParserTest {
 
     @Test
     void rangeOfIntersectionType() {
-        String code = "class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
-                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + SYSTEM_EOL
+        String code = "class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
+                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + LineSeparator.SYSTEM
                 + "}}";
         CompilationUnit cu = parse(code);
         MethodDeclaration methodDeclaration = cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
@@ -186,9 +186,9 @@ class JavaParserTest {
 
     @Test
     void rangeOfCast() {
-        String code = "class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
-                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + SYSTEM_EOL
+        String code = "class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
+                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + LineSeparator.SYSTEM
                 + "}}";
         CompilationUnit cu = parse(code);
         MethodDeclaration methodDeclaration = cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
@@ -199,9 +199,9 @@ class JavaParserTest {
 
     @Test
     void rangeOfCastNonIntersection() {
-        String code = "class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
-                + "    return (Comparator<Map.Entry<K, V>>               )(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + SYSTEM_EOL
+        String code = "class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
+                + "    return (Comparator<Map.Entry<K, V>>               )(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + LineSeparator.SYSTEM
                 + "}}";
         CompilationUnit cu = parse(code);
         MethodDeclaration methodDeclaration = cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
@@ -212,9 +212,9 @@ class JavaParserTest {
 
     @Test
     void rangeOfLambda() {
-        String code = "class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
-                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + SYSTEM_EOL
+        String code = "class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
+                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + LineSeparator.SYSTEM
                 + "}}";
         CompilationUnit cu = parse(code);
         MethodDeclaration methodDeclaration = cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
@@ -228,9 +228,9 @@ class JavaParserTest {
 
     @Test
     void rangeOfLambdaBody() {
-        String code = "class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
-                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + SYSTEM_EOL
+        String code = "class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
+                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + LineSeparator.SYSTEM
                 + "}}";
         CompilationUnit cu = parse(code);
         MethodDeclaration methodDeclaration = cu.getClassByName("A").get().getMember(0).asMethodDeclaration();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
@@ -24,10 +24,11 @@ package com.github.javaparser;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.github.javaparser.javadoc.description.JavadocDescription;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JavadocParserTest {
@@ -41,7 +42,7 @@ class JavadocParserTest {
     @Test
     void parseEmptySingleLine() {
         Assertions.assertEquals(new Javadoc(JavadocDescription.parseText("")),
-                JavadocParser.parse(SYSTEM_EOL));
+                JavadocParser.parse(LineSeparator.SYSTEM.asRawString()));
     }
 
     @Test
@@ -53,46 +54,46 @@ class JavadocParserTest {
     @Test
     void parseSingleLineWithNewLines() {
         assertEquals(new Javadoc(JavadocDescription.parseText("The string image of the token.")),
-                JavadocParser.parse(SYSTEM_EOL +
-                        "   * The string image of the token." + SYSTEM_EOL +
+                JavadocParser.parse(LineSeparator.SYSTEM +
+                        "   * The string image of the token." + LineSeparator.SYSTEM +
                         "   "));
     }
 
     @Test
     void parseCommentWithNewLines() {
-        String text = SYSTEM_EOL +
-                "   * The version identifier for this Serializable class." + SYSTEM_EOL +
-                "   * Increment only if the <i>serialized</i> form of the" + SYSTEM_EOL +
-                "   * class changes." + SYSTEM_EOL +
+        String text = LineSeparator.SYSTEM +
+                "   * The version identifier for this Serializable class." + LineSeparator.SYSTEM +
+                "   * Increment only if the <i>serialized</i> form of the" + LineSeparator.SYSTEM +
+                "   * class changes." + LineSeparator.SYSTEM +
                 "   ";
-        assertEquals(new Javadoc(JavadocDescription.parseText("The version identifier for this Serializable class." + SYSTEM_EOL +
-                        "Increment only if the <i>serialized</i> form of the" + SYSTEM_EOL +
+        assertEquals(new Javadoc(JavadocDescription.parseText("The version identifier for this Serializable class." + LineSeparator.SYSTEM +
+                        "Increment only if the <i>serialized</i> form of the" + LineSeparator.SYSTEM +
                         "class changes.")),
                 JavadocParser.parse(text));
     }
 
     @Test
     void parseCommentWithIndentation() {
-        String text = "Returns a new Token object, by default." + SYSTEM_EOL +
-                "   * However, if you want, you can create and return subclass objects based on the value of ofKind." + SYSTEM_EOL +
-                "   *" + SYSTEM_EOL +
-                "   *    case MyParserConstants.ID : return new IDToken(ofKind, image);" + SYSTEM_EOL +
-                "   *" + SYSTEM_EOL +
+        String text = "Returns a new Token object, by default." + LineSeparator.SYSTEM +
+                "   * However, if you want, you can create and return subclass objects based on the value of ofKind." + LineSeparator.SYSTEM +
+                "   *" + LineSeparator.SYSTEM +
+                "   *    case MyParserConstants.ID : return new IDToken(ofKind, image);" + LineSeparator.SYSTEM +
+                "   *" + LineSeparator.SYSTEM +
                 "   * to the following switch statement. Then you can cast matchedToken";
-        assertEquals(new Javadoc(JavadocDescription.parseText("Returns a new Token object, by default." + SYSTEM_EOL +
-                        "However, if you want, you can create and return subclass objects based on the value of ofKind." + SYSTEM_EOL +
-                        SYSTEM_EOL +
-                        "   case MyParserConstants.ID : return new IDToken(ofKind, image);" + SYSTEM_EOL +
-                        SYSTEM_EOL +
+        assertEquals(new Javadoc(JavadocDescription.parseText("Returns a new Token object, by default." + LineSeparator.SYSTEM +
+                        "However, if you want, you can create and return subclass objects based on the value of ofKind." + LineSeparator.SYSTEM +
+                        LineSeparator.SYSTEM +
+                        "   case MyParserConstants.ID : return new IDToken(ofKind, image);" + LineSeparator.SYSTEM +
+                        LineSeparator.SYSTEM +
                         "to the following switch statement. Then you can cast matchedToken")),
                 JavadocParser.parse(text));
     }
 
     @Test
     void parseBlockTagsAndEmptyDescription() {
-        String text = SYSTEM_EOL +
-                "   * @deprecated" + SYSTEM_EOL +
-                "   * @see #getEndColumn" + SYSTEM_EOL +
+        String text = LineSeparator.SYSTEM +
+                "   * @deprecated" + LineSeparator.SYSTEM +
+                "   * @see #getEndColumn" + LineSeparator.SYSTEM +
                 "   ";
         assertEquals(new Javadoc(JavadocDescription.parseText(""))
                 .addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.DEPRECATED, ""))
@@ -101,8 +102,8 @@ class JavadocParserTest {
 
     @Test
     void parseBlockTagsAndProvideTagName() {
-        String expectedText = SYSTEM_EOL +
-                "   * @unofficial" + SYSTEM_EOL + " " +
+        String expectedText = LineSeparator.SYSTEM +
+                "   * @unofficial" + LineSeparator.SYSTEM + " " +
                 "   ";
 
         Javadoc underTest = new Javadoc(JavadocDescription.parseText(""))
@@ -116,13 +117,13 @@ class JavadocParserTest {
 
     @Test
     void parseParamBlockTags() {
-        String text = SYSTEM_EOL +
-                "     * Add a field to this and automatically add the import of the type if needed" + SYSTEM_EOL +
-                "     *" + SYSTEM_EOL +
-                "     * @param typeClass the type of the field" + SYSTEM_EOL +
-                "     *       @param name the name of the field" + SYSTEM_EOL +
-                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}" + SYSTEM_EOL +
-                "     * @return the {@link FieldDeclaration} created" + SYSTEM_EOL +
+        String text = LineSeparator.SYSTEM +
+                "     * Add a field to this and automatically add the import of the type if needed" + LineSeparator.SYSTEM +
+                "     *" + LineSeparator.SYSTEM +
+                "     * @param typeClass the type of the field" + LineSeparator.SYSTEM +
+                "     *       @param name the name of the field" + LineSeparator.SYSTEM +
+                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}" + LineSeparator.SYSTEM +
+                "     * @return the {@link FieldDeclaration} created" + LineSeparator.SYSTEM +
                 "     ";
         Javadoc res = JavadocParser.parse(text);
         assertEquals(new Javadoc(JavadocDescription.parseText("Add a field to this and automatically add the import of the type if needed"))
@@ -134,18 +135,18 @@ class JavadocParserTest {
 
     @Test
     void parseMultilineParamBlockTags() {
-        String text = SYSTEM_EOL +
-                "     * Add a field to this and automatically add the import of the type if needed" + SYSTEM_EOL +
-                "     *" + SYSTEM_EOL +
-                "     * @param typeClass the type of the field" + SYSTEM_EOL +
-                "     *     continued in a second line" + SYSTEM_EOL +
-                "     * @param name the name of the field" + SYSTEM_EOL +
-                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}" + SYSTEM_EOL +
-                "     * @return the {@link FieldDeclaration} created" + SYSTEM_EOL +
+        String text = LineSeparator.SYSTEM +
+                "     * Add a field to this and automatically add the import of the type if needed" + LineSeparator.SYSTEM +
+                "     *" + LineSeparator.SYSTEM +
+                "     * @param typeClass the type of the field" + LineSeparator.SYSTEM +
+                "     *     continued in a second line" + LineSeparator.SYSTEM +
+                "     * @param name the name of the field" + LineSeparator.SYSTEM +
+                "     * @param modifiers the modifiers like {@link Modifier#PUBLIC}" + LineSeparator.SYSTEM +
+                "     * @return the {@link FieldDeclaration} created" + LineSeparator.SYSTEM +
                 "     ";
         Javadoc res = JavadocParser.parse(text);
         assertEquals(new Javadoc(JavadocDescription.parseText("Add a field to this and automatically add the import of the type if needed"))
-                .addBlockTag(JavadocBlockTag.createParamBlockTag("typeClass", "the type of the field" + SYSTEM_EOL + "    continued in a second line"))
+                .addBlockTag(JavadocBlockTag.createParamBlockTag("typeClass", "the type of the field" + LineSeparator.SYSTEM + "    continued in a second line"))
                 .addBlockTag(JavadocBlockTag.createParamBlockTag("name", "the name of the field"))
                 .addBlockTag(JavadocBlockTag.createParamBlockTag("modifiers", "the modifiers like {@link Modifier#PUBLIC}"))
                 .addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.RETURN, "the {@link FieldDeclaration} created")), res);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -22,7 +22,6 @@
 package com.github.javaparser.ast;
 
 import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -44,6 +43,7 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.utils.LineSeparator;
 
 class NodeTest {
     @Test
@@ -142,7 +142,7 @@ class NodeTest {
         MethodDeclaration methodDeclaration = cu.getType(0).getMethods().get(0);
         methodDeclaration.getName().removeForced();
         // Name is required, so to remove it the whole method is removed.
-        assertEquals(String.format("class X {%1$s}%1$s", SYSTEM_EOL), cu.toString());
+        assertEquals(String.format("class X {%1$s}%1$s", LineSeparator.SYSTEM), cu.toString());
     }
 
     @Test
@@ -153,7 +153,7 @@ class NodeTest {
                 "    swapped=false;%1$s" +
                 "    swapped=false;%1$s" +
                 "  }%1$s" +
-                "}%1$s", SYSTEM_EOL));
+                "}%1$s", LineSeparator.SYSTEM));
         // remove the second swapped=false
         ExpressionStmt target = unit.findAll(ExpressionStmt.class).get(2);
         target.remove();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ParseResultTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ParseResultTest.java
@@ -25,7 +25,6 @@ import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.ast.Node.Parsedness.PARSED;
 import static com.github.javaparser.ast.Node.Parsedness.UNPARSABLE;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -34,6 +33,7 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Problem;
+import com.github.javaparser.utils.LineSeparator;
 
 class ParseResultTest {
     private final JavaParser javaParser = new JavaParser(new ParserConfiguration());
@@ -60,6 +60,6 @@ class ParseResultTest {
         Problem problem = result.getProblem(0);
         assertThat(problem.getMessage()).isEqualTo("Parse error. Found \"{\", expected one of  \"enum\" \"exports\" \"module\" \"open\" \"opens\" \"permits\" \"provides\" \"record\" \"requires\" \"sealed\" \"strictfp\" \"to\" \"transitive\" \"uses\" \"when\" \"with\" \"yield\" <IDENTIFIER>");
 
-        assertThat(result.toString()).startsWith("Parsing failed:" + SYSTEM_EOL + "(line 1,col 1) Parse error.");
+        assertThat(result.toString()).startsWith("Parsing failed:" + LineSeparator.SYSTEM + "(line 1,col 1) Parse error.");
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
@@ -23,9 +23,10 @@ package com.github.javaparser.ast;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.javaparser.utils.LineSeparator;
+
 import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.StaticJavaParser.parsePackageDeclaration;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ReplaceNodeTest {
@@ -36,7 +37,7 @@ class ReplaceNodeTest {
         assertEquals(String.format("package z;%1$s" +
                 "%1$s" +
                 "class Y {%1$s" +
-                "}%1$s", SYSTEM_EOL), cu.toString());
+                "}%1$s", LineSeparator.SYSTEM), cu.toString());
     }
 
     @Test
@@ -48,6 +49,6 @@ class ReplaceNodeTest {
                 "class B {%1$s" +
                 "%1$s" +
                 "    int y;%1$s" +
-                "}%1$s", SYSTEM_EOL), cu.toString());
+                "}%1$s", LineSeparator.SYSTEM), cu.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
@@ -23,7 +23,8 @@ package com.github.javaparser.ast.body;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
+import com.github.javaparser.utils.LineSeparator;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ConstructorDeclarationTest {
@@ -34,6 +35,6 @@ class ConstructorDeclarationTest {
 
         assertEquals(String.format("public Cons() {%1$s" +
                 "    super();%1$s" +
-                "}", SYSTEM_EOL), cons.toString());
+                "}", LineSeparator.SYSTEM), cons.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
@@ -33,12 +33,12 @@ import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration;
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption;
 import com.github.javaparser.printer.configuration.Indentation;
 import com.github.javaparser.printer.configuration.Indentation.IndentType;
+import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.printer.configuration.PrinterConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CommentTest {
@@ -81,20 +81,20 @@ class CommentTest {
     @Test
     void testReplaceDuplicateJavaDocComment() {
         // Arrange
-        CompilationUnit cu = parse("public class MyClass {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void oneMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void anotherMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL);
+        CompilationUnit cu = parse("public class MyClass {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void oneMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void anotherMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM);
 
         MethodDeclaration methodDeclaration = cu.findFirst(MethodDeclaration.class).get();
 
@@ -122,21 +122,21 @@ class CommentTest {
     @Test
     void testRemoveDuplicateComment() {
         // Arrange
-        CompilationUnit cu = parse("public class MyClass {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void oneMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void anotherMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
+        CompilationUnit cu = parse("public class MyClass {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void oneMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void anotherMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
                 "}" +
-                SYSTEM_EOL);
+                LineSeparator.SYSTEM);
 
         MethodDeclaration methodDeclaration = cu.findFirst(MethodDeclaration.class).get();
 
@@ -160,21 +160,21 @@ class CommentTest {
     @Test
     void testRemoveDuplicateJavaDocComment() {
         // Arrange
-        CompilationUnit cu = parse("public class MyClass {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void oneMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void anotherMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
+        CompilationUnit cu = parse("public class MyClass {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void oneMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void anotherMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
                 "}" +
-                SYSTEM_EOL);
+                LineSeparator.SYSTEM);
 
         MethodDeclaration methodDeclaration = cu.findAll(MethodDeclaration.class).get(1);
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
@@ -25,10 +25,11 @@ import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.*;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.*;
 
 class NameTest {
@@ -54,7 +55,7 @@ class NameTest {
     void importName() {
         ImportDeclaration importDeclaration = parseImport("import java.util.List;");
 
-        assertEquals("import java.util.List;" + SYSTEM_EOL, importDeclaration.toString());
+        assertEquals("import java.util.List;" + LineSeparator.SYSTEM, importDeclaration.toString());
         assertEquals("import java.util.List;" , ConcreteSyntaxModel.genericPrettyPrint(importDeclaration));
     }
 
@@ -62,8 +63,8 @@ class NameTest {
     void packageName() {
         CompilationUnit cu = parse("package p1.p2;");
 
-        assertEquals("package p1.p2;" + SYSTEM_EOL + SYSTEM_EOL, cu.toString());
-        assertEquals("package p1.p2;" + SYSTEM_EOL + SYSTEM_EOL, ConcreteSyntaxModel.genericPrettyPrint(cu));
+        assertEquals("package p1.p2;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM, cu.toString());
+        assertEquals("package p1.p2;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM, ConcreteSyntaxModel.genericPrettyPrint(cu));
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
@@ -30,10 +30,11 @@ import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.*;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -122,7 +123,7 @@ class ArrayTypeTest {
         VariableDeclarationExpr variableDeclarationExpr = variableDeclarationStatement.getExpression().asVariableDeclarationExpr();
 
         variableDeclarationExpr.getVariable(0).setType(new ArrayType(new ArrayType(PrimitiveType.intType())));
-        assertEquals("@C" + SYSTEM_EOL + "int[][] a;", variableDeclarationStatement.toString());
+        assertEquals("@C" + LineSeparator.SYSTEM + "int[][] a;", variableDeclarationStatement.toString());
     }
 
     @Test
@@ -138,7 +139,7 @@ class ArrayTypeTest {
         MethodDeclaration method = parseBodyDeclaration("int[][] a()[][] {}").asMethodDeclaration();
         method.setType(new ArrayType(new ArrayType(parseClassOrInterfaceType("Blob"))));
 
-        assertEquals("Blob[][] a() {" + SYSTEM_EOL + "}", method.toString());
+        assertEquals("Blob[][] a() {" + LineSeparator.SYSTEM + "}", method.toString());
     }
 
     @Test
@@ -164,7 +165,7 @@ class ArrayTypeTest {
         MethodDeclaration method = parseBodyDeclaration("void a(int[][] a[][]) {}").asMethodDeclaration();
         method.getParameter(0).setType(new ArrayType(new ArrayType(parseClassOrInterfaceType("Blob"))));
 
-        assertEquals("void a(Blob[][] a) {" + SYSTEM_EOL + "}", method.toString());
+        assertEquals("void a(Blob[][] a) {" + LineSeparator.SYSTEM + "}", method.toString());
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ModifierVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ModifierVisitorTest.java
@@ -29,11 +29,12 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -125,7 +126,7 @@ class ModifierVisitorTest extends AbstractLexicalPreservingTest {
             }
         }, null);
 
-        assertEquals("void x() {" + SYSTEM_EOL + "}", result.toString());
+        assertEquals("void x() {" + LineSeparator.SYSTEM + "}", result.toString());
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/ClassOrInterfaceDeclarationBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/ClassOrInterfaceDeclarationBuildersTest.java
@@ -23,6 +23,8 @@ package com.github.javaparser.builders;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.function.Function;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ClassOrInterfaceDeclarationBuildersTest {
@@ -51,7 +52,7 @@ class ClassOrInterfaceDeclarationBuildersTest {
         ClassOrInterfaceDeclaration testClass = cu.addClass("test");
         testClass.addExtendedType(List.class);
         assertEquals(1, cu.getImports().size());
-        assertEquals("import " + List.class.getName() + ";" + SYSTEM_EOL,
+        assertEquals("import " + List.class.getName() + ";" + LineSeparator.SYSTEM,
                 cu.getImport(0).toString());
         assertEquals(1, testClass.getExtendedTypes().size());
         assertEquals(List.class.getSimpleName(), testClass.getExtendedTypes(0).getNameAsString());
@@ -62,7 +63,7 @@ class ClassOrInterfaceDeclarationBuildersTest {
         ClassOrInterfaceDeclaration testClass = cu.addClass("test");
         testClass.addImplementedType(Function.class);
         assertEquals(1, cu.getImports().size());
-        assertEquals("import " + Function.class.getName() + ";" + SYSTEM_EOL,
+        assertEquals("import " + Function.class.getName() + ";" + LineSeparator.SYSTEM,
                 cu.getImport(0).toString());
         assertEquals(1, testClass.getImplementedTypes().size());
         assertEquals(Function.class.getSimpleName(), testClass.getImplementedTypes(0).getNameAsString());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
@@ -29,6 +29,8 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.ElementType;
@@ -39,7 +41,6 @@ import java.util.Map;
 import static com.github.javaparser.StaticJavaParser.parseImport;
 import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CompilationUnitBuildersTest {
@@ -57,9 +58,9 @@ class CompilationUnitBuildersTest {
     cu.addImport(com.github.javaparser.StaticJavaParser.class.getCanonicalName() + ".parseImport", true, false);
     assertEquals(3, cu.getImports().size());
 
-    assertEquals("import " + Map.class.getCanonicalName() + ";" + SYSTEM_EOL, cu.getImport(0).toString());
-    assertEquals("import " + List.class.getCanonicalName() + ";" + SYSTEM_EOL, cu.getImport(1).toString());
-    assertEquals("import static " + com.github.javaparser.StaticJavaParser.class.getCanonicalName() + ".parseImport;" + SYSTEM_EOL,
+    assertEquals("import " + Map.class.getCanonicalName() + ";" + LineSeparator.SYSTEM, cu.getImport(0).toString());
+    assertEquals("import " + List.class.getCanonicalName() + ";" + LineSeparator.SYSTEM, cu.getImport(1).toString());
+    assertEquals("import static " + com.github.javaparser.StaticJavaParser.class.getCanonicalName() + ".parseImport;" + LineSeparator.SYSTEM,
         cu.getImport(2).toString());
   }
 
@@ -71,8 +72,8 @@ class CompilationUnitBuildersTest {
     cu.addImport($tartsWith$.class);
     cu.addImport("my.$tartsWith$");
     assertEquals(2, cu.getImports().size());
-    assertEquals("import " + $tartsWith$.class.getCanonicalName() + ";" + SYSTEM_EOL, cu.getImport(0).toString());
-    assertEquals("import my.$tartsWith$;" + SYSTEM_EOL, cu.getImport(1).toString());
+    assertEquals("import " + $tartsWith$.class.getCanonicalName() + ";" + LineSeparator.SYSTEM, cu.getImport(0).toString());
+    assertEquals("import my.$tartsWith$;" + LineSeparator.SYSTEM, cu.getImport(1).toString());
   }
 
   public class F$F {
@@ -84,8 +85,8 @@ class CompilationUnitBuildersTest {
     cu.addImport("my.F$F");
     // doesnt fail, but imports class "F.F"
     assertEquals(2, cu.getImports().size());
-    assertEquals("import " + F$F.class.getCanonicalName() + ";" + SYSTEM_EOL, cu.getImport(0).toString());
-    assertEquals("import my.F$F;" + SYSTEM_EOL, cu.getImport(1).toString());
+    assertEquals("import " + F$F.class.getCanonicalName() + ";" + LineSeparator.SYSTEM, cu.getImport(0).toString());
+    assertEquals("import my.F$F;" + LineSeparator.SYSTEM, cu.getImport(1).toString());
   }
 
   @Test
@@ -103,7 +104,7 @@ class CompilationUnitBuildersTest {
     assertEquals(0, cu.getImports().size());
     cu.addImport("one.two.three.DoNotIgnoreImportWithinSubPackage");
     assertEquals(1, cu.getImports().size());
-    assertEquals("import one.two.three.DoNotIgnoreImportWithinSubPackage;" + SYSTEM_EOL, cu.getImport(0).toString());
+    assertEquals("import one.two.three.DoNotIgnoreImportWithinSubPackage;" + LineSeparator.SYSTEM, cu.getImport(0).toString());
   }
 
   @Test
@@ -144,12 +145,12 @@ class CompilationUnitBuildersTest {
     cu.addImport("my.AnotherImport");
     cu.addImport("my.other.Import");
     assertEquals(2, cu.getImports().size());
-    assertEquals("import my.*;" + SYSTEM_EOL, cu.getImport(0).toString());
-    assertEquals("import my.other.Import;" + SYSTEM_EOL, cu.getImport(1).toString());
+    assertEquals("import my.*;" + LineSeparator.SYSTEM, cu.getImport(0).toString());
+    assertEquals("import my.other.Import;" + LineSeparator.SYSTEM, cu.getImport(1).toString());
     cu.addImport("my.other.*");
     assertEquals(2, cu.getImports().size());
-    assertEquals("import my.*;" + SYSTEM_EOL, cu.getImport(0).toString());
-    assertEquals("import my.other.*;" + SYSTEM_EOL, cu.getImport(1).toString());
+    assertEquals("import my.*;" + LineSeparator.SYSTEM, cu.getImport(0).toString());
+    assertEquals("import my.other.*;" + LineSeparator.SYSTEM, cu.getImport(1).toString());
   }
 
   @Test
@@ -162,7 +163,7 @@ class CompilationUnitBuildersTest {
   void typesInSubPackagesOfTheJavaLangPackageRequireExplicitImports() {
     cu.addImport(ElementType.class);
     assertEquals(1, cu.getImports().size());
-    assertEquals("import java.lang.annotation.ElementType;" + SYSTEM_EOL, cu.getImport(0).toString());
+    assertEquals("import java.lang.annotation.ElementType;" + LineSeparator.SYSTEM, cu.getImport(0).toString());
   }
 
   @Test
@@ -211,7 +212,7 @@ class CompilationUnitBuildersTest {
   @Test
   void testAddImportAnonymousClass() {
     cu.addImport(testInnerClass.class);
-    assertEquals("import " + testInnerClass.class.getCanonicalName().replace("$", ".") + ";" + SYSTEM_EOL,
+    assertEquals("import " + testInnerClass.class.getCanonicalName().replace("$", ".") + ";" + LineSeparator.SYSTEM,
         cu.getImport(0).toString());
   }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/EnumDeclarationBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/EnumDeclarationBuildersTest.java
@@ -23,11 +23,12 @@ package com.github.javaparser.builders;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EnumDeclarationBuildersTest {
@@ -38,7 +39,7 @@ class EnumDeclarationBuildersTest {
         EnumDeclaration testEnum = cu.addEnum("test");
         testEnum.addImplementedType(Function.class);
         assertEquals(1, cu.getImports().size());
-        assertEquals("import " + Function.class.getName() + ";" + SYSTEM_EOL,
+        assertEquals("import " + Function.class.getName() + ";" + LineSeparator.SYSTEM,
                 cu.getImport(0).toString());
         assertEquals(1, testEnum.getImplementedTypes().size());
         assertEquals(Function.class.getSimpleName(), testEnum.getImplementedTypes(0).getNameAsString());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithParametersBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithParametersBuildersTest.java
@@ -24,12 +24,13 @@ package com.github.javaparser.builders;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class NodeWithParametersBuildersTest {
@@ -41,7 +42,7 @@ class NodeWithParametersBuildersTest {
         addMethod.addParameter(int.class, "yay");
         Parameter myNewParam = addMethod.addAndGetParameter(List.class, "myList");
         assertEquals(1, cu.getImports().size());
-        assertEquals("import " + List.class.getName() + ";" + SYSTEM_EOL, cu.getImport(0).toString());
+        assertEquals("import " + List.class.getName() + ";" + LineSeparator.SYSTEM, cu.getImport(0).toString());
         assertEquals(2, addMethod.getParameters().size());
         assertEquals("yay", addMethod.getParameter(0).getNameAsString());
         assertEquals("List", addMethod.getParameter(1).getType().toString());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
@@ -27,6 +27,8 @@ import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.javadoc.description.JavadocDescriptionElement;
 import com.github.javaparser.javadoc.description.JavadocInlineTag;
 import com.github.javaparser.javadoc.description.JavadocSnippet;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,7 +36,6 @@ import java.util.List;
 import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.StaticJavaParser.parseJavadoc;
 import static com.github.javaparser.javadoc.description.JavadocInlineTag.Type.*;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,52 +50,52 @@ class JavadocTest {
 
     @Test
     void toTextForJavadocWithTwoLinesOfJustDescription() {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + SYSTEM_EOL + "second line"));
-        assertEquals("first line" + SYSTEM_EOL + "second line" + SYSTEM_EOL, javadoc.toText());
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + LineSeparator.SYSTEM + "second line"));
+        assertEquals("first line" + LineSeparator.SYSTEM + "second line" + LineSeparator.SYSTEM, javadoc.toText());
     }
 
     @Test
     void toTextForJavadocWithTwoLinesOfJustDescriptionAndOneBlockTag() {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + SYSTEM_EOL + "second line"));
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + LineSeparator.SYSTEM + "second line"));
         javadoc.addBlockTag("foo", "something useful");
-        assertEquals("first line" + SYSTEM_EOL + "second line" + SYSTEM_EOL + SYSTEM_EOL + "@foo something useful" + SYSTEM_EOL, javadoc.toText());
+        assertEquals("first line" + LineSeparator.SYSTEM + "second line" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + "@foo something useful" + LineSeparator.SYSTEM, javadoc.toText());
     }
 
     @Test
     void toCommentForEmptyJavadoc() {
         Javadoc javadoc = new Javadoc(new JavadocDescription());
-        assertEquals(new JavadocComment("" + SYSTEM_EOL + "\t\t "), javadoc.toComment("\t\t"));
+        assertEquals(new JavadocComment("" + LineSeparator.SYSTEM + "\t\t "), javadoc.toComment("\t\t"));
     }
 
     @Test
     void toCommentorJavadocWithTwoLinesOfJustDescription() {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + SYSTEM_EOL + "second line"));
-        assertEquals(new JavadocComment("" + SYSTEM_EOL + "\t\t * first line" + SYSTEM_EOL + "\t\t * second line" + SYSTEM_EOL + "\t\t "), javadoc.toComment("\t\t"));
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + LineSeparator.SYSTEM + "second line"));
+        assertEquals(new JavadocComment("" + LineSeparator.SYSTEM + "\t\t * first line" + LineSeparator.SYSTEM + "\t\t * second line" + LineSeparator.SYSTEM + "\t\t "), javadoc.toComment("\t\t"));
     }
 
     @Test
     void toCommentForJavadocWithTwoLinesOfJustDescriptionAndOneBlockTag() {
-        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + SYSTEM_EOL + "second line"));
+        Javadoc javadoc = new Javadoc(JavadocDescription.parseText("first line" + LineSeparator.SYSTEM + "second line"));
         javadoc.addBlockTag("foo", "something useful");
-        assertEquals(new JavadocComment("" + SYSTEM_EOL + "\t\t * first line" + SYSTEM_EOL + "\t\t * second line" + SYSTEM_EOL + "\t\t * " + SYSTEM_EOL + "\t\t * @foo something useful" + SYSTEM_EOL + "\t\t "), javadoc.toComment("\t\t"));
+        assertEquals(new JavadocComment("" + LineSeparator.SYSTEM + "\t\t * first line" + LineSeparator.SYSTEM + "\t\t * second line" + LineSeparator.SYSTEM + "\t\t * " + LineSeparator.SYSTEM + "\t\t * @foo something useful" + LineSeparator.SYSTEM + "\t\t "), javadoc.toComment("\t\t"));
     }
 
     @Test
     void descriptionAndBlockTagsAreRetrievable() {
-        Javadoc javadoc = parseJavadoc("first line" + SYSTEM_EOL + "second line" + SYSTEM_EOL + SYSTEM_EOL + "@param node a node" + SYSTEM_EOL + "@return result the result");
-        assertEquals("first line" + SYSTEM_EOL + "second line", javadoc.getDescription().toText());
+        Javadoc javadoc = parseJavadoc("first line" + LineSeparator.SYSTEM + "second line" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + "@param node a node" + LineSeparator.SYSTEM + "@return result the result");
+        assertEquals("first line" + LineSeparator.SYSTEM + "second line", javadoc.getDescription().toText());
         assertEquals(2, javadoc.getBlockTags().size());
     }
 
     @Test
     void inlineTagsAreParsable() {
         String docText =
-                "Returns the {@link TOFilename}s of all files that existed during the requested" + SYSTEM_EOL +
-                        "{@link TOVersion}. Set {@systemProperty JAVA_HOME} correctly." + SYSTEM_EOL +
-                        "" + SYSTEM_EOL +
-                        "@param versionID the id of the {@link TOVersion}." + SYSTEM_EOL +
-                        "@return the filenames" + SYSTEM_EOL +
-                        "@throws InvalidIDException if the {@link IPersistence} doesn't recognize the given versionID." + SYSTEM_EOL;
+                "Returns the {@link TOFilename}s of all files that existed during the requested" + LineSeparator.SYSTEM +
+                        "{@link TOVersion}. Set {@systemProperty JAVA_HOME} correctly." + LineSeparator.SYSTEM +
+                        "" + LineSeparator.SYSTEM +
+                        "@param versionID the id of the {@link TOVersion}." + LineSeparator.SYSTEM +
+                        "@return the filenames" + LineSeparator.SYSTEM +
+                        "@throws InvalidIDException if the {@link IPersistence} doesn't recognize the given versionID." + LineSeparator.SYSTEM;
         Javadoc javadoc = parseJavadoc(docText);
 
         List<JavadocInlineTag> inlineTags = javadoc.getDescription().getElements().stream()
@@ -118,13 +119,13 @@ class JavadocTest {
 
     @Test
     void emptyLinesBetweenBlockTagsGetsFiltered() {
-        String comment = " * The type of the Object to be mapped." + SYSTEM_EOL +
-                " * This interface maps the given Objects to existing ones in the database and" + SYSTEM_EOL +
-                " * saves them." + SYSTEM_EOL +
-                " * " + SYSTEM_EOL +
-                " * @author censored" + SYSTEM_EOL +
-                " * " + SYSTEM_EOL +
-                " * @param <T>" + SYSTEM_EOL;
+        String comment = " * The type of the Object to be mapped." + LineSeparator.SYSTEM +
+                " * This interface maps the given Objects to existing ones in the database and" + LineSeparator.SYSTEM +
+                " * saves them." + LineSeparator.SYSTEM +
+                " * " + LineSeparator.SYSTEM +
+                " * @author censored" + LineSeparator.SYSTEM +
+                " * " + LineSeparator.SYSTEM +
+                " * @param <T>" + LineSeparator.SYSTEM;
         Javadoc javadoc = parseJavadoc(comment);
         assertEquals(2, javadoc.getBlockTags().size());
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
@@ -29,6 +29,8 @@ import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.GeneratedJavaParserConstants.IDENTIFIER;
@@ -36,7 +38,6 @@ import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_9;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -147,21 +148,21 @@ class ModuleDeclarationTest {
                         "}");
 
         assertEquals(
-                "@Foo(1)" + SYSTEM_EOL +
-                        "@Foo(2)" + SYSTEM_EOL +
-                        "@Bar" + SYSTEM_EOL +
-                        "module M.N {" + SYSTEM_EOL +
-                        "    requires A.B;" + SYSTEM_EOL +
-                        "    requires transitive C.D;" + SYSTEM_EOL +
-                        "    requires static E.F;" + SYSTEM_EOL +
-                        "    requires static transitive G.H;" + SYSTEM_EOL +
-                        "    exports P.Q;" + SYSTEM_EOL +
-                        "    exports R.S to T1.U1, T2.U2;" + SYSTEM_EOL +
-                        "    opens P.Q;" + SYSTEM_EOL +
-                        "    opens R.S to T1.U1, T2.U2;" + SYSTEM_EOL +
-                        "    uses V.W;" + SYSTEM_EOL +
-                        "    provides X.Y with Z1.Z2, Z3.Z4;" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL, cu.toString());
+                "@Foo(1)" + LineSeparator.SYSTEM +
+                        "@Foo(2)" + LineSeparator.SYSTEM +
+                        "@Bar" + LineSeparator.SYSTEM +
+                        "module M.N {" + LineSeparator.SYSTEM +
+                        "    requires A.B;" + LineSeparator.SYSTEM +
+                        "    requires transitive C.D;" + LineSeparator.SYSTEM +
+                        "    requires static E.F;" + LineSeparator.SYSTEM +
+                        "    requires static transitive G.H;" + LineSeparator.SYSTEM +
+                        "    exports P.Q;" + LineSeparator.SYSTEM +
+                        "    exports R.S to T1.U1, T2.U2;" + LineSeparator.SYSTEM +
+                        "    opens P.Q;" + LineSeparator.SYSTEM +
+                        "    opens R.S to T1.U1, T2.U2;" + LineSeparator.SYSTEM +
+                        "    uses V.W;" + LineSeparator.SYSTEM +
+                        "    provides X.Y with Z1.Z2, Z3.Z4;" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM, cu.toString());
 
     }
 
@@ -186,21 +187,21 @@ class ModuleDeclarationTest {
                         "}");
 
         assertEquals(
-                "@Foo(1)" + SYSTEM_EOL +
-                        "@Foo(2)" + SYSTEM_EOL +
-                        "@Bar" + SYSTEM_EOL +
-                        "open module M.N {" + SYSTEM_EOL +
-                        "    requires A.B;" + SYSTEM_EOL +
-                        "    requires transitive C.D;" + SYSTEM_EOL +
-                        "    requires static E.F;" + SYSTEM_EOL +
-                        "    requires transitive static G.H;" + SYSTEM_EOL +
-                        "    exports P.Q;" + SYSTEM_EOL +
-                        "    exports R.S to T1.U1, T2.U2;" + SYSTEM_EOL +
-                        "    opens P.Q;" + SYSTEM_EOL +
-                        "    opens R.S to T1.U1, T2.U2;" + SYSTEM_EOL +
-                        "    uses V.W;" + SYSTEM_EOL +
-                        "    provides X.Y with Z1.Z2, Z3.Z4;" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL, ConcreteSyntaxModel.genericPrettyPrint(cu));
+                "@Foo(1)" + LineSeparator.SYSTEM +
+                        "@Foo(2)" + LineSeparator.SYSTEM +
+                        "@Bar" + LineSeparator.SYSTEM +
+                        "open module M.N {" + LineSeparator.SYSTEM +
+                        "    requires A.B;" + LineSeparator.SYSTEM +
+                        "    requires transitive C.D;" + LineSeparator.SYSTEM +
+                        "    requires static E.F;" + LineSeparator.SYSTEM +
+                        "    requires transitive static G.H;" + LineSeparator.SYSTEM +
+                        "    exports P.Q;" + LineSeparator.SYSTEM +
+                        "    exports R.S to T1.U1, T2.U2;" + LineSeparator.SYSTEM +
+                        "    opens P.Q;" + LineSeparator.SYSTEM +
+                        "    opens R.S to T1.U1, T2.U2;" + LineSeparator.SYSTEM +
+                        "    uses V.W;" + LineSeparator.SYSTEM +
+                        "    provides X.Y with Z1.Z2, Z3.Z4;" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM, ConcreteSyntaxModel.genericPrettyPrint(cu));
 
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
@@ -23,10 +23,11 @@ package com.github.javaparser.printer;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.*;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ConcreteSyntaxModelTest {
@@ -56,42 +57,42 @@ class ConcreteSyntaxModelTest {
     @Test
     void printSimplestClass() {
         Node node = parse("class A {}");
-        assertEquals("class A {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL, print(node));
+        assertEquals("class A {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printAClassWithField() {
         Node node = parse("class A { int a; }");
-        assertEquals("class A {" + SYSTEM_EOL
-                + SYSTEM_EOL +
-                "    int a;" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL, print(node));
+        assertEquals("class A {" + LineSeparator.SYSTEM
+                + LineSeparator.SYSTEM +
+                "    int a;" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printParameters() {
         Node node = parseBodyDeclaration("int x(int y, int z) {}");
-        assertEquals("int x(int y, int z) {" + SYSTEM_EOL + "}", print(node));
+        assertEquals("int x(int y, int z) {" + LineSeparator.SYSTEM + "}", print(node));
     }
 
     @Test
     void printReceiverParameter() {
         Node node = parseBodyDeclaration("int x(X A.B.this, int y, int z) {}");
-        assertEquals("int x(X A.B.this, int y, int z) {" + SYSTEM_EOL + "}", print(node));
+        assertEquals("int x(X A.B.this, int y, int z) {" + LineSeparator.SYSTEM + "}", print(node));
     }
 
     @Test
     void printAnEmptyInterface() {
         Node node = parse("interface A {}");
-        assertEquals("interface A {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL, print(node));
+        assertEquals("interface A {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printAnEmptyInterfaceWithModifier() {
         Node node = parse("public interface A {}");
-        assertEquals("public interface A {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL, print(node));
+        assertEquals("public interface A {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM, print(node));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -23,7 +23,6 @@ package com.github.javaparser.printer;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
@@ -46,6 +45,7 @@ import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration;
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption;
 import com.github.javaparser.printer.configuration.PrinterConfiguration;
+import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.utils.TestParser;
 
 class PrettyPrintVisitorTest extends TestParser {
@@ -123,7 +123,7 @@ class PrettyPrintVisitorTest extends TestParser {
         assertEquals("a = 1 / 1;", print(statement5));
 
         Statement statement6 = parseStatement("if (1 > 2 && 1 < 3 || 1 < 3){}");
-        assertEquals("if (1 > 2 && 1 < 3 || 1 < 3) {" + SYSTEM_EOL
+        assertEquals("if (1 > 2 && 1 < 3 || 1 < 3) {" + LineSeparator.SYSTEM
                 + "}", print(statement6));
 
     }
@@ -155,7 +155,7 @@ class PrettyPrintVisitorTest extends TestParser {
     void printOperatorA(){
         PrinterConfiguration conf = new DefaultPrinterConfiguration().removeOption(new DefaultConfigurationOption(ConfigOption.SPACE_AROUND_OPERATORS));
         Statement statement6 = parseStatement("if(1>2&&1<3||1<3){}");
-        assertEquals("if (1>2&&1<3||1<3) {" + SYSTEM_EOL
+        assertEquals("if (1>2&&1<3||1<3) {" + LineSeparator.SYSTEM
                 + "}", print(statement6, conf));
     }
 
@@ -181,37 +181,37 @@ class PrettyPrintVisitorTest extends TestParser {
     @Test
     void printSimplestClass() {
         Node node = parse("class A {}");
-        assertEquals("class A {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL, print(node));
+        assertEquals("class A {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printAClassWithField() {
         Node node = parse("class A { int a; }");
-        assertEquals("class A {" + SYSTEM_EOL
-                + SYSTEM_EOL +
-                "    int a;" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL, print(node));
+        assertEquals("class A {" + LineSeparator.SYSTEM
+                + LineSeparator.SYSTEM +
+                "    int a;" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printAReceiverParameter() {
         Node node = parseBodyDeclaration("int x(@O X A.B.this, int y) { }");
-        assertEquals("int x(@O X A.B.this, int y) {" + SYSTEM_EOL + "}", print(node));
+        assertEquals("int x(@O X A.B.this, int y) {" + LineSeparator.SYSTEM + "}", print(node));
     }
 
     @Test
     void printLambdaIntersectionTypeAssignment() {
-        String code = "class A {" + SYSTEM_EOL +
-                "  void f() {" + SYSTEM_EOL +
-                "    Runnable r = (Runnable & Serializable) (() -> {});" + SYSTEM_EOL +
-                "    r = (Runnable & Serializable)() -> {};" + SYSTEM_EOL +
-                "    r = (Runnable & I)() -> {};" + SYSTEM_EOL +
+        String code = "class A {" + LineSeparator.SYSTEM +
+                "  void f() {" + LineSeparator.SYSTEM +
+                "    Runnable r = (Runnable & Serializable) (() -> {});" + LineSeparator.SYSTEM +
+                "    r = (Runnable & Serializable)() -> {};" + LineSeparator.SYSTEM +
+                "    r = (Runnable & I)() -> {};" + LineSeparator.SYSTEM +
                 "  }}";
         CompilationUnit cu = parse(code);
         MethodDeclaration methodDeclaration = (MethodDeclaration) cu.getType(0).getMember(0);
 
-        assertEquals("Runnable r = (Runnable & Serializable) (() -> {" + SYSTEM_EOL + "});", print(methodDeclaration.getBody().get().getStatements().get(0)));
+        assertEquals("Runnable r = (Runnable & Serializable) (() -> {" + LineSeparator.SYSTEM + "});", print(methodDeclaration.getBody().get().getStatements().get(0)));
     }
 
     @Test
@@ -225,9 +225,9 @@ class PrettyPrintVisitorTest extends TestParser {
 
     @Test
     void printLambdaIntersectionTypeReturn() {
-        String code = "class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
-                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + SYSTEM_EOL
+        String code = "class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
+                + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); " + LineSeparator.SYSTEM
                 + "}}";
         CompilationUnit cu = parse(code);
         MethodDeclaration methodDeclaration = (MethodDeclaration) cu.getType(0).getMember(0);
@@ -237,11 +237,11 @@ class PrettyPrintVisitorTest extends TestParser {
 
     @Test
     void printClassWithoutJavaDocButWithComment() {
-        String code = String.format("/** javadoc */ public class A { %s// stuff%s}", SYSTEM_EOL, SYSTEM_EOL);
+        String code = String.format("/** javadoc */ public class A { %s// stuff%s}", LineSeparator.SYSTEM, LineSeparator.SYSTEM);
         CompilationUnit cu = parse(code);
         PrinterConfiguration ignoreJavaDoc = new DefaultPrinterConfiguration().removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_JAVADOC));
         String content = cu.toString(ignoreJavaDoc);
-        assertEquals(String.format("public class A {%s    // stuff%s}%s", SYSTEM_EOL, SYSTEM_EOL, SYSTEM_EOL), content);
+        assertEquals(String.format("public class A {%s    // stuff%s}%s", LineSeparator.SYSTEM, LineSeparator.SYSTEM, LineSeparator.SYSTEM), content);
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrinterConfigurationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrinterConfigurationTest.java
@@ -25,6 +25,7 @@ import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration;
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption;
 import com.github.javaparser.printer.configuration.PrinterConfiguration;
+import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.utils.Utils;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +55,7 @@ class PrinterConfigurationTest {
                 Integer.valueOf(5));
         assertTrue(getOption(config, ConfigOption.MAX_ENUM_CONSTANTS_TO_ALIGN_HORIZONTALLY).get().asValue() ==
                 Integer.valueOf(5));
-        assertEquals(getOption(config, ConfigOption.END_OF_LINE_CHARACTER).get().asString(), Utils.SYSTEM_EOL);
+        assertEquals(getOption(config, ConfigOption.END_OF_LINE_CHARACTER).get().asString(), LineSeparator.SYSTEM.asRawString());
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -25,7 +25,6 @@ import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,6 +51,7 @@ import com.github.javaparser.ast.type.UnionType;
 import com.github.javaparser.ast.type.VoidType;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.utils.TestUtils;
 
 class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
@@ -204,7 +204,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void addedImportShouldBePrependedWithEOL() {
-        considerCode("import a.A;" + SYSTEM_EOL + "class X{}");
+        considerCode("import a.A;" + LineSeparator.SYSTEM + "class X{}");
 
         cu.addImport("a.B");
 
@@ -350,7 +350,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
         ClassOrInterfaceDeclaration classA = cu.getClassByName("A").get();
         classA.addField("int", "myField");
-        assertEquals("class A {" + SYSTEM_EOL + "    int myField;" + SYSTEM_EOL + "}", LexicalPreservingPrinter.print(classA));
+        assertEquals("class A {" + LineSeparator.SYSTEM + "    int myField;" + LineSeparator.SYSTEM + "}", LexicalPreservingPrinter.print(classA));
     }
 
     @Test
@@ -363,7 +363,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void printASimpleCUWithoutChanges() {
-        String code = "class /*a comment*/ A {\t\t" + SYSTEM_EOL + " int f;" + SYSTEM_EOL + SYSTEM_EOL + SYSTEM_EOL
+        String code = "class /*a comment*/ A {\t\t" + LineSeparator.SYSTEM + " int f;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + LineSeparator.SYSTEM
                 + "         void foo(int p  ) { return  'z'  \t; }}";
         considerCode(code);
 
@@ -375,31 +375,31 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void printASimpleClassRemovingAField() {
-        String code = "class /*a comment*/ A {\t\t" + SYSTEM_EOL +
-                " int f;" + SYSTEM_EOL + SYSTEM_EOL + SYSTEM_EOL +
+        String code = "class /*a comment*/ A {\t\t" + LineSeparator.SYSTEM +
+                " int f;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + LineSeparator.SYSTEM +
                 "         void foo(int p  ) { return  'z'  \t; }}";
         considerCode(code);
 
         ClassOrInterfaceDeclaration c = cu.getClassByName("A").get();
         c.getMembers().remove(0);
         // This rendering is probably caused by the concret syntax model
-        assertEquals("class /*a comment*/ A {\t\t" + SYSTEM_EOL +
-        		SYSTEM_EOL +
+        assertEquals("class /*a comment*/ A {\t\t" + LineSeparator.SYSTEM +
+        		LineSeparator.SYSTEM +
                 "         void foo(int p  ) { return  'z'  \t; }}", LexicalPreservingPrinter.print(c));
     }
 
     @Test
     void printASimpleClassRemovingAMethod() {
-        String code = "class /*a comment*/ A {\t\t" + SYSTEM_EOL +
-                " int f;" + SYSTEM_EOL + SYSTEM_EOL + SYSTEM_EOL +
-                "         void foo(int p  ) { return  'z'  \t; }" + SYSTEM_EOL +
+        String code = "class /*a comment*/ A {\t\t" + LineSeparator.SYSTEM +
+                " int f;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + LineSeparator.SYSTEM +
+                "         void foo(int p  ) { return  'z'  \t; }" + LineSeparator.SYSTEM +
                 " int g;}";
         considerCode(code);
 
         ClassOrInterfaceDeclaration c = cu.getClassByName("A").get();
         c.getMembers().remove(1);
-        assertEquals("class /*a comment*/ A {\t\t" + SYSTEM_EOL +
-                " int f;" + SYSTEM_EOL + SYSTEM_EOL + SYSTEM_EOL +
+        assertEquals("class /*a comment*/ A {\t\t" + LineSeparator.SYSTEM +
+                " int f;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + LineSeparator.SYSTEM +
                 " int g;}", LexicalPreservingPrinter.print(c));
     }
 
@@ -464,8 +464,8 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                 .getStatements();
         stmts.add(s);
         MethodDeclaration m = cu.getClassByName("A").get().getMethodsByName("foo").get(0);
-        assertEquals("void foo(char p1, int p2) {" + SYSTEM_EOL +
-                "    10 + 2;" + SYSTEM_EOL +
+        assertEquals("void foo(char p1, int p2) {" + LineSeparator.SYSTEM +
+                "    10 + 2;" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(m));
     }
 
@@ -630,11 +630,11 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void printLambdaIntersectionTypeAssignment() {
-        String code = "class A {" + SYSTEM_EOL +
-                "  void f() {" + SYSTEM_EOL +
-                "    Runnable r = (Runnable & Serializable) (() -> {});" + SYSTEM_EOL +
-                "    r = (Runnable & Serializable)() -> {};" + SYSTEM_EOL +
-                "    r = (Runnable & I)() -> {};" + SYSTEM_EOL +
+        String code = "class A {" + LineSeparator.SYSTEM +
+                "  void f() {" + LineSeparator.SYSTEM +
+                "    Runnable r = (Runnable & Serializable) (() -> {});" + LineSeparator.SYSTEM +
+                "    r = (Runnable & Serializable)() -> {};" + LineSeparator.SYSTEM +
+                "    r = (Runnable & I)() -> {};" + LineSeparator.SYSTEM +
                 "  }}";
         considerCode(code);
 
@@ -643,10 +643,10 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void printLambdaIntersectionTypeReturn() {
-        String code = "class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
+        String code = "class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
                 + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
-                + SYSTEM_EOL
+                + LineSeparator.SYSTEM
                 + "}}";
         considerCode(code);
 
@@ -656,12 +656,12 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     // See issue #855
     @Test
     void handleOverrideAnnotation() {
-        considerCode("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        considerCode("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}");
 
         cu.getTypes()
@@ -674,13 +674,13 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                                 }
                             }
                         }));
-        assertEquals("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        assertEquals("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
@@ -708,7 +708,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         MethodDeclaration setter = cu
                 .getClassByName("MyRenamedClass").get()
                 .addMethod("setAField", PUBLIC);
-        assertEquals("public void setAField() {" + SYSTEM_EOL +
+        assertEquals("public void setAField() {" + LineSeparator.SYSTEM +
                 "    }", LexicalPreservingPrinter.print(setter));
     }
 
@@ -907,9 +907,9 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                                 parseClassOrInterfaceType("String"),
                                 "test2",
                                 new StringLiteralExpr("")))));
-        TestUtils.assertEqualsStringIgnoringEol("public void someMethod() {" + SYSTEM_EOL
-                + "        String test = \"\";" + SYSTEM_EOL
-                + "        String test2 = \"\";" + SYSTEM_EOL
+        TestUtils.assertEqualsStringIgnoringEol("public void someMethod() {" + LineSeparator.SYSTEM
+                + "        String test = \"\";" + LineSeparator.SYSTEM
+                + "        String test2 = \"\";" + LineSeparator.SYSTEM
                 // HACK: The right closing brace should not have indentation
                 // because the original method did not introduce indentation,
                 // however due to necessity this test was left with indentation,
@@ -920,11 +920,11 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     // See issue #866
     @Test
     void moveOverrideAnnotations() {
-        considerCode("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected @Override void initializePage() {}" + SYSTEM_EOL +
+        considerCode("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected @Override void initializePage() {}" + LineSeparator.SYSTEM +
                 "}");
 
         cu.getTypes()
@@ -940,23 +940,23 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                                 methodDeclaration.addMarkerAnnotation("Override");
                             }
                         })));
-        assertEquals("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        assertEquals("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
     // See issue #866
     @Test
     void moveOrAddOverrideAnnotations() {
-        considerCode("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected @Override void initializePage() {}" + SYSTEM_EOL +
+        considerCode("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected @Override void initializePage() {}" + LineSeparator.SYSTEM +
                 "}");
 
         cu.getTypes()
@@ -974,25 +974,25 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                                 methodDeclaration.addMarkerAnnotation("Override");
                             }
                         }));
-        assertEquals("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        assertEquals("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
     // See issue #865
     @Test
     void handleAddingMarkerAnnotation() {
-        considerCode("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        considerCode("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}");
 
         cu.getTypes()
@@ -1005,70 +1005,70 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                                 }
                             }
                         }));
-        assertEquals("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        assertEquals("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
     // See issue #865
     @Test
     void handleOverrideMarkerAnnotation() {
-        considerCode("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        considerCode("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}");
 
         cu.getTypes()
                 .forEach(type -> type.getMembers()
                         .forEach(member -> member.ifMethodDeclaration(
                                 methodDeclaration -> methodDeclaration.addMarkerAnnotation("Override"))));
-        assertEquals("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        assertEquals("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
     // See issue #865
     @Test
     void handleOverrideAnnotationAlternative() {
-        considerCode("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        considerCode("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}");
 
         cu.getTypes()
                 .forEach(type -> type.getMembers()
                         .forEach(member -> member.ifMethodDeclaration(
                                 methodDeclaration -> methodDeclaration.addAnnotation("Override"))));
-        assertEquals("public class TestPage extends Page {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void test() {}" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "   @Override" + SYSTEM_EOL +
-                "   protected void initializePage() {}" + SYSTEM_EOL +
+        assertEquals("public class TestPage extends Page {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void test() {}" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "   @Override" + LineSeparator.SYSTEM +
+                "   protected void initializePage() {}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
     @Test
     void invokeModifierVisitor() {
-        considerCode("class A {" + SYSTEM_EOL
-                + "  Object f() {" + SYSTEM_EOL
+        considerCode("class A {" + LineSeparator.SYSTEM
+                + "  Object f() {" + LineSeparator.SYSTEM
                 + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
-                + SYSTEM_EOL
+                + LineSeparator.SYSTEM
                 + "}}");
         cu.accept(new ModifierVisitor<>(), null);
     }
@@ -1079,7 +1079,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
         cu.getTypes().forEach(type -> type.addAndGetAnnotation(Deprecated.class));
 
-        assertEquals("@Deprecated" + SYSTEM_EOL +
+        assertEquals("@Deprecated" + LineSeparator.SYSTEM +
                 "public final class A {}", LexicalPreservingPrinter.print(cu));
 
     }
@@ -1090,15 +1090,15 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
         cu.getTypes().forEach(type -> type.addAndGetAnnotation(Deprecated.class));
 
-        assertEquals("@Deprecated" + SYSTEM_EOL +
+        assertEquals("@Deprecated" + LineSeparator.SYSTEM +
                 "public abstract class A {}", LexicalPreservingPrinter.print(cu));
     }
 
     @Test
     void issue1244() {
-    	considerCode("public class Foo {" + SYSTEM_EOL + SYSTEM_EOL
-                + "// Some comment" + SYSTEM_EOL + SYSTEM_EOL // does work with only one \n
-                + "public void writeExternal() {}" + SYSTEM_EOL + "}");
+    	considerCode("public class Foo {" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
+                + "// Some comment" + LineSeparator.SYSTEM + LineSeparator.SYSTEM // does work with only one \n
+                + "public void writeExternal() {}" + LineSeparator.SYSTEM + "}");
 
         cu.findAll(ClassOrInterfaceDeclaration.class).forEach(c -> {
             List<MethodDeclaration> methods = c.getMethodsByName("writeExternal");
@@ -1122,11 +1122,11 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     // See issue 1277
     @Test
     void testInvokeModifierVisitor() {
-    	considerCode("class A {" + SYSTEM_EOL +
-                "  public String message = \"hello\";" + SYSTEM_EOL +
-                "   void bar() {" + SYSTEM_EOL +
-                "     System.out.println(\"hello\");" + SYSTEM_EOL +
-                "   }" + SYSTEM_EOL +
+    	considerCode("class A {" + LineSeparator.SYSTEM +
+                "  public String message = \"hello\";" + LineSeparator.SYSTEM +
+                "   void bar() {" + LineSeparator.SYSTEM +
+                "     System.out.println(\"hello\");" + LineSeparator.SYSTEM +
+                "   }" + LineSeparator.SYSTEM +
                 "}");
 
         cu.accept(new AddFooCallModifierVisitor(), null);
@@ -1142,12 +1142,12 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void invokeModifierVisitorIssue1297() {
-    	considerCode("class A {" + SYSTEM_EOL +
-                "   public void bar() {" + SYSTEM_EOL +
-                "     System.out.println(\"hello\");" + SYSTEM_EOL +
-                "     System.out.println(\"hello\");" + SYSTEM_EOL +
-                "     // comment" + SYSTEM_EOL +
-                "   }" + SYSTEM_EOL +
+    	considerCode("class A {" + LineSeparator.SYSTEM +
+                "   public void bar() {" + LineSeparator.SYSTEM +
+                "     System.out.println(\"hello\");" + LineSeparator.SYSTEM +
+                "     System.out.println(\"hello\");" + LineSeparator.SYSTEM +
+                "     // comment" + LineSeparator.SYSTEM +
+                "   }" + LineSeparator.SYSTEM +
                 "}");
 
         cu.accept(new CallModifierVisitor(), null);
@@ -1160,10 +1160,10 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         cu.getClassByName("Foo").get()
                 .addMethod("mymethod")
                 .setBlockComment("block");
-        assertEqualsStringIgnoringEol("public class Foo {" + SYSTEM_EOL +
-                "    /*block*/" + SYSTEM_EOL +
-                "    void mymethod() {" + SYSTEM_EOL +
-                "    }" + SYSTEM_EOL +
+        assertEqualsStringIgnoringEol("public class Foo {" + LineSeparator.SYSTEM +
+                "    /*block*/" + LineSeparator.SYSTEM +
+                "    void mymethod() {" + LineSeparator.SYSTEM +
+                "    }" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
@@ -1174,25 +1174,25 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         cu.getClassByName("Foo").get()
                 .addMethod("mymethod")
                 .setLineComment("line");
-        assertEqualsStringIgnoringEol("public class Foo {" + SYSTEM_EOL +
-                "    //line" + SYSTEM_EOL +
-                "    void mymethod() {" + SYSTEM_EOL +
-                "    }" + SYSTEM_EOL +
+        assertEqualsStringIgnoringEol("public class Foo {" + LineSeparator.SYSTEM +
+                "    //line" + LineSeparator.SYSTEM +
+                "    void mymethod() {" + LineSeparator.SYSTEM +
+                "    }" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
     @Test
     void removedLineCommentsPrinted() {
-    	considerCode("public class Foo {" + SYSTEM_EOL +
-                "//line" + SYSTEM_EOL +
-                "void mymethod() {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL +
+    	considerCode("public class Foo {" + LineSeparator.SYSTEM +
+                "//line" + LineSeparator.SYSTEM +
+                "void mymethod() {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM +
                 "}");
         cu.getAllContainedComments().get(0).remove();
 
-        assertEqualsStringIgnoringEol("public class Foo {" + SYSTEM_EOL +
-                "void mymethod() {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL +
+        assertEqualsStringIgnoringEol("public class Foo {" + LineSeparator.SYSTEM +
+                "void mymethod() {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 
@@ -1214,18 +1214,18 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
 
     @Test
     void removedBlockCommentsPrinted() {
-    	considerCode("public class Foo {" + SYSTEM_EOL +
-                "/*" + SYSTEM_EOL +
-                "Block comment coming through" + SYSTEM_EOL +
-                "*/" + SYSTEM_EOL +
-                "void mymethod() {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL +
+    	considerCode("public class Foo {" + LineSeparator.SYSTEM +
+                "/*" + LineSeparator.SYSTEM +
+                "Block comment coming through" + LineSeparator.SYSTEM +
+                "*/" + LineSeparator.SYSTEM +
+                "void mymethod() {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM +
                 "}");
         cu.getAllContainedComments().get(0).remove();
 
-        assertEqualsStringIgnoringEol("public class Foo {" + SYSTEM_EOL +
-                "void mymethod() {" + SYSTEM_EOL +
-                "}" + SYSTEM_EOL +
+        assertEqualsStringIgnoringEol("public class Foo {" + LineSeparator.SYSTEM +
+                "void mymethod() {" + LineSeparator.SYSTEM +
+                "}" + LineSeparator.SYSTEM +
                 "}", LexicalPreservingPrinter.print(cu));
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
@@ -34,13 +34,14 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static com.github.javaparser.ast.Modifier.Keyword.STATIC;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 
 /**
  * These tests are more "high level" than the ones in LexicalPreservingPrinterTest.
@@ -173,13 +174,13 @@ class TransformationsTest extends  AbstractLexicalPreservingTest {
     @Test
     void issue2099AddingStatementAfterTraillingComment1() {
         considerStatement(
-                "    if(value != null) {" + SYSTEM_EOL +
-                "        value.value();" + SYSTEM_EOL +
+                "    if(value != null) {" + LineSeparator.SYSTEM +
+                "        value.value();" + LineSeparator.SYSTEM +
                 "    }");
 
-        BlockStmt blockStmt = LexicalPreservingPrinter.setup(StaticJavaParser.parseBlock("{" + SYSTEM_EOL +
-                "       value1();" + SYSTEM_EOL +
-                "    value2(); // Test" + SYSTEM_EOL +
+        BlockStmt blockStmt = LexicalPreservingPrinter.setup(StaticJavaParser.parseBlock("{" + LineSeparator.SYSTEM +
+                "       value1();" + LineSeparator.SYSTEM +
+                "    value2(); // Test" + LineSeparator.SYSTEM +
                 "}"));
 
         blockStmt.addStatement(statement);
@@ -197,13 +198,13 @@ class TransformationsTest extends  AbstractLexicalPreservingTest {
     @Test
     void issue2099AddingStatementAfterTraillingComment2() {
         considerStatement(
-                "    if(value != null) {" + SYSTEM_EOL +
-                "        value.value();" + SYSTEM_EOL +
+                "    if(value != null) {" + LineSeparator.SYSTEM +
+                "        value.value();" + LineSeparator.SYSTEM +
                 "    }");
 
-        BlockStmt blockStmt = LexicalPreservingPrinter.setup(StaticJavaParser.parseBlock("{" + SYSTEM_EOL +
-                "       value1();" + SYSTEM_EOL +
-                "    value2(); /* test */" + SYSTEM_EOL +
+        BlockStmt blockStmt = LexicalPreservingPrinter.setup(StaticJavaParser.parseBlock("{" + LineSeparator.SYSTEM +
+                "       value1();" + LineSeparator.SYSTEM +
+                "    value2(); /* test */" + LineSeparator.SYSTEM +
                 "}"));
 
         blockStmt.addStatement(statement);
@@ -222,15 +223,15 @@ class TransformationsTest extends  AbstractLexicalPreservingTest {
     @Test
     void addingStatement1() {
         considerStatement(
-                "        if(value != null) {" + SYSTEM_EOL +
-                        "            value.value();" + SYSTEM_EOL +
+                "        if(value != null) {" + LineSeparator.SYSTEM +
+                        "            value.value();" + LineSeparator.SYSTEM +
                         "        }");
 
-        CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(StaticJavaParser.parse("public class Test {" + SYSTEM_EOL +
-                "    public void method() {" + SYSTEM_EOL +
-                "           value1();" + SYSTEM_EOL +
-                "        value2(); // Test" + SYSTEM_EOL +
-                "    }" + SYSTEM_EOL +
+        CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(StaticJavaParser.parse("public class Test {" + LineSeparator.SYSTEM +
+                "    public void method() {" + LineSeparator.SYSTEM +
+                "           value1();" + LineSeparator.SYSTEM +
+                "        value2(); // Test" + LineSeparator.SYSTEM +
+                "    }" + LineSeparator.SYSTEM +
                 "}"));
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = (ClassOrInterfaceDeclaration)compilationUnit.getChildNodes().get(0);
         MethodDeclaration methodDeclaration = (MethodDeclaration)classOrInterfaceDeclaration.getChildNodes().get(2);
@@ -252,15 +253,15 @@ class TransformationsTest extends  AbstractLexicalPreservingTest {
     @Test
     void addingStatement2() {
         considerStatement(
-                "        if(value != null) {" + SYSTEM_EOL +
-                        "            value.value();" + SYSTEM_EOL +
+                "        if(value != null) {" + LineSeparator.SYSTEM +
+                        "            value.value();" + LineSeparator.SYSTEM +
                         "        }");
 
-        CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(StaticJavaParser.parse("public class Test {" + SYSTEM_EOL +
-                "    public void method() {" + SYSTEM_EOL +
-                "           value1();" + SYSTEM_EOL +
-                "        value2();" + SYSTEM_EOL +
-                "    }" + SYSTEM_EOL +
+        CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(StaticJavaParser.parse("public class Test {" + LineSeparator.SYSTEM +
+                "    public void method() {" + LineSeparator.SYSTEM +
+                "           value1();" + LineSeparator.SYSTEM +
+                "        value2();" + LineSeparator.SYSTEM +
+                "    }" + LineSeparator.SYSTEM +
                 "}"));
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = (ClassOrInterfaceDeclaration)compilationUnit.getChildNodes().get(0);
         MethodDeclaration methodDeclaration = (MethodDeclaration)classOrInterfaceDeclaration.getChildNodes().get(2);
@@ -282,15 +283,15 @@ class TransformationsTest extends  AbstractLexicalPreservingTest {
     @Test
     void addingStatement3() {
         considerStatement(
-                "        if(value != null) {" + SYSTEM_EOL +
-                        "            value.value();" + SYSTEM_EOL +
+                "        if(value != null) {" + LineSeparator.SYSTEM +
+                        "            value.value();" + LineSeparator.SYSTEM +
                         "        }");
 
-        CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(StaticJavaParser.parse("public class Test {" + SYSTEM_EOL +
-                "    public void method() {" + SYSTEM_EOL +
-                "           value1();" + SYSTEM_EOL +
-                "        value2();" + SYSTEM_EOL + SYSTEM_EOL +
-                "    }" + SYSTEM_EOL +
+        CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(StaticJavaParser.parse("public class Test {" + LineSeparator.SYSTEM +
+                "    public void method() {" + LineSeparator.SYSTEM +
+                "           value1();" + LineSeparator.SYSTEM +
+                "        value2();" + LineSeparator.SYSTEM + LineSeparator.SYSTEM +
+                "    }" + LineSeparator.SYSTEM +
                 "}"));
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = (ClassOrInterfaceDeclaration)compilationUnit.getChildNodes().get(0);
         MethodDeclaration methodDeclaration = (MethodDeclaration)classOrInterfaceDeclaration.getChildNodes().get(2);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/ArrayCreationLevelTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/ArrayCreationLevelTransformationsTest.java
@@ -28,7 +28,7 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
-import com.github.javaparser.utils.Utils;
+import com.github.javaparser.utils.LineSeparator;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -71,7 +71,7 @@ class ArrayCreationLevelTransformationsTest extends AbstractLexicalPreservingTes
     void addingAnnotation() {
         ArrayCreationLevel it = consider("[]");
         it.addAnnotation("myAnno");
-        assertTransformedToString("@myAnno"+ Utils.SYSTEM_EOL +"[]", it);
+        assertTransformedToString("@myAnno"+ LineSeparator.SYSTEM +"[]", it);
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/CompilationUnitTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/CompilationUnitTransformationsTest.java
@@ -24,9 +24,9 @@ package com.github.javaparser.printer.lexicalpreservation.transformations.ast;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
-import org.junit.jupiter.api.Test;
+import com.github.javaparser.utils.LineSeparator;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
+import org.junit.jupiter.api.Test;
 
 /**
  * Transforming CompilationUnit and verifying the LexicalPreservation works as expected.
@@ -39,7 +39,7 @@ class CompilationUnitTransformationsTest extends AbstractLexicalPreservingTest {
     void addingPackageDeclaration() {
         considerCode("class A {}");
         cu.setPackageDeclaration(new PackageDeclaration(new Name(new Name("foo"), "bar")));
-        assertTransformedToString("package foo.bar;"+ SYSTEM_EOL + SYSTEM_EOL + "class A {}", cu);
+        assertTransformedToString("package foo.bar;"+ LineSeparator.SYSTEM + LineSeparator.SYSTEM + "class A {}", cu);
     }
 
     @Test
@@ -54,7 +54,7 @@ class CompilationUnitTransformationsTest extends AbstractLexicalPreservingTest {
         considerCode("package foo.bar; class A {}");
         cu.setPackageDeclaration(new PackageDeclaration(new Name(new Name("foo2"), "baz")));
         assertTransformedToString("package foo2.baz;" +
-                SYSTEM_EOL + SYSTEM_EOL +
+                LineSeparator.SYSTEM + LineSeparator.SYSTEM +
                 " class A {}", cu);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
@@ -27,12 +27,13 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -115,7 +116,7 @@ class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPres
     void addingAnnotation() {
         AnnotationMemberDeclaration it = consider("int foo();");
         it.addAnnotation("myAnno");
-        assertTransformedToString("@myAnno" + SYSTEM_EOL + "int foo();", it);
+        assertTransformedToString("@myAnno" + LineSeparator.SYSTEM + "int foo();", it);
     }
 
     @Test
@@ -123,7 +124,7 @@ class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPres
         AnnotationMemberDeclaration it = consider("int foo();");
         it.addAnnotation("myAnno");
         it.addAnnotation("myAnno2");
-        assertTransformedToString("@myAnno" + SYSTEM_EOL + "@myAnno2" + SYSTEM_EOL + "int foo();", it);
+        assertTransformedToString("@myAnno" + LineSeparator.SYSTEM + "@myAnno2" + LineSeparator.SYSTEM + "int foo();", it);
     }
 
     @Test
@@ -135,7 +136,7 @@ class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void removingAnnotationOnPrevLine() {
-        AnnotationMemberDeclaration it = consider("@myAnno" + SYSTEM_EOL + "int foo();");
+        AnnotationMemberDeclaration it = consider("@myAnno" + LineSeparator.SYSTEM + "int foo();");
         it.getAnnotations().remove(0);
         assertTransformedToString("int foo();", it);
     }
@@ -153,7 +154,7 @@ class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPres
     void addingJavadoc() {
         AnnotationMemberDeclaration it = consider("int foo();");
         it.setJavadocComment("Cool this annotation!");
-        assertTransformedToString("@interface AD { /**Cool this annotation!*/" + SYSTEM_EOL +
+        assertTransformedToString("@interface AD { /**Cool this annotation!*/" + LineSeparator.SYSTEM +
                 "int foo(); }", it.getParentNode().get());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
@@ -28,13 +28,14 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 
 /**
  * Transforming ClassOrInterfaceDeclaration and verifying the LexicalPreservation works as expected.
@@ -169,7 +170,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
     void addingField() {
         ClassOrInterfaceDeclaration cid = consider("class A {}");
         cid.addField("int", "foo");
-        assertTransformedToString("class A {" + SYSTEM_EOL + "    int foo;" + SYSTEM_EOL + "}", cid);
+        assertTransformedToString("class A {" + LineSeparator.SYSTEM + "    int foo;" + LineSeparator.SYSTEM + "}", cid);
     }
 
     @Test
@@ -190,7 +191,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
     @Test
     void removingAnnotations() {
         ClassOrInterfaceDeclaration cid = consider(
-                "@Value" + SYSTEM_EOL +
+                "@Value" + LineSeparator.SYSTEM +
                 "public class A {}");
         cid.getAnnotationByName("Value").get().remove();
         assertTransformedToString("public class A {}", cid);
@@ -199,7 +200,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
     @Test
     void removingAnnotationsWithSpaces() {
         ClassOrInterfaceDeclaration cid = consider(
-                  "   @Value " + SYSTEM_EOL +
+                  "   @Value " + LineSeparator.SYSTEM +
                         "public class A {}");
         cid.getAnnotationByName("Value").get().remove();
         assertTransformedToString("public class A {}", cid);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/EnumDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/EnumDeclarationTransformationsTest.java
@@ -25,12 +25,13 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 
 /**
  * Transforming EnumDeclaration and verifying the LexicalPreservation works as expected.
@@ -78,13 +79,13 @@ class EnumDeclarationTransformationsTest extends AbstractLexicalPreservingTest {
 
     @Test
     void addingConstants() {
-        EnumDeclaration ed = consider("enum A {" + SYSTEM_EOL +
-                " E1" + SYSTEM_EOL +
+        EnumDeclaration ed = consider("enum A {" + LineSeparator.SYSTEM +
+                " E1" + LineSeparator.SYSTEM +
                 "}");
         ed.getEntries().addLast(new EnumConstantDeclaration("E2"));
-        assertTransformedToString("enum A {" + SYSTEM_EOL +
-                " E1," + SYSTEM_EOL +
-                " E2" + SYSTEM_EOL +
+        assertTransformedToString("enum A {" + LineSeparator.SYSTEM +
+                " E1," + LineSeparator.SYSTEM +
+                " E2" + LineSeparator.SYSTEM +
                 "}", ed);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/FieldDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/FieldDeclarationTransformationsTest.java
@@ -24,12 +24,13 @@ package com.github.javaparser.printer.lexicalpreservation.transformations.ast.bo
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 
 /**
  * Transforming FieldDeclaration and verifying the LexicalPreservation works as expected.
@@ -93,8 +94,8 @@ class FieldDeclarationTransformationsTest extends AbstractLexicalPreservingTest 
     // Annotations
     @Test
     void removingAnnotations() {
-        FieldDeclaration it = consider( SYSTEM_EOL +
-                "@Annotation" + SYSTEM_EOL +
+        FieldDeclaration it = consider( LineSeparator.SYSTEM +
+                "@Annotation" + LineSeparator.SYSTEM +
                 "public int A;");
         it.getAnnotationByName("Annotation").get().remove();
         assertTransformedToString("public int A;", it);
@@ -102,8 +103,8 @@ class FieldDeclarationTransformationsTest extends AbstractLexicalPreservingTest 
 
     @Test
     void removingAnnotationsWithSpaces() {
-        FieldDeclaration it = consider( SYSTEM_EOL +
-                "  @Annotation " + SYSTEM_EOL +
+        FieldDeclaration it = consider( LineSeparator.SYSTEM +
+                "  @Annotation " + LineSeparator.SYSTEM +
                 "public int A;");
         it.getAnnotationByName("Annotation").get().remove();
         assertTransformedToString("public int A;", it);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -36,6 +36,8 @@ import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import com.github.javaparser.utils.LineSeparator;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +47,6 @@ import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 
 /**
  * Transforming MethodDeclaration and verifying the LexicalPreservation works as expected.
@@ -72,21 +73,21 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void removingDuplicateJavaDocComment() {
         // Arrange
-        considerCode("public class MyClass {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void oneMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void anotherMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
+        considerCode("public class MyClass {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void oneMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void anotherMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
                 "}" +
-                SYSTEM_EOL);
+                LineSeparator.SYSTEM);
 
         MethodDeclaration methodDeclaration = cu.findAll(MethodDeclaration.class).get(1);
 
@@ -112,21 +113,21 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void replacingDuplicateJavaDocComment() {
         // Arrange
-        considerCode("public class MyClass {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void oneMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /**" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void anotherMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
+        considerCode("public class MyClass {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void oneMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /**" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void anotherMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
                 "}" +
-                SYSTEM_EOL);
+                LineSeparator.SYSTEM);
 
         MethodDeclaration methodDeclaration = cu.findAll(MethodDeclaration.class).get(1);
 
@@ -158,21 +159,21 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void removingDuplicateComment() {
         // Arrange
-        considerCode("public class MyClass {" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /*" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void oneMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
-                SYSTEM_EOL +
-                "  /*" + SYSTEM_EOL +
-                "   * Comment A" + SYSTEM_EOL +
-                "   */" + SYSTEM_EOL +
-                "  public void anotherMethod() {" + SYSTEM_EOL +
-                "  }" + SYSTEM_EOL +
+        considerCode("public class MyClass {" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /*" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void oneMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
+                LineSeparator.SYSTEM +
+                "  /*" + LineSeparator.SYSTEM +
+                "   * Comment A" + LineSeparator.SYSTEM +
+                "   */" + LineSeparator.SYSTEM +
+                "  public void anotherMethod() {" + LineSeparator.SYSTEM +
+                "  }" + LineSeparator.SYSTEM +
                 "}" +
-                SYSTEM_EOL);
+                LineSeparator.SYSTEM);
 
         MethodDeclaration methodDeclaration = cu.findAll(MethodDeclaration.class).get(1);
 
@@ -227,11 +228,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void removingModifiersWithExistingAnnotations() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Test" + SYSTEM_EOL +
-                        "  public void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Test" + LineSeparator.SYSTEM +
+                        "  public void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).setModifiers(new NodeList<>());
@@ -247,11 +248,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void removingModifiersWithExistingAnnotations_withVariableNumberOfSeparator() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Test" + SYSTEM_EOL +
-                        "  public      void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Test" + LineSeparator.SYSTEM +
+                        "  public      void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).setModifiers(new NodeList<>());
@@ -282,11 +283,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void replacingModifiersWithExistingAnnotations() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Test" + SYSTEM_EOL +
-                        "  public void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Test" + LineSeparator.SYSTEM +
+                        "  public void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).setModifiers(createModifierList(PROTECTED));
@@ -344,11 +345,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void addingToExistingAnnotations() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Test" + SYSTEM_EOL +
-                        "  public void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Test" + LineSeparator.SYSTEM +
+                        "  public void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).addSingleMemberAnnotation(
@@ -367,10 +368,10 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void addingAnnotationsNoModifiers() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).addMarkerAnnotation("Test");
@@ -388,11 +389,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void replacingAnnotations() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Override" + SYSTEM_EOL +
-                        "  public void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Override" + LineSeparator.SYSTEM +
+                        "  public void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).setAnnotations(new NodeList<>(new MarkerAnnotationExpr("Test")));
@@ -411,7 +412,7 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
         MethodDeclaration it = consider("void testMethod(){}");
         it.addMarkerAnnotation("Override");
         assertTransformedToString(
-                "@Override" + SYSTEM_EOL +
+                "@Override" + LineSeparator.SYSTEM +
                         "void testMethod(){}", it);
     }
 
@@ -422,11 +423,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void removingAnnotations() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Override" + SYSTEM_EOL +
-                        "  public void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Override" + LineSeparator.SYSTEM +
+                        "  public void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).getAnnotationByName("Override").get().remove();
@@ -443,11 +444,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     void removingAnnotationsWithSpaces() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Override " + SYSTEM_EOL +
-                        "  public void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Override " + LineSeparator.SYSTEM +
+                        "  public void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).getAnnotationByName("Override").get().remove();
@@ -470,11 +471,11 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     @Test
     public void addingModifiersWithExistingAnnotations() {
         considerCode(
-                "class X {" + SYSTEM_EOL +
-                        "  @Test" + SYSTEM_EOL +
-                        "  void testCase() {" + SYSTEM_EOL +
-                        "  }" + SYSTEM_EOL +
-                        "}" + SYSTEM_EOL
+                "class X {" + LineSeparator.SYSTEM +
+                        "  @Test" + LineSeparator.SYSTEM +
+                        "  void testCase() {" + LineSeparator.SYSTEM +
+                        "  }" + LineSeparator.SYSTEM +
+                        "}" + LineSeparator.SYSTEM
         );
 
         cu.getType(0).getMethods().get(0).addModifier(Modifier.finalModifier().getKeyword(), Modifier.publicModifier().getKeyword());
@@ -489,18 +490,18 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
 
     @Test
     public void parseAndPrintAnonymousClassExpression() {
-        Expression expression = parseExpression("new Object() {" + SYSTEM_EOL +
+        Expression expression = parseExpression("new Object() {" + LineSeparator.SYSTEM +
                 "}");
-         String expected = "new Object() {" + SYSTEM_EOL +
+         String expected = "new Object() {" + LineSeparator.SYSTEM +
                 "}";
         assertTransformedToString(expected, expression);
     }
 
     @Test
     public void parseAndPrintAnonymousClassStatement() {
-        Statement statement = parseStatement("Object anonymous = new Object() {" + SYSTEM_EOL +
+        Statement statement = parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM +
                 "};");
-        String expected = "Object anonymous = new Object() {" + SYSTEM_EOL +
+        String expected = "Object anonymous = new Object() {" + LineSeparator.SYSTEM +
                 "};";
         assertTransformedToString(expected, statement);
     }
@@ -509,16 +510,16 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     public void replaceBodyShouldNotBreakAnonymousClasses() {
         MethodDeclaration it = consider("public void method() { }");
         it.getBody().ifPresent(body -> {
-            Statement statement = parseStatement("Object anonymous = new Object() {" + SYSTEM_EOL +
+            Statement statement = parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM +
                     "};");
             NodeList<Statement> statements = new NodeList<>();
             statements.add(statement);
             body.setStatements(statements);
         });
 
-        String expected = "public void method() {" + SYSTEM_EOL +
-                "    Object anonymous = new Object() {" + SYSTEM_EOL +
-                "    };" + SYSTEM_EOL +
+        String expected = "public void method() {" + LineSeparator.SYSTEM +
+                "    Object anonymous = new Object() {" + LineSeparator.SYSTEM +
+                "    };" + LineSeparator.SYSTEM +
                 "}";
         assertTransformedToString(expected, it);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaToken.java
@@ -21,10 +21,11 @@
 package com.github.javaparser;
 
 import com.github.javaparser.ast.Generated;
+import com.github.javaparser.utils.LineSeparator;
+
 import java.util.List;
 import java.util.Optional;
 import static com.github.javaparser.utils.CodeGenerationUtils.f;
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -113,7 +114,7 @@ public class JavaToken {
             content = content.substring(1, content.length() - 1);
         }
         if (TokenTypes.isEndOfLineToken(kind)) {
-            content = SYSTEM_EOL;
+            content = LineSeparator.SYSTEM.asRawString();
         } else if (TokenTypes.isWhitespace(kind)) {
             content = " ";
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.github.javaparser.javadoc.description.JavadocDescription;
+import com.github.javaparser.utils.LineSeparator;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,18 +49,18 @@ class JavadocParser {
     }
 
     public static Javadoc parse(String commentContent) {
-        List<String> cleanLines = cleanLines(normalizeEolInTextBlock(commentContent, SYSTEM_EOL));
+        List<String> cleanLines = cleanLines(normalizeEolInTextBlock(commentContent, LineSeparator.SYSTEM));
         int indexOfFirstBlockTag = cleanLines.stream().filter(JavadocParser::isABlockLine).map(cleanLines::indexOf).findFirst().orElse(-1);
         List<String> blockLines;
         String descriptionText;
         if (indexOfFirstBlockTag == -1) {
-            descriptionText = trimRight(String.join(SYSTEM_EOL, cleanLines));
+            descriptionText = trimRight(String.join(LineSeparator.SYSTEM.asRawString(), cleanLines));
             blockLines = Collections.emptyList();
         } else {
-            descriptionText = trimRight(String.join(SYSTEM_EOL, cleanLines.subList(0, indexOfFirstBlockTag)));
+            descriptionText = trimRight(String.join(LineSeparator.SYSTEM.asRawString(), cleanLines.subList(0, indexOfFirstBlockTag)));
             // Combine cleaned lines, but only starting with the first block tag till the end
             // In this combined string it is easier to handle multiple lines which actually belong together
-            String tagBlock = cleanLines.subList(indexOfFirstBlockTag, cleanLines.size()).stream().collect(Collectors.joining(SYSTEM_EOL));
+            String tagBlock = cleanLines.subList(indexOfFirstBlockTag, cleanLines.size()).stream().collect(Collectors.joining(LineSeparator.SYSTEM.asRawString()));
             // Split up the entire tag back again, considering now that some lines belong to the same block tag.
             // The pattern splits the block at each new line starting with the '@' symbol, thus the symbol
             // then needs to be added again so that the block parsers handles everything correctly.
@@ -89,7 +90,7 @@ class JavadocParser {
     }
 
     private static List<String> cleanLines(String content) {
-        String[] lines = content.split(SYSTEM_EOL);
+        String[] lines = content.split(LineSeparator.SYSTEM.asRawString());
         if (lines.length == 0) {
             return Collections.emptyList();
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseProblemException.java
@@ -22,7 +22,8 @@ package com.github.javaparser;
 
 import java.util.List;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
+import com.github.javaparser.utils.LineSeparator;
+
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import static java.util.Collections.singletonList;
 
@@ -48,7 +49,7 @@ public class ParseProblemException extends RuntimeException {
     private static String createMessage(List<Problem> problems) {
         StringBuilder message = new StringBuilder();
         for (Problem problem : problems) {
-            message.append(problem.toString()).append(SYSTEM_EOL);
+            message.append(problem.toString()).append(LineSeparator.SYSTEM);
         }
         return message.toString();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParseResult.java
@@ -21,12 +21,11 @@
 package com.github.javaparser;
 
 import com.github.javaparser.ast.comments.CommentsCollection;
+import com.github.javaparser.utils.LineSeparator;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
-
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 
 /**
  * The results given when parsing with an instance of JavaParser.
@@ -100,9 +99,9 @@ public class ParseResult<T> {
         if (isSuccessful()) {
             return "Parsing successful";
         }
-        StringBuilder message = new StringBuilder("Parsing failed:").append(SYSTEM_EOL);
+        StringBuilder message = new StringBuilder("Parsing failed:").append(LineSeparator.SYSTEM);
         for (Problem problem : problems) {
-            message.append(problem.toString()).append(SYSTEM_EOL);
+            message.append(problem.toString()).append(LineSeparator.SYSTEM);
         }
         return message.toString();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/Problem.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/Problem.java
@@ -23,7 +23,8 @@ package com.github.javaparser;
 import java.util.Comparator;
 import java.util.Optional;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
+import com.github.javaparser.utils.LineSeparator;
+
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
 /**
@@ -48,12 +49,12 @@ public class Problem {
     public String toString() {
         final StringBuilder str = new StringBuilder(getVerboseMessage());
         if (cause != null) {
-            str.append(SYSTEM_EOL).append("Problem stacktrace : ").append(SYSTEM_EOL);
+            str.append(LineSeparator.SYSTEM).append("Problem stacktrace : ").append(LineSeparator.SYSTEM);
             for (int i = 0; i < cause.getStackTrace().length; i++) {
                 StackTraceElement ste = cause.getStackTrace()[i];
                 str.append("  ").append(ste.toString());
                 if (i + 1 != cause.getStackTrace().length)
-                    str.append(SYSTEM_EOL);
+                    str.append(LineSeparator.SYSTEM);
             }
         }
         return str.toString();

--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
@@ -22,11 +22,10 @@ package com.github.javaparser.javadoc;
 
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
+import com.github.javaparser.utils.LineSeparator;
 
 import java.util.LinkedList;
 import java.util.List;
-
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 
 /**
  * The structured content of a single Javadoc comment.
@@ -83,14 +82,14 @@ public class Javadoc {
         StringBuilder sb = new StringBuilder();
         if (!description.isEmpty()) {
             sb.append(description.toText());
-            sb.append(SYSTEM_EOL);
+            sb.append(LineSeparator.SYSTEM);
         }
         if (!blockTags.isEmpty()) {
-            sb.append(SYSTEM_EOL);
+            sb.append(LineSeparator.SYSTEM);
         }
         blockTags.forEach(bt -> {
             sb.append(bt.toText());
-            sb.append(SYSTEM_EOL);
+            sb.append(LineSeparator.SYSTEM);
         });
         return sb.toString();
     }
@@ -112,14 +111,14 @@ public class Javadoc {
             }
         }
         StringBuilder sb = new StringBuilder();
-        sb.append(SYSTEM_EOL);
+        sb.append(LineSeparator.SYSTEM);
         final String text = toText();
         if (!text.isEmpty()) {
-            for (String line : text.split(SYSTEM_EOL)) {
+            for (String line : text.split(LineSeparator.SYSTEM.asRawString())) {
                 sb.append(indentation);
                 sb.append(" * ");
                 sb.append(line);
-                sb.append(SYSTEM_EOL);
+                sb.append(LineSeparator.SYSTEM);
             }
         }
         sb.append(indentation);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DotPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DotPrinter.java
@@ -24,10 +24,10 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.metamodel.NodeMetaModel;
 import com.github.javaparser.metamodel.PropertyMetaModel;
+import com.github.javaparser.utils.LineSeparator;
 
 import java.util.List;
 
-import static com.github.javaparser.utils.Utils.SYSTEM_EOL;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import static java.util.stream.Collectors.toList;
 
@@ -49,7 +49,7 @@ public class DotPrinter {
         StringBuilder output = new StringBuilder();
         output.append("digraph {");
         output(node, null, "root", output);
-        output.append(SYSTEM_EOL + "}");
+        output.append(LineSeparator.SYSTEM + "}");
         return output.toString();
     }
 
@@ -62,15 +62,15 @@ public class DotPrinter {
         List<PropertyMetaModel> subLists = allPropertyMetaModels.stream().filter(PropertyMetaModel::isNodeList).collect(toList());
         String ndName = nextNodeName();
         if (outputNodeType)
-            builder.append(SYSTEM_EOL + ndName + " [label=\"" + escape(name) + " (" + metaModel.getTypeName() + ")\"];");
+            builder.append(LineSeparator.SYSTEM + ndName + " [label=\"" + escape(name) + " (" + metaModel.getTypeName() + ")\"];");
         else
-            builder.append(SYSTEM_EOL + ndName + " [label=\"" + escape(name) + "\"];");
+            builder.append(LineSeparator.SYSTEM + ndName + " [label=\"" + escape(name) + "\"];");
         if (parentNodeName != null)
-            builder.append(SYSTEM_EOL + parentNodeName + " -> " + ndName + ";");
+            builder.append(LineSeparator.SYSTEM + parentNodeName + " -> " + ndName + ";");
         for (PropertyMetaModel a : attributes) {
             String attrName = nextNodeName();
-            builder.append(SYSTEM_EOL + attrName + " [label=\"" + escape(a.getName()) + "='" + escape(a.getValue(node).toString()) + "'\"];");
-            builder.append(SYSTEM_EOL + ndName + " -> " + attrName + ";");
+            builder.append(LineSeparator.SYSTEM + attrName + " [label=\"" + escape(a.getName()) + "='" + escape(a.getValue(node).toString()) + "'\"];");
+            builder.append(LineSeparator.SYSTEM + ndName + " -> " + attrName + ";");
         }
         for (PropertyMetaModel sn : subNodes) {
             Node nd = (Node) sn.getValue(node);
@@ -81,8 +81,8 @@ public class DotPrinter {
             NodeList<? extends Node> nl = (NodeList<? extends Node>) sl.getValue(node);
             if (nl != null && nl.isNonEmpty()) {
                 String ndLstName = nextNodeName();
-                builder.append(SYSTEM_EOL + ndLstName + " [label=\"" + escape(sl.getName()) + "\"];");
-                builder.append(SYSTEM_EOL + ndName + " -> " + ndLstName + ";");
+                builder.append(LineSeparator.SYSTEM + ndLstName + " [label=\"" + escape(sl.getName()) + "\"];");
+                builder.append(LineSeparator.SYSTEM + ndName + " -> " + ndLstName + ";");
                 String slName = sl.getName().substring(0, sl.getName().length() - 1);
                 for (Node nd : nl) output(nd, ndLstName, slName, builder);
             }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
@@ -106,11 +106,8 @@ public class DefaultPrinterConfiguration implements PrinterConfiguration {
         }
 
         // DefaultConfigurationOption with initial currentValue
-        ConfigOption(Class clazz, Object value) {
+        <T> ConfigOption(Class<T> clazz, T value) {
             this.type = clazz;
-            if (!(this.type.isAssignableFrom(value.getClass()))) {
-                throw new IllegalArgumentException(String.format("%s is not an instance of %s", value, type.getName()));
-            }
             this.defaultValue = value;
         }
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
@@ -21,7 +21,7 @@ package com.github.javaparser.printer.configuration;
 
 import com.github.javaparser.printer.Printer;
 import com.github.javaparser.printer.configuration.Indentation.IndentType;
-import com.github.javaparser.utils.Utils;
+import com.github.javaparser.utils.LineSeparator;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -90,7 +90,7 @@ public class DefaultPrinterConfiguration implements PrinterConfiguration {
          * Set it to 1 or less to always align vertically.
          */
         MAX_ENUM_CONSTANTS_TO_ALIGN_HORIZONTALLY(Integer.class, Integer.valueOf(5)),
-        END_OF_LINE_CHARACTER(String.class, Utils.SYSTEM_EOL),
+        END_OF_LINE_CHARACTER(String.class, LineSeparator.SYSTEM.asRawString()),
         /**
          * Indentation proprerty
          */

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -45,14 +45,6 @@ public class Utils {
     @Deprecated
     public static final String EOL = LineSeparator.SYSTEM.asRawString();
 
-    /**
-     * @deprecated Renamed from {@link #EOL} to make it explicit that we're using the system's line separator.
-     *             New code should use {@link LineSeparator#SYSTEM} if referring to the current host system's line separator,
-     *              else {@link LineSeparator#CR} or {@link LineSeparator#LF} or {@link LineSeparator#CRLF} if referring to a specific style of line separator.
-     */
-    @Deprecated
-    public static final String SYSTEM_EOL = LineSeparator.SYSTEM.asRawString();
-
     public static <E> boolean isNullOrEmpty(Collection<E> collection) {
         return collection == null || collection.isEmpty();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -37,14 +37,6 @@ import com.github.javaparser.ast.expr.UnaryExpr;
  */
 public class Utils {
 
-    /**
-     * // TODO: Replace this within the internal codebase.
-     * @deprecated New code should use {@link LineSeparator#SYSTEM} if referring to the current host system's line separator,
-     *  else {@link LineSeparator#CR} or {@link LineSeparator#LF} or {@link LineSeparator#CRLF} if referring to a specific style of line separator.
-     */
-    @Deprecated
-    public static final String EOL = LineSeparator.SYSTEM.asRawString();
-
     public static <E> boolean isNullOrEmpty(Collection<E> collection) {
         return collection == null || collection.isEmpty();
     }


### PR DESCRIPTION
The first commit fixes the warnings themselves.
The next commit replaces a runtime check by a compile time check to solve an issue discovered while fixing the warnings (see commit description for details).
The last two commits remove the SYSTEM_EOL and EOL deprecated constants, since they are not used anymore.

If the constants should remain there for retrocompatibility, you can ignore the two last commits. I would however suggest to explicitly mention in their Javadoc that they should be removed in the future (preferably by telling the target version for removal, like the next major version or any precise reference).