### PR TITLE
Generalize DefaultPrettyPrinterVisitor

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -1846,7 +1846,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         printer.print("???;");
     }
 
-    private void printImports(NodeList<ImportDeclaration> imports, Void arg) {
+    protected void printImports(NodeList<ImportDeclaration> imports, Void arg) {
         ImportOrderingStrategy strategy = new DefaultImportOrderingStrategy();
         // Get Import strategy from configuration
         Optional<ConfigurationOption> optionalStrategy = getOption(ConfigOption.SORT_IMPORTS_STRATEGY);
@@ -1871,7 +1871,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         }
     }
 
-    private void printOrphanCommentsBeforeThisChildNode(final Node node) {
+    protected void printOrphanCommentsBeforeThisChildNode(final Node node) {
         if (!getOption(ConfigOption.PRINT_COMMENTS).isPresent()) return;
         if (node instanceof Comment) return;
         Node parent = node.getParentNode().orElse(null);
@@ -1903,7 +1903,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         }
     }
 
-    private void printOrphanCommentsEnding(final Node node) {
+    protected void printOrphanCommentsEnding(final Node node) {
         if (!getOption(ConfigOption.PRINT_COMMENTS).isPresent()) return;
         List<Node> everything = new ArrayList<>(node.getChildNodes());
         sortByBeginPosition(everything);
@@ -1932,7 +1932,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         if (expr) printer.unindent();
     }
 
-    private Optional<ConfigurationOption> getOption(ConfigOption cOption) {
+    protected Optional<ConfigurationOption> getOption(ConfigOption cOption) {
         return configuration.get(new DefaultConfigurationOption(cOption));
     }
 }


### PR DESCRIPTION
Make the code in `DefaultPrettyPrinterVisitor` a bit easier to extend.

- Add Javadoc to the various helper methods.
- Make most of the helper methods `protected` so that they can be used from overriding classes.
- Add `preVisit`/`postVisit` callbacks that can be used to gather information when nodes are about to be printed, or have just been printed.