### PR TITLE
#4664 remove misleading javadoc

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -149,7 +149,6 @@ public final class JavaParser {
      * @param in {@link InputStream} containing Java source code. It will be closed after parsing.
      * @param encoding encoding of the source code
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<CompilationUnit> parse(final InputStream in, Charset encoding) {
         return parse(COMPILATION_UNIT, provider(in, encoding));
@@ -161,7 +160,6 @@ public final class JavaParser {
      *
      * @param in {@link InputStream} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<CompilationUnit> parse(final InputStream in) {
         return parse(in, configuration.getCharacterEncoding());
@@ -174,7 +172,6 @@ public final class JavaParser {
      * @param file {@link File} containing Java source code. It will be closed after parsing.
      * @param encoding encoding of the source code
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      * @throws FileNotFoundException the file was not found
      * @deprecated set the encoding in the {@link ParserConfiguration}
      */
@@ -191,7 +188,6 @@ public final class JavaParser {
      *
      * @param file {@link File} containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      * @throws FileNotFoundException the file was not found
      */
     public ParseResult<CompilationUnit> parse(final File file) throws FileNotFoundException {
@@ -209,7 +205,6 @@ public final class JavaParser {
      * @param encoding encoding of the source code
      * @return CompilationUnit representing the Java source code
      * @throws IOException the path could not be accessed
-     * @throws ParseProblemException if the source code has parser errors
      * @deprecated set the encoding in the {@link ParserConfiguration}
      */
     @Deprecated
@@ -225,7 +220,6 @@ public final class JavaParser {
      *
      * @param path path to a file containing Java source code
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
      */
     public ParseResult<CompilationUnit> parse(final Path path) throws IOException {
@@ -242,7 +236,6 @@ public final class JavaParser {
      * @param path path to a resource containing Java source code. As resource is accessed through a class loader, a
      * leading "/" is not allowed in pathToResource
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
      */
     public ParseResult<CompilationUnit> parseResource(final String path) throws IOException {
@@ -257,7 +250,6 @@ public final class JavaParser {
      * leading "/" is not allowed in pathToResource
      * @param encoding encoding of the source code
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
      * @deprecated set the encoding in the {@link ParserConfiguration}
      */
@@ -274,7 +266,6 @@ public final class JavaParser {
      * @param path path to a resource containing Java source code. As resource is accessed through a class loader, a
      * leading "/" is not allowed in pathToResource
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      * @throws IOException the path could not be accessed
      * @deprecated set the encoding in the {@link ParserConfiguration}
      */
@@ -290,7 +281,6 @@ public final class JavaParser {
      *
      * @param reader the reader containing Java source code. It will be closed after parsing.
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<CompilationUnit> parse(final Reader reader) {
         return parse(COMPILATION_UNIT, provider(reader));
@@ -302,7 +292,6 @@ public final class JavaParser {
      *
      * @param code Java source code
      * @return CompilationUnit representing the Java source code
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<CompilationUnit> parse(String code) {
         return parse(COMPILATION_UNIT, provider(code));
@@ -314,7 +303,6 @@ public final class JavaParser {
      *
      * @param blockStatement {@link String} containing Java block code
      * @return BlockStmt representing the Java block
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<BlockStmt> parseBlock(final String blockStatement) {
         return parse(BLOCK, provider(blockStatement));
@@ -326,7 +314,6 @@ public final class JavaParser {
      *
      * @param statement {@link String} containing Java statement code
      * @return Statement representing the Java statement
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<Statement> parseStatement(final String statement) {
         return parse(STATEMENT, provider(statement));
@@ -338,7 +325,6 @@ public final class JavaParser {
      *
      * @param importDeclaration {@link String} containing Java import code
      * @return ImportDeclaration representing the Java import declaration
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<ImportDeclaration> parseImport(final String importDeclaration) {
         return parse(IMPORT_DECLARATION, provider(importDeclaration));
@@ -350,7 +336,6 @@ public final class JavaParser {
      *
      * @param expression {@link String} containing Java expression
      * @return Expression representing the Java expression
-     * @throws ParseProblemException if the source code has parser errors
      */
     @SuppressWarnings("unchecked")
     public <T extends Expression> ParseResult<T> parseExpression(final String expression) {
@@ -363,7 +348,6 @@ public final class JavaParser {
      *
      * @param annotation {@link String} containing Java annotation
      * @return AnnotationExpr representing the Java annotation
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<AnnotationExpr> parseAnnotation(final String annotation) {
         return parse(ANNOTATION, provider(annotation));
@@ -375,7 +359,6 @@ public final class JavaParser {
      *
      * @param body {@link String} containing Java body declaration
      * @return BodyDeclaration representing the Java annotation
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<BodyDeclaration<?>> parseAnnotationBodyDeclaration(final String body) {
         return parse(ANNOTATION_BODY, provider(body));
@@ -387,7 +370,6 @@ public final class JavaParser {
      *
      * @param body the body of a class or interface
      * @return BodyDeclaration representing the Java interface body
-     * @throws ParseProblemException if the source code has parser errors
      */
     @SuppressWarnings("unchecked")
     public <T extends BodyDeclaration<?>> ParseResult<T> parseBodyDeclaration(String body) {
@@ -399,7 +381,6 @@ public final class JavaParser {
      *
      * @param type the type name like a.b.c.X or Y
      * @return ClassOrInterfaceType representing the type
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<ClassOrInterfaceType> parseClassOrInterfaceType(String type) {
         return parse(CLASS_OR_INTERFACE_TYPE, provider(type));
@@ -410,7 +391,6 @@ public final class JavaParser {
      *
      * @param type the type name like a.b.c.X, Y, or int
      * @return ClassOrInterfaceType representing the type
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<Type> parseType(String type) {
         return parse(TYPE, provider(type));
@@ -422,7 +402,6 @@ public final class JavaParser {
      *
      * @param declaration a variable declaration like {@code int x=2;}
      * @return VariableDeclarationExpr representing the type
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<VariableDeclarationExpr> parseVariableDeclarationExpr(String declaration) {
         return parse(VARIABLE_DECLARATION_EXPR, provider(declaration));
@@ -433,7 +412,6 @@ public final class JavaParser {
      *
      * @param statement a statement like super("hello");
      * @return the AST for the statement.
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<ExplicitConstructorInvocationStmt> parseExplicitConstructorInvocationStmt(String statement) {
         return parse(EXPLICIT_CONSTRUCTOR_INVOCATION_STMT, provider(statement));
@@ -444,7 +422,6 @@ public final class JavaParser {
      *
      * @param qualifiedName a name like "com.laamella.parameter_source"
      * @return the AST for the name
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<Name> parseName(String qualifiedName) {
         return parse(NAME, provider(qualifiedName));
@@ -455,7 +432,6 @@ public final class JavaParser {
      *
      * @param name a name like "parameter_source"
      * @return the AST for the name
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<SimpleName> parseSimpleName(String name) {
         return parse(SIMPLE_NAME, provider(name));
@@ -466,7 +442,6 @@ public final class JavaParser {
      *
      * @param parameter a parameter like "int[] x"
      * @return the AST for the parameter
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<Parameter> parseParameter(String parameter) {
         return parse(PARAMETER, provider(parameter));
@@ -477,7 +452,6 @@ public final class JavaParser {
      *
      * @param packageDeclaration a declaration like "package com.microsoft.java;"
      * @return the AST for the parameter
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<PackageDeclaration> parsePackageDeclaration(String packageDeclaration) {
         return parse(PACKAGE_DECLARATION, provider(packageDeclaration));
@@ -488,7 +462,6 @@ public final class JavaParser {
      *
      * @param typeDeclaration a declaration like "class X {}"
      * @return the AST for the type declaration
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<TypeDeclaration<?>> parseTypeDeclaration(String typeDeclaration) {
         return parse(TYPE_DECLARATION, provider(typeDeclaration));
@@ -499,7 +472,6 @@ public final class JavaParser {
      *
      * @param moduleDeclaration a declaration like "module X {}"
      * @return the AST for the module declaration
-     * @throws ParseProblemException if the source code has parser errors
      * @see ModuleDeclaration
      */
     public ParseResult<ModuleDeclaration> parseModuleDeclaration(String moduleDeclaration) {
@@ -511,7 +483,6 @@ public final class JavaParser {
      *
      * @param moduleDirective a directive like "opens C;"
      * @return the AST for the module directive
-     * @throws ParseProblemException if the source code has parser errors
      * @see ModuleDirective
      */
     public ParseResult<ModuleDirective> parseModuleDirective(String moduleDirective) {
@@ -523,7 +494,6 @@ public final class JavaParser {
      *
      * @param typeParameter a parameter like "T extends Serializable"
      * @return the AST for the type parameter
-     * @throws ParseProblemException if the source code has parser errors
      */
     public ParseResult<TypeParameter> parseTypeParameter(String typeParameter) {
         return parse(TYPE_PARAMETER, provider(typeParameter));
@@ -534,7 +504,6 @@ public final class JavaParser {
      *
      * @param methodDeclaration a method declaration like "void foo() {}"
      * @return the AST for the method declaration
-     * @throws ParseProblemException if the source code has parser errors
      * @see MethodDeclaration
      */
     public ParseResult<MethodDeclaration> parseMethodDeclaration(String methodDeclaration) {
@@ -546,7 +515,6 @@ public final class JavaParser {
      *
      * @param arrayInitializerExpr an array initializer like "{1,2,3}"
      * @return the AST for the array initializer expression
-     * @throws ParseProblemException if the source code has parser errors
      * @see ArrayInitializerExpr
      */
     public ParseResult<ArrayInitializerExpr> parseArrayInitializerExpr(String arrayInitializerExpr) {


### PR DESCRIPTION
Fixes #4664. It is time to remove the misleading Javadoc after a decade.
