### PR TITLE
Fix issue 4724 Duplicate fields returned by JavaParserEnumDeclaration.getAllFields()

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -644,10 +644,17 @@ public class MethodResolutionLogic {
             }
             // If some null arguments have been provided, use this to eliminate some opitons.
             if (!nullParamIndexes.isEmpty()) {
-                // remove method with array param if a non array exists and arg is null
+                // filter method with array param if a non array exists and arg is null
+                // For example, if we define 2 methods
+                // {@code void get(String str0, Object ... objects)}
+                // {@code void get(String str0, String str1, Object ... objects)}
+                // and want to determine the most specific method invoked by this expression
+                // {@code foo.get("", null , new Object());}
                 Set<ResolvedMethodDeclaration> removeCandidates = new HashSet<>();
                 for (Integer nullParamIndex : nullParamIndexes) {
                     for (ResolvedMethodDeclaration methDecl : applicableMethods) {
+                        //                        if (nullParamIndex < methDecl.getNumberOfParams() &&
+                        // methDecl.getParam(nullParamIndex).getType().isArray()) {
                         if (methDecl.getParam(nullParamIndex).getType().isArray()) {
                             removeCandidates.add(methDecl);
                         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -25,7 +25,6 @@ import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.MethodUsage;
@@ -231,13 +230,6 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
         List<ResolvedFieldDeclaration> fields = javaParserTypeAdapter.getFieldsForDeclaredVariables();
 
         this.getAncestors().forEach(a -> fields.addAll(a.getAllFieldsVisibleToInheritors()));
-
-        this.wrappedNode.getMembers().stream()
-                .filter(m -> m instanceof FieldDeclaration)
-                .forEach(m -> {
-                    FieldDeclaration fd = (FieldDeclaration) m;
-                    fd.getVariables().forEach(v -> fields.add(new JavaParserFieldDeclaration(v, typeSolver)));
-                });
 
         return fields;
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -675,61 +675,15 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest
 
     @Test
     void testGetAllFields() {
-        JavaParserClassDeclaration constructorDeclaration = (JavaParserClassDeclaration)
-                typeSolver.solveType("com.github.javaparser.ast.body.ConstructorDeclaration");
+        Path src = adaptPath("src/test/resources/enums");
+        CombinedTypeSolver combinedtypeSolver = new CombinedTypeSolver();
+        combinedtypeSolver.add(new ReflectionTypeSolver());
+        combinedtypeSolver.add(new JavaParserTypeSolver(src, new LeanParserConfiguration()));
 
-        List<ResolvedFieldDeclaration> allFields = constructorDeclaration.getAllFields();
-        assertEquals(16, allFields.size());
-
-        ResolvedFieldDeclaration fieldDeclaration;
-
-        fieldDeclaration = allFields.get(0);
-        assertEquals("modifiers", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(1);
-        assertEquals("typeParameters", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(2);
-        assertEquals("name", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(3);
-        assertEquals("parameters", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(4);
-        assertEquals("throws_", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(5);
-        assertEquals("body", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(6);
-        assertEquals("annotations", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(7);
-        assertEquals("NODE_BY_BEGIN_POSITION", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(8);
-        assertEquals("range", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(9);
-        assertEquals("parentNode", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(10);
-        assertEquals("childrenNodes", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(11);
-        assertEquals("orphanComments", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(12);
-        assertEquals("userData", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(13);
-        assertEquals("comment", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(14);
-        assertEquals("ABSOLUTE_BEGIN_LINE", fieldDeclaration.getName());
-
-        fieldDeclaration = allFields.get(15);
-        assertEquals("ABSOLUTE_END_LINE", fieldDeclaration.getName());
+        JavaParserEnumDeclaration enumDecl = (JavaParserEnumDeclaration) combinedtypeSolver.solveType("COLOR");
+        assertEquals(2, enumDecl.getAllFields().size());
+        assertEquals("int", enumDecl.getAllFields().get(0).getType().describe());
+        assertEquals("int", enumDecl.getAllFields().get(1).getType().describe());
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/resources/enums/COLOR.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/enums/COLOR.java
@@ -1,0 +1,9 @@
+enum COLOR {
+    RED(0xff0000, 1),
+    GREEN(0x00ff00, 2),
+    BLUE(0x0000ff, 3);
+
+    private final int hex;
+    private final int index;
+    // constructor...
+}


### PR DESCRIPTION
Fixes #4724 .

The unit tests in the JavaParserEnumDeclarationTest class do not all seem relevant, but that's another story.
