### PR TITLE
Fix expressions in the body of switch expression entries (Issue 4440)

### DIFF
--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -4661,6 +4661,7 @@ SwitchEntry SwitchEntry():
     JavaToken begin;
     SwitchEntry ret;
     Statement stmt = null;
+    Expression expr = null;
     boolean isDefault = false;
     Expression guard = null;
 }
@@ -4711,12 +4712,15 @@ SwitchEntry SwitchEntry():
      |
         "->"
         (
-            stmt = StatementExpression()
-            {
-                TokenRange r=range(begin, token());
-                stmts.add(stmt);
-                ret = new SwitchEntry(r, labels, EXPRESSION, stmts, isDefault, guard);
-            }
+            (
+                expr = Expression()
+                {
+                    TokenRange r=range(begin, token());
+                    stmts.add(new ExpressionStmt(expr.getTokenRange().get(), expr));
+                    ret = new SwitchEntry(r, labels, EXPRESSION, stmts, isDefault, guard);
+                }
+                ";"
+            )
          |
             stmt = Block()
             {


### PR DESCRIPTION
Fixes #4440

I introduced this bug in https://github.com/javaparser/javaparser/pull/4364 to fix an issue with the LPP by expecting a `StatementExpression` instead of an `Expression` in the body of a switch statement. This did fix the semi-colon issue I had, but I didn't consider the fact that `StatementExpression` isn't just a wrapper around an `Expression`, but actually a proper subset. This meant that a lot of expression types were not supported anymore.

This PR changes this back. I didn't run into the same LPP issue again, so I suspect I just didn't understand how sequences should be parenthesized or something like that before. 
