### PR TITLE
Fix: 'permits' and 'sealed' Contextual keyworlds usage

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
@@ -112,7 +112,7 @@ class ClassOrInterfaceDeclarationTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16"})
+    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16", "JAVA_17"})
     void sealedFieldNamePermitted(ParserConfiguration.LanguageLevel languageLevel) {
     	assertDoesNotThrow(() -> {
     		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean sealed");
@@ -120,15 +120,23 @@ class ClassOrInterfaceDeclarationTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_17"})
-    void sealedFieldNameNotPermitted(ParserConfiguration.LanguageLevel languageLevel) {
-    	assertThrows(AssertionFailedError.class, () -> {
-    		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean sealed");
+    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16"})
+    void sealedClassOrInterfaceNamePermitted(ParserConfiguration.LanguageLevel languageLevel) {
+    	assertDoesNotThrow(() -> {
+    		TestParser.parseCompilationUnit(languageLevel, "class sealed {}");
         });
     }
 
     @ParameterizedTest
-    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16"})
+    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_17"})
+    void sealedClassOrInterfaceNameNotPermitted(ParserConfiguration.LanguageLevel languageLevel) {
+    	assertThrows(AssertionFailedError.class, () -> {
+    		TestParser.parseCompilationUnit(languageLevel, "class sealed {}");
+        });
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16", "JAVA_17"})
     void permitsFieldNamePermitted(ParserConfiguration.LanguageLevel languageLevel) {
     	assertDoesNotThrow(() -> {
     		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean permits");
@@ -136,10 +144,18 @@ class ClassOrInterfaceDeclarationTest {
     }
 
     @ParameterizedTest
+    @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_8","JAVA_9","JAVA_10","JAVA_11","JAVA_12","JAVA_13","JAVA_14", "JAVA_15", "JAVA_16"})
+    void permitsClassOrInterfaceNamePermitted(ParserConfiguration.LanguageLevel languageLevel) {
+    	assertDoesNotThrow(() -> {
+    		TestParser.parseCompilationUnit(languageLevel, "class permits {}");
+        });
+    }
+
+    @ParameterizedTest
     @EnumSource(value = ParserConfiguration.LanguageLevel.class, names = {"JAVA_17"})
-    void permitsFieldNameNotPermitted(ParserConfiguration.LanguageLevel languageLevel) {
+    void permitsClassOrInterfaceNameNotPermitted(ParserConfiguration.LanguageLevel languageLevel) {
     	assertThrows(AssertionFailedError.class, () -> {
-    		TestParser.parseVariableDeclarationExpr(languageLevel, "boolean permits");
+    		TestParser.parseCompilationUnit(languageLevel, "class permits {}");
         });
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java17Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java17Validator.java
@@ -20,7 +20,9 @@
  */
 package com.github.javaparser.ast.validator.language_level_validations;
 
-import com.github.javaparser.ast.validator.ReservedKeywordValidator;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.validator.SimpleValidator;
 import com.github.javaparser.ast.validator.Validator;
 
 /**
@@ -30,8 +32,8 @@ import com.github.javaparser.ast.validator.Validator;
  */
 public class Java17Validator extends Java16Validator {
 
-	final Validator sealedNotAllowedAsIdentifier = new ReservedKeywordValidator("sealed");
-	final Validator permitsNotAllowedAsIdentifier = new ReservedKeywordValidator("permits");
+	final Validator sealedNotAllowedAsIdentifier = new SimpleValidator<>(ClassOrInterfaceDeclaration.class, n -> n.getName().getIdentifier().equals("sealed"), (n, reporter) -> reporter.report(n, new UpgradeJavaMessage("'sealed' identifier is not authorised in this context.", ParserConfiguration.LanguageLevel.JAVA_17)));
+	final Validator permitsNotAllowedAsIdentifier = new SimpleValidator<>(ClassOrInterfaceDeclaration.class, n -> n.getName().getIdentifier().equals("permits"), (n, reporter) -> reporter.report(n, new UpgradeJavaMessage("'permits' identifier is not authorised in this context.", ParserConfiguration.LanguageLevel.JAVA_17)));
 
     public Java17Validator() {
         super();


### PR DESCRIPTION
Fixes #4041 

From java 17, the keywords 'permits' and 'sealed' cannot be used as type identifiers in the context of a NormalClassDeclaration or NormalInterfaceDeclaration.
