### PR TITLE
Implement MethodResolutionCapability in JavassistRecordDeclaration

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclaration.java
@@ -28,6 +28,7 @@ import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.logic.MethodResolutionCapability;
 import com.github.javaparser.resolution.model.LambdaArgumentTypePlaceholder;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
@@ -48,7 +49,10 @@ import javassist.CtField;
  * @author Federico Tomassetti
  */
 public class JavassistRecordDeclaration extends AbstractTypeDeclaration
-        implements ResolvedRecordDeclaration, MethodUsageResolutionCapability, SymbolResolutionCapability {
+        implements ResolvedRecordDeclaration,
+                MethodUsageResolutionCapability,
+                SymbolResolutionCapability,
+                MethodResolutionCapability {
 
     private CtClass ctClass;
     private TypeSolver typeSolver;
@@ -339,5 +343,11 @@ public class JavassistRecordDeclaration extends AbstractTypeDeclaration
         In case the name is composed of the internal type only, i.e. f.getName() returns B, it will also works.
          */
         return this.internalTypes().stream().anyMatch(f -> f.getName().endsWith(name));
+    }
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass);
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclarationTest.java
@@ -33,14 +33,14 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.AssociableToAST;
-import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration;
 import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclarationTest;
+import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -48,6 +48,7 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -379,5 +380,18 @@ class JavassistRecordDeclarationTest extends AbstractTypeDeclarationTest {
     @EnabledForJreRange(min = org.junit.jupiter.api.condition.JRE.JAVA_14)
     public void getAllFieldsCantBeNull() {
         assertNotNull(createValue().getAllFields());
+    }
+
+    @Test
+    @EnabledForJreRange(min = org.junit.jupiter.api.condition.JRE.JAVA_14)
+    public void testSolveMethod() {
+        JavassistRecordDeclaration compilationUnit = (JavassistRecordDeclaration) typeSolver.solveType("box.Box");
+        ResolvedType functionType = new SymbolSolver(typeSolver).classToResolvedType(Function.class);
+        SymbolReference<ResolvedMethodDeclaration> method =
+                compilationUnit.solveMethod("map", Collections.singletonList(functionType), false);
+        assertTrue(method.isSolved());
+        assertEquals(
+                "box.Box.map(java.util.function.Function<T, U>)",
+                method.getCorrespondingDeclaration().getQualifiedSignature());
     }
 }


### PR DESCRIPTION
Add an implementation of `MethodResolutionCapability` to `JavassistRecordDeclaration`, directly based on that from
`JavasassistClassDeclaration`. Comes with a unit test.