### PR TITLE
Fix IndexOutOfBoundsException when resolving calls with varargs

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -713,14 +713,22 @@ public class MethodResolutionLogic {
 
     protected static boolean isExactMatch(ResolvedMethodLikeDeclaration method, List<ResolvedType> argumentsTypes) {
         for (int i = 0; i < method.getNumberOfParams(); i++) {
-            if (!method.getParam(i).getType().equals(argumentsTypes.get(i))) {
+            ResolvedType paramType = getMethodsExplicitAndVariadicParameterType(method, i);
+            if (paramType == null) {
+                return false;
+            }
+            if (i >= argumentsTypes.size()) {
+                return false;
+            }
+            if (!paramType.equals(argumentsTypes.get(i))) {
                 return false;
             }
         }
         return true;
     }
 
-    private static ResolvedType getMethodsExplicitAndVariadicParameterType(ResolvedMethodDeclaration method, int i) {
+    private static ResolvedType getMethodsExplicitAndVariadicParameterType(
+            ResolvedMethodLikeDeclaration method, int i) {
         int numberOfParams = method.getNumberOfParams();
         if (i < numberOfParams) {
             return method.getParam(i).getType();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4722Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4722Test.java
@@ -1,0 +1,36 @@
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+public class Issue4722Test {
+    @Test
+    void test() {
+        String code = "public class Test {\n" + "    void test(String s, Object... objects) { }\n"
+                + "    void test(String s, String t, Object... objects) { }\n"
+                + "    void foo() {\n"
+                + "        test(\"hello\", \"world\");\n"
+                + "    }\n"
+                + "}";
+
+        ParserConfiguration configuration = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver())));
+        StaticJavaParser.setConfiguration(configuration);
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodCallExpr call = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration resolvedMethod = call.resolve();
+        assertEquals(
+                "Test.test(java.lang.String, java.lang.String, java.lang.Object...)",
+                resolvedMethod.getQualifiedSignature());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/javaparser/javaparser/issues/4722.

There were just some bounds checks missing which resulted in this error. This PR fixes that by adding those bounds checks and just returning `false` if they fail instead of crashing.

The unit test for this PR will fail with a `MethodAmbiguityException` until https://github.com/javaparser/javaparser/pull/4725 is merged, but it worked locally with both changes.