### PR TITLE
Fix: Issue 4829 Infinite loop in DifferenceElementCalculator when calling setPermittedTypes

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculatorTest.java
@@ -61,7 +61,7 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                 new LexicalDifferenceCalculator.CalculatedSyntaxModel(Collections.emptyList());
         LexicalDifferenceCalculator.CalculatedSyntaxModel b =
                 new LexicalDifferenceCalculator.CalculatedSyntaxModel(Collections.emptyList());
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(a, b);
+        List<DifferenceElement> differenceElements = new DifferenceElementCalculator().calculate(a, b);
         assertEquals(0, differenceElements.size());
     }
 
@@ -78,7 +78,7 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                         new CsmChild(n1),
                         new CsmToken(GeneratedJavaParserConstants.RPAREN),
                         new CsmChild(n2)));
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(a, b);
+        List<DifferenceElement> differenceElements = new DifferenceElementCalculator().calculate(a, b);
         assertEquals(4, differenceElements.size());
         assertEquals(added(new CsmToken(GeneratedJavaParserConstants.LPAREN)), differenceElements.get(0));
         assertEquals(added(new CsmChild(n1)), differenceElements.get(1));
@@ -99,7 +99,7 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                         new CsmChild(n2)));
         LexicalDifferenceCalculator.CalculatedSyntaxModel b =
                 new LexicalDifferenceCalculator.CalculatedSyntaxModel(Collections.emptyList());
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(a, b);
+        List<DifferenceElement> differenceElements = new DifferenceElementCalculator().calculate(a, b);
         assertEquals(4, differenceElements.size());
         assertEquals(removed(new CsmToken(GeneratedJavaParserConstants.LPAREN)), differenceElements.get(0));
         assertEquals(removed(new CsmChild(n1)), differenceElements.get(1));
@@ -117,7 +117,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterPropertyChange(
                         element, cu, ObservableProperty.PACKAGE_DECLARATION, null, packageDeclaration);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         assertEquals(3, differenceElements.size());
         assertEquals(added(new CsmChild(packageDeclaration)), differenceElements.get(0));
         assertEquals(kept(new CsmChild(cu.getType(0))), differenceElements.get(1));
@@ -138,7 +139,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                         ObservableProperty.MODIFIERS,
                         new NodeList<>(),
                         createModifierList(PUBLIC));
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         DifferenceElementCalculator.removeIndentationElements(differenceElements);
         int i = 0;
         assertEquals(added(new CsmChild(Modifier.publicModifier())), differenceElements.get(i++));
@@ -181,7 +183,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                         ObservableProperty.NAME,
                         annotationDeclaration.getName(),
                         newName);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         DifferenceElementCalculator.removeIndentationElements(differenceElements);
         int i = 0;
         assertEquals(kept(new CsmToken(GeneratedJavaParserConstants.AT)), differenceElements.get(i++));
@@ -219,7 +222,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterPropertyChange(
                         element, annotationDeclaration, ObservableProperty.COMMENT, null, comment);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         DifferenceElementCalculator.removeIndentationElements(differenceElements);
         int i = 0;
         assertEquals(kept(new CsmChild(Modifier.publicModifier())), differenceElements.get(i++));
@@ -261,7 +265,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                         ObservableProperty.COMMENT,
                         annotationDeclaration.getComment().get(),
                         null);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         DifferenceElementCalculator.removeIndentationElements(differenceElements);
         int i = 0;
         assertEquals(kept(new CsmChild(Modifier.publicModifier())), differenceElements.get(i++));
@@ -303,7 +308,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                         ObservableProperty.MODIFIERS,
                         createModifierList(PUBLIC),
                         new NodeList<>());
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         DifferenceElementCalculator.removeIndentationElements(differenceElements);
         int i = 0;
         assertEquals(removed(new CsmChild(Modifier.publicModifier())), differenceElements.get(i++));
