### PR TITLE
Use lambda parameter counts and block bodies for improved resolution

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/model/LambdaArgumentTypePlaceholder.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/model/LambdaArgumentTypePlaceholder.java
@@ -22,6 +22,7 @@ package com.github.javaparser.resolution.model;
 
 import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import java.util.Optional;
 
 /**
  * Placeholder used to represent a lambda argument type while it is being
@@ -33,10 +34,31 @@ public class LambdaArgumentTypePlaceholder implements ResolvedType {
 
     private int pos;
 
+    private final Optional<Integer> parameterCount;
+
+    private final Optional<Boolean> bodyBlockHasExplicitNonVoidReturn;
+
     private SymbolReference<? extends ResolvedMethodLikeDeclaration> method;
 
     public LambdaArgumentTypePlaceholder(int pos) {
         this.pos = pos;
+        this.parameterCount = Optional.empty();
+        this.bodyBlockHasExplicitNonVoidReturn = Optional.empty();
+    }
+
+    public LambdaArgumentTypePlaceholder(
+            int pos, int parameterCount, Optional<Boolean> bodyBlockHasExplicitNonVoidReturn) {
+        this.pos = pos;
+        this.parameterCount = Optional.of(parameterCount);
+        this.bodyBlockHasExplicitNonVoidReturn = bodyBlockHasExplicitNonVoidReturn;
+    }
+
+    public Optional<Integer> getParameterCount() {
+        return parameterCount;
+    }
+
+    public Optional<Boolean> bodyBlockHasExplicitNonVoidReturn() {
+        return bodyBlockHasExplicitNonVoidReturn;
     }
 
     @Override


### PR DESCRIPTION
This PR improves lambda-related method resolution by using the lambda parameter count and body for disambiguation in two cases described below. I implemented this by adding the required information to the `LambdaArgumentTypePlaceholder` class, but made sure that, if this information is not provided (such as for `MethodReferenceExpr`, type resolution behaviour will be the same as before this PR.

## Different parameter counts
```
import java.util.function.Consumer;

class Test {
    void foo(Consumer<String> consumer) {}
    void foo(Runnable r) {}

    void test() {
        foo(input -> {});
    }
}
```
`Consumer.accept` has one parameter while `Runnable.run` has zero, so since the lambda has one parameter, we know this must resolve to `foo(Consumer<String>)`

## Disambiguation by return type
```
import java.util.function.Consumer;
import java.util.function.Function;

class Test {
    void foo(Consumer<String> consumer) {}
    void foo(Function<Integer, String> func) {}

    void test() {
        foo(input -> {});
    }
}
```
In this example, the body of the lambda is a block statement which does not contain any return statements. This means that the lambda can only define a method with a `void` return type, so it must define `Consumer<String>` (the same would be true for `foo(input -> { return; })`.

If it were `foo(input -> { return ""; })` instead, then the reverse logic would apply. Since the return type of the lambda is not `void`, it cannot define `Consumer` and must therefore define `Function`.
