### PR TITLE
Fix MethodAmbiguityException for methods with varargs

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -800,11 +800,13 @@ public class MethodResolutionLogic {
                 // but eventually mark the method A as more specific if the methodB has an argument of type
                 // java.lang.Object
                 isMethodAMoreSpecific = isMethodAMoreSpecific || isJavaLangObject(paramTypeB);
-            } else // If we get to this point then we check whether one of the methods contains a parameter type that is
-            // more
-            // specific. If it does, we can assume the entire declaration is more specific as we would otherwise have
-            // a situation where the declarations are ambiguous in the given context.
-            {
+            } else {
+                // If we get to this point then we check whether one of the methods contains a parameter type that is
+                // more specific. If it does, we can assume the entire declaration is more specific as we would
+                // otherwise have a situation where the declarations are ambiguous in the given context.
+                // Note: This does not account for the case where one parameter is variadic (and therefore an array
+                // type) and the other is not, since these will never be assignable by each other. This case is checked
+                // below.
                 boolean aAssignableFromB = paramTypeA.isAssignableBy(paramTypeB);
                 boolean bAssignableFromA = paramTypeB.isAssignableBy(paramTypeA);
                 if (bAssignableFromA && !aAssignableFromB) {
@@ -814,6 +816,17 @@ public class MethodResolutionLogic {
                 if (aAssignableFromB && !bAssignableFromA) {
                     // B's parameter is more specific
                     return false;
+                }
+            }
+            // Note on safety: methodX.getParam(i) is safe because otherwise paramTypeX would be null, but add
+            // a check in case this changes in the future.
+            if (methodA.getNumberOfParams() > i && methodB.getNumberOfParams() > i) {
+                boolean paramAVariadic = methodA.getParam(i).isVariadic();
+                boolean paramBVariadic = methodB.getParam(i).isVariadic();
+                // Prefer a single parameter over a variadic parameter, e.g.
+                // foo(String s, Object... o) is preferred over foo(Object... o)
+                if (!paramAVariadic && paramBVariadic) {
+                    return true;
                 }
             }
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4710Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4710Test.java
@@ -1,0 +1,36 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+public class Issue4710Test {
+    @Test
+    void test() {
+        String code = "class Foo<T> {}\n" + "public class Test<T> {\n"
+                + "    void test(String s, Object... objects) { }\n"
+                + "    void test(String s, Foo<T> f, Object... objects) { }\n"
+                + "    void foo() {\n"
+                + "        test(\"hello\", new Foo<Integer>());\n"
+                + "    }\n"
+                + "}";
+
+        ParserConfiguration configuration = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver())));
+        StaticJavaParser.setConfiguration(configuration);
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodCallExpr call = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration resolvedMethod = call.resolve();
+        assertEquals(
+                "Test.test(java.lang.String, Foo<T>, java.lang.Object...)", resolvedMethod.getQualifiedSignature());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4723Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4723Test.java
@@ -1,0 +1,36 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+public class Issue4723Test {
+    @Test
+    void test() {
+        String code = "public class Test {\n" + "    void test(String s, Object... objects) { }\n"
+                + "    void test(String s, Integer i, Object... objects) { }\n"
+                + "    void foo() {\n"
+                + "        test(\"hello\", 2);\n"
+                + "    }\n"
+                + "}";
+
+        ParserConfiguration configuration = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver())));
+        StaticJavaParser.setConfiguration(configuration);
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodCallExpr call = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration resolvedMethod = call.resolve();
+        assertEquals(
+                "Test.test(java.lang.String, java.lang.Integer, java.lang.Object...)",
+                resolvedMethod.getQualifiedSignature());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/javaparser/javaparser/issues/4723
Should fix https://github.com/javaparser/javaparser/issues/4710

It turns out both of these issues did share a root cause after all. The issue is that the specific case of 2 methods with varargs wasn't handled by any of the existing checks for different reasons:
* There was already a check whether `methodB` has varargs while `methodA` does not, in which case `methodA` is more specific.
* There is a check to see if `parameterTypeB` is assignable by `parameterTypeA` and vice-versa which can be used to determine which method is more specific, but this doesn't apply for varags since the vararg is an array type. For example, `String` is assignable to `Object`, but not to `Object...` since the latter is an array and a String is not an array.

To fix this I added an explicit check for this. If `parameterTypeB` is variadic and `parameterTypeA` is not, then `methodA` must have the more specific signature (since both methods must be applicable to get this far into the logic).