### PR TITLE
Fix range for cast expression with lambda child

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4488Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4488Test.java
@@ -1,0 +1,49 @@
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import org.junit.jupiter.api.Test;
+
+public class Issue4488Test {
+    @Test
+    void cannotChangeMethodNameInLambda() {
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.setLexicalPreservationEnabled(true);
+        StaticJavaParser.setConfiguration(parserConfiguration);
+
+        CompilationUnit cu =
+                StaticJavaParser.parse("class Test {\n" + "	private Map<String, String> dummyMap = new HashMap<>();\n"
+                        + "	public String dummyFunction(String name) {\n"
+                        + "		return dummyMap.computeIfAbsent(name,\n"
+                        + "			(Function<String, String>) s -> SomeFunction.withAMethodHere(\"test\").build());\n"
+                        + "	}\n"
+                        + "}");
+
+        cu.accept(
+                new ModifierVisitor() {
+                    @Override
+                    public Visitable visit(MethodCallExpr mc, Object arg) {
+                        if (mc.getNameAsString().equals("withAMethodHere")) {
+                            return mc.setName("replacedMethodHere");
+                        }
+                        return super.visit(mc, arg);
+                    }
+                },
+                null);
+
+        assertEquals(
+                "class Test {\n" + "	private Map<String, String> dummyMap = new HashMap<>();\n"
+                        + "	public String dummyFunction(String name) {\n"
+                        + "		return dummyMap.computeIfAbsent(name,\n"
+                        + "			(Function<String, String>) s -> SomeFunction.replacedMethodHere(\"test\").build());\n"
+                        + "	}\n"
+                        + "}",
+                LexicalPreservingPrinter.print(cu));
+    }
+}

--- a/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserBase.java
+++ b/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserBase.java
@@ -328,6 +328,7 @@ abstract class GeneratedJavaParserBase {
             CastExpr castExpr = (CastExpr) ret;
             Expression inner = generateLambda(castExpr.getExpression(), lambdaBody);
             castExpr.setExpression(inner);
+            propagateRangeGrowthOnRight(castExpr, inner);
         } else {
             addProblem("Failed to parse lambda expression! Please create an issue at https://github.com/javaparser/javaparser/issues");
         }


### PR DESCRIPTION
Fixes #4488.

The cause of the issue is that lambda expressions are created in 2 steps (seemingly to avoid ambiguity issues). First, only a node for the lambda parameters is created (which could be a `NameExpr` or a `LambdaExpr` with only the params set) and then later in parsing the full `LambdaExpr` is created or the body is added to the `LambdaExpr`, depending on the context. The problem is that, for cast expressions, the range of the cast expression wasn't correctly adjusted.

In the recursive `generateLambda` calls, `propagateRangeGrowthOnRight` is called to update the range of the lambda expression and all ancestor nodes, but this is called before the lambda expression `inner` is added as a child to the `CastExpr` node, so the range of the cast was never updated. This PR fixes that by explicitly calling `propagateRangeGrowthOnRight` after the lambda is added to the cast.