### PR TITLE
Fix: issue 3277 StackOverflow issue while parse MethodCallExpr/FieldAccessExpr, their ancestor/child node is ObjectCreation expression which contain .new

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
@@ -21,6 +21,12 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
+import static com.github.javaparser.resolution.Navigator.demandParentNode;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
@@ -34,12 +40,6 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
-import static com.github.javaparser.resolution.Navigator.demandParentNode;
 
 /**
  * @author Federico Tomassetti
@@ -70,7 +70,7 @@ public class FieldAccessContext extends AbstractJavaParserContext<FieldAccessExp
 
     @Override
     public SymbolReference<ResolvedTypeDeclaration> solveType(String name, List<ResolvedType> typeArguments) {
-        return JavaParserFactory.getContext(demandParentNode(wrappedNode), typeSolver).solveType(name, typeArguments);
+    	return solveTypeInParentContext(name, typeArguments);
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3277Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3277Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+
+public class Issue3277Test extends AbstractResolutionTest {
+
+	@Test
+	void test() throws IOException {
+		String code =
+				"public class StackOverflowTestCase {\n"
+				+ "	private C c = new C();\n"
+				+ "\n"
+				+ "	public void method1() {\n"
+				+ "		String localVariable = ConstantA.b.new innerClassInB(c.d.str1, c.d.str2).toString();\n"
+				+ "	}\n"
+				+ "}";
+		Path pathToSourceFile = adaptPath("src/test/resources/issue3277");
+		ParserConfiguration parserConfiguration = new ParserConfiguration();
+        JavaSymbolSolver symbolSolver = new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver(), new JavaParserTypeSolver(pathToSourceFile)));
+	    parserConfiguration.setSymbolResolver(symbolSolver);
+	    JavaParser javaParser = new JavaParser(parserConfiguration);
+	    CompilationUnit cu = javaParser.parse(code).getResult().get();
+	    MethodCallExpr methodCallExpr = cu.findFirst(MethodCallExpr.class).orElse(null);
+	    assertEquals("java.lang.Object.toString()", methodCallExpr.resolve().getQualifiedSignature());
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue343Test.java
@@ -21,6 +21,14 @@
 
 package com.github.javaparser.symbolsolver;
 
+import static com.github.javaparser.StaticJavaParser.parseExpression;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.resolution.Solver;
 import com.github.javaparser.resolution.TypeSolver;
@@ -30,11 +38,6 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Note this issue number refers to the archived `javasymbolsolver` repository,
@@ -85,6 +88,6 @@ class Issue343Test extends AbstractResolutionTest {
 
     @Test
     void resolveLocaleOutsideAST() {
-        assertThrows(IllegalStateException.class, () -> getExpressionType(typeResolver, new FieldAccessExpr(new NameExpr("Locale"), "US")));
+        assertThrows(UnsolvedSymbolException.class, () -> getExpressionType(typeResolver, new FieldAccessExpr(new NameExpr("Locale"), "US")));
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue3277/B.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue3277/B.java
@@ -1,0 +1,13 @@
+public class B {
+	public class innerClassInB {
+		private String field1;
+
+		private String field2;
+
+		public innerClassInB(String field1, String field2) {
+			this.field1 = field1;
+			this.field2 = field2;
+		}
+
+	}
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue3277/C.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue3277/C.java
@@ -1,0 +1,3 @@
+public class C {
+	public D d = new D("str1", "str2");
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue3277/ConstantA.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue3277/ConstantA.java
@@ -1,0 +1,3 @@
+public class ConstantA {
+	public final static B b = new B();
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue3277/D.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue3277/D.java
@@ -1,0 +1,10 @@
+public class D {
+	public D(String str1, String str2) {
+		this.str1 = str1;
+		this.str2 = str2;
+	}
+
+	public String str1;
+
+	public String str2;
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue3277/StackOverflowTestCase.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue3277/StackOverflowTestCase.java
@@ -1,0 +1,8 @@
+public class StackOverflowTestCase {
+	private C c = new C();
+
+	public void method1() {
+		String localVariable = ConstantA.b.new innerClassInB(null, null).toString();
+		System.out.println(localVariable);
+	}
+}


### PR DESCRIPTION

Fixes #3277.

The resolution of the type of an accessed field must be delegated directly to the parent context because it cannot be done directly by the context of the accessed field.
