### PR TITLE
ForStatementContext: solveSymbolAsValue added

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -538,7 +538,7 @@ public class TypeExtractor extends DefaultVisitorAdapter {
             return result;
         }
         if (parentNode instanceof ObjectCreationExpr) {
-        	ObjectCreationExpr expr = (ObjectCreationExpr) parentNode;
+            ObjectCreationExpr expr = (ObjectCreationExpr) parentNode;
             ResolvedType result = expr.getType().resolve();
 
             if (solveLambdas) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4560Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4560Test.java
@@ -20,15 +20,14 @@
 
 package com.github.javaparser.symbolsolver;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 import org.junit.jupiter.api.Test;
 
 public class Issue4560Test extends AbstractResolutionTest {
@@ -36,14 +35,14 @@ public class Issue4560Test extends AbstractResolutionTest {
     @Test
     void test() {
 
-    	String code = "public class MyExample {\n"
-				+ "\n"
-				+ "  public static void main(String[] args) {\n"
-				+ "    \"\"\"\n"
-				+ "        Hello multiple %s!\n"
-				+ "        \"\"\".format(\"world\");\n"
-				+ "  }\n"
-				+ "}";
+        String code = "public class MyExample {\n"
+                + "\n"
+                + "  public static void main(String[] args) {\n"
+                + "    \"\"\"\n"
+                + "        Hello multiple %s!\n"
+                + "        \"\"\".format(\"world\");\n"
+                + "  }\n"
+                + "}";
 
         ParserConfiguration parserConfiguration = new ParserConfiguration()
                 .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_15)

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariableResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariableResolutionTest.java
@@ -22,14 +22,22 @@ package com.github.javaparser.symbolsolver.resolution;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.Navigator;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class VariableResolutionTest extends AbstractResolutionTest {
@@ -62,5 +70,57 @@ public class VariableResolutionTest extends AbstractResolutionTest {
                 JavaParserFacade.get(new ReflectionTypeSolver()).solveMethodAsUsage(callExpr);
 
         assertTrue(methodUsage.declaringType().getQualifiedName().equals("java.lang.String"));
+    }
+
+    @Test
+    public void symbolAsValueInForStmtTest() {
+        String code = "public class Board {\n" + "\n"
+                + "    class Field {\n"
+                + "        private final Board board;\n"
+                + "        private final int x;\n"
+                + "        private final int y;\n"
+                + "\n"
+                + "        public Field(Board board, int x, int y) {\n"
+                + "            this.board = board;\n"
+                + "            this.x = x;\n"
+                + "            this.y = y;\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n"
+                + "    /**\n"
+                + "     * Edge size of the Sudoku board.\n"
+                + "     */\n"
+                + "    public static final int SIZE = 9;\n"
+                + "    private final Field[] board = new Field[SIZE * SIZE];\n"
+                + "\n"
+                + "    /**\n"
+                + "     * Creates a Sudoku board with all of its fields being empty.\n"
+                + "     */\n"
+                + "    public Board() {\n"
+                + "        for (int x = 0; x < SIZE; x++)\n"
+                + "            for (int y = 0; y < SIZE; y++)\n"
+                + "                board[SIZE * y + x] = new Field(this, x, y);\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        final List<ObjectCreationExpr> objectCreationExprs = cu.findAll(ObjectCreationExpr.class);
+
+        for (ObjectCreationExpr objectCreationExpr : objectCreationExprs) {
+            System.err.println(objectCreationExpr.toString());
+            for (Expression e : objectCreationExpr.getArguments()) {
+                System.err.println(e.toString());
+                if (e.isNameExpr()) {
+                    NameExpr ne = e.asNameExpr();
+                    final ResolvedValueDeclaration resolve = ne.resolve();
+                    System.err.println(resolve);
+                    System.err.println(resolve.getType().describe());
+                }
+            }
+            final ResolvedConstructorDeclaration resolve = objectCreationExpr.resolve();
+            System.err.println(resolve.getQualifiedName());
+            System.err.println(resolve.getQualifiedSignature());
+        }
     }
 }


### PR DESCRIPTION
Fixes #4568.

Hi, as mentioned in #4568 solving variables which were declared in the initialization part of a ForStmt "as value" is not implemented. This patch adds ForStatementContext::solveSymbolAsValue. It's a copy of ForStatementContext::solveSymbol with small modifications. 

Please check this solution if there are any shortcomings or other problems I am not aware of.

Best regards,
Kim
