### PR TITLE
Fix Switch toString to LexicalPreservingPrinter when configured

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -367,7 +367,7 @@ class PrettyPrinterTest {
         PrinterConfiguration config = new DefaultPrinterConfiguration()
                 .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
 
-        Printer printer = new DefaultPrettyPrinter(config);
+        ConfigurablePrinter printer = new DefaultPrettyPrinter(config);
         assertFalse(printer.getConfiguration()
                 .get(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS))
                 .isPresent());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -25,10 +25,7 @@ import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.javaparser.GeneratedJavaParserConstants;
 import com.github.javaparser.JavaParser;
@@ -1862,5 +1859,30 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         String modifiedContent = LexicalPreservingPrinter.print(cu);
         System.out.println(modifiedContent);
         assertEquals(expected, LexicalPreservingPrinter.print(cu));
+    }
+
+    // issue 1821 Switch toString to LexicalPreservingPrinter when configured
+    @Test
+    void checkLPPIsDefaultPrinter() {
+        String code = "class A {void foo(int p1, float p2) { }}";
+        StaticJavaParser.getParserConfiguration().setLexicalPreservationEnabled(true);
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        assertEquals(code, cu.toString());
+    }
+
+    @Test
+    void checkLegacyLPPExecution() {
+        String code = "class A {void foo(int p1, float p2) { }}";
+        StaticJavaParser.getParserConfiguration().setLexicalPreservationEnabled(true);
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        LexicalPreservingPrinter.setup(cu);
+        assertEquals(cu.toString(), LexicalPreservingPrinter.print(cu));
+    }
+
+    @Test
+    void checkLPPIsNotDefaultPrinter() {
+        String code = "class A {void foo(int p1, float p2) { }}";
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        assertNotEquals(code, cu.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -27,8 +27,8 @@ import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.printer.ConfigurablePrinter;
 import com.github.javaparser.printer.DefaultPrettyPrinter;
-import com.github.javaparser.printer.Printer;
 import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption;
 import java.io.IOException;
@@ -45,7 +45,7 @@ class SourceRootTest {
     private final Path root = CodeGenerationUtils.mavenModuleRoot(SourceRootTest.class)
             .resolve("src/test/resources/com/github/javaparser/utils/");
     private final SourceRoot sourceRoot = new SourceRoot(root);
-    private Printer printer;
+    private ConfigurablePrinter printer;
 
     @BeforeEach
     void before() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.validator.ProblemReporter;
 import com.github.javaparser.ast.validator.Validator;
 import com.github.javaparser.ast.validator.language_level_validations.*;
 import com.github.javaparser.ast.validator.postprocessors.*;
+import com.github.javaparser.printer.lexicalpreservation.DefaultLexicalPreservingPrinter;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.github.javaparser.resolution.SymbolResolver;
 import com.github.javaparser.utils.LineSeparator;
@@ -362,7 +363,10 @@ public class ParserConfiguration {
             @Override
             public void postProcess(ParseResult<? extends Node> result, ParserConfiguration configuration) {
                 if (configuration.isLexicalPreservationEnabled()) {
-                    result.ifSuccessful(LexicalPreservingPrinter::setup);
+                    result.ifSuccessful(resultNode -> {
+                        LexicalPreservingPrinter.setup(resultNode);
+                        resultNode.setData(Node.PRINTER_KEY, new DefaultLexicalPreservingPrinter());
+                    });
                 }
             }
         });

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -44,6 +44,7 @@ import com.github.javaparser.metamodel.CompilationUnitMetaModel;
 import com.github.javaparser.metamodel.InternalProperty;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.OptionalProperty;
+import com.github.javaparser.printer.ConfigurablePrinter;
 import com.github.javaparser.printer.Printer;
 import com.github.javaparser.printer.configuration.PrinterConfiguration;
 import com.github.javaparser.utils.ClassUtils;
@@ -165,7 +166,10 @@ public class CompilationUnit extends Node {
      */
     @Override
     protected Printer getPrinter(PrinterConfiguration config) {
-        Printer printer = getPrinter().setConfiguration(config);
+        Printer printer = getPrinter();
+        if (printer instanceof ConfigurablePrinter) {
+            ((ConfigurablePrinter)printer).setConfiguration(config);
+        }
         printer(printer);
         return printer;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -168,7 +168,7 @@ public class CompilationUnit extends Node {
     protected Printer getPrinter(PrinterConfiguration config) {
         Printer printer = getPrinter();
         if (printer instanceof ConfigurablePrinter) {
-            ((ConfigurablePrinter)printer).setConfiguration(config);
+            ((ConfigurablePrinter) printer).setConfiguration(config);
         }
         printer(printer);
         return printer;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -338,16 +338,17 @@ public abstract class Node
      */
     @Override
     public final String toString() {
+        Printer printer = getPrinter();
         if (containsData(LINE_SEPARATOR_KEY)) {
-            Printer printer = getPrinter();
             LineSeparator lineSeparator = getLineEndingStyleOrDefault(LineSeparator.SYSTEM);
             PrinterConfiguration config = printer.getConfiguration();
-            config.addOption(
-                    new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER, lineSeparator.asRawString()));
-            printer.setConfiguration(config);
-            return printer.print(this);
+            if (config != null) {
+                config.addOption(new DefaultConfigurationOption(
+                        ConfigOption.END_OF_LINE_CHARACTER, lineSeparator.asRawString()));
+                printer.setConfiguration(config);
+            }
         }
-        return getPrinter().print(this);
+        return printer.print(this);
     }
 
     /**
@@ -849,7 +850,8 @@ public abstract class Node
 
     public static final DataKey<LineSeparator> LINE_SEPARATOR_KEY = new DataKey<LineSeparator>() {};
 
-    protected static final DataKey<Printer> PRINTER_KEY = new DataKey<Printer>() {};
+    // We need to expose it because we will need to use it to inject the printer
+    public static final DataKey<Printer> PRINTER_KEY = new DataKey<Printer>() {};
 
     protected static final DataKey<Boolean> PHANTOM_KEY = new DataKey<Boolean>() {};
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -346,8 +346,8 @@ public abstract class Node
                 ConfigurablePrinter configurablePrinter = (ConfigurablePrinter) printer;
                 PrinterConfiguration config = configurablePrinter.getConfiguration();
                 if (config != null) {
-                    config.addOption(new DefaultConfigurationOption(ConfigOption.END_OF_LINE_CHARACTER,
-                            lineSeparator.asRawString()));
+                    config.addOption(new DefaultConfigurationOption(
+                            ConfigOption.END_OF_LINE_CHARACTER, lineSeparator.asRawString()));
                     configurablePrinter.setConfiguration(config);
                 }
             }
@@ -361,7 +361,7 @@ public abstract class Node
      */
     public final String toString(PrinterConfiguration configuration) {
         Printer printer = getPrinter();
-        if (! (printer instanceof ConfigurablePrinter) ) {
+        if (!(printer instanceof ConfigurablePrinter)) {
             return printer.print(this);
         }
         ConfigurablePrinter configurablePrinter = (ConfigurablePrinter) printer;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConfigurablePrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConfigurablePrinter.java
@@ -18,23 +18,14 @@
  * GNU Lesser General Public License for more details.
  */
 
-package com.github.javaparser.printer.lexicalpreservation;
+package com.github.javaparser.printer;
 
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.printer.Printer;
 import com.github.javaparser.printer.configuration.PrinterConfiguration;
 
-public class DefaultLexicalPreservingPrinter implements Printer {
+public interface ConfigurablePrinter extends Printer {
 
-    /**
-     * Print a Node into a String, preserving the lexical information.
-     */
-    @Override
-    public String print(Node node) {
-        LexicalPreservingVisitor visitor = new LexicalPreservingVisitor();
-        final NodeText nodeText = LexicalPreservingPrinter.getOrCreateNodeText(node);
-        nodeText.getElements().forEach(element -> element.accept(visitor));
-        return visitor.toString();
-    }
+    Printer setConfiguration(PrinterConfiguration configuration);
+
+    PrinterConfiguration getConfiguration();
 
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/ConfigurablePrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/ConfigurablePrinter.java
@@ -27,5 +27,4 @@ public interface ConfigurablePrinter extends Printer {
     Printer setConfiguration(PrinterConfiguration configuration);
 
     PrinterConfiguration getConfiguration();
-
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinter.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 /**
  * Pretty printer for AST nodes.
  */
-public class DefaultPrettyPrinter implements Printer {
+public class DefaultPrettyPrinter implements ConfigurablePrinter {
 
     private PrinterConfiguration configuration;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrinter.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
  * @deprecated This class could be removed in a future version. Use default DefaultPrettyPrinter.
  */
 @Deprecated
-public class PrettyPrinter implements Printer {
+public class PrettyPrinter implements ConfigurablePrinter {
 
     private PrinterConfiguration configuration;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/Printer.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/Printer.java
@@ -30,7 +30,4 @@ public interface Printer {
 
     String print(Node node);
 
-    Printer setConfiguration(PrinterConfiguration configuration);
-
-    PrinterConfiguration getConfiguration();
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/Printer.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/Printer.java
@@ -20,7 +20,6 @@
 package com.github.javaparser.printer;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.printer.configuration.PrinterConfiguration;
 
 /**
  * Printer interface defines the API for a printer.
@@ -29,5 +28,4 @@ import com.github.javaparser.printer.configuration.PrinterConfiguration;
 public interface Printer {
 
     String print(Node node);
-
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DefaultLexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DefaultLexicalPreservingPrinter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.printer.Printer;
+import com.github.javaparser.printer.configuration.PrinterConfiguration;
+
+public class DefaultLexicalPreservingPrinter implements Printer {
+
+    /**
+     * Print a Node into a String, preserving the lexical information.
+     */
+    @Override
+    public String print(Node node) {
+        LexicalPreservingVisitor visitor = new LexicalPreservingVisitor();
+        final NodeText nodeText = LexicalPreservingPrinter.getOrCreateNodeText(node);
+        nodeText.getElements().forEach(element -> element.accept(visitor));
+        return visitor.toString();
+    }
+
+    @Override
+    public Printer setConfiguration(PrinterConfiguration configuration) {
+        return this;
+    }
+
+    @Override
+    public PrinterConfiguration getConfiguration() {
+        return null;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DefaultLexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DefaultLexicalPreservingPrinter.java
@@ -22,7 +22,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.printer.Printer;
-import com.github.javaparser.printer.configuration.PrinterConfiguration;
 
 public class DefaultLexicalPreservingPrinter implements Printer {
 
@@ -36,5 +35,4 @@ public class DefaultLexicalPreservingPrinter implements Printer {
         nodeText.getElements().forEach(element -> element.accept(visitor));
         return visitor.toString();
     }
-
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -45,6 +45,7 @@ import com.github.javaparser.ast.observer.PropagatingAstObserver;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.visitor.TreeVisitor;
 import com.github.javaparser.printer.ConcreteSyntaxModel;
+import com.github.javaparser.printer.Printer;
 import com.github.javaparser.printer.concretesyntaxmodel.*;
 import com.github.javaparser.printer.lexicalpreservation.LexicalDifferenceCalculator.CsmChild;
 import com.github.javaparser.utils.LineSeparator;
@@ -533,10 +534,8 @@ public class LexicalPreservingPrinter {
      * Print a Node into a String, preserving the lexical information.
      */
     public static String print(Node node) {
-        LexicalPreservingVisitor visitor = new LexicalPreservingVisitor();
-        final NodeText nodeText = getOrCreateNodeText(node);
-        nodeText.getElements().forEach(element -> element.accept(visitor));
-        return visitor.toString();
+        Printer printer = new DefaultLexicalPreservingPrinter();
+        return printer.print(node);
     }
 
     //


### PR DESCRIPTION
Fixes #1821 .

Make the LPP the default printer when configured with parserConfiguration.setLexicalPreservationEnabled(true).

The previous method of using the LexicalPreservingPrinter remains operational to activate the lexical preservation printer while keeping the default pretty printer.

THIS IS A BREAKING CHANGE ON LEXICAL PRESERVING PRINTER USAGE.
