### PR TITLE
Allow primitive types for patterns

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SwitchExprTest.java
@@ -456,4 +456,28 @@ class SwitchExprTest {
         assertEquals("Foo f", entry.getLabels().get(0).toString());
         assertEquals("f.get();", entry.getStatements().get(0).toString());
     }
+
+    @Test
+    void testRecordPatternWithPrimitiveType() {
+        SwitchExpr switchExpr =
+                parseExpression("switch (foo) { case Foo(int x) -> sink(x); }").asSwitchExpr();
+
+        assertEquals(Node.Parsedness.PARSED, switchExpr.getParsed());
+
+        SwitchEntry entry = switchExpr.getEntry(0);
+        Expression switchLabel = entry.getLabels().get(0);
+
+        assertEquals("Foo(int x)", switchLabel.toString());
+        assertTrue(switchLabel.isRecordPatternExpr());
+
+        RecordPatternExpr recordPattern = switchLabel.asRecordPatternExpr();
+
+        assertEquals("Foo", recordPattern.getType().toString());
+        assertEquals(1, recordPattern.getPatternList().size());
+        assertTrue(recordPattern.getPatternList().get(0).isTypePatternExpr());
+
+        TypePatternExpr innerType = recordPattern.getPatternList().get(0).asTypePatternExpr();
+
+        assertTrue(innerType.getType().isPrimitiveType());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/PatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/PatternExpr.java
@@ -28,7 +28,7 @@ import com.github.javaparser.ast.Generated;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.observer.ObservableProperty;
-import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PatternExprMetaModel;
@@ -66,12 +66,12 @@ import java.util.function.Consumer;
  * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8181287">JEP305: https://bugs.openjdk.java.net/browse/JDK-8181287</a>
  * @see <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.20">https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.20</a>
  */
-public abstract class PatternExpr extends Expression implements NodeWithType<PatternExpr, ReferenceType> {
+public abstract class PatternExpr extends Expression implements NodeWithType<PatternExpr, Type> {
 
-    private ReferenceType type;
+    private Type type;
 
     @AllFieldsConstructor
-    public PatternExpr(final ReferenceType type) {}
+    public PatternExpr(final Type type) {}
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
@@ -119,7 +119,7 @@ public abstract class PatternExpr extends Expression implements NodeWithType<Pat
     }
 
     @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
-    public PatternExpr setType(final ReferenceType type) {
+    public PatternExpr setType(final Type type) {
         assertNotNull(type);
         if (type == this.type) {
             return this;
@@ -131,8 +131,12 @@ public abstract class PatternExpr extends Expression implements NodeWithType<Pat
         return this;
     }
 
+    /**
+     * The types of record patters and top-level type patterns must be reference types, but nested type patterns
+     * can also have primitive types.
+     */
     @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
-    public ReferenceType getType() {
+    public Type getType() {
         return type;
     }
 
@@ -143,7 +147,7 @@ public abstract class PatternExpr extends Expression implements NodeWithType<Pat
             return false;
         }
         if (node == type) {
-            setType((ReferenceType) replacementNode);
+            setType((Type) replacementNode);
             return true;
         }
         return super.replace(node, replacementNode);
@@ -153,7 +157,7 @@ public abstract class PatternExpr extends Expression implements NodeWithType<Pat
      * This constructor is used by the parser and is considered private.
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public PatternExpr(TokenRange tokenRange, ReferenceType type) {
+    public PatternExpr(TokenRange tokenRange, Type type) {
         super(tokenRange);
         setType(type);
         customInitialization();

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
@@ -12,6 +12,7 @@ import com.github.javaparser.ast.nodeTypes.modifiers.NodeWithFinalModifier;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -68,8 +69,17 @@ public class RecordPatternExpr extends PatternExpr implements NodeWithFinalModif
 
     @AllFieldsConstructor
     public RecordPatternExpr(
-            final NodeList<Modifier> modifiers, final ReferenceType type, final NodeList<PatternExpr> patternList) {
+            final NodeList<Modifier> modifiers, final Type type, final NodeList<PatternExpr> patternList) {
         this(null, modifiers, type, patternList);
+    }
+
+    /**
+     * The type of RecordPatternExpr must always be a reference type. Only nested TypePatternExprs may have primitive
+     * types.
+     */
+    @Override
+    public ReferenceType getType() {
+        return super.getType().asReferenceType();
     }
 
     @Override
@@ -203,10 +213,7 @@ public class RecordPatternExpr extends PatternExpr implements NodeWithFinalModif
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
     public RecordPatternExpr(
-            TokenRange tokenRange,
-            NodeList<Modifier> modifiers,
-            ReferenceType type,
-            NodeList<PatternExpr> patternList) {
+            TokenRange tokenRange, NodeList<Modifier> modifiers, Type type, NodeList<PatternExpr> patternList) {
         super(tokenRange, type);
         setModifiers(modifiers);
         setPatternList(patternList);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypePatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypePatternExpr.java
@@ -28,7 +28,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.modifiers.NodeWithFinalModifier;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.CloneVisitor;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
@@ -63,7 +63,7 @@ import java.util.function.Consumer;
  * Per JEP305 (not currently listed within the JLS):
  * <br>
  * <pre>{@code Pattern:
- *      ReferenceType Identifier}</pre>
+ *      Type Identifier}</pre>
  *
  * @author Roger Howell
  *
@@ -83,7 +83,7 @@ public class TypePatternExpr extends PatternExpr
     }
 
     @AllFieldsConstructor
-    public TypePatternExpr(final NodeList<Modifier> modifiers, final ReferenceType type, SimpleName name) {
+    public TypePatternExpr(final NodeList<Modifier> modifiers, final Type type, SimpleName name) {
         this(null, modifiers, type, name);
     }
 
@@ -91,7 +91,7 @@ public class TypePatternExpr extends PatternExpr
      * This constructor is used by the parser and is considered private.
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public TypePatternExpr(TokenRange tokenRange, NodeList<Modifier> modifiers, ReferenceType type, SimpleName name) {
+    public TypePatternExpr(TokenRange tokenRange, NodeList<Modifier> modifiers, Type type, SimpleName name) {
         super(tokenRange, type);
         setModifiers(modifiers);
         setName(name);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -1298,7 +1298,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(final TypePatternExpr n, final Object arg) {
         NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
         SimpleName name = cloneNode(n.getName(), arg);
-        ReferenceType type = cloneNode(n.getType(), arg);
+        Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         TypePatternExpr r = new TypePatternExpr(n.getTokenRange().orElse(null), modifiers, type, name);
         r.setComment(comment);
@@ -1355,7 +1355,7 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     public Visitable visit(final RecordPatternExpr n, final Object arg) {
         NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
         NodeList<PatternExpr> patternList = cloneList(n.getPatternList(), arg);
-        ReferenceType type = cloneNode(n.getType(), arg);
+        Type type = cloneNode(n.getType(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         RecordPatternExpr r = new RecordPatternExpr(n.getTokenRange().orElse(null), modifiers, type, patternList);
         r.setComment(comment);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -1293,7 +1293,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     public Visitable visit(final TypePatternExpr n, final A arg) {
         NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         SimpleName name = (SimpleName) n.getName().accept(this, arg);
-        ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
+        Type type = (Type) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (name == null || type == null) return null;
         n.setModifiers(modifiers);
@@ -1307,7 +1307,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     public Visitable visit(final RecordPatternExpr n, final A arg) {
         NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         NodeList<PatternExpr> patternList = modifyList(n.getPatternList(), arg);
-        ReferenceType type = (ReferenceType) n.getType().accept(this, arg);
+        Type type = (Type) n.getType().accept(this, arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         if (type == null) return null;
         n.setModifiers(modifiers);

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -2006,8 +2006,8 @@ public final class JavaParserMetaModel {
         patternExprMetaModel.typePropertyMetaModel = new PropertyMetaModel(
                 patternExprMetaModel,
                 "type",
-                com.github.javaparser.ast.type.ReferenceType.class,
-                Optional.of(referenceTypeMetaModel),
+                com.github.javaparser.ast.type.Type.class,
+                Optional.of(typeMetaModel),
                 false,
                 false,
                 false,

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -3341,12 +3341,12 @@ PatternExpr PatternExpression():
 TypePatternExpr TypePatternExpression():
 {
     ModifierHolder modifier;
-    ReferenceType type;
+    Type type;
     SimpleName name;
 }
 {
     modifier = Modifiers()
-    type = ReferenceType(modifier.annotations)
+    type = Type(modifier.annotations)
     name = SimpleName()
     { return new TypePatternExpr(range(type, token()), modifier.modifiers, type, name); }
 }
@@ -3424,7 +3424,10 @@ Expression InstanceOfExpression():
         (
             LOOKAHEAD(PatternExpression())
             pattern = PatternExpression()
-            { ret = new InstanceOfExpr(range(ret, token()), ret, pattern.getType(), pattern); }
+            // From the JLS https://docs.oracle.com/javase/specs/jls/se21/html/jls-14.html#jls-Pattern, the type of
+            // a top-level pattern must be a reference type. This means that converting the pattern type to a
+            // reference type here is always safe if the code being parsed compiles.
+            { ret = new InstanceOfExpr(range(ret, token()), ret, pattern.getType().asReferenceType(), pattern); }
          |
             type = AnnotatedReferenceType()
             { ret = new InstanceOfExpr(range(ret, token()), ret, type, null); }


### PR DESCRIPTION
Fixes #4504.

The type of a PatternExpr has been represented by a reference type until now, which was correct before the introduction of record patterns (since a top level pattern type must always be a reference type from https://docs.oracle.com/javase/specs/jls/se21/html/jls-14.html#jls-Pattern), but now nested type patterns may have a primitive type as well. The type of a record pattern expr must still be a reference type since there aren't primitive records in java.

This PR updates the type of a pattern to reflect this, which includes making a necessary API change.
