### PR TITLE
Fix compile and test errors for Java 21 and up

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/quality/NotNullGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/quality/NotNullGenerator.java
@@ -158,11 +158,9 @@ public class NotNullGenerator extends CompilationUnitGenerator {
 
         // When the callable is a constructor we must check if is a ExplicitConstructorInvocationStmt.
         if (callableDeclaration.isConstructorDeclaration()) {
-            Optional<Statement> optionalFirstStatement = statements.getFirst();
-            if (optionalFirstStatement.isPresent()) {
-
+            if (statements.size() > 0) {
                 // Check if the first item is a "super" expr. If it's then we add the assertions after it.
-                Statement firstStatement = optionalFirstStatement.get();
+                Statement firstStatement = statements.getFirst();
                 if (firstStatement instanceof ExplicitConstructorInvocationStmt) {
                     position = 1;
                 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
@@ -121,46 +121,6 @@ class NodeListTest extends AbstractLexicalPreservingTest {
         assertEquals("[abc, bcd, cde, xxx]", list.toString());
     }
 
-    @Test
-    public void getFirstWhenEmpty() {
-        final NodeList<Name> list = nodeList();
-
-        Optional<Name> first = list.getFirst();
-
-        assertFalse(first.isPresent());
-        assertEquals("Optional.empty", first.toString());
-    }
-
-    @Test
-    public void getFirstWhenNonEmpty() {
-        final NodeList<Name> list = nodeList(new Name("abc"), new Name("bcd"), new Name("cde"));
-
-        Optional<Name> first = list.getFirst();
-
-        assertTrue(first.isPresent());
-        assertEquals("Optional[abc]", first.toString());
-    }
-
-    @Test
-    public void getLastWhenEmpty() {
-        final NodeList<Name> list = nodeList();
-
-        Optional<Name> last = list.getLast();
-
-        assertFalse(last.isPresent());
-        assertEquals("Optional.empty", last.toString());
-    }
-
-    @Test
-    public void getLastWhenNonEmpty() {
-        final NodeList<Name> list = nodeList(new Name("abc"), new Name("bcd"), new Name("cde"));
-
-        Optional<Name> last = list.getLast();
-
-        assertTrue(last.isPresent());
-        assertEquals("Optional[cde]", last.toString());
-    }
-
     @Nested
     class IteratorTest {
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
@@ -228,23 +228,27 @@ public class NodeList<N extends Node>
     }
 
     /**
-     * @return the first node, or empty if the list is empty.
+     * @return the first node, or throw if the list is empty.
+     *
+     * @throws NoSuchElementException
      */
-    public Optional<N> getFirst() {
+    public N getFirst() {
         if (isEmpty()) {
-            return Optional.empty();
+            throw new NoSuchElementException();
         }
-        return Optional.of(get(0));
+        return get(0);
     }
 
     /**
-     * @return the last node, or empty if the list is empty.
+     * @return the last node, or throw if the list is empty.
+     *
+     * @throws NoSuchElementException
      */
-    public Optional<N> getLast() {
+    public N getLast() {
         if (isEmpty()) {
-            return Optional.empty();
+            throw new NoSuchElementException();
         }
-        return Optional.of(get(size() - 1));
+        return get(size() - 1);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/CallableDeclaration.java
@@ -456,7 +456,7 @@ public abstract class CallableDeclaration<T extends CallableDeclaration<?>> exte
      * Returns true if the method has a variable number of arguments
      */
     public boolean isVariableArityMethod() {
-        return getParameters().size() > 0 && getParameters().getLast().get().isVarArgs();
+        return getParameters().size() > 0 && getParameters().getLast().isVarArgs();
     }
 
     /*

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/NormalCompletionVisitor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/NormalCompletionVisitor.java
@@ -124,7 +124,7 @@ public class NormalCompletionVisitor extends GenericVisitorWithDefaults<Boolean,
     @Override
     public Boolean visit(BlockStmt block, Void unused) {
         return block.getStatements().isEmpty()
-                || block.getStatements().getLast().get().accept(this, unused);
+                || block.getStatements().getLast().accept(this, unused);
     }
 
     /**
@@ -298,12 +298,12 @@ public class NormalCompletionVisitor extends GenericVisitorWithDefaults<Boolean,
             // In this case, the switch stmt is a classic switch, so check:
             // - The last statement in the switch block can complete normally.
             // - There is at least one switch label after the last switch block statement group.
-            SwitchEntry lastEntry = entries.getLast().get();
+            SwitchEntry lastEntry = entries.getLast();
             if (lastEntry.getStatements().isEmpty()) {
                 return true;
             }
 
-            Statement lastStmt = lastEntry.getStatements().getLast().get();
+            Statement lastStmt = lastEntry.getStatements().getLast();
             if (lastStmt.accept(this, unused)) {
                 return true;
             }
@@ -334,8 +334,8 @@ public class NormalCompletionVisitor extends GenericVisitorWithDefaults<Boolean,
             return true;
         }
 
-        if (switchEntry.getStatements().getLast().isPresent()
-                && switchEntry.getStatements().getLast().get().accept(this, unused)) {
+        if (switchEntry.getStatements().size() > 0
+                && switchEntry.getStatements().getLast().accept(this, unused)) {
             return true;
         }
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
@@ -119,10 +119,8 @@ public class BlockStmtContext extends StatementContext<BlockStmt> {
             // defined in the context of the wrapped node whether it is located before or after the statement that
             // interests us
             // because a variable cannot be (re)defined after having been used
-            wrappedNode
-                    .getStatements()
-                    .getLast()
-                    .ifPresent(stmt -> variableDeclarators.addAll(localVariablesExposedToChild(stmt)));
+            variableDeclarators.addAll(
+                    localVariablesExposedToChild(wrappedNode.getStatements().getLast()));
             if (!variableDeclarators.isEmpty()) {
                 // FIXME: Work backwards from the current statement, to only consider declarations prior to this
                 // statement.

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -199,8 +199,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
             // All objects implicitly extend java.lang.Object -- inject it here (only when this isn't java.lang.Object)
             return Optional.of(object());
         }
-        return Optional.of(
-                toReferenceType(wrappedNode.getExtendedTypes().getFirst().get()));
+        return Optional.of(toReferenceType(wrappedNode.getExtendedTypes().getFirst()));
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
@@ -66,7 +66,13 @@ public abstract class AbstractSymbolResolutionTest {
         JDK15(15),
         JDK16(16),
         JDK17(17),
-        JDK18(18);
+        JDK18(18),
+        JDK19(19),
+        JDK20(20),
+        JDK21(21),
+        JDK22(22),
+        JDK23(23),
+        JDK24(24);
 
         private final Integer major;
 
@@ -116,9 +122,22 @@ public abstract class AbstractSymbolResolutionTest {
                 return JDK17;
             } else if ("18".equals(javaVersion) || javaVersion.startsWith("18.")) {
                 return JDK18;
+            } else if ("19".equals(javaVersion) || javaVersion.startsWith("19.")) {
+                return JDK19;
+            } else if ("20".equals(javaVersion) || javaVersion.startsWith("20.")) {
+                return JDK20;
+            } else if ("21".equals(javaVersion) || javaVersion.startsWith("21.")) {
+                return JDK21;
+            } else if ("22".equals(javaVersion) || javaVersion.startsWith("22.")) {
+                return JDK22;
+            } else if ("23".equals(javaVersion) || javaVersion.startsWith("23.")) {
+                return JDK23;
+            } else if ("24".equals(javaVersion) || javaVersion.startsWith("24.")) {
+                return JDK24;
             }
 
-            throw new IllegalStateException("Unable to determine the current version of java running");
+            throw new IllegalStateException(
+                    "Unable to determine the current version of java running from: " + javaVersion);
         }
 
         /**


### PR DESCRIPTION
Java 21 reserves List<T> methods getFirst() and getLast() to return objects with type T. The original methods added to return an Optional<T> are removed in favour of using the default implementation. The tests for these methods go away as well because they would be redundant now.

Existing callsites are easy to convert: either check size() first if the callsite was using ifPresent(), or directly get the object in case the code was already calling getFirst().get() or getLast().get().

Fixes #4454.