### PR TITLE
Fix NormalAnnotationExpr Javadoc

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NormalAnnotationExpr.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
- * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
  *
  * This file is part of JavaParser.
  *
@@ -37,7 +37,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
- * An annotation that has zero or more key-value pairs.<br>{@code @Mapping(a=5, d=10)}
+ * An annotation that has one or more key-value pairs.<br>{@code @Mapping(a=5, d=10)}
  * @author Julio Vilmar Gesser
  */
 public class NormalAnnotationExpr extends AnnotationExpr {


### PR DESCRIPTION
> An annotation that has **zero or more key-value pairs**.

This is wrong or at least misleading: if an annotation has zero key-value pairs, JavaParser will emit an instance of the specialized class `MarkerAnnotationExpr`, not a `NormalAnnotationExpr`.