### PR TITLE
Exclude unavailable macos <-> java version combinations from github tests

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -35,6 +35,19 @@ jobs:
         ## Different JDK versions have different implementations etc. -- test on all combinations (ideally 8 to latest).
         ### exclude pre-8 (min development version jdk8)
         jdk: [ 8,9,10,11,12,13,14,15,16,17,18 ]
+        # The below configurations are no longer available on github runners and is not supported by the 
+        # setup-java action, nor are they available from the supported distributions.
+        # See https://github.com/actions/setup-java for details
+        exclude:
+          - os: macos-latest
+            jdk: 9
+          - os: macos-latest
+            jdk: 10
+          - os: macos-latest
+            jdk: 12
+          - os: macos-latest
+            jdk: 14
+
     env:
       OS: ${{ matrix.os }}
       JDK: ${{ matrix.jdk }}


### PR DESCRIPTION
This PR excludes the java versions currently failing on macos from the list of distributions that are tested. I went through the list of supported distributions on https://github.com/actions/setup-java (both the versions they mention there and the release archives for each distribution) and none of them seem to support these EoL versions. 

I'm sure there is a way to test these versions, but it will likely take a fair amount of work to set this up. Until this is done (if it does happen), I think it is better to exclude these versions for 2 reasons:
1. Having consistent expected build failures as part of the standard PR workflow makes it easier to miss legitimate issues
2. The following LTS releases are already tested: java 8 (older than the oldest excluded release), java 11 (in the middle of the excluded releases), and java 17 (newer than the newest release). It seems very unlikely that the tests would fail for one of the excluded versions, but pass for all of the surrounding versions for which the tests are being run