### PR TITLE
Fixed issue #4450 and added unit tests

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
@@ -40,7 +40,9 @@ public interface ResolvedValueDeclaration extends ResolvedDeclaration {
     static boolean IsPublicStaticField(ResolvedValueDeclaration declaration) {
         if(declaration instanceof ResolvedFieldDeclaration) {
             ResolvedFieldDeclaration resolvedFieldDeclaration = (ResolvedFieldDeclaration)declaration;
-            return resolvedFieldDeclaration.isStatic() && resolvedFieldDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC;
+            if(resolvedFieldDeclaration.isStatic() && resolvedFieldDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC) {
+                return true;
+            };
         }
 
         return declaration instanceof ResolvedEnumConstantDeclaration;

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
@@ -21,7 +21,6 @@
 package com.github.javaparser.resolution.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
-import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
@@ -20,7 +20,6 @@
  */
 package com.github.javaparser.resolution.declarations;
 
-import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.resolution.types.ResolvedType;
 
 /**
@@ -34,17 +33,4 @@ public interface ResolvedValueDeclaration extends ResolvedDeclaration {
      * Type of the declaration.
      */
     ResolvedType getType();
-
-
-
-    static boolean IsPublicStaticField(ResolvedValueDeclaration declaration) {
-        if(declaration instanceof ResolvedFieldDeclaration) {
-            ResolvedFieldDeclaration resolvedFieldDeclaration = (ResolvedFieldDeclaration)declaration;
-            if(resolvedFieldDeclaration.isStatic() && resolvedFieldDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC) {
-                return true;
-            };
-        }
-
-        return declaration instanceof ResolvedEnumConstantDeclaration;
-    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
@@ -37,15 +37,10 @@ public interface ResolvedValueDeclaration extends ResolvedDeclaration {
 
 
 
-    public static boolean IsPublicStaticMember(ResolvedValueDeclaration declaration) {
+    static boolean IsPublicStaticField(ResolvedValueDeclaration declaration) {
         if(declaration instanceof ResolvedFieldDeclaration) {
             ResolvedFieldDeclaration resolvedFieldDeclaration = (ResolvedFieldDeclaration)declaration;
             return resolvedFieldDeclaration.isStatic() && resolvedFieldDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC;
-        }
-
-        if(declaration instanceof ResolvedMethodDeclaration) {
-            ResolvedMethodDeclaration resolvedMethodDeclaration = (ResolvedMethodDeclaration)declaration;
-            return resolvedMethodDeclaration.isStatic() && resolvedMethodDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC;
         }
 
         return declaration instanceof ResolvedEnumConstantDeclaration;

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedValueDeclaration.java
@@ -20,6 +20,8 @@
  */
 package com.github.javaparser.resolution.declarations;
 
+import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
 
 /**
@@ -33,4 +35,20 @@ public interface ResolvedValueDeclaration extends ResolvedDeclaration {
      * Type of the declaration.
      */
     ResolvedType getType();
+
+
+
+    public static boolean IsPublicStaticMember(ResolvedValueDeclaration declaration) {
+        if(declaration instanceof ResolvedFieldDeclaration) {
+            ResolvedFieldDeclaration resolvedFieldDeclaration = (ResolvedFieldDeclaration)declaration;
+            return resolvedFieldDeclaration.isStatic() && resolvedFieldDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC;
+        }
+
+        if(declaration instanceof ResolvedMethodDeclaration) {
+            ResolvedMethodDeclaration resolvedMethodDeclaration = (ResolvedMethodDeclaration)declaration;
+            return resolvedMethodDeclaration.isStatic() && resolvedMethodDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC;
+        }
+
+        return declaration instanceof ResolvedEnumConstantDeclaration;
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/SymbolResolutionCapability.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/SymbolResolutionCapability.java
@@ -34,4 +34,13 @@ public interface SymbolResolutionCapability {
 	 * @return Symbol reference of the resolved value.
 	 */
 	SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, TypeSolver typeSolver);
+
+
+	/**
+	 * Resolve a public static field declared directly within the type
+	 * @param name Field / symbol name.
+	 * @param typeSolver Symbol solver to resolve type usage.
+	 * @return Symbol reference of the resolved value.
+	 */
+	SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver);
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
@@ -60,14 +60,23 @@ public class ClassOrInterfaceDeclarationContext extends AbstractJavaParserContex
 
     @Override
     public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name) {
+        SymbolReference<? extends ResolvedValueDeclaration> classResolveResult = this.solveSymbolInClass(name);
+        if(classResolveResult.isSolved()) {
+            return classResolveResult;
+        }
+
+        // then to parent
+        return solveSymbolInParentContext(name);
+    }
+
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbolInClass(String name) {
         if (typeSolver == null) throw new IllegalArgumentException();
 
         if (this.getDeclaration().hasVisibleField(name)) {
             return SymbolReference.solved(this.getDeclaration().getVisibleField(name));
         }
 
-        // then to parent
-        return solveSymbolInParentContext(name);
+        return SymbolReference.unsolved();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -94,7 +94,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
 
                     // avoid infinite recursion
                     if (!isAncestorOf(importedType)) {
-                        SymbolReference<? extends ResolvedValueDeclaration> ref = new SymbolSolver(typeSolver).solveSymbolInType(importedType, name);
+                        SymbolReference<? extends ResolvedValueDeclaration> ref = new SymbolSolver(typeSolver).solvePublicStaticSymbolInType(importedType, name);
                         if (ref.isSolved()) {
                             return ref;
                         }
@@ -108,7 +108,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
 
                     if (memberName.equals(name)) {
                         ResolvedTypeDeclaration importedType = typeSolver.solveType(typeName);
-                        return new SymbolSolver(typeSolver).solveSymbolInType(importedType, memberName);
+                        return new SymbolSolver(typeSolver).solvePublicStaticSymbolInType(importedType, memberName);
                     }
                 }
             }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
@@ -50,6 +50,16 @@ public class EnumDeclarationContext extends AbstractJavaParserContext<EnumDeclar
 
     @Override
     public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name) {
+        SymbolReference<? extends ResolvedValueDeclaration> enumResolutionResult = solveSymbolInEnum(name);
+        if(enumResolutionResult.isSolved()) {
+            return enumResolutionResult;
+        }
+
+        // then to parent
+        return solveSymbolInParentContext(name);
+    }
+
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbolInEnum(String name) {
         if (typeSolver == null) throw new IllegalArgumentException();
 
         // among constants
@@ -63,8 +73,7 @@ public class EnumDeclarationContext extends AbstractJavaParserContext<EnumDeclar
             return SymbolReference.solved(this.getDeclaration().getField(name));
         }
 
-        // then to parent
-        return solveSymbolInParentContext(name);
+        return SymbolReference.unsolved();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -44,6 +44,7 @@ import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionC
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ClassOrInterfaceDeclarationContext;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 
@@ -332,6 +333,20 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
     @Override
     public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, TypeSolver typeSolver) {
         return getContext().solveSymbol(name);
+    }
+
+    @Override
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        Context context = getContext();
+        if (context instanceof ClassOrInterfaceDeclarationContext) {
+            SymbolReference<? extends ResolvedValueDeclaration> reference = ((ClassOrInterfaceDeclarationContext) context).solveSymbolInClass(name);
+            if (reference.getDeclaration().isPresent() &&
+                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get())) {
+                return reference;
+            }
+        }
+
+        return SymbolReference.unsolved();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -341,7 +341,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
         if (context instanceof ClassOrInterfaceDeclarationContext) {
             SymbolReference<? extends ResolvedValueDeclaration> reference = ((ClassOrInterfaceDeclarationContext) context).solveSymbolInClass(name);
             if (reference.getDeclaration().isPresent() &&
-                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get())) {
+                    ResolvedValueDeclaration.IsPublicStaticField(reference.getDeclaration().get())) {
                 return reference;
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -21,9 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
@@ -47,6 +44,10 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ClassOrInterfaceDeclarationContext;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -341,7 +342,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
         if (context instanceof ClassOrInterfaceDeclarationContext) {
             SymbolReference<? extends ResolvedValueDeclaration> reference = ((ClassOrInterfaceDeclarationContext) context).solveSymbolInClass(name);
             if (reference.getDeclaration().isPresent() &&
-                    ResolvedValueDeclaration.IsPublicStaticField(reference.getDeclaration().get())) {
+                    DeclarationUtils.IsPublicStaticField(reference.getDeclaration().get())) {
                 return reference;
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -48,6 +48,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.EnumDeclarationContext;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionFactory;
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -227,7 +228,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
         if (context instanceof EnumDeclarationContext) {
             SymbolReference<? extends ResolvedValueDeclaration> reference = ((EnumDeclarationContext) context).solveSymbolInEnum(name);
             if (reference.getDeclaration().isPresent() &&
-                    ResolvedValueDeclaration.IsPublicStaticField(reference.getDeclaration().get())) {
+                    DeclarationUtils.IsPublicStaticField(reference.getDeclaration().get())) {
                 return reference;
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -21,9 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
@@ -48,8 +45,12 @@ import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapabi
 import com.github.javaparser.symbolsolver.core.resolution.TypeVariableResolutionCapability;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.EnumDeclarationContext;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -219,6 +220,19 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
     @Override
     public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, TypeSolver typeSolver) {
         return getContext().solveSymbol(name);
+    }
+
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        Context context = getContext();
+        if (context instanceof EnumDeclarationContext) {
+            SymbolReference<? extends ResolvedValueDeclaration> reference = ((EnumDeclarationContext) context).solveSymbolInEnum(name);
+            if (reference.getDeclaration().isPresent() &&
+                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get())) {
+                return reference;
+            }
+        }
+
+        return SymbolReference.unsolved();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -227,7 +227,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
         if (context instanceof EnumDeclarationContext) {
             SymbolReference<? extends ResolvedValueDeclaration> reference = ((EnumDeclarationContext) context).solveSymbolInEnum(name);
             if (reference.getDeclaration().isPresent() &&
-                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get())) {
+                    ResolvedValueDeclaration.IsPublicStaticField(reference.getDeclaration().get())) {
                 return reference;
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -21,9 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
@@ -44,8 +41,13 @@ import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionC
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ClassOrInterfaceDeclarationContext;
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.EnumDeclarationContext;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -301,6 +303,20 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
     @Override
     public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name, TypeSolver typeSolver) {
         return getContext().solveSymbol(name);
+    }
+
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        Context context = getContext();
+        if (context instanceof ClassOrInterfaceDeclarationContext) {
+            SymbolReference<? extends ResolvedValueDeclaration> reference = ((ClassOrInterfaceDeclarationContext) context).solveSymbolInClass(name);
+
+            if (reference.getDeclaration().isPresent() &&
+                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get())) {
+                return reference;
+            }
+        }
+
+        return SymbolReference.unsolved();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -311,7 +311,8 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
             SymbolReference<? extends ResolvedValueDeclaration> reference = ((ClassOrInterfaceDeclarationContext) context).solveSymbolInClass(name);
 
             if (reference.getDeclaration().isPresent() &&
-                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get())) {
+                    (reference.getDeclaration().get() instanceof ResolvedFieldDeclaration ||
+                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get()))) {
                 return reference;
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -311,7 +311,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
 
             if (reference.getDeclaration().isPresent() &&
                     (reference.getDeclaration().get() instanceof ResolvedFieldDeclaration ||
-                    ResolvedValueDeclaration.IsPublicStaticMember(reference.getDeclaration().get()))) {
+                    ResolvedValueDeclaration.IsPublicStaticField(reference.getDeclaration().get()))) {
                 return reference;
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -44,6 +44,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ClassOrInterfaceDeclarationContext;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -311,7 +312,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
 
             if (reference.getDeclaration().isPresent() &&
                     (reference.getDeclaration().get() instanceof ResolvedFieldDeclaration ||
-                    ResolvedValueDeclaration.IsPublicStaticField(reference.getDeclaration().get()))) {
+                            DeclarationUtils.IsPublicStaticField(reference.getDeclaration().get()))) {
                 return reference;
             }
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -42,7 +42,6 @@ import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapabi
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ClassOrInterfaceDeclarationContext;
-import com.github.javaparser.symbolsolver.javaparsermodel.contexts.EnumDeclarationContext;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -21,10 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.resolution.Context;
@@ -41,9 +37,13 @@ import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionC
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
-
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
 import javassist.CtClass;
 import javassist.CtField;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Federico Tomassetti
@@ -165,7 +165,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
+                DeclarationUtils.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -165,7 +165,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -161,6 +161,18 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
         return SymbolReference.unsolved();
     }
 
+    @Override
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
+        if(resolvedSymbol.getDeclaration().isPresent() &&
+                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+            return resolvedSymbol;
+        }
+
+        return SymbolReference.unsolved();
+    }
+
+
     private SymbolReference<? extends ResolvedValueDeclaration> solveSymbolForFQN(String symbolName, String fqn) {
         if (fqn == null) {
             return SymbolReference.unsolved();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -227,6 +227,16 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
         return SymbolReference.unsolved();
     }
 
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
+        if(resolvedSymbol.getDeclaration().isPresent() &&
+                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+            return resolvedSymbol;
+        }
+
+        return SymbolReference.unsolved();
+    }
+
     private SymbolReference<? extends ResolvedValueDeclaration> solveSymbolForFQN(String symbolName, String fqn) {
         if (fqn == null) {
             return SymbolReference.unsolved();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -21,12 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.MethodUsage;
@@ -41,10 +35,16 @@ import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionC
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
-
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
 import javassist.CtClass;
 import javassist.CtField;
 import javassist.bytecode.AccessFlag;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -230,7 +230,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
+                DeclarationUtils.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -230,7 +230,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -222,7 +222,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -219,6 +219,16 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
         return SymbolReference.unsolved();
     }
 
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
+        if(resolvedSymbol.getDeclaration().isPresent() &&
+                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+            return resolvedSymbol;
+        }
+
+        return SymbolReference.unsolved();
+    }
+
     private SymbolReference<? extends ResolvedValueDeclaration> solveSymbolForFQN(String symbolName, String fqn) {
         if (fqn == null) {
             return SymbolReference.unsolved();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -21,9 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javassistmodel;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.MethodUsage;
@@ -39,9 +36,12 @@ import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionC
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
-
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
 import javassist.CtClass;
 import javassist.CtField;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -222,7 +222,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
+                DeclarationUtils.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -305,6 +305,16 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
         return SymbolReference.unsolved();
     }
 
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
+        if(resolvedSymbol.getDeclaration().isPresent() &&
+                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+            return resolvedSymbol;
+        }
+
+        return SymbolReference.unsolved();
+    }
+
     @Override
     public boolean hasDirectlyAnnotation(String canonicalName) {
         return reflectionClassAdapter.hasDirectlyAnnotation(canonicalName);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -21,13 +21,6 @@
 
 package com.github.javaparser.symbolsolver.reflectionmodel;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.resolution.Context;
@@ -45,6 +38,14 @@ import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapabi
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ContextHelper;
 import com.github.javaparser.symbolsolver.logic.AbstractClassDeclaration;
 import com.github.javaparser.symbolsolver.reflectionmodel.comparators.MethodComparator;
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -308,7 +309,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
+                DeclarationUtils.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -308,7 +308,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -40,6 +40,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionCapability;
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
 
 /**
  * @author Federico Tomassetti
@@ -240,7 +241,7 @@ public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> 
   public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
       SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
       if(resolvedSymbol.getDeclaration().isPresent() &&
-              ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
+              DeclarationUtils.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
           return resolvedSymbol;
       }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -240,7 +240,7 @@ public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> 
   public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
       SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
       if(resolvedSymbol.getDeclaration().isPresent() &&
-              ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+              ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
           return resolvedSymbol;
       }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -237,6 +237,16 @@ public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> 
     return SymbolReference.unsolved();
   }
 
+  public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+      SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
+      if(resolvedSymbol.getDeclaration().isPresent() &&
+              ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+          return resolvedSymbol;
+      }
+
+      return SymbolReference.unsolved();
+  }
+
   @Override
   public List<ResolvedEnumConstantDeclaration> getEnumConstants() {
       return Arrays.stream(clazz.getFields())

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -249,7 +249,7 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -246,6 +246,16 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
         return SymbolReference.unsolved();
     }
 
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
+        SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
+        if(resolvedSymbol.getDeclaration().isPresent() &&
+                ResolvedValueDeclaration.IsPublicStaticMember(resolvedSymbol.getDeclaration().get())) {
+            return resolvedSymbol;
+        }
+
+        return SymbolReference.unsolved();
+    }
+
     @Override
     public List<ResolvedReferenceType> getAncestors(boolean acceptIncompleteList) {
         // we do not attempt to perform any symbol solving when analyzing ancestors in the reflection model, so we can

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -43,6 +43,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionCapability;
 import com.github.javaparser.symbolsolver.core.resolution.SymbolResolutionCapability;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
+import com.github.javaparser.symbolsolver.utils.DeclarationUtils;
 
 /**
  * @author Federico Tomassetti
@@ -249,7 +250,7 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
     public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticField(String name, TypeSolver typeSolver) {
         SymbolReference<? extends ResolvedValueDeclaration> resolvedSymbol = solveSymbol(name, typeSolver);
         if(resolvedSymbol.getDeclaration().isPresent() &&
-                ResolvedValueDeclaration.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
+                DeclarationUtils.IsPublicStaticField(resolvedSymbol.getDeclaration().get())) {
             return resolvedSymbol;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/SymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/SymbolSolver.java
@@ -188,4 +188,12 @@ public class SymbolSolver implements Solver {
         }
         return new ReferenceTypeImpl(declaration);
     }
+
+    public SymbolReference<? extends ResolvedValueDeclaration> solvePublicStaticSymbolInType(ResolvedTypeDeclaration typeDeclaration, String memberName) {
+        if (typeDeclaration instanceof SymbolResolutionCapability) {
+            return ((SymbolResolutionCapability) typeDeclaration).solvePublicStaticField(memberName, typeSolver);
+        }
+        return SymbolReference.unsolved();
+
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/utils/DeclarationUtils.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/utils/DeclarationUtils.java
@@ -1,0 +1,19 @@
+package com.github.javaparser.symbolsolver.utils;
+
+import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.resolution.declarations.ResolvedEnumConstantDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+
+public class DeclarationUtils {
+    public static boolean IsPublicStaticField(ResolvedValueDeclaration declaration) {
+        if(declaration instanceof ResolvedFieldDeclaration) {
+            ResolvedFieldDeclaration resolvedFieldDeclaration = (ResolvedFieldDeclaration)declaration;
+            if(resolvedFieldDeclaration.isStatic() && resolvedFieldDeclaration.accessSpecifier() == AccessSpecifier.PUBLIC) {
+                return true;
+            };
+        }
+
+        return declaration instanceof ResolvedEnumConstantDeclaration;
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4450Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4450Test.java
@@ -1,0 +1,36 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class Issue4450Test extends AbstractSymbolResolutionTest {
+  @Test
+  public void testIssue4450() throws IOException {
+    Path issueResourcesPath = adaptPath("src/test/resources/issue4450");
+    ReflectionTypeSolver rts = new ReflectionTypeSolver();
+    JavaParserTypeSolver jpts = new JavaParserTypeSolver(issueResourcesPath);
+    CombinedTypeSolver cts = new CombinedTypeSolver();
+    cts.add(rts);
+    cts.add(jpts);
+    ParserConfiguration pc = new ParserConfiguration()
+        .setSymbolResolver(new JavaSymbolSolver(cts));
+    StaticJavaParser.setConfiguration(pc);
+    CompilationUnit cu = StaticJavaParser.parse(issueResourcesPath.resolve("a/RefCycleClass.java"));
+
+    // We shouldn't throw a mismatched symbol
+    assertDoesNotThrow(() -> cu.findAll(NameExpr.class).stream()
+            .map(NameExpr::resolve)
+            .findAny().get());
+  }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefClass2.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefClass2.java
@@ -1,0 +1,5 @@
+package a;
+
+public class RefClass2 {
+    public static Runnable unknownName;
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefClass2.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefClass2.java
@@ -2,4 +2,5 @@ package a;
 
 public class RefClass2 {
     public static Runnable unknownName;
+    public Runnable nonStatic;
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleClass.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleClass.java
@@ -11,5 +11,6 @@ public class RefCycleClass {
 
     public void runMe() {
         unknownName.run();
+        RefCycleEnum myEnum = Value1;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleClass.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleClass.java
@@ -1,0 +1,15 @@
+package a;
+
+import static a.RefCycleEnum.*;
+import static a.RefClass2.*;
+
+public class RefCycleClass {
+
+    public static int value1Value = 1;
+
+    private RefCycleEnum theEnum;
+
+    public void runMe() {
+        unknownName.run();
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleClassFailure.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleClassFailure.java
@@ -1,0 +1,9 @@
+package a;
+
+import static a.RefClass2.*;
+
+public class RefCycleClassFailure {
+    public void runMe() {
+        nonStatic.run();
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleEnum.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4450/a/RefCycleEnum.java
@@ -1,0 +1,13 @@
+package a;
+
+import static a.RefCycleClass.*;
+
+public enum RefCycleEnum {
+    Value1(value1Value);
+
+    private RefCycleEnum(int value) {
+	Underlying = value;
+    }
+    
+    public final int Underlying;
+}


### PR DESCRIPTION
When looking up a symbol in a type based on a static import, restrict search to members of the type.

Fixes #4450 
