### PR TITLE
Fix issue #4607: don't forget to clone guard when cloning stmt.SwitchEntry

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/other/TokenKindGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/other/TokenKindGenerator.java
@@ -92,7 +92,11 @@ public class TokenKindGenerator extends Generator {
 
     private void generateValueOfEntry(SwitchStmt valueOfSwitch, String name, IntegerLiteralExpr kind) {
         final SwitchEntry entry = new SwitchEntry(
-                new NodeList<>(kind), SwitchEntry.Type.STATEMENT_GROUP, new NodeList<>(new ReturnStmt(name)), false);
+                new NodeList<>(kind),
+                SwitchEntry.Type.STATEMENT_GROUP,
+                new NodeList<>(new ReturnStmt(name)),
+                false,
+                null);
         valueOfSwitch.getEntries().addFirst(entry);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
@@ -107,4 +107,11 @@ class SwitchStmtTest {
         assertEquals("CustomDeployTableModel.ARTIFACT_NAME", switchLabel.toString());
         assertTrue(switchLabel.isFieldAccessExpr());
     }
+
+    @Test
+    void issue4607Test() {
+        SwitchStmt switchStmt = parseStatement("switch (o) { case String s when s.length() == 1 -> 0; }")
+                .asSwitchStmt();
+        assertEquals(switchStmt.toString(), switchStmt.clone().toString());
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntry.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/stmt/SwitchEntry.java
@@ -134,8 +134,9 @@ public class SwitchEntry extends Node implements NodeWithStatements<SwitchEntry>
             final NodeList<Expression> labels,
             final Type type,
             final NodeList<Statement> statements,
-            final boolean isDefault) {
-        this(null, labels, type, statements, isDefault, null);
+            final boolean isDefault,
+            final Expression guard) {
+        this(null, labels, type, statements, isDefault, guard);
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -893,7 +893,8 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<Expression> labels = cloneList(n.getLabels(), arg);
         NodeList<Statement> statements = cloneList(n.getStatements(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
-        SwitchEntry r = new SwitchEntry(n.getTokenRange().orElse(null), labels, n.getType(), statements, n.isDefault());
+        SwitchEntry r =
+                new SwitchEntry(n.getTokenRange().orElse(null), labels, n.getType(), statements, n.isDefault(), guard);
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
         copyData(n, r);

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -442,6 +442,7 @@ public final class JavaParserMetaModel {
         switchEntryMetaModel.getConstructorParameters().add(switchEntryMetaModel.typePropertyMetaModel);
         switchEntryMetaModel.getConstructorParameters().add(switchEntryMetaModel.statementsPropertyMetaModel);
         switchEntryMetaModel.getConstructorParameters().add(switchEntryMetaModel.isDefaultPropertyMetaModel);
+        switchEntryMetaModel.getConstructorParameters().add(switchEntryMetaModel.guardPropertyMetaModel);
         switchStmtMetaModel.getConstructorParameters().add(switchStmtMetaModel.selectorPropertyMetaModel);
         switchStmtMetaModel.getConstructorParameters().add(switchStmtMetaModel.entriesPropertyMetaModel);
         synchronizedStmtMetaModel.getConstructorParameters().add(synchronizedStmtMetaModel.expressionPropertyMetaModel);


### PR DESCRIPTION
Fixes #4607.