### PR TITLE
Add feature of creating pretty formatted arrays of annotations

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
@@ -666,4 +666,36 @@ class DefaultPrettyPrinterTest {
 
         assertEqualsStringIgnoringEol(expectedCode, actualCode);
     }
+
+    @Test
+    void testArrayOfAnnotationsFormat() {
+        String expectedCode = "import io.swagger.v3.oas.annotations.Operation;\n" +
+                "import io.swagger.v3.oas.annotations.Parameter;\n" +
+                "import io.swagger.v3.oas.annotations.responses.ApiResponse;\n" +
+                "import io.swagger.v3.oas.annotations.responses.ApiResponses;\n" +
+                "import org.springframework.http.HttpStatus;\n" +
+                "import org.springframework.http.ResponseEntity;\n" +
+                "import org.springframework.web.bind.annotation.DeleteMapping;\n" +
+                "\n" +
+                "@Deprecated\n" +
+                "public class UserController2 {\n" +
+                "\n" +
+                "    @Operation(summary = \"Delete a user\")\n" +
+                "    @ApiResponses(value = {\n" +
+                "            @ApiResponse(responseCode = \"204\", description = \"OK\"),\n" +
+                "            @ApiResponse(responseCode = \"404\", description = \"Failed\")\n" +
+                "    })\n" +
+                "    @DeleteMapping(\"/{id}\")\n" +
+                "    public ResponseEntity<Void> deleteUser(@Parameter(description = \"ID of the user\", required = true) int id) {\n" +
+                "        return new ResponseEntity<>(HttpStatus.NOT_FOUND);\n" +
+                "    }\n" +
+                "}\n";
+
+        printerConfiguration.addOption(new DefaultConfigurationOption(ConfigOption.INDENT_PRINT_ARRAYS_OF_ANNOTATIONS, true));
+        CompilationUnit cu = parserAdapter.parse(expectedCode);
+        Printer printer = getDefaultPrinter(printerConfiguration);
+        String actualCode = printer.print(cu);
+
+        assertEqualsStringIgnoringEol(expectedCode, actualCode);
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
@@ -666,4 +666,65 @@ class DefaultPrettyPrinterTest {
 
         assertEqualsStringIgnoringEol(expectedCode, actualCode);
     }
+
+    @Test
+    void testArrayOfAnnotationsFormat() {
+        String expectedCode = "import io.swagger.v3.oas.annotations.Operation;\n" +
+                "import io.swagger.v3.oas.annotations.Parameter;\n" +
+                "import io.swagger.v3.oas.annotations.responses.ApiResponse;\n" +
+                "import io.swagger.v3.oas.annotations.responses.ApiResponses;\n" +
+                "import org.springframework.http.HttpStatus;\n" +
+                "import org.springframework.http.ResponseEntity;\n" +
+                "import org.springframework.web.bind.annotation.DeleteMapping;\n" +
+                "\n" +
+                "@Deprecated\n" +
+                "public class UserController2 {\n" +
+                "\n" +
+                "    @Operation(summary = \"Delete a user\")\n" +
+                "    @ApiResponses(value = {\n" +
+                "            @ApiResponse(responseCode = \"204\", description = \"OK\"),\n" +
+                "            @ApiResponse(responseCode = \"404\", description = \"Failed\")\n" +
+                "    })\n" +
+                "    @DeleteMapping(\"/{id}\")\n" +
+                "    public ResponseEntity<Void> deleteUser(@Parameter(description = \"ID of the user\", required = true) int id) {\n" +
+                "        return new ResponseEntity<>(HttpStatus.NOT_FOUND);\n" +
+                "    }\n" +
+                "}\n";
+
+        printerConfiguration.addOption(new DefaultConfigurationOption(ConfigOption.INDENT_PRINT_ARRAYS_OF_ANNOTATIONS, true));
+        CompilationUnit cu = parserAdapter.parse(expectedCode);
+        Printer printer = getDefaultPrinter(printerConfiguration);
+        String actualCode = printer.print(cu);
+
+        assertEqualsStringIgnoringEol(expectedCode, actualCode);
+    }
+
+
+    @Test
+    void testArrayOfAnnotationsDisableFormat() {
+        String expectedCode = "import io.swagger.v3.oas.annotations.Operation;\n" +
+                "import io.swagger.v3.oas.annotations.Parameter;\n" +
+                "import io.swagger.v3.oas.annotations.responses.ApiResponse;\n" +
+                "import io.swagger.v3.oas.annotations.responses.ApiResponses;\n" +
+                "import org.springframework.http.HttpStatus;\n" +
+                "import org.springframework.http.ResponseEntity;\n" +
+                "import org.springframework.web.bind.annotation.DeleteMapping;\n" +
+                "\n" +
+                "@Deprecated\n" +
+                "public class UserController2 {\n" +
+                "\n" +
+                "    @Operation(summary = \"Delete a user\")\n" +
+                "    @ApiResponses(value = { @ApiResponse(responseCode = \"204\", description = \"OK\"), @ApiResponse(responseCode = \"404\", description = \"Failed\") })\n" +
+                "    @DeleteMapping(\"/{id}\")\n" +
+                "    public ResponseEntity<Void> deleteUser(@Parameter(description = \"ID of the user\", required = true) int id) {\n" +
+                "        return new ResponseEntity<>(HttpStatus.NOT_FOUND);\n" +
+                "    }\n" +
+                "}\n";
+
+        CompilationUnit cu = parserAdapter.parse(expectedCode);
+        Printer printer = getDefaultPrinter(printerConfiguration);
+        String actualCode = printer.print(cu);
+
+        assertEqualsStringIgnoringEol(expectedCode, actualCode);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -615,6 +615,8 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
                 printer.print(" ");
             }
         }
