### PR TITLE
fix: LexicalPreservingPrinter can't print PrimitiveType

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PrimitiveTypeMetaModel;
+import com.github.javaparser.printer.Stringable;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -84,7 +85,7 @@ public class PrimitiveType extends Type implements NodeWithAnnotations<Primitive
         return new PrimitiveType(Primitive.DOUBLE);
     }
 
-    public enum Primitive {
+    public enum Primitive implements Stringable {
         BOOLEAN("Boolean", "Z"),
         CHAR("Character", "C"),
         BYTE("Byte", "B"),

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -542,38 +542,6 @@ public class LexicalPreservingPrinter {
     // Methods to handle transformations
     //
     private static void prettyPrintingTextNode(Node node, NodeText nodeText) {
-        if (node instanceof PrimitiveType) {
-            PrimitiveType primitiveType = (PrimitiveType) node;
-            switch (primitiveType.getType()) {
-                case BOOLEAN:
-                    nodeText.addToken(BOOLEAN, node.toString());
-                    break;
-                case CHAR:
-                    nodeText.addToken(CHAR, node.toString());
-                    break;
-                case BYTE:
-                    nodeText.addToken(BYTE, node.toString());
-                    break;
-                case SHORT:
-                    nodeText.addToken(SHORT, node.toString());
-                    break;
-                case INT:
-                    nodeText.addToken(INT, node.toString());
-                    break;
-                case LONG:
-                    nodeText.addToken(LONG, node.toString());
-                    break;
-                case FLOAT:
-                    nodeText.addToken(FLOAT, node.toString());
-                    break;
-                case DOUBLE:
-                    nodeText.addToken(DOUBLE, node.toString());
-                    break;
-                default:
-                    throw new IllegalArgumentException();
-            }
-            return;
-        }
         if (node instanceof JavadocComment) {
             Comment comment = (JavadocComment) node;
             nodeText.addToken(
@@ -679,7 +647,11 @@ public class LexicalPreservingPrinter {
         if (!node.containsData(NODE_TEXT_DATA)) {
             NodeText nodeText = new NodeText();
             node.setData(NODE_TEXT_DATA, nodeText);
-            prettyPrintingTextNode(node, nodeText);
+            if (!node.hasRange() && node instanceof PrimitiveType) {
+                interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
+            } else {
+                prettyPrintingTextNode(node, nodeText);
+            }
         }
         return node.getData(NODE_TEXT_DATA);
     }


### PR DESCRIPTION
fixes. #4781 

## Issue Analysis
When adding primitive type fields via LexicalPreservingPrinter, keywords like `int`, `boolean` get omitted:

```java
// Expected: class Foo { int foo; }
// Actual:   class Foo { foo; }    // 'int' missing
```

## Root Cause
Dynamically created `PrimitiveType` nodes lack proper NodeText initialization. The existing `prettyPrintingTextNode()` relied on `node.toString()` which returns empty strings for uninitialized nodes.

## My Solution: CSM-Based Architecture Approach

**Removed Special Case Handling**: Eliminated the hardcoded PrimitiveType switch statement in `prettyPrintingTextNode()` (38 lines removed).

**Enhanced `getOrCreateNodeText()`**: Added proper handling for dynamically created PrimitiveType nodes:
```java
if (!node.hasRange() && node instanceof PrimitiveType) {
    interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
} else {
    prettyPrintingTextNode(node, nodeText);
}
```

**Made Primitive enum implement Stringable**: For consistency with JavaParser's design patterns.

nstead of special-casing PrimitiveType, I leveraged JavaParser's existing CSM (ConcreteSyntaxModel) infrastructure which already knows how to render primitive types correctly.

## Question
Does this CSM-based approach align well with JavaParser's lexical preservation architecture? I chose this over the simpler hardcoded string approach because it maintains consistency with how other AST nodes are handled.
