### PR TITLE
Fix for #3710 by cutting off resolution loops involving object creation steps.

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -117,6 +117,12 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
         Node notMethodNode = parentNode;
         // To avoid loops JP must ensure that the scope of the parent context
         // is not the same as the current node.
+        // For most part, this can be achieved that the scope of the nodes is different,
+        // but in some cases, we may have loops of length > 1. This is the case for expressions
+        // that have something like a "receiver" - field accesses, method calls and the
+        // non-static inner class variant of constructor calls. We handle these by just
+        // skipping all method calls, field accesses, and all constructor calls that have
+        // a receiver (i.e., outer.new Inner()), as identified by hasScope.
         while (notMethodNode instanceof MethodCallExpr
                 || notMethodNode instanceof FieldAccessExpr
                 || (notMethodNode instanceof ObjectCreationExpr && notMethodNode.hasScope())

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -119,6 +119,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
         // is not the same as the current node.
         while (notMethodNode instanceof MethodCallExpr
                 || notMethodNode instanceof FieldAccessExpr
+                || (notMethodNode instanceof ObjectCreationExpr && notMethodNode.hasScope())
                 || (notMethodNode != null
                         && notMethodNode.hasScope()
                         && getScope(notMethodNode).equals(wrappedNode))) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3710Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3710Test.java
@@ -15,9 +15,14 @@ import org.junit.jupiter.api.Test;
 public class Issue3710Test {
     @Test
     void resolve_method_used_as_scope_for_inner_class_object_creation() {
-        String sourceCode = "class Example {\n" + "  void test() {\n"
-                + "    com.github.javaparser.symbolsolver.Outer.make().new Inner();\n"
+        String sourceCode = "class Example {\n"
+                + "  void test() {\n"
+                + "    Outer.make().new Inner();\n"
                 + "  }\n"
+                + "}\n"
+                + "class Outer {\n"
+                + "  class Inner {}\n"
+                + "  static Outer make() { return new Outer(); }\n"
                 + "}";
         CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
         combinedTypeSolver.add(new ReflectionTypeSolver(false));
@@ -29,15 +34,6 @@ public class Issue3710Test {
 
         ResolvedMethodDeclaration resolvedMethod = methodCall.get().resolve();
 
-        Assertions.assertEquals(
-                "com.github.javaparser.symbolsolver.Outer.make()", resolvedMethod.getQualifiedSignature());
-    }
-}
-
-class Outer {
-    class Inner {}
-
-    static Outer make() {
-        return new Outer();
+        Assertions.assertEquals("Outer.make()", resolvedMethod.getQualifiedSignature());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3710Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3710Test.java
@@ -1,0 +1,43 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.SymbolResolver;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class Issue3710Test {
+    @Test
+    void resolve_method_used_as_scope_for_inner_class_object_creation() {
+        String sourceCode = "class Example {\n" + "  void test() {\n"
+                + "    com.github.javaparser.symbolsolver.Outer.make().new Inner();\n"
+                + "  }\n"
+                + "}";
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver(false));
+        SymbolResolver resolver = new JavaSymbolSolver(combinedTypeSolver);
+        ParserConfiguration config = new ParserConfiguration().setSymbolResolver(resolver);
+        JavaParser parser = new JavaParser(config);
+        CompilationUnit compilationUnit = parser.parse(sourceCode).getResult().get();
+        Optional<MethodCallExpr> methodCall = compilationUnit.findFirst(MethodCallExpr.class);
+
+        ResolvedMethodDeclaration resolvedMethod = methodCall.get().resolve();
+
+        Assertions.assertEquals(
+                "com.github.javaparser.symbolsolver.Outer.make()", resolvedMethod.getQualifiedSignature());
+    }
+}
+
+class Outer {
+    class Inner {}
+
+    static Outer make() {
+        return new Outer();
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3710Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3710Test.java
@@ -4,6 +4,7 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
@@ -35,5 +36,64 @@ public class Issue3710Test {
         ResolvedMethodDeclaration resolvedMethod = methodCall.get().resolve();
 
         Assertions.assertEquals("Outer.make()", resolvedMethod.getQualifiedSignature());
+    }
+
+    @Test
+    void resolve_chained_inner_class_object_creation() {
+        String sourceCode = "class Example {\n"
+                + "  void test() {\n"
+                + "    Outer.make().new Middle().new Inner();\n"
+                + "  }\n"
+                + "}\n"
+                + "class Outer {\n"
+                + "  class Middle { class Inner {} }\n"
+                + "  static Outer make() { return new Outer(); }\n"
+                + "}";
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver(false));
+        SymbolResolver resolver = new JavaSymbolSolver(combinedTypeSolver);
+        ParserConfiguration config = new ParserConfiguration().setSymbolResolver(resolver);
+        JavaParser parser = new JavaParser(config);
+        CompilationUnit compilationUnit = parser.parse(sourceCode).getResult().get();
+        Optional<ObjectCreationExpr> constructorCall = compilationUnit.findFirst(ObjectCreationExpr.class);
+
+        ObjectCreationExpr innerConstructor = constructorCall.get();
+        ObjectCreationExpr middleConstructor = innerConstructor.getScope().get().asObjectCreationExpr();
+        MethodCallExpr outerFactory = middleConstructor.getScope().get().asMethodCallExpr();
+
+        Assertions.assertEquals(
+                "Outer.Middle.Inner.Inner()", innerConstructor.resolve().getQualifiedSignature());
+        Assertions.assertEquals(
+                "Outer.Middle.Middle()", middleConstructor.resolve().getQualifiedSignature());
+        Assertions.assertEquals("Outer.make()", outerFactory.resolve().getQualifiedSignature());
+    }
+
+    @Test
+    void resolve_inner_class_object_creation_starting_with_constructor() {
+        String sourceCode = "class Example {\n"
+                + "  void test() {\n"
+                + "    new Outer().new Middle().new Inner();\n"
+                + "  }\n"
+                + "}\n"
+                + "class Outer {\n"
+                + "  class Middle { class Inner {} }\n"
+                + "}";
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new ReflectionTypeSolver(false));
+        SymbolResolver resolver = new JavaSymbolSolver(combinedTypeSolver);
+        ParserConfiguration config = new ParserConfiguration().setSymbolResolver(resolver);
+        JavaParser parser = new JavaParser(config);
+        CompilationUnit compilationUnit = parser.parse(sourceCode).getResult().get();
+        Optional<ObjectCreationExpr> constructorCall = compilationUnit.findFirst(ObjectCreationExpr.class);
+
+        ObjectCreationExpr innerConstructor = constructorCall.get();
+        ObjectCreationExpr middleConstructor = innerConstructor.getScope().get().asObjectCreationExpr();
+        ObjectCreationExpr outerConstructor = middleConstructor.getScope().get().asObjectCreationExpr();
+
+        Assertions.assertEquals(
+                "Outer.Middle.Inner.Inner()", innerConstructor.resolve().getQualifiedSignature());
+        Assertions.assertEquals(
+                "Outer.Middle.Middle()", middleConstructor.resolve().getQualifiedSignature());
+        Assertions.assertEquals("Outer.Outer()", outerConstructor.resolve().getQualifiedSignature());
     }
 }


### PR DESCRIPTION
Fixes #3710.
The idea of the fix is that the scope in inner class object creation expressions, e.g., `makeOuter().new Inner()`, can cause resolution loops in just the same way that the scope of a field access or method call can, and should be handled in the same way.