### PR TITLE
 Use lambda parameter counts and block bodies for improved resolution 

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedMethodDeclaration.java
@@ -89,6 +89,12 @@ public interface ResolvedMethodDeclaration extends ResolvedMethodLikeDeclaration
         if (returnType.describe().equals(otherResolvedType.erasure().describe())) {
             return true;
         }
+        // At this point, R2 is not a type variable and R1 cannot be converted to a
+        // subtype of R2 by unchecked conversion, so if R1 is a type variable,
+        // then it cannot be assumed that it is return type substitutable.
+        if (returnType.isTypeVariable()) {
+            return false;
+        }
         throw new UnsupportedOperationException("Return-Type-Substituable must be implemented on reference type.");
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/model/LambdaArgumentTypePlaceholder.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/model/LambdaArgumentTypePlaceholder.java
@@ -22,6 +22,7 @@ package com.github.javaparser.resolution.model;
 
 import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import java.util.Optional;
 
 /**
  * Placeholder used to represent a lambda argument type while it is being
@@ -33,10 +34,31 @@ public class LambdaArgumentTypePlaceholder implements ResolvedType {
 
     private int pos;
 
+    private final Optional<Integer> parameterCount;
+
+    private final Optional<Boolean> bodyBlockHasExplicitNonVoidReturn;
+
     private SymbolReference<? extends ResolvedMethodLikeDeclaration> method;
 
     public LambdaArgumentTypePlaceholder(int pos) {
         this.pos = pos;
+        this.parameterCount = Optional.empty();
+        this.bodyBlockHasExplicitNonVoidReturn = Optional.empty();
+    }
+
+    public LambdaArgumentTypePlaceholder(
+            int pos, int parameterCount, Optional<Boolean> bodyBlockHasExplicitNonVoidReturn) {
+        this.pos = pos;
+        this.parameterCount = Optional.of(parameterCount);
+        this.bodyBlockHasExplicitNonVoidReturn = bodyBlockHasExplicitNonVoidReturn;
+    }
+
+    public Optional<Integer> getParameterCount() {
+        return parameterCount;
+    }
+
+    public Optional<Boolean> bodyBlockHasExplicitNonVoidReturn() {
+        return bodyBlockHasExplicitNonVoidReturn;
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -265,6 +265,17 @@ public class JavaParserFacade {
             while (parameterValue instanceof EnclosedExpr) {
                 parameterValue = ((EnclosedExpr) parameterValue).getInner();
             }
+            // In order to resolve a call with a lambda expr as an argument, the functional interface implemented
+            // by that lambda must be determined. This is done by collecting the candidate functional methods in
+            // scope and then excluding non-applicable methods if any of the following hold:
+            //   1. The lambda and the candidate method do not have the same number of arguments/parameters
+            //   2. The lambda has an explicit empty/void return statement `return;` in the body block, but the
+            //      candidate method has a non-void return type.
+            //   3. The lambda has an explicit non-void return statement, e.g. `return x;`, but the candidate
+            //      method has a void return type.
+            // For JavaParser to be able to perform the same filtering, we need to keep track of the number of
+            // arguments to the lambda, as well as whether there is an explicit void/non-void return statement,
+            // so this information is added to the `LambdaArgumentTypePlaceholder` in the block below.
             if (parameterValue.isLambdaExpr()) {
                 LambdaExpr lambdaExpr = parameterValue.asLambdaExpr();
                 Optional<Boolean> bodyBlockHasExplicitNonVoidReturn;


### PR DESCRIPTION
This PR re-opens https://github.com/javaparser/javaparser/pull/4757 with a fix for the last crash I mentioned that occurred when attempting to find the functional method. Please see the bottom of the PR description for a description of the issue and fix.

# Original PR description
This PR improves lambda-related method resolution by using the lambda parameter count and body for disambiguation in two cases described below. I implemented this by adding the required information to the `LambdaArgumentTypePlaceholder` class, but made sure that, if this information is not provided (such as for `MethodReferenceExpr`, type resolution behaviour will be the same as before this PR.

## Different parameter counts
```
import java.util.function.Consumer;

class Test {
    void foo(Consumer<String> consumer) {}
    void foo(Runnable r) {}

    void test() {
        foo(input -> {});
    }
}
```
`Consumer.accept` has one parameter while `Runnable.run` has zero, so since the lambda has one parameter, we know this must resolve to `foo(Consumer<String>)`

## Disambiguation by return type
```
import java.util.function.Consumer;
import java.util.function.Function;

class Test {
    void foo(Consumer<String> consumer) {}
    void foo(Function<Integer, String> func) {}

    void test() {
        foo(input -> {});
    }
}
```
In this example, the body of the lambda is a block statement which does not contain any return statements. This means that the lambda can only define a method with a `void` return type, so it must define `Consumer<String>` (the same would be true for `foo(input -> { return; })`.

If it were `foo(input -> { return ""; })` instead, then the reverse logic would apply. Since the return type of the lambda is not `void`, it cannot define `Consumer` and must therefore define `Function`.

# New in this PR

This issue occurred when attempting to resolve a call to a  method where one of the parameters is a functional interface that extends a different functional interface but overrides one of the generic types, for example:
```
import java.util.function.Function;
 
@FunctionalInterface
interface ReturnStringFunction<T> extends Function<T, String> {
  String apply(T t);
}

class Foo {
  static <T> String foo(T t) { return null; }
}

public class Test {
  <T> String acceptsFunction(ReturnStringFunction<T> consumer) { return null; }

  void test() {
    acceptsFunction(Foo::foo);
  }
}
```
In this example, the `Foo::foo` method reference has to be resolved to resolve the `acceptsFunction` call. 2 candidate methods for the method implemented by `Foo::foo` are found:
```
R apply(T t) from java.util.function.Function<T, R>
```
and
```
String apply(T t) from ReturnStringFunction<T>
```

At some point during the resolution, it must be determined whether these method return types are substitutable or not. The logic for doing this already exists, but `method1.isReturnTypeSubstitutable(method2.returnType())` only handles the case where the return type of method2 is a type variable. If the return type of method1 is a type variable, then this crashes with an `UnsupportedOperationException`. I've added a fix where, if the return type of method1 is a type variable and all other checks have been done, `false` is returned since in general the concrete return type of `method2` cannot be substituted for the type variable.