### PR TITLE
Fix: issue 4697 Updating the com.google.guava:guava dependency to v334.5-jre fails.

### DIFF
--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -43,11 +43,15 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.checkerframework</groupId>
+			<artifactId>checker-qual</artifactId>
+		</dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <!-- Set JPMS module name -->
+			<!-- Set JPMS module name -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/cache/DefaultCacheStats.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/cache/DefaultCacheStats.java
@@ -26,7 +26,6 @@ import static com.google.common.math.LongMath.saturatedSubtract;
 import com.github.javaparser.resolution.cache.Cache;
 import com.github.javaparser.resolution.cache.CacheStats;
 import java.util.Arrays;
-import javax.annotation.CheckForNull;
 
 /**
  * Statistics about the performance of a {@link Cache}. Instances of this class are immutable.
@@ -290,7 +289,7 @@ public class DefaultCacheStats implements CacheStats {
     }
 
     @Override
-    public boolean equals(@CheckForNull Object object) {
+    public boolean equals(Object object) {
         if (object instanceof CacheStats) {
             CacheStats other = (CacheStats) object;
             return hitCount == other.hitCount()

--- a/pom.xml
+++ b/pom.xml
@@ -395,8 +395,13 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.4.0-jre</version>
+                <version>33.4.6-jre</version>
             </dependency>
+			<dependency>
+				<groupId>org.checkerframework</groupId>
+				<artifactId>checker-qual</artifactId>
+				<version>3.49.2</version>
+			</dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>


### PR DESCRIPTION


Fixes #4697 .


Since version 33.4.0-jre the checker-framework library is no longer ported by the guava project. This causes compilation errors when using certain annotations. To correct the errors, it must be added as a dependency of the project. This is a temporary solution as the JP project is trying to free itself as much as possible from external dependencies.
As for the CheckForNull annotation, which doesn't belong to the checker-qual library, I've simply chosen to remove it from the code rather than add yet another dependency.