+        printOrphanCommentsEnding(n);
+        printer.print("}");
     }
 
     private boolean doPrintAsArrayOfAnnotations(final ArrayInitializerExpr n) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -588,18 +588,39 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         printComment(n.getComment(), arg);
         printer.print("{");
         if (!isNullOrEmpty(n.getValues())) {
-            printer.print(" ");
+            final boolean multiLine = doPrintAsArrayOfAnnotations(n);
+            if (multiLine) {
+                printer.println();
+                printer.indent();
+                printer.indent();
+            } else {
+                printer.print(" ");
+            }
+
             for (final Iterator<Expression> i = n.getValues().iterator(); i.hasNext(); ) {
                 final Expression expr = i.next();
                 expr.accept(this, arg);
                 if (i.hasNext()) {
-                    printer.print(", ");
+                    printer.print(multiLine ? "," : ", ");
+                    if (multiLine)
+                        printer.println();
                 }
             }
-            printer.print(" ");
+
+            if (multiLine) {
+                printer.println();
+                printer.unindent();
+                printer.unindent();
+            } else {
+                printer.print(" ");
+            }
         }
         printOrphanCommentsEnding(n);
         printer.print("}");
+    }
+
+    private boolean doPrintAsArrayOfAnnotations(final ArrayInitializerExpr n) {
+        return getOption(ConfigOption.INDENT_PRINT_ARRAYS_OF_ANNOTATIONS).isPresent() && n.getValues().stream().allMatch(s -> s instanceof AnnotationExpr);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -588,18 +588,46 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         printComment(n.getComment(), arg);
         printer.print("{");
         if (!isNullOrEmpty(n.getValues())) {
-            printer.print(" ");
-            for (final Iterator<Expression> i = n.getValues().iterator(); i.hasNext(); ) {
-                final Expression expr = i.next();
-                expr.accept(this, arg);
-                if (i.hasNext()) {
-                    printer.print(", ");
-                }
-            }
-            printer.print(" ");
+            printFormattedArray(n, arg, doPrintAsArrayOfAnnotations(n));
         }
         printOrphanCommentsEnding(n);
         printer.print("}");
+    }
+
+    private boolean doPrintAsArrayOfAnnotations(final ArrayInitializerExpr n) {
+        return getOption(ConfigOption.INDENT_PRINT_ARRAYS_OF_ANNOTATIONS).isPresent() && n.getValues().stream().allMatch(s -> s instanceof AnnotationExpr);
+    }
+
+    private void printFormattedArray(final ArrayInitializerExpr n, final Void arg, final boolean multiline) {
+        if (multiline) {
+            printer.println();
+            printer.indent();
+            printer.indent();
+        } else {
+            printer.print(" ");
+        }
+
+        basicPrintArray(n, arg, multiline);
+        if (multiline) {
+            printer.println();
+            printer.unindent();
+            printer.unindent();
+        } else {
+            printer.print(" ");
+        }
+
+    }
+
+    private void basicPrintArray(final ArrayInitializerExpr n, final Void arg, boolean multiLIne) {
+        for (final Iterator<Expression> i = n.getValues().iterator(); i.hasNext(); ) {
+            final Expression expr = i.next();
+            expr.accept(this, arg);
+            if (i.hasNext()) {
+                printer.print(multiLIne ? "," : ", ");
+                if (multiLIne)
+                    printer.println();
+            }
+        }
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
@@ -93,8 +93,22 @@ public class DefaultPrinterConfiguration implements PrinterConfiguration {
         /**
          * Indentation proprerty
          */
-        INDENTATION(Indentation.class, new Indentation(IndentType.SPACES, 4));
+        INDENTATION(Indentation.class, new Indentation(IndentType.SPACES, 4)),
 
+        /**
+         * This parameter allows to print pretty formatted arrays
+         * <pre>{@code
+         *     @ApiResponses(value = {
+         *        @ApiResponse(responseCode = "200", description = "OK"),
+         *        @ApiResponse(responseCode = "404", description = "Error")
+         *     })
+         * }<pre>
+         * instead of inline like this
+         * <pre>{@code
+         *         @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK"), @ApiResponse(responseCode = "404", description = "Error")})
+         * }<pre>
+         */
+        INDENT_PRINT_ARRAYS_OF_ANNOTATIONS(Boolean.class);
         Object defaultValue;
 
         Class type;


### PR DESCRIPTION
Adds parameter to create multiline arrays of annotations to make it more readable 

instead of 

`@ApiResponses(value = {@ApiResponse(responseCode = "204", description = "OK"), @ApiResponse(responseCode = "404", description = "Failed")})`

it produces more readable version
```
    @ApiResponses(value = {
            @ApiResponse(responseCode = "204", description = "OK"),
            @ApiResponse(responseCode = "404", description = "Failed")
    })
```