### PR TITLE
Fix javadoc of Name class

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/Name.java
@@ -44,7 +44,7 @@ import java.util.Optional;
  * The rightmost identifier is "identifier",
  * The one to the left of it is "qualifier.identifier", etc.
  * <p>
- * You can construct one from a String with the name(...) method.
+ * You can construct one from a String with the {@link com.github.javaparser.StaticJavaParser#parseName(String)} method.
  *
  * @author Julio Vilmar Gesser
  * @see SimpleName


### PR DESCRIPTION
I could not find the mentioned `name(...)` method in this class. After a while, I found `StaticJavaParser.parseName()` and I guess that is the one that should be linked here.