### PR TITLE
fix: preserve primitive type keywords in LexicalPreservingPrinter

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.PrimitiveTypeMetaModel;
+import com.github.javaparser.printer.Stringable;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -84,7 +85,7 @@ public class PrimitiveType extends Type implements NodeWithAnnotations<Primitive
         return new PrimitiveType(Primitive.DOUBLE);
     }
 
-    public enum Primitive {
+    public enum Primitive implements Stringable {
         BOOLEAN("Boolean", "Z"),
         CHAR("Character", "C"),
         BYTE("Byte", "B"),

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -598,7 +598,6 @@ public class LexicalPreservingPrinter {
             interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
             return;
         }
-
         if (node instanceof JavadocComment) {
             Comment comment = (JavadocComment) node;
             nodeText.addToken(

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -543,37 +543,10 @@ public class LexicalPreservingPrinter {
     //
     private static void prettyPrintingTextNode(Node node, NodeText nodeText) {
         if (node instanceof PrimitiveType) {
-            PrimitiveType primitiveType = (PrimitiveType) node;
-            switch (primitiveType.getType()) {
-                case BOOLEAN:
-                    nodeText.addToken(BOOLEAN, node.toString());
-                    break;
-                case CHAR:
-                    nodeText.addToken(CHAR, node.toString());
-                    break;
-                case BYTE:
-                    nodeText.addToken(BYTE, node.toString());
-                    break;
-                case SHORT:
-                    nodeText.addToken(SHORT, node.toString());
-                    break;
-                case INT:
-                    nodeText.addToken(INT, node.toString());
-                    break;
-                case LONG:
-                    nodeText.addToken(LONG, node.toString());
-                    break;
-                case FLOAT:
-                    nodeText.addToken(FLOAT, node.toString());
-                    break;
-                case DOUBLE:
-                    nodeText.addToken(DOUBLE, node.toString());
-                    break;
-                default:
-                    throw new IllegalArgumentException();
-            }
+            interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
             return;
         }
+
         if (node instanceof JavadocComment) {
             Comment comment = (JavadocComment) node;
             nodeText.addToken(


### PR DESCRIPTION
Fixes #4817. #4781 

Remove switch statement for primitiveType in LexicalPreservingPrinter
+)  preserve primitive type keywords in LexicalPreservingPrinter