### PR TITLE
Fix crash on SwitchExpr entries if tokens are not stored

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -21,6 +21,9 @@
 
 package com.github.javaparser.ast.expr;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
@@ -439,5 +442,24 @@ class SwitchExprTest {
         assertEquals(10, switchLabelRange.begin.column);
         assertEquals(2, switchLabelRange.end.line);
         assertEquals(45, switchLabelRange.end.column);
+    }
+
+    @Test
+    void switchExprWithoutTokensStored() {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setStoreTokens(false);
+        config.setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
+        JavaParser parser = new JavaParser(config);
+
+        ParseResult<SwitchExpr> result = parser.parseExpression("switch (o) {\n" +
+                "    case Foo f -> f.get();\n" +
+                "}");
+
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getProblems().isEmpty());
+
+        SwitchEntry entry = result.getResult().get().getEntry(0);
+        assertEquals("Foo f", entry.getLabels().get(0).toString());
+        assertEquals("f.get();", entry.getStatements().get(0).toString());
     }
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -4716,7 +4716,8 @@ SwitchEntry SwitchEntry():
                 expr = Expression()
                 {
                     TokenRange r=range(begin, token());
-                    stmts.add(new ExpressionStmt(expr.getTokenRange().get(), expr));
+                    // expr.getTokenRange() will not be present if storeTokens is false
+                    stmts.add(new ExpressionStmt(expr.getTokenRange().orElse(null), expr));
                     ret = new SwitchEntry(r, labels, EXPRESSION, stmts, isDefault, guard);
                 }
                 ";"


### PR DESCRIPTION
When creating SwitchExpr entries with an expression on the RHS, an ExpressionStmt is instantiated with the token range of the child Expression used as the token range for the ExpressionStmt. The problem is that this was not done safely, since `expr.getTokenRange()` can be empty if the `storeTokens` configuration option is disabled and in this case the parser would crash. This PR provides a safe alternative for this case, preventing the crash.

This is an old bug that was most likely introduced with the original `SwitchExpr` support, but I missed it during my refactorings of the code.