### PR TITLE
Fix: solveMethodAsUsage() for implicit method <enum>::values()

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -58,6 +58,8 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
         implements ResolvedEnumDeclaration, MethodResolutionCapability, MethodUsageResolutionCapability,
         SymbolResolutionCapability {
 
+    private static final String VALUES = "values";
+
     private TypeSolver typeSolver;
     private EnumDeclaration wrappedNode;
     private JavaParserTypeAdapter<com.github.javaparser.ast.body.EnumDeclaration> javaParserTypeAdapter;
@@ -193,13 +195,16 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
     @Override
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentTypes,
                                                     Context invokationContext, List<ResolvedType> typeParameters) {
+        if (VALUES.equals(name) && argumentTypes.isEmpty()) {
+            return Optional.of(new MethodUsage(new JavaParserEnumDeclaration.ValuesMethod(this, typeSolver)));
+        }
         return getContext().solveMethodAsUsage(name, argumentTypes);
     }
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> argumentsTypes,
                                                                   boolean staticOnly) {
-        if ("values".equals(name) && argumentsTypes.isEmpty()) {
+        if (VALUES.equals(name) && argumentsTypes.isEmpty()) {
             return SymbolReference.solved(new JavaParserEnumDeclaration.ValuesMethod(this, typeSolver));
         }
         if ("valueOf".equals(name) && argumentsTypes.size() == 1) {
@@ -392,7 +397,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
 
         @Override
         public String getName() {
-            return "values";
+            return VALUES;
         }
 
         @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/EnumResolutionTest.java
@@ -188,4 +188,37 @@ class EnumResolutionTest extends AbstractResolutionTest {
         assertTrue(rd.isStatic());
     }
 
+    @Test
+    public void testResolveValuesMethodAndReturnType() {
+        String s =
+                "public class ClassTest {\n" +
+                "    public enum SecurityPolicyScopedTemplatesKeys {\n" +
+                "        SUSPICIOUS(\"suspicious\");\n" +
+                "        private String displayName;\n" +
+                "\n" +
+                "        private SecurityPolicyScopedTemplatesKeys(String displayName) {\n" +
+                "            this.displayName = displayName;\n" +
+                "        }\n" +
+                "\n" +
+                "        public String getDisplayName() {\n" +
+                "            return this.displayName;\n" +
+                "        }\n" +
+                "\n" +
+                "        public SecurityPolicyScopedTemplatesKeys m(int id) {\n" +
+                "            return values()[id];\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(s);
+        MethodCallExpr methodCallExpr = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rd = methodCallExpr.resolve();
+        assertEquals("values", rd.getName());
+        assertEquals("ClassTest.SecurityPolicyScopedTemplatesKeys[]", rd.getReturnType().describe());
+        final ResolvedType resolvedType = methodCallExpr.calculateResolvedType();
+        assertEquals("ClassTest.SecurityPolicyScopedTemplatesKeys[]", resolvedType.describe());
+        assertTrue(rd.isStatic());
+    }
+
 }


### PR DESCRIPTION
Hi everyone,

this pull request fixes the remaining problem mentioned in #4416 and adds a test. 

Calculating the type of an expression, containing the implicit method `values()`, with `calculateResolvedType()` throws an exception.  

Reason: `calculateResolvedType()` uses the method `solveMethodAsUsage(...)` and this method is not able to resolve the implicit method `values()`.


Best regards 
Kim