### PR TITLE
Disable spotless ratcheting and fix formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,4 @@ Our development workflow is based on Pull Request. If you are not familiar with 
 - Pull requests often stay open for at least a few days to give people a chance to review it.
 - A pull request is merged when all comments on it have been resolved.
 - If you create a pull request for an issue, mention the issue in the format #123 to make github link it automatically.
+- Before submitting a pull request, please run `./mvnw spotless:apply` to format your code to avoid any formatting related issues during review.

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -21,11 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
@@ -41,6 +36,10 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserInterfaceDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Federico Tomassetti
@@ -49,11 +48,12 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
 
     private static final String DEFAULT_PACKAGE = "java.lang";
 
-	// Contains the names of static import declarations with asterisks that have
-	// already been resolved. The aim is to keep a history of name searches for the
-	// same resolution attempt in order to avoid a recursive issue leading to a
-	// stackoverflow exception. See issues 4450 & 2720
-    private static ThreadLocal<List<String>> resolvedStaticImport = ThreadLocal.withInitial(() -> new ArrayList<String>());
+    // Contains the names of static import declarations with asterisks that have
+    // already been resolved. The aim is to keep a history of name searches for the
+    // same resolution attempt in order to avoid a recursive issue leading to a
+    // stackoverflow exception. See issues 4450 & 2720
+    private static ThreadLocal<List<String>> resolvedStaticImport =
+            ThreadLocal.withInitial(() -> new ArrayList<String>());
 
     ///
     /// Static methods
@@ -91,20 +91,20 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
             if (importDecl.isStatic()) {
                 if (importDecl.isAsterisk()) {
                     String qName = importDecl.getNameAsString();
-					// Try to resolve the name in from declarations imported with asterisks only if
-					// they have not already been analysed, otherwise this can lead to an infinite
-					// loop via circular dependencies.
-					if (!isAlreadyResolved(qName)) {
-						resolvedStaticImport.get().add(qName);
-						ResolvedTypeDeclaration importedType = typeSolver.solveType(qName);
+                    // Try to resolve the name in from declarations imported with asterisks only if
+                    // they have not already been analysed, otherwise this can lead to an infinite
+                    // loop via circular dependencies.
+                    if (!isAlreadyResolved(qName)) {
+                        resolvedStaticImport.get().add(qName);
+                        ResolvedTypeDeclaration importedType = typeSolver.solveType(qName);
 
-						SymbolReference<? extends ResolvedValueDeclaration> ref = new SymbolSolver(typeSolver)
-								.solveSymbolInType(importedType, name);
-						if (ref.isSolved()) {
-							resolvedStaticImport.remove(); // clear the search history
-							return ref;
-						}
-					}
+                        SymbolReference<? extends ResolvedValueDeclaration> ref =
+                                new SymbolSolver(typeSolver).solveSymbolInType(importedType, name);
+                        if (ref.isSolved()) {
+                            resolvedStaticImport.remove(); // clear the search history
+                            return ref;
+                        }
+                    }
                 } else {
                     String whole = importDecl.getNameAsString();
 
@@ -120,14 +120,14 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
             }
         }
 
-		// Clear of the search history because we don't want this context to be reused
-		// in another search.
-		resolvedStaticImport.remove();
+        // Clear of the search history because we don't want this context to be reused
+        // in another search.
+        resolvedStaticImport.remove();
         return SymbolReference.unsolved();
     }
 
     private boolean isAlreadyResolved(String qName) {
-    	return resolvedStaticImport.get().contains(qName);
+        return resolvedStaticImport.get().contains(qName);
     }
 
     @Override
@@ -329,12 +329,12 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                         return SymbolReference.unsolved();
                     }
 
-					ResolvedTypeDeclaration ref = typeSolver.solveType(importString);
-					SymbolReference<ResolvedMethodDeclaration> method = MethodResolutionLogic.solveMethodInType(ref,
-							name, argumentsTypes, true);
-					if (method.isSolved()) {
-						return method;
-					}
+                    ResolvedTypeDeclaration ref = typeSolver.solveType(importString);
+                    SymbolReference<ResolvedMethodDeclaration> method =
+                            MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true);
+                    if (method.isSolved()) {
+                        return method;
+                    }
                 } else {
                     String qName = importDecl.getNameAsString();
 
@@ -396,5 +396,4 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
         String memberName = qName.substring(index + 1);
         return memberName;
     }
-
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4450Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4450Test.java
@@ -21,6 +21,7 @@
 package com.github.javaparser.symbolsolver;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -28,7 +29,6 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -39,23 +39,23 @@ public class Issue4450Test extends AbstractSymbolResolutionTest {
     public void test() throws IOException {
         ParserConfiguration config = new ParserConfiguration();
         Path issueResourcesPath = adaptPath("src/test/resources/issue4450");
-	    JavaParserTypeSolver jpts = new JavaParserTypeSolver(issueResourcesPath);
+        JavaParserTypeSolver jpts = new JavaParserTypeSolver(issueResourcesPath);
         CombinedTypeSolver cts = new CombinedTypeSolver();
         cts.add(new ReflectionTypeSolver(false));
         cts.add(jpts);
         config.setSymbolResolver(new JavaSymbolSolver(cts));
         StaticJavaParser.setConfiguration(config);
-	    StaticJavaParser.setConfiguration(config);
-	    CompilationUnit cu = StaticJavaParser.parse(issueResourcesPath.resolve("a/RefCycleClass.java"));
+        StaticJavaParser.setConfiguration(config);
+        CompilationUnit cu = StaticJavaParser.parse(issueResourcesPath.resolve("a/RefCycleClass.java"));
 
-	    // We shouldn't throw a mismatched symbol
-	    assertDoesNotThrow(() -> cu.findAll(NameExpr.class).stream()
-	            .map(NameExpr::resolve)
-	            .findAny().get());
+        // We shouldn't throw a mismatched symbol
+        assertDoesNotThrow(() -> cu.findAll(NameExpr.class).stream()
+                .map(NameExpr::resolve)
+                .findAny()
+                .get());
 
-	    cu.findAll(NameExpr.class).forEach(expr -> {
-	    	expr.resolve().getName();
-	    });
+        cu.findAll(NameExpr.class).forEach(expr -> {
+            expr.resolve().getName();
+        });
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -346,8 +346,6 @@
                     <!-- This is the last version with Java 8 support -->
                     <version>2.43.0</version>
                     <configuration>
-                        <!-- limit format enforcement to just the files changed by this feature branch -->
-                        <ratchetFrom>origin/master</ratchetFrom>
                         <java>
                             <!-- google-java-format, but better: see https://github.com/palantir/palantir-java-format -->
                             <palantirJavaFormat/>


### PR DESCRIPTION
This PR fixes the formatting issue that caused the spotless check in https://github.com/javaparser/javaparser/pull/4477 to fail, but also disables the spotless ratcheting feature. With ratcheting enabled, spotless will only check and reformat files that differ from the versions on the master branch, but that makes fixing inconsistencies that have been merged to master more difficult and can hide issues that have already been merged.