### PR TITLE
Fix: issue 4697 Updating the com.google.guava:guava dependency to v334.5-jre fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,11 +392,17 @@
                 <artifactId>javassist</artifactId>
                 <version>3.30.2-GA</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.4.0-jre</version>
-            </dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>33.4.5-jre</version>
+				<exclusions>
+					<exclusion>
+		 				<groupId>com.google.code.findbugs</groupId>
+						<artifactId>jsr305</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>


### PR DESCRIPTION

Fixes #4697 .
