### PR TITLE
Fixed #3674

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -171,6 +171,12 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                     throw new IllegalStateException("Unexpectedly more than one reference in scope");
             }
         }
+        if(parentContext instanceof BlockStmtContext) {
+        	// if parent context is BlockStmtContext, when we call parentContext.solveSymbol(name) we lose the position within the block
+        	// so we pass the current context to the block context
+        	BlockStmtContext context = (BlockStmtContext)parentContext;
+        	parentContext = new BlockStmtContext(context.wrappedNode, context.typeSolver, this);
+        }
 
         return parentContext.solveSymbol(name);
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3674Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3674Test.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.ast.body.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserFieldDeclaration;
+
+public class Issue3674Test extends AbstractResolutionTest {
+
+    @Test
+    void test() {
+
+        String code = "public class Class {\n" + "\n"
+                + "        int attribute;\n"
+                + "\n"
+                + "        private int method() {\n"
+                + "            int value = attribute;\n"
+                + "            double attribute = 0.0;\n"
+                + "            return (int) (attribute + 1);\n"
+                + "        }\n"
+                + "}";
+        ParserConfiguration parserConfiguration =
+                new ParserConfiguration().setSymbolResolver(symbolResolver(defaultTypeSolver()));
+
+        CompilationUnit cu =
+                JavaParserAdapter.of(new JavaParser(parserConfiguration)).parse(code);
+
+        MethodDeclaration oce = cu.findFirst(MethodDeclaration.class).get();
+        VariableDeclarationExpr decl = oce.findFirst(VariableDeclarationExpr.class).get();
+
+        NameExpr nameAttributeExpr = oce.findFirst(NameExpr.class).get();
+        ResolvedValueDeclaration res = nameAttributeExpr.resolve();
+        assertTrue(res instanceof JavaParserFieldDeclaration);
+        JavaParserFieldDeclaration resolvedFieldDeclaration = (JavaParserFieldDeclaration)res;
+        assertEquals(resolvedFieldDeclaration.getName(),"attribute");
+        assertEquals(resolvedFieldDeclaration.getType().describe(),"int");
+        
+    }
+}


### PR DESCRIPTION
Solves for the issue #3674 described below where `attribute ` in  `int value = attribute;` should resolve to the field `int attribute;
`
Stores the current statement when resolving via it's parent Block Statement and then limits variable declarations to consider as matches from within the Block Statement to only Variables declared before the stored statement.

Considering the following class:

```
class Class {

    int attribute;

    private int method() {
        int value = attribute;
        double attribute = 0.0;
        return (int) (attribute + 1);
    }
}
```
When resolving the line:
int value = attribute;

Setting the JavaParser with the solver as shown in the following code (Kotlin):

StaticJavaParser.setConfiguration(ParserConfiguration().setSymbolResolver(JavaSymbolSolver(CombinedTypeSolver())))
The NameExpr <attribute> provides the VariableDeclarationExpr <double attribute = 0.0> instead of the FieldDeclaration <int attribute;>.