### PR TITLE
Add better instructions for re-formatting the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,4 +29,51 @@ Our development workflow is based on Pull Request. If you are not familiar with 
 - Pull requests often stay open for at least a few days to give people a chance to review it.
 - A pull request is merged when all comments on it have been resolved.
 - If you create a pull request for an issue, mention the issue in the format #123 to make github link it automatically.
-- Before submitting a pull request, please run `./mvnw spotless:apply` to format your code to avoid any formatting related issues during review.
+- Before creating a commit (or at least before submitting a pull request), please reformat the project with the instructions given below
+  to avoid any formatting-related issues during the review.
+
+### Note on formatting the project:
+
+- If you are developing on a machine with bash installed, execute `./run_core_metamodel_generator.sh && ./run_core_generators.sh`. This
+  will re-run all of the code generators and then re-format the entire project as a final step. This ensures that:
+  - All the code that needs to be generated has been generated correctly.
+  - None of the changes you've added will be overwritten by code generation in the future.
+  - All of your changes are correctly formatted (including changes made during code generation, for example whitespace changes).
+
+  The PR check for style runs these generators and checks that the diff after doing so is empty, so if you've run this on your machine,
+  then that check should not fail.
+
+- If you are developing on a machine without bash, execute `./mvnw spotless:apply`. This will re-format the project, but without
+  running the code generators. This will be sufficient in many cases, but it's still possible that changes are introduced during
+  code generation which would cause the PR style check to fail. If this happens, some manual changes are required.
+
+  To fix this:
+  1. Go to the job output for the failed `Spotless check` job by clicking the red cross next to the job.
+  2. Scroll to the bottom of the `Generate code and format` output tab. 
+  3. There, you will see output from the diff command showing what failed. For example, in https://github.com/javaparser/javaparser/actions/runs/10389076737/job/28766249645,
+     that output is:
+    ```
+    [INFO] ------------------------------------------------------------------------
+    diff --git a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
+    index 7bc7f46b9..429889e35 100644
+    --- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
+    +++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/RecordPatternExpr.java
+    @@ -17,7 +17,6 @@
+      * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      * GNU Lesser General Public License for more details.
+      */
+    -
+     package com.github.javaparser.ast.expr;
+     
+     import static com.github.javaparser.utils.Utils.assertNotNull;
+    Error: Process completed with exit code 1.
+    ```
+
+  4. Verify that this output does not overwrite any code you wrote which would change the behaviour. If it does, you probably implemented
+     something manually when it should've been generated and this will be overwritten next time the code generators are run. This requires
+     a manual fix to your code to prevent issues in the future.
+  5. If no major issues are found, copy this output, excluding the `[INFO] --...` line and the `Error: Process complete with exit code 1.` 
+     line and paste that into a patch file (for example, `/tmp/style.patch`, but the name and location aren't important).
+  6. From the javaparser project directory, run `git apply /tmp/style.patch` (substituting `/tmp/style.patch` for the path of your
+     patch file). `git status` should now show that all the files mentioned in the patch are modified.
+  7. Add and commit the changes and push to update the PR.


### PR DESCRIPTION
The style check I've added has caused some confusion for 2 reasons:
1. What I've explicitly communicated so far is not consistent with what's actually being checked
2. The instructions I added to CONTRIBUTING.md are not sufficient to guarantee that a change will pass the style check.

Specifically, I mentioned in the original spotless PR that the check that is run first runs the code generators, then runs spotless. In later comments and in `CONTRIBUTING.md`, however, I said that running `./mvnw spotless:apply` would fix style errors. This was not correct and I did not consider that the code generators would introduce style changes that wouldn't be "fixed" by spotless. 

There have been a few cases where the generators have made whitespace changes that weren't changed by spotless, however, and the instructions I gave also don't give any guidance in cases where there are legitimate codegen issues (for example if someone implemented a method manually when it should've been generated), so I've updated the instructions in `CONTRIBUTING.md` to be much more clear (and correct) about what's required.

I also mentioned creating a custom maven command  (for example `./mvnw format`) to make this process simpler for contributors, but this would only work on systems with `bash` available and isn't much simpler than running the code generators in any case. I think just having better instructions available is a better solution.