### PR TITLE
Fix record declarations nested in annotation declarations

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/AnnotationMemberDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/AnnotationMemberDeclarationTest.java
@@ -21,10 +21,16 @@
 
 package com.github.javaparser.ast.body;
 
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.resolution.Navigator;
+import com.github.javaparser.utils.TestParser;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -61,5 +67,24 @@ class AnnotationMemberDeclarationTest {
         decl.removeDefaultValue();
 
         assertFalse(defaultValue.getParentNode().isPresent());
+    }
+
+    @Test
+    void annotationDeclarationShouldSupportRecordChild() {
+        CompilationUnit cu = TestParser.parseCompilationUnit(
+                ParserConfiguration.LanguageLevel.BLEEDING_EDGE,
+                "" +
+                        "@interface Foo {\n" +
+                        "    record Bar(String s) {}\n" +
+                        "}"
+                );
+
+        RecordDeclaration bar = cu.getAnnotationDeclarationByName("Foo").get().getMember(0).asRecordDeclaration();
+
+        assertEquals(1, bar.getParameters().size());
+
+        Parameter parameter = bar.getParameter(0);
+        assertEquals("String", parameter.getTypeAsString());
+        assertEquals("s", parameter.getNameAsString());
     }
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -5599,6 +5599,10 @@ NodeList<BodyDeclaration<?>> AnnotationTypeBody():
  *         (one of)
  *         Annotation public
  *         abstract
+ *     ClassDeclaration:
+ *         NormalClassDeclaration
+ *         EnumDeclaration
+ *         RecordDeclaration
  * }<pre>
  * For Convenience:
  * <pre>{@code
@@ -5614,6 +5618,10 @@ BodyDeclaration<?> AnnotationBodyDeclaration():
 {
     modifier = Modifiers()
     (
+        // This case must be checked before AnnotationTypeMemberDeclaration since the prefixes are the same
+        LOOKAHEAD(RecordDeclaration())
+        ret = RecordDeclaration(modifier)
+     |
         LOOKAHEAD(Type() Identifier() "(")
         ret = AnnotationTypeMemberDeclaration(modifier)
      |


### PR DESCRIPTION
From the grammar
```
AnnotationTypeMemberDeclaration:
    AnnotationTypeElementDeclaration
    ConstantDeclaration
    ClassDeclaration
    InterfaceDeclaration
    ;
ClassDeclaration:
    NormalClassDeclaration
    EnumDeclaration
    RecordDeclaration
```

it is possible to declare a record as a child of an annotation declaration, but this case is currently not handled, leading to parse errors. This PR adds that case to the JavaParser grammar with some tests. I added the lpp test to make sure it works, but no fixes were required there.

(I discovered this issue when parsing some larger projects to see if there are any more switch-related bugs, but this is an older bug that is unrelated to any recent changes)