### PR TITLE
Fix: issue 4492 resolve LambdaExpr has NullPointException

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundLogic.java
@@ -56,6 +56,11 @@ public class LeastUpperBoundLogic {
             throw new IllegalArgumentException();
         }
 
+		// If there is only one type then the lub is the type itself
+		if (types.size() == 1) {
+			return types.iterator().next();
+		}
+
         // The direct supertypes of the null type are all reference types other than the null type itself.
         // One way to handle this case is to remove the type null from the list of types.
         // Provides the concret type of Lazy type if needed

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/LeastUpperBoundTest.java
@@ -77,6 +77,12 @@ class LeastUpperBoundTest {
     }
 
     @Test
+    public void lub_of_one_null_element_is_itself() {
+        ResolvedType lub = leastUpperBound(NullType.INSTANCE);
+        assertEquals(lub, lub);
+    }
+
+    @Test
     public void lub_should_fail_if_no_type_provided() {
         try {
             ResolvedType lub = leastUpperBound(new ResolvedType[] {});


### PR DESCRIPTION
Fixes #4492 

If there is only one type then the lub is the type itself. This correction is only partial, but it does provide a solution to the issue raised. 
