### PR TITLE
Improves documentation on the raw langage level

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -186,6 +186,8 @@ public class ParserConfiguration {
 
         /**
          * Does no post processing or validation. Only for people wanting the fastest parsing.
+         * Using the RAW language level can lead to parsing errors for features introduced in a specific version of Java
+         * (see issue https://github.com/javaparser/javaparser/issues/4813).
          */
         public static LanguageLevel RAW = null;
 


### PR DESCRIPTION
Fixes #4813 .

Using the RAW language level can lead to parsing errors for features introduced in a specific version of Java
