### PR TITLE
Add git-blame-ignore-revs file to ignore the reformatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Applied automatic formatting to the entire project
+# See https://github.com/javaparser/javaparser/issues/4408 for details
+5106428130cd3ff052a57d37a3d192f040da5edf


### PR DESCRIPTION
The motivation is discussed in https://github.com/javaparser/javaparser/issues/4408

With this file in place, github will ignore https://github.com/javaparser/javaparser/commit/5106428130cd3ff052a57d37a3d192f040da5edf for determining where a change was made. For git cli, `git config blame.ignoreRevFile` needs to be used to configure this.

An example of this working can be found at https://github.com/johannescoetzee/javaparser/blame/johannes/git-blame-ignore/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java (just an arbitrary file I chose on the relevant branch on my fork).