### PR TITLE
Add missing type erasure in ClassOrInterfaceType.toDescriptor

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java
@@ -266,7 +266,7 @@ public class ClassOrInterfaceType extends ReferenceType
     @Override
     public String toDescriptor() {
         return String.format(
-                "L%s;", resolve().asReferenceType().getQualifiedName().replace(".", "/"));
+                "L%s;", resolve().erasure().asReferenceType().getQualifiedName().replace(".", "/"));
     }
 
     @Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/ast/type/ClassOrInterfaceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/ast/type/ClassOrInterfaceTypeTest.java
@@ -75,4 +75,20 @@ class ClassOrInterfaceTypeTest {
 
         assertEquals("Ljava/lang/String;", classOrInterfaceType.toDescriptor());
     }
+
+    @Test
+    void testToDescriptorWithTypeVariables() {
+        ParseResult<CompilationUnit> compilationUnit =
+                javaParser.parse("public class A  { public static <T extends String> void method(T arg); }");
+
+        assertEquals(
+                "(Ljava/lang/String;)V",
+                compilationUnit
+                        .getResult()
+                        .get()
+                        .getType(0)
+                        .getMethodsByName("method")
+                        .get(0)
+                        .toDescriptor());
+    }
 }


### PR DESCRIPTION
Fixes #4519.

This fixes a bug in `toDescriptor` where we try to derive binary names of non-erased types (which may be type variables or wildcards, and therefore not have binary names) by always looking at the erasure.

