### PR TITLE
Fix scope for variables introduced by pattern expressions

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -1143,6 +1143,7 @@ public abstract class Node
      * @see <a href="https://en.wikipedia.org/wiki/Post-order">Post-order traversal</a>
      */
     public static class PostOrderIterator implements Iterator<Node> {
+
         private final Stack<Level> stack = new Stack<>();
 
         public PostOrderIterator(Node root) {
@@ -1192,8 +1193,11 @@ public abstract class Node
          * has been expanded, i.e., if its children have been processed.
          */
         private static class Level {
+
             private final List<Node> nodes;
+
             private int index = 0;
+
             private boolean expanded = false;
 
             public Level(List<Node> nodes) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -136,6 +136,9 @@ public class JavaParserFactory {
         if (node instanceof ObjectCreationExpr) {
             return new ObjectCreationContext((ObjectCreationExpr) node, typeSolver);
         }
+        if (node instanceof ConditionalExpr) {
+            return new ConditionalExprContext((ConditionalExpr) node, typeSolver);
+        }
         if (node instanceof NameExpr) {
             // to resolve a name when in a fieldAccess context, we can go up until we get a node other than
             // FieldAccessExpr,

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -75,6 +75,9 @@ public class JavaParserFactory {
         if (node instanceof WhileStmt) {
             return new WhileStatementContext((WhileStmt) node, typeSolver);
         }
+        if (node instanceof DoStmt) {
+            return new DoStatementContext((DoStmt) node, typeSolver);
+        }
         if (node instanceof InstanceOfExpr) {
             return new InstanceOfExprContext((InstanceOfExpr) node, typeSolver);
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -72,6 +72,9 @@ public class JavaParserFactory {
         if (node instanceof IfStmt) {
             return new IfStatementContext((IfStmt) node, typeSolver);
         }
+        if (node instanceof WhileStmt) {
+            return new WhileStatementContext((WhileStmt) node, typeSolver);
+        }
         if (node instanceof InstanceOfExpr) {
             return new InstanceOfExprContext((InstanceOfExpr) node, typeSolver);
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/NormalCompletionVisitor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/NormalCompletionVisitor.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.symbolsolver.javaparsermodel;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.stmt.*;
+import com.github.javaparser.ast.visitor.GenericVisitorWithDefaults;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * When deciding into which scope pattern variables should be introduced, it is sometimes necessary to determine whether
+ * a statement can complete normally {@see https://docs.oracle.com/javase/specs/jls/se22/html/jls-14.html#jls-14.22}.
+ * The JLS specifies that a statement can complete normally only if it is reachable and specifies rules for what it
+ * means for a statement to be reachable, but that part can be ignored in JavaParser since having unreachable code
+ * results in a compilation error and is thus not supported. This means that all of the rules are implemented with the
+ * assumption that provided nodes are reachable.
+ *
+ * An example of where this is needed is for the following rule regarding pattern variables introduced by if-statements.
+ * 6.3.2.2. if Statements {@see https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2.2}:
+ *   The following rules apply to a statement if (e) S (§14.9.1):
+ *     A pattern variable is introduced by if (e) S iff (i) it is introduced by e when false and (ii) S cannot complete
+ *     normally.
+ *
+ * This means that in this example:
+ * {@code
+ *   if (!(x instanceof Foo f)) {
+ *       return;
+ *   }
+ *   System.out.println(f);
+ * }
+ * f will be in scope for the println call since the block making up the then-block of the if statement (S in the rule
+ * above) cannot complete normally (since the last statement, return, cannot complete normally).
+ * But, in this example:
+ * {@code
+ *   if (!(x instanceof Foo f)) { }
+ * }
+ * f is not introduced by the if statement since the empty then-block can complete normally.
+ */
+public class NormalCompletionVisitor extends GenericVisitorWithDefaults<Boolean, Void> {
+
+    private static String[] nonEnhancedSwitchTypes = new String[] {
+        "java.lang.Byte", "java.lang.Character", "java.lang.Integer", "java.lang.Short", "java.lang.String"
+    };
+
+    @Override
+    public Boolean defaultAction(Node n, Void unused) {
+        return true;
+    }
+
+    /**
+     * A break statement cannot complete normally.
+     */
+    @Override
+    public Boolean visit(BreakStmt breakStmt, Void unused) {
+        return false;
+    }
+
+    /**
+     * A continue statement cannot complete normally.
+     */
+    @Override
+    public Boolean visit(ContinueStmt continueStmt, Void unused) {
+        return false;
+    }
+
+    /**
+     * A return statement cannot complete normally.
+     */
+    @Override
+    public Boolean visit(ReturnStmt returnStmt, Void unused) {
+        return false;
+    }
+
+    /**
+     * A throw statement cannot complete normally.
+     */
+    @Override
+    public Boolean visit(ThrowStmt throwStmt, Void unused) {
+        return false;
+    }
+
+    /**
+     * A yield statement cannot complete normally.
+     */
+    @Override
+    public Boolean visit(YieldStmt yieldStmt, Void unused) {
+        return false;
+    }
+
+    /**
+     * An empty block that is not a switch block can complete normally iff it is reachable.
+     *
+     * A non-empty block that is not a switch block can complete normally iff the last statement in it can complete
+     * normally.
+     *
+     * The first statement in a non-empty block that is not a switch block is reachable iff the block is reachable.
+     *
+     * Every other statement S in a non-empty block that is not a switch block is reachable iff the statement preceding
+     * S can complete normally.
+     */
+    @Override
+    public Boolean visit(BlockStmt block, Void unused) {
+        return block.getStatements().isEmpty()
+                || block.getStatements().getLast().get().accept(this, unused);
+    }
+
+    /**
+     * A labeled statement can complete normally if at least one of the following is true:
+     * - The contained statement can complete normally.
+     * - There is a reachable break statement that exits the labeled statement.
+     */
+    @Override
+    public Boolean visit(LabeledStmt labeledStmt, Void unused) {
+        if (labeledStmt.getStatement().accept(this, unused)) {
+            return true;
+        }
+
+        List<BreakStmt> matchingBreaks = labeledStmt.findAll(
+                BreakStmt.class,
+                breakStmt -> breakStmt.getLabel().isPresent()
+                        && breakStmt
+                                .getLabel()
+                                .get()
+                                .getIdentifier()
+                                .equals(labeledStmt.getLabel().getIdentifier()));
+
+        return !matchingBreaks.isEmpty();
+    }
+
+    /**
+     * An if-then statement can complete normally iff it is reachable.
+     *
+     * An if-then-else statement can complete normally iff the then-statement can complete normally or the
+     * else-statement can complete normally.
+     */
+    @Override
+    public Boolean visit(IfStmt ifStmt, Void unused) {
+        if (!ifStmt.getElseStmt().isPresent()) {
+            return true;
+        }
+
+        return ifStmt.getThenStmt().accept(this, unused)
+                || ifStmt.getElseStmt().get().accept(this, unused);
+    }
+
+    /**
+     * A while statement can complete normally iff at least one of the following is true:
+     * - The while statement is reachable and the condition expression is not a constant expression with value true.
+     * - There is a reachable break statement that exits the while statement.
+     */
+    @Override
+    public Boolean visit(WhileStmt whileStmt, Void unused) {
+        /**
+         * FIXME: To implement this properly, constant expression evaluation would need to be implemented.
+         *  this is specifically necessary for the first statement in the docstring.
+         *
+         * Simply returning true here will only cause issues where the while statement is the only statement, or the
+         * last statement in a block for which it should be determined if it completes normally. For example, keeping
+         * in mind the rule:
+         *   A pattern variable is introduced by if (e) S iff
+         *     (i) it is introduced by e when false and
+         *     (ii) S cannot complete normally.
+         *
+         * {@code
+         * while(true) {}
+         * }
+         * cannot complete normally since
+         *   (i) the condition is a constant expression with value true and
+         *   (ii) there is no break statement that exits the loop.
+         *
+         * Therefore, in:
+         * {@code
+         * if (!(x instanceof Foo f)) {
+         *     while (true) {}
+         * }
+         * System.out.println(f);
+         * }
+         * the if statement should introduce the variable f into scope, so the f that is printed should be the pattern
+         * variable.
+         *
+         * Simply returning true in this visit method would mean that {@code while (true) {}} is erroneously considered
+         * to complete normally and this example will not be handled correctly.
+         *
+         * As long as the last statement is not the while, however, JavaParser will still handle this correctly for
+         * compiling code.
+         */
+        return true;
+    }
+
+    /**
+     * A do statement can complete normally iff at least one of the following is true:
+     * - The contained statement can complete normally and the condition expression is not a constant expression
+     *   with value true.
+     * - The do statement contains a reachable continue statement with no label, and the do statement is the innermost
+     *   while, do, or for statement that contains that continue statement, and the continue statement continues that do
+     *   statement, and the condition expression is not a constant expression with value true.
+     * - The do statement contains a reachable continue statement with label L, and the do statement has label L, and
+     *   the continue statement continues that do statement, and the condition expression is not a constant expression
+     *   with value true.
+     * - There is a reachable break statement that exits the do statement.
+     */
+    @Override
+    public Boolean visit(DoStmt doStmt, Void unused) {
+        // FIXME: See comment in while visit method
+        return true;
+    }
+
+    /**
+     * A basic for statement can complete normally iff at least one of the following is true:
+     * - The for statement is reachable, there is a condition expression, and the condition expression is not a constant
+     *   expression with value true.
+     * - There is a reachable break statement that exits the for statement.
+     */
+    @Override
+    public Boolean visit(ForStmt forStmt, Void unused) {
+        // FIXME: See comment in while visit method
+        return true;
+    }
+
+    /**
+     * A synchronized statement can complete normally iff the contained statement can complete normally.
+     */
+    @Override
+    public Boolean visit(SynchronizedStmt synchronizedStmt, Void unused) {
+        return synchronizedStmt.getBody().accept(this, unused);
+    }
+
+    /**
+     * A try statement can complete normally iff both of the following are true:
+     * - The try block can complete normally or any catch block can complete normally.
+     * - If the try statement has a finally block, then the finally block can complete normally.
+     */
+    @Override
+    public Boolean visit(TryStmt tryStmt, Void unused) {
+        if (tryStmt.getFinallyBlock().isPresent() && !(tryStmt.getFinallyBlock().get()).accept(this, unused)) {
+            return false;
+        }
+
+        if (tryStmt.getTryBlock().accept(this, unused)) {
+            return true;
+        }
+
+        return tryStmt.getCatchClauses().stream()
+                .anyMatch(catchClause -> catchClause.getBody().accept(this, unused));
+    }
+
+    /**
+     * A switch statement whose switch block is empty, or contains only switch labels, can complete normally.
+     *
+     * A switch statement whose switch block consists of switch labeled statement groups can complete normally iff at
+     *   least one of the following is true:
+     * - The last statement in the switch block can complete normally.
+     * - There is at least one switch label after the last switch block statement group.
+     * - There is a reachable break statement that exits the switch statement.
+     * - The switch statement is not enhanced and its switch block does not contain a default label.
+     *
+     * A switch statement whose switch block consists of switch rules can complete normally iff at least one of the
+     *   following is true:
+     * - One of the switch rules introduces a switch rule expression (which is necessarily a statement expression).
+     * - One of the switch rules introduces a switch rule block that can complete normally.
+     * - One of the switch rules introduces a switch rule block that contains a reachable break statement which exits
+     *   the switch statement.
+     * - The switch statement is not enhanced and its switch block does not contain a default label.
+     */
+    @Override
+    public Boolean visit(SwitchStmt switchStmt, Void unused) {
+        // TODO
+        NodeList<SwitchEntry> entries = switchStmt.getEntries();
+
+        if (entries.isEmpty()) {
+            return true;
+        }
+
+        if (entries.get(0).getType().equals(SwitchEntry.Type.STATEMENT_GROUP)) {
+            // In this case, the switch stmt is a classic switch, so check:
+            // - The last statement in the switch block can complete normally.
+            // - There is at least one switch label after the last switch block statement group.
+            SwitchEntry lastEntry = entries.getLast().get();
+            if (lastEntry.getStatements().isEmpty()) {
+                return true;
+            }
+
+            Statement lastStmt = lastEntry.getStatements().getLast().get();
+            if (lastStmt.accept(this, unused)) {
+                return true;
+            }
+        } else if (entries.stream().anyMatch(entry -> switchRuleCompletesNormally(entry, unused))) {
+            return true;
+        }
+
+        if (containsCorrespondingBreak(switchStmt)) {
+            return true;
+        }
+
+        if (!isEnhanced(switchStmt) && !entries.stream().anyMatch(entry -> entry.isDefault())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * A switch statement whose switch block consists of switch rules can complete normally iff at least one of the
+     *   following is true:
+     * - One of the switch rules introduces a switch rule expression (which is necessarily a statement
+     *   expression).
+     * - One of the switch rules introduces a switch rule block that can complete normally.
+     */
+    private boolean switchRuleCompletesNormally(SwitchEntry switchEntry, Void unused) {
+        if (switchEntry.getType().equals(SwitchEntry.Type.EXPRESSION)) {
+            return true;
+        }
+
+        if (switchEntry.getStatements().getLast().isPresent()
+                && switchEntry.getStatements().getLast().get().accept(this, unused)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param statement should be one of: SwitchStatement, WhileStatement, DoStatement, ForStatement
+     * @return true if a break corresponding to the statement is found; false otherwise
+     */
+    public static boolean containsCorrespondingBreak(Statement statement) {
+        List<BreakStmt> breakStatements = statement.findAll(
+                BreakStmt.class, breakStmt -> !breakStmt.getLabel().isPresent());
+
+        for (BreakStmt breakStmt : breakStatements) {
+            Optional<Node> maybeParentNode = breakStmt.getParentNode();
+            while (true) {
+                if (!maybeParentNode.isPresent()) {
+                    throw new IllegalStateException("Found AST node without a parent in subtree of Statement");
+                }
+
+                Node parentNode = maybeParentNode.get();
+
+                if (parentNode instanceof SwitchStmt
+                        || parentNode instanceof WhileStmt
+                        || parentNode instanceof DoStmt
+                        || parentNode instanceof ForStmt
+                        || parentNode instanceof ForEachStmt) {
+                    if (parentNode == statement) {
+                        return true;
+                    } else {
+                        break;
+                    }
+                }
+
+                maybeParentNode = maybeParentNode.flatMap(node -> node.getParentNode());
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * From https://docs.oracle.com/javase/specs/jls/se21/html/jls-14.html#jls-14.11.2
+     *   An enhanced switch statement is one where either
+     *   (i) the type of the selector expression is not char, byte, short, int, Character, Byte, Short, Integer, String,
+     *       or an enum type, or
+     *   (ii) there is a case pattern or null literal associated with the switch block.
+     *
+     * Since this relies on resolving the type of the selector expression, it might not be possible to determine whether
+     * a given switch statement is enhanced or not. If this cannot be determined, assume that it is enhanced.
+     */
+    private static boolean isEnhanced(SwitchStmt stmt) {
+        for (SwitchEntry entry : stmt.getEntries()) {
+            if (entry.isDefault() || entry.getLabels().stream().anyMatch(label -> label.isNullLiteralExpr())) {
+                return false;
+            }
+        }
+
+        try {
+            ResolvedType selectorType = stmt.getSelector().calculateResolvedType();
+
+            if (selectorType.isPrimitive()) {
+                return false;
+            }
+
+            for (String nonEnhancedTypeName : nonEnhancedSwitchTypes) {
+                if (nonEnhancedTypeName.equals(selectorType.describe())) {
+                    return false;
+                }
+            }
+
+            if (selectorType.isReferenceType()) {
+                ResolvedReferenceType selectorRefType = selectorType.asReferenceType();
+
+                if (selectorRefType.getTypeDeclaration().isPresent()
+                        && selectorRefType.getTypeDeclaration().get().isEnum()) {
+                    return false;
+                }
+            }
+        } catch (UnsolvedSymbolException e) {
+            // Assume the switch is enhanced if the selector type cannot be resolved.
+            return true;
+        }
+
+        return true;
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/PatternVariableResult.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/PatternVariableResult.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.symbolsolver.javaparsermodel;
+
+import com.github.javaparser.ast.expr.TypePatternExpr;
+import java.util.LinkedList;
+import java.util.List;
+
+public class PatternVariableResult {
+    private List<TypePatternExpr> variablesIntroducedIfTrue;
+    private List<TypePatternExpr> variablesIntroducedIfFalse;
+
+    public PatternVariableResult(
+            LinkedList<TypePatternExpr> variablesIntroducedIfTrue,
+            LinkedList<TypePatternExpr> variablesIntroducedIfFalse) {
+        this.variablesIntroducedIfTrue = variablesIntroducedIfTrue;
+        this.variablesIntroducedIfFalse = variablesIntroducedIfFalse;
+    }
+
+    public PatternVariableResult() {
+        variablesIntroducedIfTrue = new LinkedList<>();
+        variablesIntroducedIfFalse = new LinkedList<>();
+    }
+
+    public List<TypePatternExpr> getVariablesIntroducedIfTrue() {
+        return variablesIntroducedIfTrue;
+    }
+
+    public List<TypePatternExpr> getVariablesIntroducedIfFalse() {
+        return variablesIntroducedIfFalse;
+    }
+
+    public void addVariablesIntroducedIfTrue(List<TypePatternExpr> patterns) {
+        variablesIntroducedIfTrue.addAll(patterns);
+    }
+
+    public void addVariablesIntroducedIfFalse(List<TypePatternExpr> patterns) {
+        variablesIntroducedIfFalse.addAll(patterns);
+    }
+
+    public void clearVariablesIntroducedIfTrue() {
+        variablesIntroducedIfTrue.clear();
+    }
+
+    public void clearVariablesIntroducedIfFalse() {
+        variablesIntroducedIfFalse.clear();
+    }
+
+    public void swapTrueAndFalse() {
+        List<TypePatternExpr> temp = variablesIntroducedIfTrue;
+        variablesIntroducedIfTrue = variablesIntroducedIfFalse;
+        variablesIntroducedIfFalse = temp;
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/PatternVariableVisitor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/PatternVariableVisitor.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.symbolsolver.javaparsermodel;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.visitor.GenericVisitorWithDefaults;
+import java.util.*;
+
+public class PatternVariableVisitor extends GenericVisitorWithDefaults<PatternVariableResult, Void> {
+
+    private static PatternVariableVisitor patternVariableVisitor = null;
+
+    private PatternVariableVisitor() {}
+
+    public static PatternVariableVisitor getInstance() {
+        if (patternVariableVisitor == null) {
+            patternVariableVisitor = new PatternVariableVisitor();
+        }
+        return patternVariableVisitor;
+    }
+
+    @Override
+    public PatternVariableResult defaultAction(Node node, Void unused) {
+        return new PatternVariableResult();
+    }
+
+    @Override
+    public PatternVariableResult visit(BinaryExpr expression, Void unused) {
+        if (expression.getOperator().equals(BinaryExpr.Operator.AND)) {
+            return getVariablesIntroducedByAnd(expression);
+        }
+        if (expression.getOperator().equals(BinaryExpr.Operator.OR)) {
+            return getVariablesIntroducedByOr(expression);
+        }
+
+        return new PatternVariableResult();
+    }
+
+    /**
+     * The following rules apply to a conditional-and expression a && b:
+     * - A pattern variable is introduced by a && b when true iff either
+     *   (i) it is introduced by a when true or
+     *   (ii) it is introduced by b when true.
+     *
+     * It should be noted that there is no rule for introducing a pattern variable by a && b when false.
+     * This is because it cannot be determined at compile time which operand will evaluate to false.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.1
+     */
+    private static PatternVariableResult getVariablesIntroducedByAnd(BinaryExpr expression) {
+        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableResult introducedByLeft = expression.getLeft().accept(variableVisitor, null);
+        PatternVariableResult introducedByRight = expression.getRight().accept(variableVisitor, null);
+
+        introducedByLeft.addVariablesIntroducedIfTrue(introducedByRight.getVariablesIntroducedIfTrue());
+        introducedByLeft.clearVariablesIntroducedIfFalse();
+
+        return introducedByLeft;
+    }
+
+    /**
+     * The following rules apply to a conditional-or expression a || b:
+     * - A pattern variable is introduced by a || b when false iff either
+     *   (i) it is introduced by a when false or
+     *   (ii) it is introduced by b when false.
+     *
+     * It should be noted that there is no rule for introducing a pattern variable by a || b when true.
+     * This is because it cannot be determined at compile time which operand will evaluate to true.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.2
+     */
+    private static PatternVariableResult getVariablesIntroducedByOr(BinaryExpr expression) {
+        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableResult introducedByLeft = expression.getLeft().accept(variableVisitor, null);
+        PatternVariableResult introducedByRight = expression.getRight().accept(variableVisitor, null);
+
+        introducedByLeft.addVariablesIntroducedIfFalse(introducedByRight.getVariablesIntroducedIfFalse());
+        introducedByLeft.clearVariablesIntroducedIfTrue();
+
+        return introducedByLeft;
+    }
+
+    @Override
+    public PatternVariableResult visit(UnaryExpr expr, Void unused) {
+        if (expr.getOperator().equals(UnaryExpr.Operator.LOGICAL_COMPLEMENT)) {
+            return getVariablesIntroducedByLogicalComplement(expr);
+        }
+
+        return new PatternVariableResult();
+    }
+
+    /**
+     *  The following rules apply to a logical complement expression !a:
+     *  - A pattern variable is introduced by !a when true iff it is introduced by a when false.
+     *  - A pattern variable is introduced by !a when false iff it is introduced by a when true.
+     *
+     *  https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.3
+     */
+    private static PatternVariableResult getVariablesIntroducedByLogicalComplement(UnaryExpr unaryExpr) {
+        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableResult introducedByChild = unaryExpr.getExpression().accept(variableVisitor, null);
+
+        introducedByChild.swapTrueAndFalse();
+
+        return introducedByChild;
+    }
+
+    /**
+     * The following rule applies to an instanceof expression with a pattern operand, a instanceof p:
+     * - A pattern variable is introduced by a instanceof p when true iff the pattern p contains a declaration of the pattern variable.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.5
+     */
+    public PatternVariableResult visit(InstanceOfExpr instanceOfExpr, Void unused) {
+        LinkedList<TypePatternExpr> variablesIntroducedIfTrue = new LinkedList<>();
+        LinkedList<TypePatternExpr> variablesIntroducedIfFalse = new LinkedList<>();
+
+        instanceOfExpr.getPattern().ifPresent(patternExpr -> {
+            Queue<PatternExpr> patternQueue = new ArrayDeque<>();
+            patternQueue.add(patternExpr);
+
+            while (!patternQueue.isEmpty()) {
+                PatternExpr toCheck = patternQueue.remove();
+                if (toCheck.isTypePatternExpr()) {
+                    variablesIntroducedIfTrue.add(toCheck.asTypePatternExpr());
+                } else if (toCheck.isRecordPatternExpr()) {
+                    patternQueue.addAll(toCheck.asRecordPatternExpr().getPatternList());
+                } else {
+                    throw new IllegalStateException("Found illegal pattern type in InstanceOf"
+                            + toCheck.getClass().getCanonicalName());
+                }
+            }
+        });
+
+        return new PatternVariableResult(variablesIntroducedIfTrue, variablesIntroducedIfFalse);
+    }
+
+    /**
+     * The following rules apply to a parenthesized expression (a):
+     * - A pattern variable is introduced by (a) when true iff it is introduced by a when true.
+     * - A pattern variable is introduced by (a) when false iff it is introduced by a when false.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.7
+     */
+    public PatternVariableResult visit(EnclosedExpr enclosedExpr, Void unused) {
+        return enclosedExpr.getInner().accept(this, unused);
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/PatternVariableVisitor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/PatternVariableVisitor.java
@@ -27,17 +27,6 @@ import java.util.*;
 
 public class PatternVariableVisitor extends GenericVisitorWithDefaults<PatternVariableResult, Void> {
 
-    private static PatternVariableVisitor patternVariableVisitor = null;
-
-    private PatternVariableVisitor() {}
-
-    public static PatternVariableVisitor getInstance() {
-        if (patternVariableVisitor == null) {
-            patternVariableVisitor = new PatternVariableVisitor();
-        }
-        return patternVariableVisitor;
-    }
-
     @Override
     public PatternVariableResult defaultAction(Node node, Void unused) {
         return new PatternVariableResult();
@@ -67,7 +56,7 @@ public class PatternVariableVisitor extends GenericVisitorWithDefaults<PatternVa
      * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.1
      */
     private static PatternVariableResult getVariablesIntroducedByAnd(BinaryExpr expression) {
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         PatternVariableResult introducedByLeft = expression.getLeft().accept(variableVisitor, null);
         PatternVariableResult introducedByRight = expression.getRight().accept(variableVisitor, null);
 
@@ -89,7 +78,7 @@ public class PatternVariableVisitor extends GenericVisitorWithDefaults<PatternVa
      * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.2
      */
     private static PatternVariableResult getVariablesIntroducedByOr(BinaryExpr expression) {
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         PatternVariableResult introducedByLeft = expression.getLeft().accept(variableVisitor, null);
         PatternVariableResult introducedByRight = expression.getRight().accept(variableVisitor, null);
 
@@ -116,7 +105,7 @@ public class PatternVariableVisitor extends GenericVisitorWithDefaults<PatternVa
      *  https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.3
      */
     private static PatternVariableResult getVariablesIntroducedByLogicalComplement(UnaryExpr unaryExpr) {
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         PatternVariableResult introducedByChild = unaryExpr.getExpression().accept(variableVisitor, null);
 
         introducedByChild.swapTrueAndFalse();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -330,4 +330,17 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
 
         return discoveredTypePatterns;
     }
+
+    public SymbolReference<? extends ResolvedValueDeclaration> findExposedPatternInParentContext(
+            Node parent, String name) {
+        Context context = JavaParserFactory.getContext(parent, typeSolver);
+        List<TypePatternExpr> patternVariablesExposedToWrappedNode =
+                context.typePatternExprsExposedToChild(wrappedNode);
+        for (TypePatternExpr typePatternExpr : patternVariablesExposedToWrappedNode) {
+            if (typePatternExpr.getNameAsString().equals(name)) {
+                return SymbolReference.solved(JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver));
+            }
+        }
+        return SymbolReference.unsolved();
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -39,6 +39,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.core.resolution.TypeVariableResolutionCapability;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableVisitor;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypePatternDeclaration;
 import java.util.*;
@@ -342,5 +343,17 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
             }
         }
         return SymbolReference.unsolved();
+    }
+
+    @Override
+    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
+        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        return wrappedNode.accept(variableVisitor, null).getVariablesIntroducedIfTrue();
+    }
+
+    @Override
+    public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
+        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        return wrappedNode.accept(variableVisitor, null).getVariablesIntroducedIfFalse();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -347,13 +347,13 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
 
     @Override
     public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         return wrappedNode.accept(variableVisitor, null).getVariablesIntroducedIfTrue();
     }
 
     @Override
     public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         return wrappedNode.accept(variableVisitor, null).getVariablesIntroducedIfFalse();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ArrayAccessExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ArrayAccessExprContext.java
@@ -79,7 +79,7 @@ import com.github.javaparser.resolution.model.SymbolReference;
  *
  * @author Roger Howell
  */
-public class ArrayAccessExprContext extends AbstractJavaParserContext<ArrayAccessExpr> {
+public class ArrayAccessExprContext extends ExpressionContext<ArrayAccessExpr> {
 
     public ArrayAccessExprContext(ArrayAccessExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class BinaryExprContext extends AbstractJavaParserContext<BinaryExpr> {
+public class BinaryExprContext extends ExpressionContext<BinaryExpr> {
 
     public BinaryExprContext(BinaryExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
@@ -22,11 +22,8 @@ package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.BinaryExpr;
-import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.TypePatternExpr;
-import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableResult;
 import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableVisitor;
 import java.util.*;
@@ -35,150 +32,6 @@ public class BinaryExprContext extends ExpressionContext<BinaryExpr> {
 
     public BinaryExprContext(BinaryExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
-    }
-
-    @Override
-    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-
-        BinaryExpr binaryExpr = wrappedNode;
-        Expression leftBranch = binaryExpr.getLeft();
-        Expression rightBranch = binaryExpr.getRight();
-
-        List<TypePatternExpr> results = new ArrayList<>();
-
-        if (binaryExpr.getOperator().equals(BinaryExpr.Operator.EQUALS)) {
-            if (rightBranch.isBooleanLiteralExpr()) {
-                if (rightBranch.asBooleanLiteralExpr().getValue() == true) {
-                    // "x" instanceof String s == true
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-                } else {
-                    // "x" instanceof String s == false
-                }
-            } else if (leftBranch.isBooleanLiteralExpr()) {
-                if (leftBranch.asBooleanLiteralExpr().getValue() == true) {
-                    // true == "x" instanceof String s
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(rightBranch));
-                } else {
-                    // false == "x" instanceof String s
-                }
-            }
-        } else if (binaryExpr.getOperator().equals(BinaryExpr.Operator.NOT_EQUALS)) {
-            if (rightBranch.isBooleanLiteralExpr()) {
-                if (rightBranch.asBooleanLiteralExpr().getValue() == true) {
-                    // "x" instanceof String s != true
-                } else {
-                    // "x" instanceof String s != false
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-                }
-            } else if (leftBranch.isBooleanLiteralExpr()) {
-                if (leftBranch.asBooleanLiteralExpr().getValue() == true) {
-                    // true != "x" instanceof String s
-                } else {
-                    // false != "x" instanceof String s
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(rightBranch));
-                }
-            }
-
-            // TODO/FIXME: There are other cases where it may be ambiguously true until runtime e.g. `"x" instanceof
-            // String s == (new Random().nextBoolean())`
-
-        } else if (binaryExpr.getOperator().equals(BinaryExpr.Operator.AND)) {
-            // "x" instanceof String s && s.length() > 0
-            // "x" instanceof String s && "x" instanceof String s2
-            results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-            results.addAll(patternExprsExposedToDirectParentFromBranch(rightBranch));
-        } else {
-            return new ArrayList<>();
-        }
-
-        return results;
-    }
-
-    @Override
-    public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
-
-        BinaryExpr binaryExpr = wrappedNode;
-        Expression leftBranch = binaryExpr.getLeft();
-        Expression rightBranch = binaryExpr.getRight();
-
-        List<TypePatternExpr> results = new ArrayList<>();
-
-        // FIXME: Redo the `.getValue() == true` to take more complex code into account when determining if definitively
-        // true (e.g. `
-        if (binaryExpr.getOperator().equals(BinaryExpr.Operator.EQUALS)) {
-            if (rightBranch.isBooleanLiteralExpr()) {
-                if (isDefinitivelyTrue(rightBranch)) {
-                    // "x" instanceof String s == true
-                    // "x" instanceof String s == !(false)
-                    // No negations.
-                } else {
-                    // "x" instanceof String s == false
-                    // "x" instanceof String s == !(true)
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-                }
-            } else if (leftBranch.isBooleanLiteralExpr()) {
-                if (isDefinitivelyTrue(leftBranch)) {
-                    // true == "x" instanceof String s
-                    // !(false) == "x" instanceof String s
-                    // No negations.
-                } else {
-                    // false == "x" instanceof String s
-                    // !(true) == "x" instanceof String s
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(rightBranch));
-                }
-            }
-        } else if (binaryExpr.getOperator().equals(BinaryExpr.Operator.NOT_EQUALS)) {
-            if (rightBranch.isBooleanLiteralExpr()) {
-                if (isDefinitivelyTrue(rightBranch)) {
-                    // "x" instanceof String s != true
-                    // "x" instanceof String s != !(false)
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-                } else {
-                    // "x" instanceof String s != false
-                    // "x" instanceof String s != !(true)
-                }
-            } else if (leftBranch.isBooleanLiteralExpr()) {
-                if (isDefinitivelyTrue(leftBranch)) {
-                    // true != "x" instanceof String s
-                    // !(false) != "x" instanceof String s
-                    results.addAll(patternExprsExposedToDirectParentFromBranch(rightBranch));
-                } else {
-                    // false != "x" instanceof String s
-                    // !(true) != "x" instanceof String s
-                }
-            }
-
-            // TODO/FIXME: There are other cases where it may be ambiguously true until runtime e.g. `"x" instanceof
-            // String s == (new Random().nextBoolean())`
-
-        } else if (binaryExpr.getOperator().equals(BinaryExpr.Operator.AND)) {
-            // "x" instanceof String s && s.length() > 0
-            // "x" instanceof String s && "x" instanceof String s2
-            results.addAll(negatedPatternExprsExposedToDirectParentFromBranch(leftBranch));
-            results.addAll(negatedPatternExprsExposedToDirectParentFromBranch(rightBranch));
-        } else {
-            return new ArrayList<>();
-        }
-
-        return results;
-    }
-
-    private List<TypePatternExpr> patternExprsExposedToDirectParentFromBranch(Expression branch) {
-        if (branch.isEnclosedExpr() || branch.isBinaryExpr() || branch.isUnaryExpr() || branch.isInstanceOfExpr()) {
-            Context branchContext = JavaParserFactory.getContext(branch, typeSolver);
-            return branchContext.typePatternExprsExposedFromChildren();
-        }
-
-        return new ArrayList<>();
-    }
-
-    private List<TypePatternExpr> negatedPatternExprsExposedToDirectParentFromBranch(Expression branch) {
-        if (branch.isEnclosedExpr() || branch.isBinaryExpr() || branch.isUnaryExpr() || branch.isInstanceOfExpr()) {
-            Context branchContext = JavaParserFactory.getContext(branch, typeSolver);
-            return branchContext.negatedTypePatternExprsExposedFromChildren();
-        }
-
-        return new ArrayList<>();
     }
 
     public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
@@ -239,47 +92,5 @@ public class BinaryExprContext extends ExpressionContext<BinaryExpr> {
         }
 
         return results;
-    }
-
-    public Optional<TypePatternExpr> typePatternExprInScope(String name) {
-        BinaryExpr binaryExpr = wrappedNode;
-        Expression leftBranch = binaryExpr.getLeft();
-        Expression rightBranch = binaryExpr.getRight();
-
-        List<TypePatternExpr> patternExprs = patternExprsExposedToDirectParentFromBranch(leftBranch);
-        Optional<TypePatternExpr> localResolutionResults = patternExprs.stream()
-                .filter(vd -> vd.getNameAsString().equals(name))
-                .findFirst();
-
-        if (localResolutionResults.isPresent()) {
-            return localResolutionResults;
-        }
-
-        // If we don't find the parameter locally, escalate up the scope hierarchy to see if it is declared there.
-        if (!getParent().isPresent()) {
-            return Optional.empty();
-        }
-        Context parentContext = getParent().get();
-        return parentContext.typePatternExprInScope(name);
-    }
-
-    private boolean isDefinitivelyTrue(Expression expression) {
-        // TODO: Consider combinations of literal true/false, enclosed expressions, and negations.
-        if (expression.isBooleanLiteralExpr()) {
-            if (expression.asBooleanLiteralExpr().getValue() == true) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isDefinitivelyFalse(Expression expression) {
-        // TODO: Consider combinations of literal true/false, enclosed expressions, and negations.
-        if (expression.isBooleanLiteralExpr()) {
-            if (expression.asBooleanLiteralExpr().getValue() == false) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
@@ -60,7 +60,7 @@ public class BinaryExprContext extends ExpressionContext<BinaryExpr> {
         List<TypePatternExpr> results = new LinkedList<>();
 
         if (wrappedNode.getRight().containsWithinRange(child)) {
-            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
             PatternVariableResult patternsInScope = wrappedNode.getLeft().accept(variableVisitor, null);
 
             results.addAll(patternsInScope.getVariablesIntroducedIfTrue());
@@ -85,7 +85,7 @@ public class BinaryExprContext extends ExpressionContext<BinaryExpr> {
         List<TypePatternExpr> results = new LinkedList<>();
 
         if (wrappedNode.getRight().containsWithinRange(child)) {
-            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
             PatternVariableResult patternsInScope = wrappedNode.getLeft().accept(variableVisitor, null);
 
             results.addAll(patternsInScope.getVariablesIntroducedIfFalse());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BinaryExprContext.java
@@ -27,9 +27,9 @@ import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableResult;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableVisitor;
+import java.util.*;
 
 public class BinaryExprContext extends ExpressionContext<BinaryExpr> {
 
@@ -182,24 +182,61 @@ public class BinaryExprContext extends ExpressionContext<BinaryExpr> {
     }
 
     public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
-        BinaryExpr binaryExpr = wrappedNode;
-        Expression leftBranch = binaryExpr.getLeft();
-        Expression rightBranch = binaryExpr.getRight();
-
-        List<TypePatternExpr> results = new ArrayList<>();
-        if (child == leftBranch) {
-            results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-        } else if (child == rightBranch) {
-            if (binaryExpr.getOperator().equals(BinaryExpr.Operator.AND)) {
-                // "" instanceof String s && "" instanceof String s2
-                results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-            }
+        if (wrappedNode.getOperator().equals(BinaryExpr.Operator.AND)) {
+            return typePatternExprsExposedToChildByAnd(child);
         }
-        //        else if (binaryExpr.getOperator().equals(BinaryExpr.Operator.AND) && rightBranch.isAncestorOf(child))
-        // {
-        //            // "" instanceof String s && "" instanceof String s2
-        //            results.addAll(patternExprsExposedToDirectParentFromBranch(leftBranch));
-        //        }
+        if (wrappedNode.getOperator().equals(BinaryExpr.Operator.OR)) {
+            return typePatternExprsExposedToChildByOr(child);
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * The following rules apply to a conditional-and expression a && b:
+     * - A pattern variable introduced by a when true is definitely matched at b.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.3.1.1
+     */
+    private List<TypePatternExpr> typePatternExprsExposedToChildByAnd(Node child) {
+        if (!wrappedNode.getOperator().equals(BinaryExpr.Operator.AND)) {
+            throw new IllegalStateException(
+                    "Attempting to find patterns exposed by &&-expression, but wrapped operator is a "
+                            + wrappedNode.getOperator().asString());
+        }
+
+        List<TypePatternExpr> results = new LinkedList<>();
+
+        if (wrappedNode.getRight().containsWithinRange(child)) {
+            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableResult patternsInScope = wrappedNode.getLeft().accept(variableVisitor, null);
+
+            results.addAll(patternsInScope.getVariablesIntroducedIfTrue());
+        }
+
+        return results;
+    }
+
+    /**
+     * The following rules apply to a conditional-and expression a || b:
+     * - A pattern variable introduced by a when false is definitely matched at b.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.3.1.2
+     */
+    private List<TypePatternExpr> typePatternExprsExposedToChildByOr(Node child) {
+        if (!wrappedNode.getOperator().equals(BinaryExpr.Operator.OR)) {
+            throw new IllegalStateException(
+                    "Attempting to find patterns exposed by ||-expression, but wrapped operator is a "
+                            + wrappedNode.getOperator().asString());
+        }
+
+        List<TypePatternExpr> results = new LinkedList<>();
+
+        if (wrappedNode.getRight().containsWithinRange(child)) {
+            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableResult patternsInScope = wrappedNode.getLeft().accept(variableVisitor, null);
+
+            results.addAll(patternsInScope.getVariablesIntroducedIfFalse());
+        }
 
         return results;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
@@ -37,7 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
-public class BlockStmtContext extends AbstractJavaParserContext<BlockStmt> {
+public class BlockStmtContext extends StatementContext<BlockStmt> {
 
     public BlockStmtContext(BlockStmt wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
@@ -132,6 +132,13 @@ public class BlockStmtContext extends StatementContext<BlockStmt> {
                     }
                 }
             }
+
+            SymbolReference<? extends ResolvedValueDeclaration> resolvedFromPattern =
+                    findExposedPatternInParentContext(optionalParent.get().getWrappedNode(), name);
+
+            if (resolvedFromPattern.isSolved()) {
+                return resolvedFromPattern;
+            }
         }
 
         // Otherwise continue as normal...

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ConditionalExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ConditionalExprContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.ConditionalExpr;
+import com.github.javaparser.ast.expr.TypePatternExpr;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableResult;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableVisitor;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ConditionalExprContext extends ExpressionContext<ConditionalExpr> {
+
+    public ConditionalExprContext(ConditionalExpr wrappedNode, TypeSolver typeSolver) {
+        super(wrappedNode, typeSolver);
+    }
+
+    /**
+     * The following rules apply to a conditional expression a ? b : c:
+     * - A pattern variable introduced by a when true is definitely matched at b.
+     * - A pattern variable introduced by a when false is definitely matched at c.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.3.1.4
+     */
+    @Override
+    public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
+        List<TypePatternExpr> results = new LinkedList<>();
+
+        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableResult patternsInScope = wrappedNode.getCondition().accept(variableVisitor, null);
+
+        if (wrappedNode.getThenExpr().containsWithinRange(child)) {
+            results.addAll(patternsInScope.getVariablesIntroducedIfTrue());
+        } else if (wrappedNode.getElseExpr().containsWithinRange(child)) {
+            results.addAll(patternsInScope.getVariablesIntroducedIfFalse());
+        }
+
+        return results;
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ConditionalExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ConditionalExprContext.java
@@ -47,7 +47,7 @@ public class ConditionalExprContext extends ExpressionContext<ConditionalExpr> {
     public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
         List<TypePatternExpr> results = new LinkedList<>();
 
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         PatternVariableResult patternsInScope = wrappedNode.getCondition().accept(variableVisitor, null);
 
         if (wrappedNode.getThenExpr().containsWithinRange(child)) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/DoStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/DoStatementContext.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.TypePatternExpr;
+import com.github.javaparser.ast.stmt.DoStmt;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.javaparsermodel.NormalCompletionVisitor;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableResult;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableVisitor;
+import java.util.LinkedList;
+import java.util.List;
+
+public class DoStatementContext extends StatementContext<DoStmt> {
+
+    public DoStatementContext(DoStmt wrappedNode, TypeSolver typeSolver) {
+        super(wrappedNode, typeSolver);
+    }
+
+    /**
+     * The following rule applies to a statement do S while (e):
+     * - A pattern variable is introduced by do S while (e) iff
+     *   (i) it is introduced by e when false and
+     *   (ii) S does not contain a reachable break statement for which the do statement is the break target.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.3.2.4
+     */
+    @Override
+    public List<TypePatternExpr> getIntroducedTypePatterns() {
+        List<TypePatternExpr> results = new LinkedList<>();
+
+        if (!NormalCompletionVisitor.containsCorrespondingBreak(wrappedNode)) {
+            Expression condition = wrappedNode.getCondition();
+
+            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
+
+            results.addAll(patternsInScope.getVariablesIntroducedIfFalse());
+        }
+
+        return results;
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/DoStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/DoStatementContext.java
@@ -52,7 +52,7 @@ public class DoStatementContext extends StatementContext<DoStmt> {
         if (!NormalCompletionVisitor.containsCorrespondingBreak(wrappedNode)) {
             Expression condition = wrappedNode.getCondition();
 
-            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
             PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
 
             results.addAll(patternsInScope.getVariablesIntroducedIfFalse());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnclosedExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnclosedExprContext.java
@@ -21,58 +21,11 @@
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
 import com.github.javaparser.ast.expr.EnclosedExpr;
-import com.github.javaparser.ast.expr.TypePatternExpr;
-import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
-import java.util.ArrayList;
-import java.util.List;
 
 public class EnclosedExprContext extends ExpressionContext<EnclosedExpr> {
 
     public EnclosedExprContext(EnclosedExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
-    }
-
-    @Override
-    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-        List<TypePatternExpr> results = new ArrayList<>();
-
-        /*
-         * Test for an assignment expression
-         * Example:
-         *     while ((numChars = reader.read(buffer, 0, buffer.length)) > 0) {
-         *         result.append(buffer, 0, numChars);
-         *     }
-         */
-        if (!wrappedNode.getInner().isAssignExpr()) {
-            // Propagate any pattern expressions "up" without modification
-            Context innerContext = JavaParserFactory.getContext(wrappedNode.getInner(), typeSolver);
-            if (!this.equals(innerContext)) {
-                results = new ArrayList<>(innerContext.typePatternExprsExposedFromChildren());
-            }
-        }
-        return results;
-    }
-
-    @Override
-    public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
-        List<TypePatternExpr> results = new ArrayList<>();
-
-        /*
-         * Test for an assignment expression
-         * Example:
-         *     while ((numChars = reader.read(buffer, 0, buffer.length)) > 0) {
-         *         result.append(buffer, 0, numChars);
-         *     }
-         */
-        if (!wrappedNode.getInner().isAssignExpr()) {
-            // Propagate any pattern expressions "up" without modification
-            Context innerContext = JavaParserFactory.getContext(wrappedNode.getInner(), typeSolver);
-            if (!this.equals(innerContext)) {
-                results = new ArrayList<>(innerContext.negatedTypePatternExprsExposedFromChildren());
-            }
-        }
-        return results;
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnclosedExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnclosedExprContext.java
@@ -28,7 +28,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-public class EnclosedExprContext extends AbstractJavaParserContext<EnclosedExpr> {
+public class EnclosedExprContext extends ExpressionContext<EnclosedExpr> {
 
     public EnclosedExprContext(EnclosedExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ExpressionContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ExpressionContext.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.resolution.Context;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.model.SymbolReference;
+import com.github.javaparser.resolution.model.Value;
+import java.util.Optional;
+
+/**
+ * @author Johannes Coetzee
+ */
+public class ExpressionContext<N extends Expression> extends AbstractJavaParserContext<N> {
+
+    public ExpressionContext(N wrappedNode, TypeSolver typeSolver) {
+        super(wrappedNode, typeSolver);
+    }
+
+    @Override
+    public Optional<Value> solveSymbolAsValue(String name) {
+        SymbolReference<? extends ResolvedValueDeclaration> solvedSymbol = solveSymbol(name);
+        return solvedSymbol.getDeclaration().map(Value::from);
+    }
+
+    @Override
+    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name) {
+        Optional<Node> maybeParent = getParent().map(Context::getWrappedNode);
+
+        if (maybeParent.isPresent()) {
+            SymbolReference<? extends ResolvedValueDeclaration> symbolFromPattern =
+                    findExposedPatternInParentContext(maybeParent.get(), name);
+            if (symbolFromPattern.isSolved()) {
+                return symbolFromPattern;
+            }
+        }
+
+        return solveSymbolInParentContext(name);
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 /**
  * @author Federico Tomassetti
  */
-public class FieldAccessContext extends AbstractJavaParserContext<FieldAccessExpr> {
+public class FieldAccessContext extends ExpressionContext<FieldAccessExpr> {
 
     private static final String ARRAY_LENGTH_FIELD_NAME = "length";
 
@@ -67,8 +67,7 @@ public class FieldAccessContext extends AbstractJavaParserContext<FieldAccessExp
                 }
             }
         }
-        return JavaParserFactory.getContext(demandParentNode(wrappedNode), typeSolver)
-                .solveSymbol(name);
+        return super.solveSymbol(name);
     }
 
     @Override
@@ -100,7 +99,7 @@ public class FieldAccessContext extends AbstractJavaParserContext<FieldAccessExp
             }
             return Optional.empty();
         }
-        return solveSymbolAsValueInParentContext(name);
+        return super.solveSymbolAsValue(name);
     }
 
     /*

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForEachStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForEachStatementContext.java
@@ -36,7 +36,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import java.util.Collections;
 import java.util.List;
 
-public class ForEachStatementContext extends AbstractJavaParserContext<ForEachStmt> {
+public class ForEachStatementContext extends StatementContext<ForEachStmt> {
 
     public ForEachStatementContext(ForEachStmt wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
@@ -64,7 +64,7 @@ public class ForStatementContext extends StatementContext<ForStmt> {
         if ((givenNodeIsWithinUpdate || givenNodeIsWithinBody)
                 && wrappedNode.getCompare().isPresent()) {
             Expression condition = wrappedNode.getCompare().get();
-            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
             PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
 
             results.addAll(patternsInScope.getVariablesIntroducedIfTrue());
@@ -89,7 +89,7 @@ public class ForStatementContext extends StatementContext<ForStmt> {
         Optional<Expression> maybeCompare = wrappedNode.getCompare();
 
         if (maybeCompare.isPresent() && !NormalCompletionVisitor.containsCorrespondingBreak(wrappedNode)) {
-            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
             PatternVariableResult patternsInScope = maybeCompare.get().accept(variableVisitor, null);
 
             results.addAll(patternsInScope.getVariablesIntroducedIfFalse());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
@@ -33,14 +33,69 @@ import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.javaparsermodel.NormalCompletionVisitor;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableResult;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableVisitor;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 public class ForStatementContext extends StatementContext<ForStmt> {
 
     public ForStatementContext(ForStmt wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
+    }
+
+    /**
+     * The following rules apply to a basic for statement:
+     * - A pattern variable introduced by the condition expression when true is definitely matched at both the
+     *   incrementation part and the contained statement.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2.5
+     */
+    @Override
+    public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
+        List<TypePatternExpr> results = new LinkedList<>();
+
+        boolean givenNodeIsWithinUpdate =
+                wrappedNode.getUpdate().stream().anyMatch(expr -> expr.containsWithinRange(child));
+        boolean givenNodeIsWithinBody = wrappedNode.getBody().containsWithinRange(child);
+        if ((givenNodeIsWithinUpdate || givenNodeIsWithinBody)
+                && wrappedNode.getCompare().isPresent()) {
+            Expression condition = wrappedNode.getCompare().get();
+            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
+
+            results.addAll(patternsInScope.getVariablesIntroducedIfTrue());
+        }
+
+        return results;
+    }
+
+    /**
+     * The following rules apply to a basic for statement:
+     * - A pattern variable is introduced by a basic for statement iff
+     *   (i) it is introduced by the condition expression when false and
+     *   (ii) the contained statement, S, does not contain a reachable break for which the basic for statement is the
+     *        break target.
+     *
+     * https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.3.2.5
+     */
+    @Override
+    public List<TypePatternExpr> getIntroducedTypePatterns() {
+        List<TypePatternExpr> results = new LinkedList<>();
+
+        Optional<Expression> maybeCompare = wrappedNode.getCompare();
+
+        if (maybeCompare.isPresent() && !NormalCompletionVisitor.containsCorrespondingBreak(wrappedNode)) {
+            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableResult patternsInScope = maybeCompare.get().accept(variableVisitor, null);
+
+            results.addAll(patternsInScope.getVariablesIntroducedIfFalse());
+        }
+
+        return results;
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
@@ -37,7 +37,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import java.util.LinkedList;
 import java.util.List;
 
-public class ForStatementContext extends AbstractJavaParserContext<ForStmt> {
+public class ForStatementContext extends StatementContext<ForStmt> {
 
     public ForStatementContext(ForStmt wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/IfStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/IfStatementContext.java
@@ -51,7 +51,7 @@ public class IfStatementContext extends StatementContext<IfStmt> {
      */
     @Override
     public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         List<TypePatternExpr> results = new LinkedList<>();
 
         Expression condition = wrappedNode.getCondition();
@@ -85,7 +85,7 @@ public class IfStatementContext extends StatementContext<IfStmt> {
      */
     @Override
     public List<TypePatternExpr> getIntroducedTypePatterns() {
-        PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+        PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
         Expression condition = wrappedNode.getCondition();
         PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/InstanceOfExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/InstanceOfExprContext.java
@@ -29,8 +29,6 @@ import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypePatternDeclaration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -73,17 +71,5 @@ public class InstanceOfExprContext extends ExpressionContext<InstanceOfExpr> {
 
         // if nothing is found we should check for existing patterns and ask the parent context
         return super.solveSymbol(name);
-    }
-
-    @Override
-    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-        List<TypePatternExpr> results = new ArrayList<>();
-
-        // If this instanceof expression has a pattern, add it to the list.
-        wrappedNode
-                .getPattern()
-                .ifPresent(patternExpr -> results.addAll(typePatternExprsDiscoveredInPattern(patternExpr)));
-
-        return results;
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/InstanceOfExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/InstanceOfExprContext.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 /**
  * @author Roger Howell
  */
-public class InstanceOfExprContext extends AbstractJavaParserContext<InstanceOfExpr> {
+public class InstanceOfExprContext extends ExpressionContext<InstanceOfExpr> {
 
     public InstanceOfExprContext(InstanceOfExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
@@ -71,8 +71,8 @@ public class InstanceOfExprContext extends AbstractJavaParserContext<InstanceOfE
             }
         } // TODO: Also consider unary expr context
 
-        // if nothing is found we should ask the parent context
-        return solveSymbolInParentContext(name);
+        // if nothing is found we should check for existing patterns and ask the parent context
+        return super.solveSymbol(name);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -54,7 +54,7 @@ import java.util.*;
 /**
  * @author Federico Tomassetti
  */
-public class LambdaExprContext extends AbstractJavaParserContext<LambdaExpr> {
+public class LambdaExprContext extends ExpressionContext<LambdaExpr> {
 
     public LambdaExprContext(LambdaExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
@@ -174,8 +174,8 @@ public class LambdaExprContext extends AbstractJavaParserContext<LambdaExpr> {
             }
         }
 
-        // if nothing is found we should ask the parent context
-        return solveSymbolAsValueInParentContext(name);
+        // if nothing is found we should check for patterns and ask the parent context
+        return super.solveSymbolAsValue(name);
     }
 
     /*
@@ -216,8 +216,8 @@ public class LambdaExprContext extends AbstractJavaParserContext<LambdaExpr> {
             }
         }
 
-        // if nothing is found we should ask the parent context
-        return solveSymbolInParentContext(name);
+        // if nothing is found we should check for patterns and ask the parent context
+        return super.solveSymbol(name);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -31,7 +31,6 @@ import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.logic.MethodResolutionLogic;
 import com.github.javaparser.resolution.model.SymbolReference;
-import com.github.javaparser.resolution.model.Value;
 import com.github.javaparser.resolution.model.typesystem.LazyType;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.resolution.types.*;
@@ -41,7 +40,7 @@ import com.github.javaparser.utils.Pair;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallExpr> {
+public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
 
     ///
     /// Constructors
@@ -145,11 +144,6 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
         }
 
         return methodUsage;
-    }
-
-    @Override
-    public Optional<Value> solveSymbolAsValue(String name) {
-        return solveSymbolAsValueInParentContext(name);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
@@ -45,7 +45,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import java.util.*;
 
-public class MethodReferenceExprContext extends AbstractJavaParserContext<MethodReferenceExpr> {
+public class MethodReferenceExprContext extends ExpressionContext<MethodReferenceExpr> {
 
     ///
     /// Constructors

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
@@ -30,7 +30,6 @@ import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
@@ -40,7 +39,7 @@ import java.util.List;
 /**
  * @author Federico Tomassetti
  */
-public class ObjectCreationContext extends AbstractJavaParserContext<ObjectCreationExpr> {
+public class ObjectCreationContext extends ExpressionContext<ObjectCreationExpr> {
 
     public ObjectCreationContext(ObjectCreationExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
@@ -69,12 +68,6 @@ public class ObjectCreationContext extends AbstractJavaParserContext<ObjectCreat
             parentNode = demandParentNode(parentNode);
         }
         return JavaParserFactory.getContext(parentNode, typeSolver).solveType(name, typeArguments);
-    }
-
-    @Override
-    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name) {
-        return JavaParserFactory.getContext(demandParentNode(wrappedNode), typeSolver)
-                .solveSymbol(name);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
@@ -345,4 +345,8 @@ public class StatementContext<N extends Statement> extends AbstractJavaParserCon
         // Statements never make pattern expressions available.
         return Collections.emptyList();
     }
+
+    public List<TypePatternExpr> getIntroducedTypePatterns() {
+        return Collections.emptyList();
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
@@ -37,7 +37,6 @@ import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.Value;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
@@ -337,18 +336,5 @@ public class StatementContext<N extends Statement> extends AbstractJavaParserCon
 
     public List<TypePatternExpr> getIntroducedTypePatterns() {
         return Collections.emptyList();
-    }
-
-    public SymbolReference<? extends ResolvedValueDeclaration> findExposedPatternInParentContext(
-            Node parent, String name) {
-        Context context = JavaParserFactory.getContext(parent, typeSolver);
-        List<TypePatternExpr> patternVariablesExposedToWrappedNode =
-                context.typePatternExprsExposedToChild(wrappedNode);
-        for (TypePatternExpr typePatternExpr : patternVariablesExposedToWrappedNode) {
-            if (typePatternExpr.getNameAsString().equals(name)) {
-                return SymbolReference.solved(JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver));
-            }
-        }
-        return SymbolReference.unsolved();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
@@ -322,18 +322,6 @@ public class StatementContext<N extends Statement> extends AbstractJavaParserCon
         return solveMethodInParentContext(name, argumentsTypes, false);
     }
 
-    @Override
-    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-        // Statements never make pattern expressions available.
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
-        // Statements never make pattern expressions available.
-        return Collections.emptyList();
-    }
-
     public List<TypePatternExpr> getIntroducedTypePatterns() {
         return Collections.emptyList();
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/TryWithResourceContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/TryWithResourceContext.java
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class TryWithResourceContext extends AbstractJavaParserContext<TryStmt> {
+public class TryWithResourceContext extends StatementContext<TryStmt> {
 
     public TryWithResourceContext(TryStmt wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/UnaryExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/UnaryExprContext.java
@@ -28,7 +28,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-public class UnaryExprContext extends AbstractJavaParserContext<UnaryExpr> {
+public class UnaryExprContext extends ExpressionContext<UnaryExpr> {
 
     public UnaryExprContext(UnaryExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/UnaryExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/UnaryExprContext.java
@@ -20,56 +20,12 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
-import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
-import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
-import java.util.ArrayList;
-import java.util.List;
 
 public class UnaryExprContext extends ExpressionContext<UnaryExpr> {
 
     public UnaryExprContext(UnaryExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
-    }
-
-    @Override
-    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-        List<TypePatternExpr> results = new ArrayList<>();
-
-        // Propagate any pattern expressions "up"
-        if (wrappedNode.getOperator() == UnaryExpr.Operator.LOGICAL_COMPLEMENT) {
-            Context innerContext = JavaParserFactory.getContext(wrappedNode.getExpression(), typeSolver);
-
-            // Avoid infinite loop
-            if (!this.equals(innerContext)) {
-                // Note that `UnaryExpr.Operator.LOGICAL_COMPLEMENT` is `!`
-                // Previously negated pattern expressions are now available (double negatives) -- e.g. if(!!("a"
-                // instanceof String s)) {}
-                results.addAll(innerContext.negatedTypePatternExprsExposedFromChildren());
-            }
-        }
-
-        return results;
-    }
-
-    @Override
-    public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
-        List<TypePatternExpr> results = new ArrayList<>();
-
-        // Propagate any pattern expressions "up"
-        if (wrappedNode.getOperator() == UnaryExpr.Operator.LOGICAL_COMPLEMENT) {
-            Context innerContext = JavaParserFactory.getContext(wrappedNode.getExpression(), typeSolver);
-
-            if (!this.equals(innerContext)) {
-                // Note that `UnaryExpr.Operator.LOGICAL_COMPLEMENT` is `!`
-                // Previously available pattern expressions are now negated (double negatives) -- e.g. if(!("a"
-                // instanceof String s)) {}
-                results.addAll(innerContext.typePatternExprsExposedFromChildren());
-            }
-        }
-
-        return results;
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/VariableDeclarationExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/VariableDeclarationExprContext.java
@@ -23,12 +23,8 @@ package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
-import com.github.javaparser.resolution.model.SymbolReference;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,22 +37,6 @@ public class VariableDeclarationExprContext extends ExpressionContext<VariableDe
         super(wrappedNode, typeSolver);
     }
 
-    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name) {
-        List<TypePatternExpr> patternExprs = typePatternExprsExposedFromChildren();
-        for (int i = 0; i < patternExprs.size(); i++) {
-            if (patternExprs.get(i).isTypePatternExpr()) {
-                TypePatternExpr typePatternExpr = patternExprs.get(i).asTypePatternExpr();
-                if (typePatternExpr.getNameAsString().equals(name)) {
-                    return SymbolReference.solved(JavaParserSymbolDeclaration.patternVar(typePatternExpr, typeSolver));
-                }
-            }
-        }
-
-        // Look for a pattern introducing this variable, then default to solving in parent context if unable to solve
-        // directly here.
-        return super.solveSymbol(name);
-    }
-
     @Override
     public List<VariableDeclarator> localVariablesExposedToChild(Node child) {
         for (int i = 0; i < wrappedNode.getVariables().size(); i++) {
@@ -65,18 +45,6 @@ public class VariableDeclarationExprContext extends ExpressionContext<VariableDe
             }
         }
         // TODO: Consider pattern exprs
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-        // Variable declarations never make pattern expressions available.
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
-        // Variable declarations never make pattern expressions available.
         return Collections.emptyList();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/VariableDeclarationExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/VariableDeclarationExprContext.java
@@ -35,7 +35,7 @@ import java.util.List;
 /**
  * @author Federico Tomassetti
  */
-public class VariableDeclarationExprContext extends AbstractJavaParserContext<VariableDeclarationExpr> {
+public class VariableDeclarationExprContext extends ExpressionContext<VariableDeclarationExpr> {
 
     public VariableDeclarationExprContext(VariableDeclarationExpr wrappedNode, TypeSolver typeSolver) {
         super(wrappedNode, typeSolver);
@@ -52,8 +52,9 @@ public class VariableDeclarationExprContext extends AbstractJavaParserContext<Va
             }
         }
 
-        // Default to solving in parent context if unable to solve directly here.
-        return solveSymbolInParentContext(name);
+        // Look for a pattern introducing this variable, then default to solving in parent context if unable to solve
+        // directly here.
+        return super.solveSymbol(name);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/VariableDeclaratorContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/VariableDeclaratorContext.java
@@ -23,7 +23,6 @@ package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.TypePatternExpr;
 import com.github.javaparser.resolution.TypeSolver;
 import java.util.Collections;
 import java.util.List;
@@ -44,18 +43,6 @@ public class VariableDeclaratorContext extends AbstractJavaParserContext<Variabl
             return Collections.singletonList(wrappedNode);
         }
 
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<TypePatternExpr> typePatternExprsExposedFromChildren() {
-        // Variable declarators never make pattern expressions available.
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<TypePatternExpr> negatedTypePatternExprsExposedFromChildren() {
-        // Variable declarators never make pattern expressions available.
         return Collections.emptyList();
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/WhileStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/WhileStatementContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.TypePatternExpr;
+import com.github.javaparser.ast.stmt.WhileStmt;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableResult;
+import com.github.javaparser.symbolsolver.javaparsermodel.PatternVariableVisitor;
+import java.util.LinkedList;
+import java.util.List;
+
+public class WhileStatementContext extends StatementContext<WhileStmt> {
+
+    public WhileStatementContext(WhileStmt wrappedNode, TypeSolver typeSolver) {
+        super(wrappedNode, typeSolver);
+    }
+
+    /**
+     *  The following rules apply to a statement while (e) S:
+     *  - A pattern variable introduced by e when true is definitely matched at S.
+     *
+     *  https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2.3
+     */
+    @Override
+    public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
+        List<TypePatternExpr> results = new LinkedList<>();
+
+        boolean givenNodeIsWithinBody = wrappedNode.getBody().containsWithinRange(child);
+        if (givenNodeIsWithinBody) {
+            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            Expression condition = wrappedNode.getCondition();
+            PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
+
+            results.addAll(patternsInScope.getVariablesIntroducedIfTrue());
+        }
+
+        return results;
+    }
+}

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/WhileStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/WhileStatementContext.java
@@ -50,7 +50,7 @@ public class WhileStatementContext extends StatementContext<WhileStmt> {
 
         boolean givenNodeIsWithinBody = wrappedNode.getBody().containsWithinRange(child);
         if (givenNodeIsWithinBody) {
-            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
             Expression condition = wrappedNode.getCondition();
             PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
 
@@ -74,7 +74,7 @@ public class WhileStatementContext extends StatementContext<WhileStmt> {
 
         if (!NormalCompletionVisitor.containsCorrespondingBreak(wrappedNode)) {
             Expression condition = wrappedNode.getCondition();
-            PatternVariableVisitor variableVisitor = PatternVariableVisitor.getInstance();
+            PatternVariableVisitor variableVisitor = new PatternVariableVisitor();
             PatternVariableResult patternsInScope = condition.accept(variableVisitor, null);
 
             results.addAll(patternsInScope.getVariablesIntroducedIfFalse());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -50,7 +50,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -961,38 +960,6 @@ class ContextTest extends AbstractSymbolResolutionTest {
             assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(unaryExpr, "i", message);
             assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(unaryExpr, "b", message);
         }
-
-        @Test
-        void recordPatternExprInBinaryExpr() {
-            String message = "Only s must be available from this expression.";
-            BinaryExpr binaryExpr = parse(
-                            ParserConfiguration.LanguageLevel.JAVA_21,
-                            "true == a instanceof Box(String s, Box(Integer i, Boolean b))",
-                            ParseStart.EXPRESSION)
-                    .asBinaryExpr();
-            assertOnePatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            assertOnePatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "i", message);
-            assertOnePatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "b", message);
-            assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "i", message);
-            assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "b", message);
-        }
-
-        @Test
-        void recordPatternExprInNegatedBinaryExpr() {
-            String message = "Only s must be available from this expression.";
-            BinaryExpr binaryExpr = parse(
-                            ParserConfiguration.LanguageLevel.JAVA_21,
-                            "true != a instanceof Box(String s, Box(Integer i, Boolean b))",
-                            ParseStart.EXPRESSION)
-                    .asBinaryExpr();
-            assertNoPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            assertNoPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "i", message);
-            assertNoPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "b", message);
-            assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "i", message);
-            assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "b", message);
-        }
     }
 
     @Nested
@@ -1106,181 +1073,6 @@ class ContextTest extends AbstractSymbolResolutionTest {
                         unaryExpr,
                         "s",
                         message + " -- " + "Double negative means that it is true - it should be available.");
-            }
-        }
-
-        @Nested
-        class TypePatternExprBinaryExprTests {
-
-            @Test
-            void instanceOfPatternExprBinaryExpr1() {
-                String message = "Only s must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "a instanceof String s == true",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertOnePatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-                assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr2() {
-                String message = "Only s must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "true == a instanceof String s",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertOnePatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-                assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr3() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "a instanceof String s == false",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertNoPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-                assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr4() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "false == a instanceof String s",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertNoPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-                assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr5() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "a instanceof String s != true",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertNoPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr5_negated() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "a instanceof String s != true",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr5b() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                EnclosedExpr enclosedExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "(a instanceof String s != true)",
-                                ParseStart.EXPRESSION)
-                        .asEnclosedExpr();
-                assertNoPatternExprsExposedToImmediateParentInContextNamed(enclosedExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr5b_negated() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                EnclosedExpr enclosedExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "(a instanceof String s != true)",
-                                ParseStart.EXPRESSION)
-                        .asEnclosedExpr();
-                assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(enclosedExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr6() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "a instanceof String s != false",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertOnePatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr6_negated() {
-                String message = "Only s (NEGATED) must be available from this expression.";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "a instanceof String s != false",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr7() {
-                String message = "Only s (NEGATED) must be available from this double-negated expression.";
-                UnaryExpr unaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "!(a instanceof String s != true)",
-                                ParseStart.EXPRESSION)
-                        .asUnaryExpr();
-                assertOnePatternExprsExposedToImmediateParentInContextNamed(unaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr7_negated() {
-                String message = "Only s must be available from this double-negated expression.";
-                UnaryExpr unaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "!(a instanceof String s != true)",
-                                ParseStart.EXPRESSION)
-                        .asUnaryExpr();
-                assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(unaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr8() {
-                String message = "Only s must be available from this double-negated expression.";
-                UnaryExpr unaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "!(a instanceof String s != false)",
-                                ParseStart.EXPRESSION)
-                        .asUnaryExpr();
-                assertNoPatternExprsExposedToImmediateParentInContextNamed(unaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr8_negated() {
-                String message = "Only s must be available from this double-negated expression.";
-                UnaryExpr unaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "!(a instanceof String s != false)",
-                                ParseStart.EXPRESSION)
-                        .asUnaryExpr();
-                assertOneNegatedPatternExprsExposedToImmediateParentInContextNamed(unaryExpr, "s", message);
-            }
-
-            @Test
-            void instanceOfPatternExprBinaryExpr9() {
-                String message =
-                        "Must be no patterns available from this || expression (neither is guaranteed to be true).";
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "(a instanceof String s) || a instanceof String s2",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-                assertNoPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
-                assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(binaryExpr, "s", message);
             }
         }
 
@@ -1536,35 +1328,6 @@ class ContextTest extends AbstractSymbolResolutionTest {
                 assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(rightBranch, "s", message);
                 assertOnePatternExprsExposedToImmediateParentInContextNamed(rightBranch, "s2", message);
                 assertNoNegatedPatternExprsExposedToImmediateParentInContextNamed(rightBranch, "s2", message);
-            }
-
-            @Test
-            void instanceOfPatternExprResolution_expr_AND_solving1() {
-                BinaryExpr binaryExpr = parse(
-                                ParserConfiguration.LanguageLevel.JAVA_14_PREVIEW,
-                                "a instanceof String s && s instanceof String s2",
-                                ParseStart.EXPRESSION)
-                        .asBinaryExpr();
-
-                String message;
-
-                message = "Only s must be available on the LEFT branch of an AND.";
-                Expression leftBranch = binaryExpr.getLeft();
-                Context leftBranchContext = JavaParserFactory.getContext(leftBranch, typeSolver);
-                SymbolReference<? extends ResolvedValueDeclaration> left_s = leftBranchContext.solveSymbol("s");
-                assertTrue(left_s.isSolved());
-                Optional<TypePatternExpr> optionalPatternExpr = leftBranchContext.typePatternExprInScope("s");
-                assertTrue(optionalPatternExpr.isPresent());
-                SymbolReference<? extends ResolvedValueDeclaration> left_s2 = leftBranchContext.solveSymbol("s2");
-                assertFalse(left_s2.isSolved());
-
-                message = "s and s2 must be available on the RIGHT branch of an AND.";
-                Expression rightBranch = binaryExpr.getRight();
-                Context rightBranchContext = JavaParserFactory.getContext(rightBranch, typeSolver);
-                SymbolReference<? extends ResolvedValueDeclaration> right_s = rightBranchContext.solveSymbol("s");
-                assertTrue(right_s.isSolved());
-                SymbolReference<? extends ResolvedValueDeclaration> right_s2 = rightBranchContext.solveSymbol("s2");
-                assertTrue(right_s2.isSolved());
             }
 
             @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
@@ -33,6 +33,7 @@ import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -191,6 +192,7 @@ public class PatternVariableIntroductionTest {
         }
 
         @Test
+        @Disabled("Until bug mentioned in https://github.com/javaparser/javaparser/issues/4344 is fixed")
         public void conditionalAnd4() {
             CompilationUnit cu = parse("class Test {\n"
                     + "    public void test(Object o) {\n"

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
@@ -1,0 +1,1241 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.symbolsolver.resolution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.stmt.SwitchStmt;
+import com.github.javaparser.resolution.Navigator;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the rules for variables introduced by patterns as described in
+ *   https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1
+ * and
+ *   https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2
+ */
+public class PatternVariableIntroductionTest {
+
+    private CompilationUnit parse(String code) {
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
+        return new JavaParser(parserConfiguration).parse(code).getResult().get();
+    }
+
+    /**
+     * Tests for 6.3.1.1. Conditional-And Operator &&
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.1
+     *
+     * The following rules apply to a conditional-and expression a && b
+     * - A pattern variable introduced by a when true is definitely matched at b.
+     * - A pattern variable is introduced by a && b when true iff either
+     *     (i) it is introduced by a when true or
+     *     (ii) it is introduced by b when true.
+     */
+    @Nested
+    class ConditionalAnd {
+
+        @Test
+        public void conditionalAnd1() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "        if (o instanceof String value && value.length() > 5) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalAnd1Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "        if (!(o instanceof String value) && value.length() > 5) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void conditionalAnd2_1() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (o instanceof String value && b) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalAnd2_2() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (b && o instanceof String value) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalAnd2_3() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, Object p) {\n"
+                    + "        if (o instanceof String value1 && p instanceof Integer value2) {\n"
+                    + "            System.out.println(value1 + value2);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name1 = Navigator.findNameExpression(cu, "value1").get();
+            assertEquals("java.lang.String", name1.resolve().getType().describe());
+            NameExpr name2 = Navigator.findNameExpression(cu, "value2").get();
+            assertEquals("java.lang.Integer", name2.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalAnd2_1Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (!(o instanceof String value) && b) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void conditionalAnd2_2Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (b && !(o instanceof String value)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void conditionalAnd2_3Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, Object p) {\n"
+                    + "        if (!(o instanceof String value1) && !(p instanceof Integer value2)) {\n"
+                    + "            System.out.println(value1 + value2);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name1 = Navigator.findNameExpression(cu, "value1").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name1.resolve());
+            NameExpr name2 = Navigator.findNameExpression(cu, "value2").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name2.resolve());
+        }
+
+        @Test
+        public void conditionalAnd3() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o, boolean a, boolean b, boolean c, boolean d, boolean e) {\n"
+                    + "        if (((a && ((o instanceof String value && b) && c)) && (d && (value.length() > 5 && e)))) {\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalAnd4() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (o instanceof Boolean value && value) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.Boolean", name.resolve().getType().describe());
+        }
+    }
+
+    /**
+     * Tests for 6.3.1.2. Conditional-Or Operator ||
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.2
+     *
+     * The following rules apply to a conditional-or expression a || b
+     * - A pattern variable introduced by a when false is definitely matched at b.
+     * - A pattern variable is introduced by a || b when false iff either
+     *     (i) it is introduced by a when false or
+     *     (ii) it is introduced by b when false.
+     */
+    @Nested
+    class ConditionalOr {
+        @Test
+        public void conditionalOr1() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "        if (!(o instanceof String value) || value.length() > 5) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalOr1Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "        if (o instanceof String value || value.length() > 5) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void conditionalOr2_1() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (!(!(o instanceof String value) || b)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalOr2_2() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (!(b || !(o instanceof String value))) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalOr2_1Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (!(o instanceof String value || b)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void conditionalOr2_2Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o, boolean b) {\n"
+                    + "        if (!(b || o instanceof String value)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void conditionalOr3() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o, boolean a, boolean b, boolean c, boolean d, boolean e) {\n"
+                    + "        if (((a || ((!(o instanceof String value) || b) || c)) || (d || (value.length() > 5 || e)))) {\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}\n");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+    }
+
+    /**
+     * Tests for 6.3.1.3. Conditional-Or Operator ||
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.3
+     *
+     * The following rules apply to a logical complement expression !a
+     * - A pattern variable is introduced by !a when true iff it is introduced by a when false.
+     * - A pattern variable is introduced by !a when false iff it is introduced by a when true.
+     */
+    @Nested
+    class LogicalComplementOperator {
+        @Test
+        public void logicalComplementOperator1() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void logicalComplementOperator2() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "        if (!(!(o instanceof String value))) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+    }
+
+    /**
+     * Tests for 6.3.1.4. Conditional-Or Operator ||
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.4
+     *
+     * The following rules apply to a conditional expression a ? b : c
+     * - A pattern variable introduced by a when true is definitely matched at b.
+     * - A pattern variable introduced by a when false is definitely matched at c.
+     */
+    @Nested
+    class ConditionalOperator {
+
+        @Test
+        public void conditionalOperator1() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "      boolean b = o instanceof String value ? value.length() > 0 : false;\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalOperator1Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "      boolean b = o instanceof String value ? false : value.length() > 5;\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void conditionalOperator2() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "      boolean b = !(o instanceof String value) ? false : value.length() > 5;\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void conditionalOperator2Negated() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "      boolean b = !(o instanceof String value) ? value.length() > 0 : false;\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+    }
+
+    /**
+     * Tests for 6.3.1.5. Pattern Match Operator instanceof
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.5
+     *
+     * The following rule applies to an instanceof expression with a pattern operand, a instanceof p
+     * - A pattern variable is introduced by a instanceof p when true iff the pattern p contains a declaration
+     *   of the pattern variable
+     */
+    @Nested
+    class PatternMatchOperator {
+        @Test
+        public void patternMatchOperator() {
+            CompilationUnit cu = parse("public class Test {\n"
+                    + "    public void foo(Object o) {\n"
+                    + "        if (o instanceof String value) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+    }
+
+    /**
+     * Tests for 6.3.1.6. switch Expressions
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.6
+     *
+     * The following rule applies to a switch expression with a switch block consisting of switch rules
+     * - A pattern variable introduced by a switch label is definitely matched in the associated switch rule expression,
+     * switch rule block, or switch rule throw statement.
+     *
+     * The following rules apply to a switch expression with a switch block consisting of switch labeled statement
+     * groups
+     * - A pattern variable introduced by a switch label is definitely matched in all the statements of the associated
+     *   switch labeled statement group.
+     * - A pattern variable introduced by a statement S contained in a switch labeled statement group is definitely
+     *   matched at all the statements following S, if any, in the switch labeled statement group.
+     */
+    @Nested
+    class SwitchExpressions {
+        @Test
+        public void switchExpressions1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public String test(Object o) {\n"
+                    + "        return switch (o) {\n"
+                    + "            case String value -> value + \";\";\n"
+                    + "            default -> \"\";\n"
+                    + "        };\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void switchExpressions1Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public String test(Object o) {\n"
+                    + "        return switch (o) {\n"
+                    + "            case String value -> \";\";\n"
+                    + "            default -> value + \"\";\n"
+                    + "        };\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void switchExpressions2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case String value -> {\n"
+                    + "                String s = value;\n"
+                    + "            }\n"
+                    + "            default -> {}\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void switchExpressions2Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case String value -> {\n"
+                    + "            }\n"
+                    + "            default -> {\n"
+                    + "                String s = value;\n"
+                    + "            }\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void switchExpressions3() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case String value -> throw new RuntimeException(value);\n"
+                    + "            default -> {}\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void switchExpressions3Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case String value -> {}\n"
+                    + "            default -> throw new RuntimeException(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void switchExpressions4() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case String value:\n"
+                    + "                System.out.println(value);\n"
+                    + "            default:\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void switchExpressions4Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case String value:\n"
+                    + "            default:\n"
+                    + "                System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void switchExpressions5() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case Integer value:\n"
+                    + "                System.out.println(value);\n"
+                    + "            case String value:\n"
+                    + "                System.out.println(value);\n"
+                    + "            default:\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            SwitchStmt switchStmt = cu.getClassByName("Test")
+                    .get()
+                    .getMethods()
+                    .get(0)
+                    .getBody()
+                    .get()
+                    .getStatements()
+                    .get(0)
+                    .asSwitchStmt();
+
+            NameExpr firstValue = Navigator.findNameExpression(
+                            switchStmt.getEntries().get(0), "value")
+                    .get();
+            assertEquals("java.lang.Integer", firstValue.resolve().getType().describe());
+            NameExpr secondValue = Navigator.findNameExpression(
+                            switchStmt.getEntries().get(1), "value")
+                    .get();
+            assertEquals("java.lang.String", secondValue.resolve().getType().describe());
+        }
+
+        @Test
+        public void switchExpressions6() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        switch (o) {\n"
+                    + "            case Integer value:\n"
+                    + "            case String otherValue:\n"
+                    + "                System.out.println(value);\n"
+                    + "            default:\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+    }
+
+    /**
+     * Tests for 6.3.1.7. Parenthesized Expressions
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.1.7
+     *
+     * The following rules apply to a parenthesized expression (a) (§15.8.5):
+     * - A pattern variable is introduced by (a) when true iff it is introduced by a when true.
+     * - A pattern variable is introduced by (a) when false iff it is introduced by a when false.
+     */
+    @Nested
+    class ParenthesizedExpressions {
+        @Test
+        public void parenthesizedExpressions1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if ((((((((o instanceof String value)))))))) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        } else {\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void parenthesizedExpressions1Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if ((((((((o instanceof String value)))))))) {\n"
+                    + "        } else {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void parenthesizedExpressions2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(((((((o instanceof String value)))))))) {\n"
+                    + "        } else {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void parenthesizedExpressions2Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(((((((o instanceof String value)))))))) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        } else {\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+    }
+
+    /**
+     * Tests for 6.3.2.2. if Statements
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2.2
+     *
+     * The following rules apply to a statement if (e) S
+     * - A pattern variable introduced by e when true is definitely matched at S.
+     * - A pattern variable is introduced by if (e) S iff
+     *   (i) it is introduced by e when false and
+     *   (ii) S cannot complete normally.
+     *
+     * The following rules apply to a statement if (e) S else T
+     * - A pattern variable introduced by e when true is definitely matched at S.
+     * - A pattern variable introduced by e when false is definitely matched at T.
+     * - A pattern variable is introduced by if (e) S else T iff either:
+     *   - It is introduced by e when true, and S can complete normally, and T cannot complete normally; or
+     *   - It is introduced by e when false, and S cannot complete normally, and T can complete normally.
+     *
+     */
+    @Nested
+    class IfStatements {
+        @Test
+        public void ifStatements1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (o instanceof String value) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void ifStatements1Negated1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void ifStatements1Negated2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o, boolean b) {\n"
+                    + "        if (o instanceof String value || b) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void ifStatements2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "            return;\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void ifStatements2Negated1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (o instanceof String value) {\n"
+                    + "            return;\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void ifStatements2Negated2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void ifStatements3() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "            throw new RuntimeException();\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void ifStatements4() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (o instanceof String value) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        } else {\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void ifStatements4Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (o instanceof String value) {\n"
+                    + "        } else {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void ifStatements5() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "        } else {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void ifStatements5Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        } else {\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void ifStatements6() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (o instanceof String value) {\n"
+                    + "        } else {\n"
+                    + "            return;\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void ifStatements6Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (o instanceof String value) {\n"
+                    + "        } else {\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void ifStatements7() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "            return;\n"
+                    + "        } else {\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void ifStatements7Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        if (!(o instanceof String value)) {\n"
+                    + "        } else {\n"
+                    + "            return;\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+    }
+
+    /**
+     * Tests for 6.3.2.3. while Statements
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2.3
+     *
+     *  The following rules apply to a statement while (e) S
+     *  - A pattern variable introduced by e when true is definitely matched at S.
+     *  - A pattern variable is introduced by while (e) S iff
+     *    (i) it is introduced by e when false and
+     *    (ii) S does not contain a reachable break statement for which the while statement is the break target
+     */
+    @Nested
+    class WhileStatements {
+        @Test
+        public void whileStatements1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        while (o instanceof String value) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void whileStatements1Negated1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        while (!(o instanceof String value)) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void whileStatements1Negated2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o, boolean b) {\n"
+                    + "        while (o instanceof String value || b) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void whileStatements2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        while (!(o instanceof String value)) {\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void whileStatements2Negated1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        while (!(o instanceof String value)) {\n"
+                    + "            break;\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void whileStatements3() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        first:\n"
+                    + "        while (true) {\n"
+                    + "            while (!(o instanceof String value)) {\n"
+                    + "                break first;\n"
+                    + "            }\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void whileStatements4() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        first:\n"
+                    + "        while (!(o instanceof String value)) {\n"
+                    + "            break first;\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void whileStatements5() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        while (o instanceof String value)\n"
+                    + "            System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+    }
+
+    /**
+     * Tests for 6.3.2.4. do Statements
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2.4
+     *
+     * The following rule applies to a statement do S while (e)
+     * - A pattern variable is introduced by do S while (e) iff
+     *   (i) it is introduced by e when false and
+     *   (ii) S does not contain a reachable break statement for which the do statement is the break target
+     */
+    @Nested
+    class DoStatements {
+        @Test
+        public void doStatements1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        do {\n"
+                    + "        } while (!(o instanceof String value));\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void doStatements1Negated1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        do {\n"
+                    + "            break;"
+                    + "        } while (!(o instanceof String value));\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+    }
+
+    /**
+     * Tests for 6.3.2.5. for Statements
+     * https://docs.oracle.com/javase/specs/jls/se22/html/jls-6.html#jls-6.3.2.5
+     *
+     *  The following rules apply to a basic for statement
+     *  - A pattern variable introduced by the condition expression when true is definitely matched at both the
+     *    incrementation part and the contained statement.
+     *  - A pattern variable is introduced by a basic for statement iff
+     *    (i) it is introduced by the condition expression when false and
+     *    (ii) the contained statement, S, does not contain a reachable break for which the basic for statement is the
+     *         break target
+     *
+     * An enhanced for statement is defined by translation to a basic for statement, so no special rules need to be
+     * provided for it.
+     */
+    @Nested
+    class ForStatements {
+        @Test
+        public void forStatements1() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (int i = 0; o instanceof String value; i += value.length()) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void forStatements1Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (int i = 0; o instanceof String value || i < 3; i += value.length()) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void forStatements2() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (; o instanceof String value; ) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void forStatements2Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (; !(o instanceof String value); ) {\n"
+                    + "            System.out.println(value);\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void forStatements3() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (; !(o instanceof String value); ) {\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void forStatements3Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (; !(o instanceof String value); ) {\n"
+                    + "            break;\n"
+                    + "        }\n"
+                    + "        System.out.println(value);\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+
+        @Test
+        public void forStatements4() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (int i = 0; o instanceof String value; value.length()) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertEquals("java.lang.String", name.resolve().getType().describe());
+        }
+
+        @Test
+        public void forStatements4Negated() {
+            CompilationUnit cu = parse("class Test {\n"
+                    + "    public void test(Object o) {\n"
+                    + "        for (int i = 0; !(o instanceof String value); value.length()) { }\n"
+                    + "    }\n"
+                    + "}");
+
+            NameExpr name = Navigator.findNameExpression(cu, "value").get();
+            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4525 

I tried to stay as close as possible to the JLS for the changes in this PR since the rules regarding variables introduced by pattern expressions are very specific. For most of the methods I added, I added a comment quoting the rule from the JLS that is implemented by the specific method. If something doesn't make sense, feel free to ask and I'll try to explain (or correct it if I made a mistake) :)

# PatternVariableVisitor
The `PatternVariableVisitor` was added to replace the `*typePatternExprsExposedFromChildren` methods in `Context`. In my opinion this is a cleaner implementation for 2 reasons:
* It avoids having to create contexts for all the children as the tree is traversed downwards looking for patterns
* It keeps the logic for searching for patterns contained in a single file which makes it easier to read through and reason about.

# Context changes
A new `getIntroducedTypePatterns` method was added to `StatementContext` with implementations for `if`, `do`, `while`, and `for` statements. This method is used to find pattern expressions introduced by rules such as
```
A pattern variable is introduced by if (e) S iff (i) it is introduced by e when false and (ii) S cannot complete normally. 
```

When attempting to solve a type in context, one of the steps is now to search for pattern expressions exposed to the child in the parent. I implemented it this way instead of attempting to solve the symbol in the parent context directly since this avoids the problem mentioned in https://github.com/javaparser/javaparser/issues/4344, among others. This adds yet another path through which a symbol can be solved, which is not ideal, but fixing the issues with losing positional information/context history when attempting to solve symbols is outside the scope of this PR (although I'd be happy to take a look at some point since I think I understand the `javaparsermodel` process for solving symbols fairly well by now).

I've also cleaned up implementations for the `*typePatternExprsExposedFromChildren` methods and removed now-unnecessary helper methods.

# NormalCompletionVisitor
Some rules (such as that for if statements mentioned above) require knowledge about whether a statement can complete normally. Similar to the PatternVariableVisitor, I've added a separate visitor for this to keep the logic contained. I've implemented most of the rules described in the JLS, but notably did not implement the rules for loops correctly since this requires knowledge of whether the loop condition is a constant expression that evaluates to true/false. Since this PR was already getting quite big and this only affects an edge-case which I suspect is rather rare, I decided to put it aside for now with a comment of what needs to change. I'll come back to it at some point, but I think that's worth a separate change.

# Test changes
I added tests to test all of the rules for pattern variable scope mentioned in the JLS and also removed some old tests that were testing incorrect behaviour (see the linked issue for a comment describing some of these rules). I verified all of the tests that I've added with javac.

I added some negative tests of the form
```
        @Test
        public void conditionalOr1Negated() {
            CompilationUnit cu = parse("public class Test {\n"
                    + "    public void foo(Object o) {\n"
                    + "        if (o instanceof String value || value.length() > 5) { }\n"
                    + "    }\n"
                    + "}");

            NameExpr name = Navigator.findNameExpression(cu, "value").get();
            assertThrows(UnsolvedSymbolException.class, () -> name.resolve());
        }
```
Even though the code in this test doesn't compile, these tests still confirm that a pattern variable isn't incorrectly introduced into a given scope. As mentioned in the linked issue, one can always add a field `value` which would make this example compile and which would demonstrate how this could cause shadowing issues, but the tests as I wrote them are easier to verify with the compiler and test only how pattern variables are introduced into scope, instead of a combination of how the variables are introduced into scope and resolution of fields, for example.