@@ -339,7 +345,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterPropertyChange(
                         md, ObservableProperty.DEFAULT_VALUE, md.getDefaultValue(), null);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         int i = 0;
         assertEquals(kept(new CsmChild(md.getType())), differenceElements.get(i++));
         assertEquals(kept(new CsmToken(spaceTokenKind())), differenceElements.get(i++));
@@ -362,7 +369,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
         Expression defaultValue = new IntegerLiteralExpr(("10"));
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterPropertyChange(md, ObservableProperty.DEFAULT_VALUE, null, defaultValue);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         int i = 0;
         assertEquals(kept(new CsmChild(md.getType())), differenceElements.get(i++));
         assertEquals(kept(new CsmToken(spaceTokenKind())), differenceElements.get(i++));
@@ -385,7 +393,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterPropertyChange(
                         cd, ObservableProperty.MODIFIERS, new NodeList<>(), createModifierList(PUBLIC));
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         int i = 0;
         assertEquals(added(new CsmChild(Modifier.publicModifier())), differenceElements.get(i++));
         assertEquals(added(new CsmToken(spaceTokenKind())), differenceElements.get(i++));
@@ -405,7 +414,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                 new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(ecd);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterPropertyChange(ecd, ObservableProperty.NAME, ecd.getName(), newName);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         int i = 0;
         assertEquals(DifferenceElement.removed(new CsmChild(ecd.getName())), differenceElements.get(i++));
         assertEquals(DifferenceElement.added(new CsmChild(newName)), differenceElements.get(i++));
@@ -425,7 +435,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                 .calculatedSyntaxModelForNode(m.getBody().get());
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterListAddition(m.getBody().get(), ObservableProperty.STATEMENTS, 0, s);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         int i = 0;
         assertEquals(
                 DifferenceElement.kept(new CsmToken(GeneratedJavaParserConstants.LBRACE)), differenceElements.get(i++));
@@ -446,7 +457,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                 new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(md);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterListRemoval(md, ObservableProperty.PARAMETERS, 0);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         int i = 0;
         assertEquals(DifferenceElement.kept(new CsmChild(Modifier.publicModifier())), differenceElements.get(i++));
         assertEquals(DifferenceElement.kept(new CsmToken(spaceTokenKind())), differenceElements.get(i++));
@@ -471,7 +483,8 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
                 new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(md);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterListAddition(md, ObservableProperty.PARAMETERS, 0, newParameter);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(csmOriginal, csmChanged);
+        List<DifferenceElement> differenceElements =
+                new DifferenceElementCalculator().calculate(csmOriginal, csmChanged);
         int i = 0;
         assertEquals(DifferenceElement.kept(new CsmChild(Modifier.publicModifier())), differenceElements.get(i++));
         assertEquals(DifferenceElement.kept(new CsmToken(spaceTokenKind())), differenceElements.get(i++));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4829Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4829Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ParserConfiguration.LanguageLevel;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import org.junit.jupiter.api.Test;
