### PR TITLE
Fix bug in VisitorSet.toString()

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
@@ -136,8 +136,7 @@ class VisitorSetTest {
 
     @Test
     void visitorSetForType() {
-        Set<Type> set =
-                new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        Set<Type> set = new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.addAll(parseMethodDeclaration("public void main(String args) {}").findAll(Type.class));
         System.out.println(set);
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
@@ -22,10 +22,12 @@
 package com.github.javaparser.utils;
 
 import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseMethodDeclaration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.ObjectIdentityEqualsVisitor;
 import com.github.javaparser.ast.visitor.ObjectIdentityHashCodeVisitor;
 import java.util.*;
@@ -130,5 +132,13 @@ class VisitorSetTest {
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.addAll(list);
         for (CompilationUnit u : set.toArray(new CompilationUnit[2])) assertTrue(set.contains(u));
+    }
+
+    @Test
+    void visitorSetForType() {
+        Set<Type> set =
+                new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
+        set.addAll(parseMethodDeclaration("public void main(String args) {}").findAll(Type.class));
+        System.out.println(set);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorSet.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/VisitorSet.java
@@ -152,7 +152,7 @@ public class VisitorSet<N extends Node> implements Set<N> {
         StringBuilder sb = new StringBuilder("[");
         if (size() == 0) return sb.append("]").toString();
         for (EqualsHashcodeOverridingFacade facade : innerSet) {
-            sb.append(facade.overridden.toString() + ",");
+            sb.append(facade.overridden.toString() + ", ");
         }
         return sb.replace(sb.length() - 2, sb.length(), "]").toString();
     }


### PR DESCRIPTION
Hello, I find a bug in VisitorSet.toString() due to missing a space, and the last useful character will be removed, causing a wrong output.
- The right output: 
<img width="215" alt="image" src="https://github.com/user-attachments/assets/86a83772-fc0c-45de-8182-b8a26e834643">

- The wrong ouput:
<img width="171" alt="image" src="https://github.com/user-attachments/assets/0752071d-d790-4c30-a967-324b819e6edd">
