### PR TITLE
Add missing copyright notice to RecordPatternExpr.java

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
@@ -17,7 +17,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.expr;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
 package com.github.javaparser.ast.expr;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;


### PR DESCRIPTION
I missed this in the original PR adding support for record patterns