### PR TITLE
Fix: issue 4747 Lexical preserving fails after replacing MarkerAnnotationExpr name

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4747Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4747Test.java
@@ -23,13 +23,9 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 
-import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
-import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import org.junit.jupiter.api.Test;
 
 public class Issue4747Test extends AbstractLexicalPreservingTest {
@@ -54,10 +50,8 @@ public class Issue4747Test extends AbstractLexicalPreservingTest {
                 null);
 
         String actual = LexicalPreservingPrinter.print(cu);
-        String expected = "public class TestClass {\n"
-                + "    @TestMarkerAnnotation\n"
-                + "    public void method1() {}\n"
-                + "}";
+        String expected =
+                "public class TestClass {\n" + "    @TestMarkerAnnotation\n" + "    public void method1() {}\n" + "}";
 
         assertEqualsStringIgnoringEol(expected, actual);
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4747Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4747Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import org.junit.jupiter.api.Test;
+
+public class Issue4747Test extends AbstractLexicalPreservingTest {
+
+    @Test
+    void test() {
+        final String code = "public class TestClass {\n"
+                + "    @com.abc.def.TestMarkerAnnotation\n"
+                + "    public void method1() {}\n"
+                + "}";
+        considerCode(code);
+        cu.accept(
+                new ModifierVisitor<Void>() {
+                    public Visitable visit(final MarkerAnnotationExpr expr, final Void arg) {
+                        if (expr.getNameAsString().equals("com.abc.def.TestMarkerAnnotation")) {
+                            expr.setName("TestMarkerAnnotation");
+                        }
+
+                        return super.visit(expr, arg);
+                    }
+                },
+                null);
+
+        String actual = LexicalPreservingPrinter.print(cu);
+        String expected = "public class TestClass {\n"
+                + "    @TestMarkerAnnotation\n"
+                + "    public void method1() {}\n"
+                + "}";
+
+        assertEqualsStringIgnoringEol(expected, actual);
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/Difference.java
@@ -634,6 +634,15 @@ public class Difference {
             // see issue #3721 this case is linked for example to a change of type of variable declarator
             nodeText.removeElement(originalIndex);
             diffIndex++;
+        } else if (originalElement.isChild() && removed.isToken()) {
+            // see issue #4747 this case is linked for example to a change of the annotation name
+            // This happens because changing a name results in the creation of a token when the syntax of the modified
+            // node is evaluated, whereas parsing an annotation results in a representation containing a child node
+            // (representing the annotation name). When the annotation name is modified, the element to be deleted (the
+            // child node) is compared with the token containing the character string representing the new annotation
+            // name.
+            nodeText.removeElement(originalIndex);
+            diffIndex++;
         } else {
             throw new UnsupportedOperationException("removed " + removed.getElement() + " vs " + originalElement);
         }


### PR DESCRIPTION

Fixes #4747 .

This happens because changing a name results in the creation of a token when the syntax of the modified node is evaluated, whereas parsing an annotation results in a representation containing a child node (representing the annotation name). When the annotation name is modified, the element to be deleted (the child node) is compared with the token containing the character string representing the new annotation name.
