### PR TITLE
Fix: <enum>::values() is a static method, was not static

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -387,7 +387,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
 
         @Override
         public boolean isStatic() {
-            return false;
+            return true;
         }
 
         @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
@@ -157,4 +157,35 @@ class EnumResolutionTest extends AbstractResolutionTest {
         assertEquals("java.lang.String", rd.getParam(0).describeType());
     }
 
+    @Test
+    public void testResolveValuesMethod() {
+        String s =
+                "public class ClassTest {\n" +
+                "    public enum SecurityPolicyScopedTemplatesKeys {\n" +
+                "        SUSPICIOUS(\"suspicious\");\n" +
+                "        private String displayName;\n" +
+                "\n" +
+                "        private SecurityPolicyScopedTemplatesKeys(String displayName) {\n" +
+                "            this.displayName = displayName;\n" +
+                "        }\n" +
+                "\n" +
+                "        public String getDisplayName() {\n" +
+                "            return this.displayName;\n" +
+                "        }\n" +
+                "    }\n" +
+                "\n" +
+                "    public SecurityPolicyScopedTemplatesKeys m(int id) {\n" +
+                "        return SecurityPolicyScopedTemplatesKeys.values()[id];\n" +
+                "    }\n" +
+                "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(s);
+        MethodCallExpr methodCallExpr = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rd = methodCallExpr.resolve();
+        assertEquals("values", rd.getName());
+        assertEquals("ClassTest.SecurityPolicyScopedTemplatesKeys[]", rd.getReturnType().describe());
+        assertTrue(rd.isStatic());
+    }
+
 }


### PR DESCRIPTION
Hi everyone,

while working with enums, I noticed that javaparser recognices <enum>::values() as a not static method.

This pull request fixes this bug and adds an additional test.

Best regards
Kim
