### PR TITLE
Fix added switch entries printed by LPP

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConcreteSyntaxModel.java
@@ -869,51 +869,49 @@ public class ConcreteSyntaxModel {
                         conditional(
                                 SWITCH_STATEMENT_ENTRY,
                                 FLAG,
-                                conditional(
-                                        ObservableProperty.LABELS,
-                                        IS_NOT_EMPTY,
-                                        sequence(
-                                                token(GeneratedJavaParserConstants.CASE),
-                                                space(),
-                                                list(ObservableProperty.LABELS),
-                                                token(GeneratedJavaParserConstants.COLON)),
-                                        sequence(
-                                                token(GeneratedJavaParserConstants._DEFAULT),
-                                                token(GeneratedJavaParserConstants.COLON))),
-                                conditional(
-                                        ObservableProperty.LABELS,
-                                        IS_NOT_EMPTY,
+                                sequence(
                                         conditional(
-                                                ObservableProperty.DEFAULT,
-                                                FLAG,
+                                                ObservableProperty.LABELS,
+                                                IS_NOT_EMPTY,
                                                 sequence(
                                                         token(GeneratedJavaParserConstants.CASE),
                                                         space(),
-                                                        list(ObservableProperty.LABELS),
-                                                        comma(),
-                                                        space(),
-                                                        token(GeneratedJavaParserConstants._DEFAULT),
-                                                        space(),
-                                                        token(GeneratedJavaParserConstants.ARROW)),
-                                                sequence(
-                                                        token(GeneratedJavaParserConstants.CASE),
-                                                        space(),
-                                                        list(ObservableProperty.LABELS),
-                                                        conditional(
-                                                                ObservableProperty.GUARD,
-                                                                IS_PRESENT,
-                                                                sequence(
-                                                                        space(),
-                                                                        token(GeneratedJavaParserConstants.WHEN),
-                                                                        space(),
-                                                                        child(ObservableProperty.GUARD))),
-                                                        space(),
-                                                        token(GeneratedJavaParserConstants.ARROW))),
-                                        sequence(
-                                                token(GeneratedJavaParserConstants._DEFAULT),
-                                                space(),
-                                                token(GeneratedJavaParserConstants.ARROW)))),
-                        newline(),
+                                                        list(ObservableProperty.LABELS)),
+                                                token(GeneratedJavaParserConstants._DEFAULT)),
+                                        token(GeneratedJavaParserConstants.COLON),
+                                        newline()),
+                                sequence(
+                                        conditional(
+                                                ObservableProperty.LABELS,
+                                                IS_NOT_EMPTY,
+                                                conditional(
+                                                        ObservableProperty.DEFAULT,
+                                                        FLAG,
+                                                        sequence(
+                                                                token(GeneratedJavaParserConstants.CASE),
+                                                                space(),
+                                                                list(ObservableProperty.LABELS),
+                                                                comma(),
+                                                                space(),
+                                                                token(GeneratedJavaParserConstants._DEFAULT)),
+                                                        sequence(
+                                                                token(GeneratedJavaParserConstants.CASE),
+                                                                space(),
+                                                                list(ObservableProperty.LABELS),
+                                                                conditional(
+                                                                        ObservableProperty.GUARD,
+                                                                        IS_PRESENT,
+                                                                        sequence(
+                                                                                space(),
+                                                                                token(
+                                                                                        GeneratedJavaParserConstants
+                                                                                                .WHEN),
+                                                                                space(),
+                                                                                child(ObservableProperty.GUARD))))),
+                                                token(GeneratedJavaParserConstants._DEFAULT)),
+                                        space(),
+                                        token(GeneratedJavaParserConstants.ARROW),
+                                        space())),
                         indent(),
                         list(ObservableProperty.STATEMENTS, newline(), none(), newline()),
                         unindent()));

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -4715,16 +4715,12 @@ SwitchEntry SwitchEntry():
      |
         "->"
         (
-            (
-                expr = Expression()
-                {
-                    TokenRange r=range(begin, token());
-                    // expr.getTokenRange() will not be present if storeTokens is false
-                    stmts.add(new ExpressionStmt(expr.getTokenRange().orElse(null), expr));
-                    ret = new SwitchEntry(r, labels, EXPRESSION, stmts, isDefault, guard);
-                }
-                ";"
-            )
+            stmt = SwitchEntryExpression()
+            {
+                TokenRange r=range(begin, token());
+                stmts.add(stmt);
+                ret = new SwitchEntry(r, labels, EXPRESSION, stmts, isDefault, guard);
+            }
          |
             stmt = Block()
             {
@@ -4742,6 +4738,36 @@ SwitchEntry SwitchEntry():
         )
     )
     { return ret; }
+}
+
+/**
+* This method provides special handling for the case
+*
+*<pre>{@code
+*     SwitchRule:
+*         SwitchLabel -> Expression ;
+* }</pre}
+*
+* for switch entries in the JLS. The expression in the entry body is
+* represented as an ExpressionStmt in JavaParser, but the regular
+* StatementExpression() production cannot be used since that only
+* supports a subset of expressions while any expression is supported
+* in the entry body.
+*/
+ExpressionStmt SwitchEntryExpression():
+{
+    Expression expr;
+}
+{
+    expr = Expression()
+    ";"
+    {
+        TokenRange r = expr.getTokenRange().orElse(null);
+        if (r != null) {
+            r = r.withEnd(token());
+        }
+        return new ExpressionStmt(r, expr);
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes #4646.

This PR includes 2 changes to fix the token range of switch expression entries. Before, the token range of the `ExpressionStmt` (which is added to the switch entry) was set to the token range of the `Expression` contained in it. This was incorrect, since the token range for the `ExpressionStmt` should include the `;` at the end. This could be fixed in the `SwitchEntry` production/method, but I decided to move it into a separate method is a cleaner solution overall.

After fixing the token range, the LPP output was better, but still formatted strangely:
```
case 2023 -> new Object();
case 2024 ->
    new java.lang.Object();
```
This was because of shared logic between the older switch statement entries with `:` and the newer switch expression entries in the `ConcreteSyntaxModel`. To fix this, I effectively moved a shared `newline()` after the `:/->` to only affect the switch statement entries and added a space after the `->` for switch expressions. I also refactored everything a bit to avoid duplicating the `space(), token(ARROW), space()` at the end of each `->` branch and the `token(COLON), newline()` at the end of each `:` branch.