### PR TITLE
Fix missed generated code from PatternExpr refactor

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/PatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/PatternExpr.java
@@ -31,8 +31,8 @@ import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.PatternExprMetaModel;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.TokenRange;
-
 import static com.github.javaparser.utils.Utils.assertNotNull;
+import com.github.javaparser.ast.Node;
 
 /**
  * <h1>Pattern Matching in Java</h1>
@@ -135,5 +135,26 @@ public abstract class PatternExpr extends Expression implements NodeWithType<Pat
     @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
     public ReferenceType getType() {
         return type;
+    }
+
+    @Override
+    public boolean replace(Node node, Node replacementNode) {
+        if (node == null) {
+            return false;
+        }
+        if (node == type) {
+            setType((ReferenceType) replacementNode);
+            return true;
+        }
+        return super.replace(node, replacementNode);
+    }
+
+    /**
+     * This constructor is used by the parser and is considered private.
+     */
+    public PatternExpr(TokenRange tokenRange, ReferenceType type) {
+        super(tokenRange);
+        setType(type);
+        customInitialization();
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypePatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypePatternExpr.java
@@ -70,7 +70,7 @@ import com.github.javaparser.metamodel.TypePatternExprMetaModel;
  * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8181287">JEP305: https://bugs.openjdk.java.net/browse/JDK-8181287</a>
  * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.20">https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.20</a>
  */
-public class TypePatternExpr extends PatternExpr implements NodeWithSimpleName<TypePatternExpr>,  NodeWithFinalModifier<TypePatternExpr> {
+public class TypePatternExpr extends PatternExpr implements NodeWithSimpleName<TypePatternExpr>, NodeWithFinalModifier<TypePatternExpr> {
 
     private NodeList<Modifier> modifiers;
 
@@ -90,9 +90,8 @@ public class TypePatternExpr extends PatternExpr implements NodeWithSimpleName<T
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
     public TypePatternExpr(TokenRange tokenRange, NodeList<Modifier> modifiers, ReferenceType type, SimpleName name) {
-        super(tokenRange);
+        super(tokenRange, type);
         setModifiers(modifiers);
-        setType(type);
         setName(name);
         customInitialization();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -578,7 +578,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     @Override
     public Visitable visit(final InstanceOfExpr n, final A arg) {
         Expression expression = (Expression) n.getExpression().accept(this, arg);
-        TypePatternExpr pattern = n.getPattern().map(s -> (TypePatternExpr) s.accept(this, arg)).orElse(null);
+        PatternExpr pattern = n.getPattern().map(s -> (PatternExpr) s.accept(this, arg)).orElse(null);
         ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (expression == null || type == null)

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -203,6 +203,7 @@ public final class JavaParserMetaModel {
         objectCreationExprMetaModel.getConstructorParameters().add(objectCreationExprMetaModel.typeArgumentsPropertyMetaModel);
         objectCreationExprMetaModel.getConstructorParameters().add(objectCreationExprMetaModel.argumentsPropertyMetaModel);
         objectCreationExprMetaModel.getConstructorParameters().add(objectCreationExprMetaModel.anonymousClassBodyPropertyMetaModel);
+        patternExprMetaModel.getConstructorParameters().add(patternExprMetaModel.typePropertyMetaModel);
         singleMemberAnnotationExprMetaModel.getConstructorParameters().add(annotationExprMetaModel.namePropertyMetaModel);
         singleMemberAnnotationExprMetaModel.getConstructorParameters().add(singleMemberAnnotationExprMetaModel.memberValuePropertyMetaModel);
         simpleNameMetaModel.getConstructorParameters().add(simpleNameMetaModel.identifierPropertyMetaModel);
@@ -213,7 +214,7 @@ public final class JavaParserMetaModel {
         thisExprMetaModel.getConstructorParameters().add(thisExprMetaModel.typeNamePropertyMetaModel);
         typeExprMetaModel.getConstructorParameters().add(typeExprMetaModel.typePropertyMetaModel);
         typePatternExprMetaModel.getConstructorParameters().add(typePatternExprMetaModel.modifiersPropertyMetaModel);
-        typePatternExprMetaModel.getConstructorParameters().add(typePatternExprMetaModel.typePropertyMetaModel);
+        typePatternExprMetaModel.getConstructorParameters().add(patternExprMetaModel.typePropertyMetaModel);
         typePatternExprMetaModel.getConstructorParameters().add(typePatternExprMetaModel.namePropertyMetaModel);
         unaryExprMetaModel.getConstructorParameters().add(unaryExprMetaModel.expressionPropertyMetaModel);
         unaryExprMetaModel.getConstructorParameters().add(unaryExprMetaModel.operatorPropertyMetaModel);
@@ -614,7 +615,7 @@ public final class JavaParserMetaModel {
         fieldAccessExprMetaModel.getDerivedPropertyMetaModels().add(fieldAccessExprMetaModel.usingDiamondOperatorPropertyMetaModel);
         instanceOfExprMetaModel.expressionPropertyMetaModel = new PropertyMetaModel(instanceOfExprMetaModel, "expression", com.github.javaparser.ast.expr.Expression.class, Optional.of(expressionMetaModel), false, false, false, false);
         instanceOfExprMetaModel.getDeclaredPropertyMetaModels().add(instanceOfExprMetaModel.expressionPropertyMetaModel);
-        instanceOfExprMetaModel.patternPropertyMetaModel = new PropertyMetaModel(instanceOfExprMetaModel, "pattern", com.github.javaparser.ast.expr.TypePatternExpr.class, Optional.of(typePatternExprMetaModel), true, false, false, false);
+        instanceOfExprMetaModel.patternPropertyMetaModel = new PropertyMetaModel(instanceOfExprMetaModel, "pattern", com.github.javaparser.ast.expr.PatternExpr.class, Optional.of(patternExprMetaModel), true, false, false, false);
         instanceOfExprMetaModel.getDeclaredPropertyMetaModels().add(instanceOfExprMetaModel.patternPropertyMetaModel);
         instanceOfExprMetaModel.typePropertyMetaModel = new PropertyMetaModel(instanceOfExprMetaModel, "type", com.github.javaparser.ast.type.ReferenceType.class, Optional.of(referenceTypeMetaModel), false, false, false, false);
         instanceOfExprMetaModel.getDeclaredPropertyMetaModels().add(instanceOfExprMetaModel.typePropertyMetaModel);
@@ -668,6 +669,8 @@ public final class JavaParserMetaModel {
         objectCreationExprMetaModel.getDeclaredPropertyMetaModels().add(objectCreationExprMetaModel.typeArgumentsPropertyMetaModel);
         objectCreationExprMetaModel.usingDiamondOperatorPropertyMetaModel = new PropertyMetaModel(objectCreationExprMetaModel, "usingDiamondOperator", boolean.class, Optional.empty(), false, false, false, false);
         objectCreationExprMetaModel.getDerivedPropertyMetaModels().add(objectCreationExprMetaModel.usingDiamondOperatorPropertyMetaModel);
+        patternExprMetaModel.typePropertyMetaModel = new PropertyMetaModel(patternExprMetaModel, "type", com.github.javaparser.ast.type.ReferenceType.class, Optional.of(referenceTypeMetaModel), false, false, false, false);
+        patternExprMetaModel.getDeclaredPropertyMetaModels().add(patternExprMetaModel.typePropertyMetaModel);
         singleMemberAnnotationExprMetaModel.memberValuePropertyMetaModel = new PropertyMetaModel(singleMemberAnnotationExprMetaModel, "memberValue", com.github.javaparser.ast.expr.Expression.class, Optional.of(expressionMetaModel), false, false, false, false);
         singleMemberAnnotationExprMetaModel.getDeclaredPropertyMetaModels().add(singleMemberAnnotationExprMetaModel.memberValuePropertyMetaModel);
         simpleNameMetaModel.identifierPropertyMetaModel = new PropertyMetaModel(simpleNameMetaModel, "identifier", java.lang.String.class, Optional.empty(), false, true, false, false);
@@ -686,8 +689,6 @@ public final class JavaParserMetaModel {
         typePatternExprMetaModel.getDeclaredPropertyMetaModels().add(typePatternExprMetaModel.modifiersPropertyMetaModel);
         typePatternExprMetaModel.namePropertyMetaModel = new PropertyMetaModel(typePatternExprMetaModel, "name", com.github.javaparser.ast.expr.SimpleName.class, Optional.of(simpleNameMetaModel), false, false, false, false);
         typePatternExprMetaModel.getDeclaredPropertyMetaModels().add(typePatternExprMetaModel.namePropertyMetaModel);
-        typePatternExprMetaModel.typePropertyMetaModel = new PropertyMetaModel(typePatternExprMetaModel, "type", com.github.javaparser.ast.type.ReferenceType.class, Optional.of(referenceTypeMetaModel), false, false, false, false);
-        typePatternExprMetaModel.getDeclaredPropertyMetaModels().add(typePatternExprMetaModel.typePropertyMetaModel);
         unaryExprMetaModel.expressionPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "expression", com.github.javaparser.ast.expr.Expression.class, Optional.of(expressionMetaModel), false, false, false, false);
         unaryExprMetaModel.getDeclaredPropertyMetaModels().add(unaryExprMetaModel.expressionPropertyMetaModel);
         unaryExprMetaModel.operatorPropertyMetaModel = new PropertyMetaModel(unaryExprMetaModel, "operator", com.github.javaparser.ast.expr.UnaryExpr.Operator.class, Optional.empty(), false, false, false, false);

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/PatternExprMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/PatternExprMetaModel.java
@@ -46,4 +46,6 @@ public class PatternExprMetaModel extends ExpressionMetaModel {
     protected PatternExprMetaModel(Optional<BaseNodeMetaModel> superNodeMetaModel, Class<? extends Node> type, String name, String packageName, boolean isAbstract, boolean hasWildcard) {
         super(superNodeMetaModel, type, name, packageName, isAbstract, hasWildcard);
     }
+
+    public PropertyMetaModel typePropertyMetaModel;
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/SwitchEntryMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/SwitchEntryMetaModel.java
@@ -51,7 +51,5 @@ public class SwitchEntryMetaModel extends NodeMetaModel {
 
     public PropertyMetaModel typePropertyMetaModel;
 
-    public PropertyMetaModel guardedEntryPropertyMetaModel;
-
     public PropertyMetaModel switchStatementEntryPropertyMetaModel;
 }


### PR DESCRIPTION
While working on the `RecordPatternExpr` feature, I noticed that I missed some generated code while filtering style changes from actual changes in https://github.com/javaparser/javaparser/pull/4387. For this PR, I just re-ran the core metamodel generator and core generators again and added the relevant changes.

I would like to draw attention to my reformatting proposal (see https://github.com/javaparser/javaparser/issues/4408) as well. I understand that reformatting the entire project is not a decision to be taken lightly, but I think it is important to prevent mistakes like these while also making contributions easier. The approach I mentioned in the issue is of course just one approach and I'm open to any suggestions on how to improve it. Even if that approach isn't chosen, I hope that my ideas on how to minimise the impact of such a change are of some use.