### PR TITLE
Make JarTypeSolver and ReflectionTypeSolver a bit more versatile.

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
@@ -27,10 +27,13 @@ import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclar
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.symbolsolver.javassistmodel.JavassistFactory;
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 import javassist.ClassPool;
 import javassist.NotFoundException;
 
@@ -99,34 +102,34 @@ public class JarTypeSolver implements TypeSolver {
     /**
      * Create a {@link JarTypeSolver} from a {@link Path}.
      *
-     * @param pathToJar The path where the jar is located.
+     * @param pathToJarOrClassFileHierarchy The path where the jar or class file hierarchy is located.
      *
-     * @throws IOException If an I/O exception occurs while reading the Jar.
+     * @throws IOException If an I/O exception occurs while reading the Jar or class file hierarchy.
      */
-    public JarTypeSolver(Path pathToJar) throws IOException {
-        this(pathToJar.toFile());
+    public JarTypeSolver(Path pathToJarOrClassFileHierarchy) throws IOException {
+        this(pathToJarOrClassFileHierarchy.toFile());
     }
 
     /**
      * Create a {@link JarTypeSolver} from a {@link File}.
      *
-     * @param pathToJar The file pointing to the jar is located.
+     * @param pathToJarOrClassFileHierarchy The file pointing to the jar or class file hierarchy is located.
      *
-     * @throws IOException If an I/O exception occurs while reading the Jar.
+     * @throws IOException If an I/O exception occurs while reading the Jar or class file hierarchy.
      */
-    public JarTypeSolver(File pathToJar) throws IOException {
-        this(pathToJar.getAbsolutePath());
+    public JarTypeSolver(File pathToJarOrClassFileHierarchy) throws IOException {
+        this(pathToJarOrClassFileHierarchy.getAbsolutePath());
     }
 
     /**
      * Create a {@link JarTypeSolver} from a path in a {@link String} format.
      *
-     * @param pathToJar The path pointing to the jar.
+     * @param pathToJarOrClassFileHierarchy The path pointing to the jar or class file hierarchy.
      *
-     * @throws IOException If an I/O exception occurs while reading the Jar.
+     * @throws IOException If an I/O exception occurs while reading the Jar or class file hierarchy.
      */
-    public JarTypeSolver(String pathToJar) throws IOException {
-        addPathToJar(pathToJar);
+    public JarTypeSolver(String pathToJarOrClassFileHierarchy) throws IOException {
+        addPathToJar(pathToJarOrClassFileHierarchy);
     }
 
     /**
@@ -173,14 +176,14 @@ public class JarTypeSolver implements TypeSolver {
     /**
      * Utility method to register a new class path.
      *
-     * @param pathToJar The path pointing to the jar file.
+     * @param pathToJarOrClassFileHierarchy The path pointing to the jar file or class file hierarchy.
      *
-     * @throws IOException If an I/O error occurs while reading the JarFile.
+     * @throws IOException If an I/O error occurs while reading the JarFile or class file hierarchy.
      */
-    private void addPathToJar(String pathToJar) throws IOException {
+    private void addPathToJar(String pathToJarOrClassFileHierarchy) throws IOException {
         try {
-            classPool.appendClassPath(pathToJar);
-            registerKnownClassesFor(pathToJar);
+            classPool.appendClassPath(pathToJarOrClassFileHierarchy);
+            registerKnownClassesFor(pathToJarOrClassFileHierarchy);
         } catch (NotFoundException e) {
             // If JavaAssist throws a NotFoundException we should notify the user
             // with a FileNotFoundException.
@@ -196,32 +199,76 @@ public class JarTypeSolver implements TypeSolver {
      * When we create a new {@link JarTypeSolver} we should store the list of
      * solvable types.
      *
-     * @param pathToJar The path to the jar file.
+     * @param pathToJarOrClassFileHierarchy The path to the jar file or .class file hierarchy.
      *
-     * @throws IOException If an I/O error occurs while reading the JarFile.
+     * @throws IOException If an I/O error occurs while reading the JarFile or .class file hierarchy.
      */
-    private void registerKnownClassesFor(String pathToJar) throws IOException {
-        try (JarFile jarFile = new JarFile(pathToJar)) {
+    private void registerKnownClassesFor(String pathToJarOrClassFileHierarchy) throws IOException {
+        Path jarOrClassFileHierarchy = Paths.get(pathToJarOrClassFileHierarchy);
+        if (Files.isDirectory(jarOrClassFileHierarchy)) {
+            try (Stream<Path> classFiles = Files.walk(jarOrClassFileHierarchy)) {
+                classFiles
+                        .filter(path -> Files.isRegularFile(path)
+                                && path.getFileName().toString().endsWith(CLASS_EXTENSION))
+                        .forEach(pathToClassFile -> {
+                            // We can't just use path.toString here, since path seperators are OS-dependent.
+                            String packagePrefix = convertPathToPackagePrefix(jarOrClassFileHierarchy, pathToClassFile);
+                            String classFileName = pathToClassFile.getFileName().toString();
+                            String classNameWithDollars =
+                                    classFileName.substring(0, classFileName.length() - CLASS_EXTENSION.length());
+                            String classPoolName = packagePrefix + classNameWithDollars;
+                            String qualifiedName = packagePrefix + classNameWithDollars.replace('$', '.');
 
-            Enumeration<JarEntry> jarEntries = jarFile.entries();
-            while (jarEntries.hasMoreElements()) {
+                            // If the qualified name is the same as the class pool name we don't need to duplicate store
+                            // two
+                            // different String instances. Let's reuse the same.
+                            if (qualifiedName.equals(classPoolName)) {
+                                knownClasses.put(qualifiedName, qualifiedName);
+                            } else {
+                                knownClasses.put(qualifiedName, classPoolName);
+                            }
+                        });
+            }
+        } else if (Files.isRegularFile(jarOrClassFileHierarchy)) {
+            try (JarFile jarFile = new JarFile(pathToJarOrClassFileHierarchy)) {
 
-                JarEntry entry = jarEntries.nextElement();
-                // Check if the entry is a .class file
-                if (!entry.isDirectory() && entry.getName().endsWith(CLASS_EXTENSION)) {
-                    String qualifiedName = convertEntryPathToClassName(entry.getName());
-                    String classPoolName = convertEntryPathToClassPoolName(entry.getName());
+                Enumeration<JarEntry> jarEntries = jarFile.entries();
+                while (jarEntries.hasMoreElements()) {
 
-                    // If the qualified name is the same as the class pool name we don't need to duplicate store two
-                    // different String instances. Let's reuse the same.
-                    if (qualifiedName.equals(classPoolName)) {
-                        knownClasses.put(qualifiedName, qualifiedName);
-                    } else {
-                        knownClasses.put(qualifiedName, classPoolName);
+                    JarEntry entry = jarEntries.nextElement();
+                    // Check if the entry is a .class file
+                    if (!entry.isDirectory() && entry.getName().endsWith(CLASS_EXTENSION)) {
+                        String qualifiedName = convertEntryPathToClassName(entry.getName());
+                        String classPoolName = convertEntryPathToClassPoolName(entry.getName());
+
+                        // If the qualified name is the same as the class pool name we don't need to duplicate store two
+                        // different String instances. Let's reuse the same.
+                        if (qualifiedName.equals(classPoolName)) {
+                            knownClasses.put(qualifiedName, qualifiedName);
+                        } else {
+                            knownClasses.put(qualifiedName, classPoolName);
+                        }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Given a apth to class file inside a class file hierarchy, extract the package name from the path.
+     * @param pathToClassFileHierarchy the root of the class file hierarchy
+     * @param pathToClassFile the path to the class file, inside the hierarchy
+     * @return the package name of the class file
+     */
+    private static String convertPathToPackagePrefix(Path pathToClassFileHierarchy, Path pathToClassFile) {
+        Path packagePath = pathToClassFileHierarchy.relativize(pathToClassFile).getParent();
+        StringBuilder packagePrefixBuilder = new StringBuilder();
+        if (packagePath != null) {
+            for (Path component : packagePath) {
+                packagePrefixBuilder.append(component.toString()).append('.');
+            }
+        }
+        return packagePrefixBuilder.toString();
     }
 
     /**

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolver.java
@@ -255,7 +255,7 @@ public class JarTypeSolver implements TypeSolver {
     }
 
     /**
-     * Given a apth to class file inside a class file hierarchy, extract the package name from the path.
+     * Given a path to a class file inside a class file hierarchy, extract the package name from the path.
      * @param pathToClassFileHierarchy the root of the class file hierarchy
      * @param pathToClassFile the path to the class file, inside the hierarchy
      * @return the package name of the class file

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
@@ -82,11 +82,10 @@ class JarTypeSolverTest extends AbstractTypeSolverTest<JarTypeSolver> {
     }
 
     @Test
-    void classFileHierarchy() throws IOException {
+    void classFileHierarchy(@TempDir Path tempDir) throws IOException {
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
 
         // Unpack the jar file into a class hierarchy
-        Path tempDir = Files.createTempDirectory("jp");
         try (JarInputStream jarInputStream = new JarInputStream(Files.newInputStream(pathToJar))) {
             for (JarEntry entry = jarInputStream.getNextJarEntry();
                     entry != null;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JarTypeSolverTest.java
@@ -30,9 +30,12 @@ import com.google.common.collect.Sets;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -76,6 +79,34 @@ class JarTypeSolverTest extends AbstractTypeSolverTest<JarTypeSolver> {
         assertEquals(
                 false, jarTypeSolver.tryToSolveType("com.github.javaparser.Foo").isSolved());
         assertEquals(false, jarTypeSolver.tryToSolveType("Foo").isSolved());
+    }
+
+    @Test
+    void classFileHierarchy() throws IOException {
+        Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
+
+        // Unpack the jar file into a class hierarchy
+        Path tempDir = Files.createTempDirectory("jp");
+        try (JarInputStream jarInputStream = new JarInputStream(Files.newInputStream(pathToJar))) {
+            for (JarEntry entry = jarInputStream.getNextJarEntry();
+                    entry != null;
+                    entry = jarInputStream.getNextJarEntry()) {
+                if (entry.isDirectory()) {
+                    Files.createDirectories(tempDir.resolve(entry.getName()));
+                } else {
+                    Files.copy(jarInputStream, tempDir.resolve(entry.getName()));
+                }
+            }
+        }
+
+        JarTypeSolver jarTypeSolver = new JarTypeSolver(tempDir);
+        assertEquals(
+                true,
+                jarTypeSolver
+                        .tryToSolveType("com.github.javaparser.SourcesHelper")
+                        .isSolved());
+        assertEquals(
+                false, jarTypeSolver.tryToSolveType("com.github.javaparser.Foo").isSolved());
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/ReflectionTypeSolverTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typesolvers/ReflectionTypeSolverTest.java
@@ -85,4 +85,28 @@ class ReflectionTypeSolverTest extends ClassLoaderTypeSolverTest<ReflectionTypeS
                         },
                         null));
     }
+
+    @Test
+    void testFilteringAll() {
+        ReflectionTypeSolver reflectionTypeSolver = new ReflectionTypeSolver(false);
+        assertEquals(true, reflectionTypeSolver.hasType("java.lang.Object"));
+        assertEquals(true, reflectionTypeSolver.hasType("org.xml.sax.Parser"));
+        assertEquals(true, reflectionTypeSolver.hasType(this.getClass().getCanonicalName()));
+    }
+
+    @Test
+    void testFilteringJRE() {
+        ReflectionTypeSolver reflectionTypeSolver = new ReflectionTypeSolver(true);
+        assertEquals(true, reflectionTypeSolver.hasType("java.lang.Object"));
+        assertEquals(false, reflectionTypeSolver.hasType("org.xml.sax.Parser"));
+        assertEquals(false, reflectionTypeSolver.hasType(this.getClass().getCanonicalName()));
+    }
+
+    @Test
+    void testFilteringJCL() {
+        ReflectionTypeSolver reflectionTypeSolver = new ReflectionTypeSolver(ReflectionTypeSolver.JCL_ONLY);
+        assertEquals(true, reflectionTypeSolver.hasType("java.lang.Object"));
+        assertEquals(true, reflectionTypeSolver.hasType("org.xml.sax.Parser"));
+        assertEquals(false, reflectionTypeSolver.hasType(this.getClass().getCanonicalName()));
+    }
 }


### PR DESCRIPTION
Two improvements to `TypeSolver`:
- `JarTypeSolver` can now also resolves types that live in `.class` files hierarchies (think the output from `javac`), without packaging them in a jar file first.
- `ReflectionTypeSolver` gets more flexible filtering; in particular, a pre-made filter is added for the entire Java Class Library.