### PR TITLE
XmlPrinter: fix duplicate attribute name in generated xml

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
@@ -22,9 +22,12 @@
 package com.github.javaparser.printer;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
+import static com.github.javaparser.StaticJavaParser.parseType;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.type.Type;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
@@ -161,7 +164,19 @@ class XmlPrinterTest {
         String output = xmlOutput.output(expression);
 
         assertXMLEquals(
-                "<root type='BinaryExpr' operator='PLUS'><left type='IntegerLiteralExpr' value='1'></left><right type='IntegerLiteralExpr' value='1'></right></root>",
+                "<root _type='BinaryExpr' operator='PLUS'><left _type='IntegerLiteralExpr' value='1'></left><right _type='IntegerLiteralExpr' value='1'></right></root>",
+                output);
+    }
+
+    @Test
+    void testWithTypeXmlKeyCollision() throws SAXException, IOException {
+        Type type = parseType("int");
+        XmlPrinter xmlOutput = new XmlPrinter(true);
+
+        String output = xmlOutput.output(type);
+
+        assertXMLEquals(
+                "<root _type='PrimitiveType' type='INT'></root>",
                 output);
     }
 
@@ -185,7 +200,7 @@ class XmlPrinterTest {
         String output = xmlOutput.output(expression);
 
         assertXMLEquals(
-                "<root type='MethodCallExpr'><name type='SimpleName' identifier='a'></name><arguments><argument type='IntegerLiteralExpr' value='1'></argument><argument type='IntegerLiteralExpr' value='2'></argument></arguments></root>",
+                "<root _type='MethodCallExpr'><name _type='SimpleName' identifier='a'></name><arguments><argument _type='IntegerLiteralExpr' value='1'></argument><argument _type='IntegerLiteralExpr' value='2'></argument></arguments></root>",
                 output);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
@@ -164,7 +164,12 @@ class XmlPrinterTest {
         String output = xmlOutput.output(expression);
 
         assertXMLEquals(
-                "<root _type='BinaryExpr' operator='PLUS'><left _type='IntegerLiteralExpr' value='1'></left><right _type='IntegerLiteralExpr' value='1'></right></root>",
+                ""
+                        // Expected
+                        + "<root nodeType='BinaryExpr' operator='PLUS'>"
+                        + "<left nodeType='IntegerLiteralExpr' value='1'></left>"
+                        + "<right nodeType='IntegerLiteralExpr' value='1'></right>"
+                        + "</root>",
                 output);
     }
 
@@ -176,7 +181,7 @@ class XmlPrinterTest {
         String output = xmlOutput.output(type);
 
         assertXMLEquals(
-                "<root _type='PrimitiveType' type='INT'></root>",
+                "<root nodeType='PrimitiveType' type='INT'></root>",
                 output);
     }
 
@@ -200,7 +205,15 @@ class XmlPrinterTest {
         String output = xmlOutput.output(expression);
 
         assertXMLEquals(
-                "<root _type='MethodCallExpr'><name _type='SimpleName' identifier='a'></name><arguments><argument _type='IntegerLiteralExpr' value='1'></argument><argument _type='IntegerLiteralExpr' value='2'></argument></arguments></root>",
+                ""
+                        // Expected
+                        + "<root nodeType='MethodCallExpr'>"
+                        + "<name nodeType='SimpleName' identifier='a'></name>"
+                        + "<arguments>"
+                        + "<argument nodeType='IntegerLiteralExpr' value='1'></argument>"
+                        + "<argument nodeType='IntegerLiteralExpr' value='2'></argument>"
+                        + "</arguments>"
+                        + "</root>",
                 output);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.type.Type;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
@@ -180,9 +179,7 @@ class XmlPrinterTest {
 
         String output = xmlOutput.output(type);
 
-        assertXMLEquals(
-                "<root nodeType='PrimitiveType' type='INT'></root>",
-                output);
+        assertXMLEquals("<root nodeType='PrimitiveType' type='INT'></root>", output);
     }
 
     @Test

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
@@ -182,7 +182,7 @@ public class XmlPrinter {
         xmlWriter.writeStartElement(name);
         // Output node type attribute
         if (outputNodeType) {
-            xmlWriter.writeAttribute("type", metaModel.getTypeName());
+            xmlWriter.writeAttribute("_type", metaModel.getTypeName());
         }
         try {
             // Output attributes

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
@@ -182,7 +182,7 @@ public class XmlPrinter {
         xmlWriter.writeStartElement(name);
         // Output node type attribute
         if (outputNodeType) {
-            xmlWriter.writeAttribute("_type", metaModel.getTypeName());
+            xmlWriter.writeAttribute("nodeType", metaModel.getTypeName());
         }
         try {
             // Output attributes


### PR DESCRIPTION
Patch of #4805