### PR TITLE
Fix lookahead for pattern expression in switch entries [Issue 4455]

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -415,5 +416,20 @@ class SwitchExprTest {
         assertTrue(switchExpr.getEntry(1).getLabels().isEmpty());
         assertTrue(switchExpr.getEntry(1).isDefault());
         assertEquals("1;", switchExpr.getEntry(1).getStatements().get(0).toString());
+    }
+
+    @Test
+    void issue4455Test() {
+        SwitchExpr switchExpr = parseExpression("switch (column) {\n" +
+                "  case CustomDeployTableModel.ARTIFACT_NAME -> {}\n" +
+                "}").asSwitchExpr();
+
+        assertEquals(Node.Parsedness.PARSED, switchExpr.getParsed());
+
+        SwitchEntry entry = switchExpr.getEntry(0);
+        Expression switchLabel = entry.getLabels().get(0);
+
+        assertEquals("CustomDeployTableModel.ARTIFACT_NAME", switchLabel.toString());
+        assertTrue(switchLabel.isFieldAccessExpr());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -21,6 +21,8 @@
 
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -421,7 +423,7 @@ class SwitchExprTest {
     @Test
     void issue4455Test() {
         SwitchExpr switchExpr = parseExpression("switch (column) {\n" +
-                "  case CustomDeployTableModel.ARTIFACT_NAME -> {}\n" +
+                "    case CustomDeployTableModel.ARTIFACT_NAME -> {}\n" +
                 "}").asSwitchExpr();
 
         assertEquals(Node.Parsedness.PARSED, switchExpr.getParsed());
@@ -431,5 +433,12 @@ class SwitchExprTest {
 
         assertEquals("CustomDeployTableModel.ARTIFACT_NAME", switchLabel.toString());
         assertTrue(switchLabel.isFieldAccessExpr());
+        assertTrue(switchLabel.getRange().isPresent());
+
+        Range switchLabelRange = switchLabel.getRange().get();
+        assertEquals(2, switchLabelRange.begin.line);
+        assertEquals(10, switchLabelRange.begin.column);
+        assertEquals(2, switchLabelRange.end.line);
+        assertEquals(45, switchLabelRange.end.column);
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -22,7 +22,6 @@
 package com.github.javaparser.ast.expr;
 
 import com.github.javaparser.Range;
-import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.VariableDeclarator;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
@@ -23,8 +23,12 @@ package com.github.javaparser.ast.stmt;
 
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.SwitchExpr;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.EXPRESSION;
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.STATEMENT_GROUP;
+import static com.github.javaparser.utils.TestParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitchStmtTest {
@@ -83,6 +88,21 @@ class SwitchStmtTest {
 
         assertTrue(switchStmt.getEntry(0).isDefault());
         assertInstanceOf(NullLiteralExpr.class, switchStmt.getEntry(0).getLabels().get(0));
+    }
+
+    @Test
+    void issue4455Test() {
+        SwitchStmt switchStmt = parseStatement("switch (column) {\n" +
+                "  case CustomDeployTableModel.ARTIFACT_NAME:\n" +
+                "}").asSwitchStmt();
+
+        assertEquals(Node.Parsedness.PARSED, switchStmt.getParsed());
+
+        SwitchEntry entry = switchStmt.getEntry(0);
+        Expression switchLabel = entry.getLabels().get(0);
+
+        assertEquals("CustomDeployTableModel.ARTIFACT_NAME", switchLabel.toString());
+        assertTrue(switchLabel.isFieldAccessExpr());
     }
 
 

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -4689,7 +4689,7 @@ SwitchEntry SwitchEntry():
             * This lookahead is necessary to avoid ambiguity with the ConditionalExpression branch
             * below.
             */
-            LOOKAHEAD(3)
+            LOOKAHEAD(PatternExpression())
             label = PatternExpression() { labels = add(labels, label); }
             [
               "when"


### PR DESCRIPTION
Fixes #4455.

The bug was that the `LOOKAHEAD(3)` (or in general any fixed-distance lookahead) is not sufficient to determine whether `Foo.Bar.Baz. ...` is a field access expression or a nested type name. Without knowledge about the next symbol, `CustomDeployTableModel.ARTIFACT_NAME` could just be the name of an inner class `ARTIFACT_NAME`

With this PR, I've changed the lookahead to check whether the next tokens describe a pattern expression, which could be slow for long expressions, but will keep inspecting tokens until the answer is unambiguous.
