### PR TITLE
Add link to the guide to adding nodes in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ We noticed we get the best feedback from those.
 Here are [some fun project ideas](https://github.com/javaparser/javaparser/labels/fun%20project%20idea).
 - If you start working on an issue, please say so with a comment in the issue.
 - If you know how to fix a problem, please fix it and open a pull request instead of opening an issue.
+- If you would like to add new nodes, or new fields to existing nodes, check out the [Guide to Adding New Nodes and Fields](https://github.com/javaparser/javaparser/wiki/A-Detailed-Guide-to-Adding-New-Nodes-and-Fields).
 
 Thanks for helping!
 


### PR DESCRIPTION
I wrote this as a walkthrough for the changes I made in https://github.com/javaparser/javaparser/pull/4432 and I think this guide would be useful for future contributors who want to add support for new Java features. `CONTRIBUTING.md` already has a link to the wiki, but I think it's worth adding a specific mention of this page since it mentions all of the major `JavaParser` components and is a fairly comprehensive overview of what's required when adding new nodes.
