### PR TITLE
Refactor: Do some missed Pattern to TypePattern renamings

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedDeclaration.java
@@ -63,7 +63,7 @@ public interface ResolvedDeclaration extends AssociableToAST {
     /**
      * Does this declaration represents a pattern declaration?
      */
-    default boolean isPattern() {
+    default boolean isTypePattern() {
         return false;
     }
 
@@ -128,7 +128,7 @@ public interface ResolvedDeclaration extends AssociableToAST {
     /**
      * Return this as a PatternDeclaration or throw an UnsupportedOperationException
      */
-    default ResolvedPatternDeclaration asPattern() {
+    default ResolvedTypePatternDeclaration asTypePattern() {
         throw new UnsupportedOperationException(String.format("%s is not a Pattern", this));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypePatternDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedTypePatternDeclaration.java
@@ -23,22 +23,22 @@ package com.github.javaparser.resolution.declarations;
 import com.github.javaparser.ast.expr.TypePatternExpr;
 
 /**
- * Declaration of a pattern expression.
+ * Declaration of a type pattern expression.
  * <p>
  * WARNING: Implemented fairly blindly. Unsure if required or even appropriate. Use with extreme caution.
  *
  * @author Roger Howell
  * @see TypePatternExpr
  */
-public interface ResolvedPatternDeclaration extends ResolvedValueDeclaration {
+public interface ResolvedTypePatternDeclaration extends ResolvedValueDeclaration {
 
     @Override
-    default boolean isPattern() {
+    default boolean isTypePattern() {
         return true;
     }
 
     @Override
-    default ResolvedPatternDeclaration asPattern() {
+    default ResolvedTypePatternDeclaration asTypePattern() {
         return this;
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -166,7 +166,7 @@ public class JavaParserFactory {
             return new ParameterSymbolDeclarator((Parameter) node, typeSolver);
         }
         if (node instanceof TypePatternExpr) {
-            return new PatternSymbolDeclarator((TypePatternExpr) node, typeSolver);
+            return new TypePatternSymbolDeclarator((TypePatternExpr) node, typeSolver);
         }
         if (node instanceof ExpressionStmt) {
             ExpressionStmt expressionStmt = (ExpressionStmt) node;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -38,7 +38,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.core.resolution.TypeVariableResolutionCapability;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserPatternDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypePatternDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 
 /**
@@ -154,7 +154,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             if (localResolutionResults.isPresent() && localResolutionResults.get().isTypePatternExpr()) {
                 if (typePatternExprs.size() == 1) {
                     TypePatternExpr typePatternExpr = localResolutionResults.get().asTypePatternExpr();
-                    JavaParserPatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
+                    JavaParserTypePatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
                     return SymbolReference.solved(decl);
                 }
                 if(typePatternExprs.size() > 1) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/InstanceOfExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/InstanceOfExprContext.java
@@ -27,7 +27,7 @@ import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserPatternDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypePatternDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 
 import java.util.ArrayList;
@@ -50,7 +50,7 @@ public class InstanceOfExprContext extends AbstractJavaParserContext<InstanceOfE
         if(optionalPatternExpr.isPresent() && (optionalPatternExpr.get().isTypePatternExpr())) {
             TypePatternExpr typePatternExpr = optionalPatternExpr.get().asTypePatternExpr();
             if(typePatternExpr.getNameAsString().equals(name)) {
-                JavaParserPatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
+                JavaParserTypePatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
                 return SymbolReference.solved(decl);
             }
         }
@@ -66,7 +66,7 @@ public class InstanceOfExprContext extends AbstractJavaParserContext<InstanceOfE
             Optional<PatternExpr> optionalPatternExpr1 = parentContext.patternExprInScope(name);
             if(optionalPatternExpr1.isPresent() && (optionalPatternExpr1.get().isTypePatternExpr())) {
                 TypePatternExpr typePatternExpr = optionalPatternExpr1.get().asTypePatternExpr();
-                JavaParserPatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
+                JavaParserTypePatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
                 return SymbolReference.solved(decl);
             }
         } // TODO: Also consider unary expr context

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/SwitchEntryContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/SwitchEntryContext.java
@@ -36,7 +36,7 @@ import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserPatternDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypePatternDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 
 import java.util.List;
@@ -86,7 +86,7 @@ public class SwitchEntryContext extends AbstractJavaParserContext<SwitchEntry> {
 
             TypePatternExpr typePatternExpr = e.asTypePatternExpr();
             if (typePatternExpr.getNameAsString().equals(name)) {
-                JavaParserPatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
+                JavaParserTypePatternDeclaration decl = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
                 return SymbolReference.solved(decl);
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclaration.java
@@ -50,8 +50,8 @@ public final class JavaParserSymbolDeclaration {
         return new JavaParserVariableDeclaration(variableDeclarator, typeSolver);
     }
 
-    public static JavaParserPatternDeclaration patternVar(TypePatternExpr typePatternExpr, TypeSolver typeSolver) {
-        return new JavaParserPatternDeclaration(typePatternExpr, typeSolver);
+    public static JavaParserTypePatternDeclaration patternVar(TypePatternExpr typePatternExpr, TypeSolver typeSolver) {
+        return new JavaParserTypePatternDeclaration(typePatternExpr, typeSolver);
     }
 
     public static int getParamPos(Parameter parameter) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclaration.java
@@ -24,7 +24,7 @@ package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedPatternDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypePatternDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 
@@ -35,7 +35,7 @@ import java.util.Optional;
  *
  * @author Roger Howell
  */
-public class JavaParserTypePatternDeclaration implements ResolvedPatternDeclaration {
+public class JavaParserTypePatternDeclaration implements ResolvedTypePatternDeclaration {
 
     private final TypePatternExpr wrappedNode;
     private final TypeSolver typeSolver;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclaration.java
@@ -35,12 +35,12 @@ import java.util.Optional;
  *
  * @author Roger Howell
  */
-public class JavaParserPatternDeclaration implements ResolvedPatternDeclaration {
+public class JavaParserTypePatternDeclaration implements ResolvedPatternDeclaration {
 
     private final TypePatternExpr wrappedNode;
     private final TypeSolver typeSolver;
 
-    public JavaParserPatternDeclaration(TypePatternExpr wrappedNode, TypeSolver typeSolver) {
+    public JavaParserTypePatternDeclaration(TypePatternExpr wrappedNode, TypeSolver typeSolver) {
         this.wrappedNode = wrappedNode;
         this.typeSolver = typeSolver;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarators/TypePatternSymbolDeclarator.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarators/TypePatternSymbolDeclarator.java
@@ -32,9 +32,9 @@ import java.util.List;
 /**
  * @author Roger Howell
  */
-public class PatternSymbolDeclarator extends AbstractSymbolDeclarator<TypePatternExpr> {
+public class TypePatternSymbolDeclarator extends AbstractSymbolDeclarator<TypePatternExpr> {
 
-    public PatternSymbolDeclarator(TypePatternExpr wrappedNode, TypeSolver typeSolver) {
+    public TypePatternSymbolDeclarator(TypePatternExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
     }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionPatternDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionPatternDeclaration.java
@@ -22,7 +22,7 @@
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedPatternDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypePatternDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 
 /**
@@ -30,7 +30,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
  *
  * @author Roger Howell
  */
-public class ReflectionPatternDeclaration implements ResolvedPatternDeclaration {
+public class ReflectionPatternDeclaration implements ResolvedTypePatternDeclaration {
 
     private Class<?> type;
     private TypeSolver typeSolver;
@@ -68,7 +68,7 @@ public class ReflectionPatternDeclaration implements ResolvedPatternDeclaration 
     }
 
     @Override
-    public boolean isPattern() {
+    public boolean isTypePattern() {
         return true;
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/resolution/declarations/ResolvedDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/resolution/declarations/ResolvedDeclarationTest.java
@@ -68,10 +68,10 @@ public interface ResolvedDeclarationTest extends AssociableToASTTest {
     @Test
     default void whenDeclarationIsAPatternTheCallToTheMethodAsPatternShouldNotThrow() {
         ResolvedDeclaration resolvedDeclaration = createValue();
-        if (resolvedDeclaration.isPattern())
-            assertDoesNotThrow(resolvedDeclaration::asPattern);
+        if (resolvedDeclaration.isTypePattern())
+            assertDoesNotThrow(resolvedDeclaration::asTypePattern);
         else
-            assertThrows(UnsupportedOperationException.class, resolvedDeclaration::asPattern);
+            assertThrows(UnsupportedOperationException.class, resolvedDeclaration::asTypePattern);
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/resolution/declarations/ResolvedTypePatternDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/resolution/declarations/ResolvedTypePatternDeclarationTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public interface ResolvedPatternDeclarationTest extends ResolvedValueDeclarationTest {
+public interface ResolvedTypePatternDeclarationTest extends ResolvedValueDeclarationTest {
 
     @Override
     ResolvedPatternDeclaration createValue();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/resolution/declarations/ResolvedTypePatternDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/resolution/declarations/ResolvedTypePatternDeclarationTest.java
@@ -28,11 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public interface ResolvedTypePatternDeclarationTest extends ResolvedValueDeclarationTest {
 
     @Override
-    ResolvedPatternDeclaration createValue();
+    ResolvedTypePatternDeclaration createValue();
 
     @Test
     default void resolvedPatternShouldBeMarkedAsPattern() {
-        assertTrue(createValue().isPattern());
+        assertTrue(createValue().isTypePattern());
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserPatternDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserPatternDeclarationTest.java
@@ -44,16 +44,16 @@ class JavaParserPatternDeclarationTest implements ResolvedPatternDeclarationTest
     @Override
     public Optional<Node> getWrappedDeclaration(AssociableToAST associableToAST) {
         return Optional.of(
-                safeCast(associableToAST, JavaParserPatternDeclaration.class).getWrappedNode()
+                safeCast(associableToAST, JavaParserTypePatternDeclaration.class).getWrappedNode()
         );
     }
 
     @Override
-    public JavaParserPatternDeclaration createValue() {
+    public JavaParserTypePatternDeclaration createValue() {
         TypePatternExpr wrappedNode = StaticJavaParser.parse("class A {a() {if (object instanceof String d) return;}}")
                 .findFirst(TypePatternExpr.class).get();
         ReflectionTypeSolver typeSolver = new ReflectionTypeSolver();
-        return new JavaParserPatternDeclaration(wrappedNode, typeSolver);
+        return new JavaParserTypePatternDeclaration(wrappedNode, typeSolver);
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclarationTest.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedTypePatternDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.Test;
@@ -81,15 +82,15 @@ class JavaParserSymbolDeclarationTest {
     /**
      * Try to create a pattern variable using {@link JavaParserSymbolDeclaration#patternVar(TypePatternExpr, TypeSolver)} and check
      * if the returned declaration is marked as a pattern and can be converted to a
-     * {@link com.github.javaparser.resolution.declarations.ResolvedPatternDeclaration} using {@link ResolvedValueDeclaration#asPattern()}.
+     * {@link ResolvedTypePatternDeclaration} using {@link ResolvedValueDeclaration#asTypePattern()}.
      */
     @Test
     void createdPatternVariableShouldBeMarkedAsPatternVar() {
         TypePatternExpr typePatternExpr = new TypePatternExpr();
         ResolvedValueDeclaration patternVar = JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver);
 
-        assertTrue(patternVar.isPattern());
-        assertDoesNotThrow(patternVar::asPattern);
+        assertTrue(patternVar.isTypePattern());
+        assertDoesNotThrow(patternVar::asTypePattern);
     }
 
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclarationTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.BeforeAll;
 
 import java.util.Optional;
 
-class JavaParserPatternDeclarationTest implements ResolvedPatternDeclarationTest {
+class JavaParserTypePatternDeclarationTest implements ResolvedPatternDeclarationTest {
 
     @BeforeAll
     public static void setup() {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypePatternDeclarationTest.java
@@ -26,14 +26,14 @@ import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.resolution.declarations.AssociableToAST;
-import com.github.javaparser.resolution.declarations.ResolvedPatternDeclarationTest;
+import com.github.javaparser.resolution.declarations.ResolvedTypePatternDeclarationTest;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.Optional;
 
-class JavaParserTypePatternDeclarationTest implements ResolvedPatternDeclarationTest {
+class JavaParserTypePatternDeclarationTest implements ResolvedTypePatternDeclarationTest {
 
     @BeforeAll
     public static void setup() {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -1300,9 +1300,9 @@ class ContextTest extends AbstractSymbolResolutionTest {
                 assertTrue(symbolReference.isSolved(), "symbol not solved");
                 ResolvedDeclaration correspondingDeclaration = symbolReference.getCorrespondingDeclaration();
                 assertEquals("s", correspondingDeclaration.getName(), "unexpected name for the solved symbol");
-                assertTrue(correspondingDeclaration.isPattern());
-                assertEquals("s", correspondingDeclaration.asPattern().getName(), "unexpected name for the solved pattern");
-                assertEquals("java.lang.String", correspondingDeclaration.asPattern().getType().asReferenceType().getQualifiedName(), "unexpected type for the solved pattern");
+                assertTrue(correspondingDeclaration.isTypePattern());
+                assertEquals("s", correspondingDeclaration.asTypePattern().getName(), "unexpected name for the solved pattern");
+                assertEquals("java.lang.String", correspondingDeclaration.asTypePattern().getType().asReferenceType().getQualifiedName(), "unexpected type for the solved pattern");
 
             }
 
@@ -1369,7 +1369,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
 
                     SymbolReference<? extends ResolvedValueDeclaration> s = context.solveSymbol("s");
                     assertTrue(s.isSolved());
-                    assertTrue(s.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s.getCorrespondingDeclaration().isTypePattern());
                 }
 
                 @Test
@@ -1389,7 +1389,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
 
                     SymbolReference<? extends ResolvedValueDeclaration> s = context.solveSymbol("s");
                     assertTrue(s.isSolved());
-                    assertTrue(s.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s.getCorrespondingDeclaration().isTypePattern());
                 }
 
                 @Test
@@ -1452,7 +1452,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
                     Context context_list = JavaParserFactory.getContext(methodCallExpr_list, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_list = context_list.solveSymbol("s");
                     assertTrue(s_list.isSolved());
-                    assertFalse(s_list.getCorrespondingDeclaration().isPattern());
+                    assertFalse(s_list.getCorrespondingDeclaration().isTypePattern());
 //                    assertTrue(s_list.getCorrespondingDeclaration().isVariable()); // Should pass but seemingly not implemented/overridden, perhaps?
 
                     // The second one should resolve to the pattern variable (the string).
@@ -1460,7 +1460,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
                     Context context_string = JavaParserFactory.getContext(methodCallExpr_string, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_string = context_string.solveSymbol("s");
                     assertTrue(s_string.isSolved());
-                    assertTrue(s_string.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s_string.getCorrespondingDeclaration().isTypePattern());
                 }
 
                 @Test
@@ -1489,7 +1489,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
                     Context context_list = JavaParserFactory.getContext(methodCallExpr_list, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_list = context_list.solveSymbol("s");
                     assertTrue(s_list.isSolved());
-                    assertFalse(s_list.getCorrespondingDeclaration().isPattern());
+                    assertFalse(s_list.getCorrespondingDeclaration().isTypePattern());
 //                    assertTrue(s_list.getCorrespondingDeclaration().isVariable()); // Should pass but seemingly not implemented/overridden, perhaps?
 
                     // The second one should resolve to the pattern variable (the string).
@@ -1497,21 +1497,21 @@ class ContextTest extends AbstractSymbolResolutionTest {
                     Context context_string = JavaParserFactory.getContext(methodCallExpr_string, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_string = context_string.solveSymbol("s");
                     assertTrue(s_string.isSolved());
-                    assertTrue(s_string.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s_string.getCorrespondingDeclaration().isTypePattern());
 
                     // The third one should resolve to the pattern variable (the string).
                     MethodCallExpr methodCallExpr_string2 = methodCallExprs.get(2);
                     Context context_string2 = JavaParserFactory.getContext(methodCallExpr_string2, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_string2 = context_string2.solveSymbol("s");
                     assertTrue(s_string2.isSolved());
-                    assertTrue(s_string2.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s_string2.getCorrespondingDeclaration().isTypePattern());
 
                     // The fourth one should resolve to the pattern variable (the string).
                     MethodCallExpr methodCallExpr_string3 = methodCallExprs.get(2);
                     Context context_string3 = JavaParserFactory.getContext(methodCallExpr_string3, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_string3 = context_string3.solveSymbol("s");
                     assertTrue(s_string3.isSolved());
-                    assertTrue(s_string3.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s_string3.getCorrespondingDeclaration().isTypePattern());
                 }
 
                 @Test
@@ -1540,28 +1540,28 @@ class ContextTest extends AbstractSymbolResolutionTest {
                     Context context_list = JavaParserFactory.getContext(methodCallExpr_list, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_list = context_list.solveSymbol("s");
                     assertTrue(s_list.isSolved());
-                    assertFalse(s_list.getCorrespondingDeclaration().isPattern());
+                    assertFalse(s_list.getCorrespondingDeclaration().isTypePattern());
 
                     // The second one should resolve to the standard variable (the list).
                     MethodCallExpr methodCallExpr_string = methodCallExprs.get(1);
                     Context context_string = JavaParserFactory.getContext(methodCallExpr_string, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_string = context_string.solveSymbol("s");
                     assertTrue(s_string.isSolved());
-                    assertFalse(s_string.getCorrespondingDeclaration().isPattern());
+                    assertFalse(s_string.getCorrespondingDeclaration().isTypePattern());
 
                     // The third one should resolve to the pattern variable (the string).
                     MethodCallExpr methodCallExpr_string2 = methodCallExprs.get(2);
                     Context context_string2 = JavaParserFactory.getContext(methodCallExpr_string2, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_string2 = context_string2.solveSymbol("s");
                     assertTrue(s_string2.isSolved());
-                    assertTrue(s_string2.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s_string2.getCorrespondingDeclaration().isTypePattern());
 
                     // The fourth one should resolve to the pattern variable (the string).
                     MethodCallExpr methodCallExpr_string3 = methodCallExprs.get(2);
                     Context context_string3 = JavaParserFactory.getContext(methodCallExpr_string3, typeSolver);
                     SymbolReference<? extends ResolvedValueDeclaration> s_string3 = context_string3.solveSymbol("s");
                     assertTrue(s_string3.isSolved());
-                    assertTrue(s_string3.getCorrespondingDeclaration().isPattern());
+                    assertTrue(s_string3.getCorrespondingDeclaration().isTypePattern());
                 }
             }
         }


### PR DESCRIPTION
While working on the symbol solver changes for record patterns, I realised that I missed a few Pattern renamings (see commit messages for details). I also thought it would be better to fix these in a separate PR since they aren't really related to record patterns.