+
+class Issue4829Test extends AbstractLexicalPreservingTest {
+
+    @Test
+    public void test() {
+
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.setLanguageLevel(LanguageLevel.JAVA_17);
+        StaticJavaParser.setConfiguration(parserConfiguration);
+        considerCode("public sealed interface Foo permits A,B,C,D,E,F,G,H,I {}");
+
+        cu.findAll(ClassOrInterfaceDeclaration.class)
+                .forEach(declaration -> declaration.setPermittedTypes(NodeList.nodeList()));
+
+        String expected = "public sealed interface Foo {}";
+
+        assertEqualsStringIgnoringEol(expected, LexicalPreservingPrinter.print(cu));
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
@@ -183,7 +183,6 @@ class DifferenceElementCalculator {
     List<DifferenceElement> calculate(
             LexicalDifferenceCalculator.CalculatedSyntaxModel original,
             LexicalDifferenceCalculator.CalculatedSyntaxModel after) {
-
         // For performance reasons we use the positions of matching children
         // to guide the calculation of the difference
         //
@@ -311,13 +310,10 @@ class DifferenceElementCalculator {
     private List<DifferenceElement> calculateImpl(
             LexicalDifferenceCalculator.CalculatedSyntaxModel original,
             LexicalDifferenceCalculator.CalculatedSyntaxModel after) {
-
         String key = original.hashCode() + "-" + after.hashCode();
-
         if (cache.containsKey(key)) {
             return cache.get(key);
         }
-
         List<DifferenceElement> result = calculateImpl2(original, after);
         cache.put(key, result);
         return result;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculator.java
@@ -26,12 +26,11 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.printer.concretesyntaxmodel.*;
 import com.github.javaparser.printer.lexicalpreservation.LexicalDifferenceCalculator.CalculatedSyntaxModel;
 import com.github.javaparser.printer.lexicalpreservation.LexicalDifferenceCalculator.CsmChild;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 class DifferenceElementCalculator {
+
+    private Map<String, List<DifferenceElement>> cache;
 
     // internally keep track of a node position in a List<CsmElement>
     public static class ChildPositionInfo {
@@ -120,7 +119,19 @@ class DifferenceElementCalculator {
                 a.getClass().getSimpleName() + " " + b.getClass().getSimpleName());
     }
 
-    private static boolean replacement(CsmElement a, CsmElement b) {
+    /**
+     * Remove from the difference all the elements related to indentation.
+     * This is mainly intended for test purposes.
+     */
+    static void removeIndentationElements(List<DifferenceElement> elements) {
+        elements.removeIf(el -> el.getElement() instanceof CsmIndent || el.getElement() instanceof CsmUnindent);
+    }
+
+    public DifferenceElementCalculator() {
+        cache = new HashMap<>();
+    }
+
+    private boolean replacement(CsmElement a, CsmElement b) {
         if (a instanceof CsmIndent || b instanceof CsmIndent || a instanceof CsmUnindent || b instanceof CsmUnindent) {
             return false;
         }
@@ -153,7 +164,7 @@ class DifferenceElementCalculator {
     /**
      * Find the positions of all the given children.
      */
-    private static List<ChildPositionInfo> findChildrenPositions(
+    private List<ChildPositionInfo> findChildrenPositions(
             LexicalDifferenceCalculator.CalculatedSyntaxModel calculatedSyntaxModel) {
         List<ChildPositionInfo> positions = new ArrayList<>();
         for (int i = 0; i < calculatedSyntaxModel.elements.size(); i++) {
@@ -169,9 +180,10 @@ class DifferenceElementCalculator {
      * Calculate the Difference between two CalculatedSyntaxModel elements, determining which elements were kept,
      * which were added and which were removed.
      */
-    static List<DifferenceElement> calculate(
+    List<DifferenceElement> calculate(
             LexicalDifferenceCalculator.CalculatedSyntaxModel original,
             LexicalDifferenceCalculator.CalculatedSyntaxModel after) {
+
         // For performance reasons we use the positions of matching children
         // to guide the calculation of the difference
         //
@@ -262,7 +274,7 @@ class DifferenceElementCalculator {
         return elements;
     }
 
-    private static void considerRemoval(NodeText nodeTextForChild, List<DifferenceElement> elements) {
+    private void considerRemoval(NodeText nodeTextForChild, List<DifferenceElement> elements) {
         for (TextElement el : nodeTextForChild.getElements()) {
             if (el instanceof ChildTextElement) {
                 ChildTextElement cte = (ChildTextElement) el;
@@ -276,7 +288,7 @@ class DifferenceElementCalculator {
         }
     }
 
-    private static int considerRemoval(CsmElement removedElement, int originalIndex, List<DifferenceElement> elements) {
+    private int considerRemoval(CsmElement removedElement, int originalIndex, List<DifferenceElement> elements) {
         boolean dealtWith = false;
         if (removedElement instanceof CsmChild) {
             CsmChild removedChild = (CsmChild) removedElement;
@@ -296,18 +308,37 @@ class DifferenceElementCalculator {
         return originalIndex;
     }
 
-    private static List<DifferenceElement> calculateImpl(
+    private List<DifferenceElement> calculateImpl(
             LexicalDifferenceCalculator.CalculatedSyntaxModel original,
             LexicalDifferenceCalculator.CalculatedSyntaxModel after) {
+
+        String key = original.hashCode() + "-" + after.hashCode();
+
+        if (cache.containsKey(key)) {
+            return cache.get(key);
+        }
+
+        List<DifferenceElement> result = calculateImpl2(original, after);
+        cache.put(key, result);
+        return result;
+    }
+
+    private List<DifferenceElement> calculateImpl2(
+            LexicalDifferenceCalculator.CalculatedSyntaxModel original,
+            LexicalDifferenceCalculator.CalculatedSyntaxModel after) {
+        // This list will hold the final differences between the two models.
         List<DifferenceElement> elements = new LinkedList<>();
+        // Pointers to traverse both sequences (before and after).
         int originalIndex = 0;
         int afterIndex = 0;
         // We move through the two CalculatedSyntaxModel, moving both forward when we have a match
         // and moving just one side forward when we have an element kept or removed
         do {
+            // elements remain only in the original sequence everything left must be marked as removed.
             if (originalIndex < original.elements.size() && afterIndex >= after.elements.size()) {
                 CsmElement removedElement = original.elements.get(originalIndex);
                 originalIndex = considerRemoval(removedElement, originalIndex, elements);
+                // elements remain only in the "after" sequence everything left must be marked as added.
             } else if (originalIndex >= original.elements.size() && afterIndex < after.elements.size()) {
                 elements.add(new Added(after.elements.get(afterIndex)));
                 afterIndex++;
@@ -315,30 +346,39 @@ class DifferenceElementCalculator {
                 CsmElement nextOriginal = original.elements.get(originalIndex);
                 CsmElement nextAfter = after.elements.get(afterIndex);
                 if ((nextOriginal instanceof CsmMix) && (nextAfter instanceof CsmMix)) {
+                    // If sub-elements are identical, mark everything as kept
                     if (((CsmMix) nextAfter).getElements().equals(((CsmMix) nextOriginal).getElements())) {
                         // No reason to deal with a reshuffled, we are just going to keep everything as it is
                         ((CsmMix) nextAfter).getElements().forEach(el -> elements.add(new Kept(el)));
                     } else {
+                        // Otherwise, same type but with shuffled/reorganized content
                         elements.add(new Reshuffled((CsmMix) nextOriginal, (CsmMix) nextAfter));
                     }
                     originalIndex++;
                     afterIndex++;
                 } else if (matching(nextOriginal, nextAfter)) {
+                    // The two elements match according to a custom "matching" rule
                     elements.add(new Kept(nextOriginal));
                     originalIndex++;
                     afterIndex++;
                 } else if (replacement(nextOriginal, nextAfter)) {
+                    // The two elements represent a replacement: remove the old one and add the new one.
                     originalIndex = considerRemoval(nextOriginal, originalIndex, elements);
                     elements.add(new Added(nextAfter));
                     afterIndex++;
+                    // Ambiguous case: it could be either an addition or a removal.
                 } else {
                     // We can try to remove the element or add it and look which one leads to the lower difference
+                    // Try hypothesis A: treat "nextAfter" as an addition
                     List<DifferenceElement> addingElements =
                             calculate(original.from(originalIndex), after.from(afterIndex + 1));
+                    long costAddingElements = cost(addingElements);
+                    // Try hypothesis B: treat "nextOriginal" as a removal
                     List<DifferenceElement> removingElements = null;
-                    if (cost(addingElements) > 0) {
+                    if (costAddingElements > 0) {
                         removingElements = calculate(original.from(originalIndex + 1), after.from(afterIndex));
                     }
+                    // Choose the cheaper option based on cost.
                     if (removingElements == null || cost(removingElements) > cost(addingElements)) {
                         elements.add(new Added(nextAfter));
                         afterIndex++;
@@ -352,15 +392,7 @@ class DifferenceElementCalculator {
         return elements;
     }
 
-    private static long cost(List<DifferenceElement> elements) {
+    private long cost(List<DifferenceElement> elements) {
         return elements.stream().filter(e -> !(e instanceof Kept)).count();
-    }
-
-    /**
-     * Remove from the difference all the elements related to indentation.
-     * This is mainly intended for test purposes.
-     */
-    static void removeIndentationElements(List<DifferenceElement> elements) {
-        elements.removeIf(el -> el.getElement() instanceof CsmIndent || el.getElement() instanceof CsmUnindent);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -68,6 +68,16 @@ class LexicalDifferenceCalculator {
         void removeIndentationElements() {
             elements.removeIf(el -> el instanceof CsmIndent || el instanceof CsmUnindent);
         }
+
+        public int hashCode() {
+            return elements.hashCode();
+        }
+
+        public boolean equals(Object other) {
+            if (other == null) return false;
+            if (!(other instanceof CalculatedSyntaxModel)) return false;
+            return elements.equals(other);
+        }
     }
 
     public static class CsmChild implements CsmElement {
@@ -122,7 +132,7 @@ class LexicalDifferenceCalculator {
         CalculatedSyntaxModel original = calculatedSyntaxModelForNode(element, container);
         CalculatedSyntaxModel after =
                 calculatedSyntaxModelAfterListRemoval(element, observableProperty, nodeList, index);
-        return DifferenceElementCalculator.calculate(original, after);
+        return new DifferenceElementCalculator().calculate(original, after);
     }
 
     List<DifferenceElement> calculateListAdditionDifference(
@@ -132,7 +142,7 @@ class LexicalDifferenceCalculator {
         CalculatedSyntaxModel original = calculatedSyntaxModelForNode(element, container);
         CalculatedSyntaxModel after =
                 calculatedSyntaxModelAfterListAddition(element, observableProperty, nodeList, index, nodeAdded);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(original, after);
+        List<DifferenceElement> differenceElements = new DifferenceElementCalculator().calculate(original, after);
         // Set the line separator character tokens
         LineSeparator lineSeparator = container.getLineEndingStyleOrDefault(LineSeparator.SYSTEM);
         replaceEolTokens(differenceElements, lineSeparator);
@@ -164,7 +174,7 @@ class LexicalDifferenceCalculator {
         CalculatedSyntaxModel original = calculatedSyntaxModelForNode(element, container);
         CalculatedSyntaxModel after =
                 calculatedSyntaxModelAfterListReplacement(element, observableProperty, nodeList, index, newValue);
-        return DifferenceElementCalculator.calculate(original, after);
+        return new DifferenceElementCalculator().calculate(original, after);
     }
 
     void calculatePropertyChange(
@@ -176,7 +186,7 @@ class LexicalDifferenceCalculator {
         CalculatedSyntaxModel original = calculatedSyntaxModelForNode(element, observedNode);
         CalculatedSyntaxModel after =
                 calculatedSyntaxModelAfterPropertyChange(element, observedNode, property, oldValue, newValue);
-        List<DifferenceElement> differenceElements = DifferenceElementCalculator.calculate(original, after);
+        List<DifferenceElement> differenceElements = new DifferenceElementCalculator().calculate(original, after);
         Difference difference = new Difference(differenceElements, nodeText, observedNode);
         difference.apply();
     }


### PR DESCRIPTION
The algorithm that calculates the differences in representation of a node following a change has exponential complexity when we remove the permits clause. One solution is to add memoisation to eliminate recalculations. This reduces the complexity to O(n*m).

Fixes #4829 .
