### PR TITLE
Fix resolution of lambdas used as varargs

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -741,14 +741,24 @@ public class MethodResolutionLogic {
         return true;
     }
 
-    private static ResolvedType getMethodsExplicitAndVariadicParameterType(
-            ResolvedMethodLikeDeclaration method, int i) {
+    public static ResolvedType getMethodsExplicitAndVariadicParameterType(ResolvedMethodLikeDeclaration method, int i) {
         int numberOfParams = method.getNumberOfParams();
         if (i < numberOfParams) {
             return method.getParam(i).getType();
         }
         if (method.hasVariadicParameter()) {
             return method.getParam(numberOfParams - 1).getType();
+        }
+        return null;
+    }
+
+    public static ResolvedType getMethodUsageExplicitAndVariadicParameterType(MethodUsage method, int i) {
+        int numberOfParams = method.getNoParams();
+        if (i < numberOfParams) {
+            return method.getParamType(i);
+        }
+        if (method.getDeclaration().hasVariadicParameter()) {
+            return method.getParamType(numberOfParams - 1);
         }
         return null;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -39,6 +39,7 @@ import com.github.javaparser.resolution.*;
 import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.logic.FunctionalInterfaceLogic;
 import com.github.javaparser.resolution.logic.InferenceContext;
+import com.github.javaparser.resolution.logic.MethodResolutionLogic;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.Value;
 import com.github.javaparser.resolution.model.typesystem.LazyType;
@@ -484,8 +485,15 @@ public class TypeExtractor extends DefaultVisitorAdapter {
                     () -> refMethod.getCorrespondingDeclaration().getName());
 
             // The type parameter referred here should be the java.util.stream.Stream.T
-            ResolvedType result =
-                    refMethod.getCorrespondingDeclaration().getParam(pos).getType();
+            ResolvedType result = MethodResolutionLogic.getMethodsExplicitAndVariadicParameterType(
+                    refMethod.getCorrespondingDeclaration(), pos);
+
+            // It's possible that the lambda may be used as a vararg, in which case the resolved type will be an
+            // array type. In this case, the component type should be used instead when finding the functional
+            // method below.
+            if (result.isArray()) {
+                result = result.asArrayType().getComponentType();
+            }
 
             if (solveLambdas) {
                 if (callExpr.hasScope()) {
@@ -554,6 +562,13 @@ public class TypeExtractor extends DefaultVisitorAdapter {
         // We need to replace the type variables
         Context ctx = JavaParserFactory.getContext(node, typeSolver);
         result = result.solveGenericTypes(ctx);
+
+        // It's possible that the lambda may be used as a vararg, in which case the resolved type will be an
+        // array type. In this case, the component type should be used instead when finding the functional
+        // method below.
+        if (result.isArray()) {
+            result = result.asArrayType().getComponentType();
+        }
 
         // We should find out which is the functional method (e.g., apply) and replace the params of the
         // solveLambdas with it, to derive so the values. We should also consider the value returned by the


### PR DESCRIPTION
This PR fixes an issue I encountered when attempting to resolve lambdas that were used as varargs, for example the second argument in
```
class Test {
    void acceptConsumers(Consumer<String>... consumers) {}
    void test(Consumer<String> first) {
        acceptConsumers(first, s -> System.out.println(s));
    }
}
```

At first this resulted in an `IndexOutOfBounds` crash when trying to get the type of the parameter with index 1. The fix for this was to make `MethodResolutionLogic.getMethodsExplicitAndVariadicParameterType` public and to use that to get the type (since this accounts for varargs already) and to add a `getMethodUsageExplicitAndVariadicParameterType` to do the same for `MethodUsage`. 

This fixed the `IndexOutOfBounds` crash, but resulted in a new issue where `acceptConsumers` couldn't be resolved. This is because, when getting the expected parameter type from the parent (in this case the `acceptConsumers` call), the returned type is an array of `Consumer` due to the varargs. It's not possible for a lambda to define an array type, however, so the resolution fails. This broke the rest of the lambda resolution logic, so to fix it the type is now unwrapped and the component type is used instead.