### PR TITLE
Fix constructor resolution issue 4703

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/ConstructorResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/ConstructorResolutionLogic.java
@@ -184,9 +184,9 @@ public class ConstructorResolutionLogic {
         boolean possibleAmbiguity = false;
         for (int i = 1; i < applicableConstructors.size(); i++) {
             other = applicableConstructors.get(i);
-            if (isMoreSpecific(winningCandidate, other, typeSolver)) {
+            if (MethodResolutionLogic.isMoreSpecific(winningCandidate, other, argumentsTypes)) {
                 possibleAmbiguity = false;
-            } else if (isMoreSpecific(other, winningCandidate, typeSolver)) {
+            } else if (MethodResolutionLogic.isMoreSpecific(other, winningCandidate, argumentsTypes)) {
                 possibleAmbiguity = false;
                 winningCandidate = other;
             } else {
@@ -213,39 +213,5 @@ public class ConstructorResolutionLogic {
             }
         }
         return SymbolReference.solved(winningCandidate);
-    }
-
-    private static boolean isMoreSpecific(
-            ResolvedConstructorDeclaration constructorA,
-            ResolvedConstructorDeclaration constructorB,
-            TypeSolver typeSolver) {
-        boolean oneMoreSpecificFound = false;
-        if (constructorA.getNumberOfParams() < constructorB.getNumberOfParams()) {
-            return true;
-        }
-        if (constructorA.getNumberOfParams() > constructorB.getNumberOfParams()) {
-            return false;
-        }
-        for (int i = 0; i < constructorA.getNumberOfParams(); i++) {
-            ResolvedType tdA = constructorA.getParam(i).getType();
-            ResolvedType tdB = constructorB.getParam(i).getType();
-            // B is more specific
-            if (tdB.isAssignableBy(tdA) && !tdA.isAssignableBy(tdB)) {
-                oneMoreSpecificFound = true;
-            }
-            // A is more specific
-            if (tdA.isAssignableBy(tdB) && !tdB.isAssignableBy(tdA)) {
-                return false;
-            }
-            // if it matches a variadic and a not variadic I pick the not variadic
-            if (!tdA.isArray() && tdB.isArray()) {
-                return true;
-            }
-            // FIXME
-            if (i == (constructorA.getNumberOfParams() - 1) && tdA.arrayLevel() > tdB.arrayLevel()) {
-                return true;
-            }
-        }
-        return oneMoreSpecificFound;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -720,7 +720,8 @@ public class MethodResolutionLogic {
         return true;
     }
 
-    private static ResolvedType getMethodsExplicitAndVariadicParameterType(ResolvedMethodDeclaration method, int i) {
+    private static ResolvedType getMethodsExplicitAndVariadicParameterType(
+            ResolvedMethodLikeDeclaration method, int i) {
         int numberOfParams = method.getNumberOfParams();
         if (i < numberOfParams) {
             return method.getParam(i).getType();
@@ -731,8 +732,10 @@ public class MethodResolutionLogic {
         return null;
     }
 
-    private static boolean isMoreSpecific(
-            ResolvedMethodDeclaration methodA, ResolvedMethodDeclaration methodB, List<ResolvedType> argumentTypes) {
+    static boolean isMoreSpecific(
+            ResolvedMethodLikeDeclaration methodA,
+            ResolvedMethodLikeDeclaration methodB,
+            List<ResolvedType> argumentTypes) {
         final boolean aVariadic = methodA.hasVariadicParameter();
         final boolean bVariadic = methodB.hasVariadicParameter();
         final int aNumberOfParams = methodA.getNumberOfParams();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/Issue4703Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/Issue4703Test.java
@@ -1,0 +1,51 @@
+package com.github.javaparser.symbolsolver.resolution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class Issue4703Test {
+    @Test
+    void ecisResolutionTest() {
+        String clazz = "public class Test {\n" + "    public Test(Test test, int... values) {\n"
+                + "        System.out.println(test);\n"
+                + "        System.out.println(values);\n"
+                + "    }\n"
+                + "    public Test(int... values) {\n"
+                + "        this(null, values);\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        final CompilationUnit cu = StaticJavaParser.parse(clazz);
+        final List<ConstructorDeclaration> all = cu.findAll(ConstructorDeclaration.class);
+        for (ConstructorDeclaration cd : all) System.out.println(cd.getSignature());
+        final Optional<ExplicitConstructorInvocationStmt> ecis = cu.findFirst(ExplicitConstructorInvocationStmt.class);
+        assertEquals("Test(Test, int...)", ecis.get().resolve().getSignature());
+    }
+
+    @Test
+    void specificEcisResolutionTest() {
+        String clazz = "public class Test {\n" + "    public Test(Test test, int... values) {\n"
+                + "        System.out.println(test);\n"
+                + "        System.out.println(values);\n"
+                + "    }\n"
+                + "    public Test(int... values) {\n"
+                + "        this(new Test(), values);\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        final CompilationUnit cu = StaticJavaParser.parse(clazz);
+        final List<ConstructorDeclaration> all = cu.findAll(ConstructorDeclaration.class);
+        for (ConstructorDeclaration cd : all) System.out.println(cd.getSignature());
+        final Optional<ExplicitConstructorInvocationStmt> ecis = cu.findFirst(ExplicitConstructorInvocationStmt.class);
+        assertEquals("Test(Test, int...)", ecis.get().resolve().getSignature());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/javaparser/javaparser/issues/4703.

The `isMoreSpecific` methods in `ConstructorResolutionLogic` and `MethodResolutionLogic` were two methods that solve the same problem, but `MethodResolutionLogic.isMoreSpecific` is a lot more comprehensive. This PR fixes the linked issue and probably a number of other constructor resolution bugs by getting rid of the barebones `ConstructorResolutionLogic.isMoreSpecific` method and using the one in `MethodResolutionLogic` which now accepts `ResolvedMethodLikeDeclarations`. This should also simplify maintenance.

I suspect it's possible to "merge" more of the functionality between `ConstructorResolutionLogic` and `MethodResolutionLogic` into a `MethodLikeResolutionLogic`, but there may be subtle differences to look out for and that's beyond the scope of this particular PR.