### PR TITLE
Automatically format code after codegen and validate with a github action

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -118,3 +118,23 @@ jobs:
           distribution: 'zulu'
       - name: Validate Project Checkstyle
         run: ./mvnw -B checkstyle:check
+
+  spotless_check:
+    name: Validate code generation and formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: "0"
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+      - name: Generate code and format
+        run: |
+          ./run_core_metamodel_generator.sh
+          # ./run_core_generators.sh automatically runs ./mvnw spotless:apply
+          ./run_core_generators.sh
+          git diff --exit-code

--- a/run_core_generators.sh
+++ b/run_core_generators.sh
@@ -17,3 +17,6 @@ popd
 if [ "$?" -ne 0 ]; then
     exit 1
 fi
+
+# Format code to make diff more understandable
+./mvnw spotless:apply


### PR DESCRIPTION
This is the final PR related to https://github.com/javaparser/javaparser/issues/4408

This PR includes 2 changes:
* run the code formatter automatically after code generation. This should make it more immediately  obvious what changed during codegen without the mandatory manual step of running the formatter
* add a github action which runs the code generators and formatter and fails if the diff from this is non-empty. This will ensure that nothing in the PR will be overwritten by code generators later on and that everything which needs to be generated was (avoiding a situation where contributors manually implement "generated" methods)

I tested this in https://github.com/johannescoetzee/javaparser/pull/1. Some of the later commits are missing since I cleaned up the branch for this PR, but the relevant github jobs were:
Working run
https://github.com/johannescoetzee/javaparser/actions/runs/9485459827/job/26137443518?pr=1

Incorrect formatting
https://github.com/johannescoetzee/javaparser/actions/runs/9485678529/job/26138198159?pr=1

Fixed again
https://github.com/johannescoetzee/javaparser/actions/runs/9485811857/job/26138677223?pr=1

Missing generated code
https://github.com/johannescoetzee/javaparser/actions/runs/9485852607/job/26138825304?pr=1

We could potentially remove the checkstyle job, but  I'm not sure whether that checks anything not covered by spotless. I'll do a bit of research on that.