### PR TITLE
Fix resolution for method refs used as varargs

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/VariadicResolutionTest.java
@@ -172,4 +172,26 @@ class VariadicResolutionTest extends AbstractResolutionTest {
         assertEquals("foo.Foo.fooId(java.lang.String)", resolvedMethod.getQualifiedSignature());
         assertEquals("java.lang.String", resolvedMethod.getReturnType().describe());
     }
+
+    @Test
+    void methodRefAsVariadicArgument() throws IOException {
+        String code = "import foo.Foo;\n" + "import java.util.function.Function;\n"
+                + "class Test {\n"
+                + "    static void collectFunctions(Function... functions) {}\n"
+                + "    void test() {\n"
+                + "        Function func1 = () -> {};\n"
+                + "        collectFunctions(func1, Object::hashCode);\n"
+                + "    }\n"
+                + "}";
+
+        CombinedTypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver());
+        ParserConfiguration configuration =
+                new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        StaticJavaParser.setConfiguration(configuration);
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodCallExpr call = cu.findFirst(MethodCallExpr.class).get();
+        assertEquals("void", call.calculateResolvedType().describe());
+    }
 }


### PR DESCRIPTION
This PR is effectively the same thing as https://github.com/javaparser/javaparser/pull/4752, but for fixing a crash where a vararg `MethodReferenceExpr` is resolved as a method usage. The first change fixes an `IndexOutOfBounds` crash, while the second fixes the same issue as in the linked PR where the resulting type is an `ArrayType(...)` which breaks the rest of the resolution logic.
