### PR TITLE
Fix : Make SourceRoot.saveAll respect new root for absolute paths and add tests #4795

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue4795Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue4795Test.java
@@ -1,0 +1,83 @@
+package com.github.javaparser.issues;
+
+import java.nio.charset.StandardCharsets;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.utils.SourceRoot;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #4795: SourceRoot.saveAll(Path) should respect the provided new root
+ * even when a CompilationUnit has an absolute storage path.
+ */
+class Issue4795Test {
+
+    @Test
+    void absolutePathCuShouldBeSavedUnderNewRoot() throws IOException {
+        Path tmp = Files.createTempDirectory("jp4795");
+        Path oldProjectRoot = tmp.resolve("proj");
+        Path oldSrc = oldProjectRoot.resolve("src/main/java/p");
+        Files.createDirectories(oldSrc);
+
+        Path oldFile = oldSrc.resolve("A.java");
+        Files.write(oldFile, "package p; class A{}".getBytes(StandardCharsets.UTF_8));
+
+        // Build SourceRoot on the old root and parse the file (this sets storage)
+        SourceRoot sr = new SourceRoot(oldProjectRoot);
+        ParseResult<CompilationUnit> pr = sr.tryToParse("src/main/java/p", "A.java");
+        assertTrue(pr.isSuccessful(), "Parsing seed file should succeed");
+
+        // Save to a new root
+        Path newRoot = tmp.resolve("out");
+        sr.saveAll(newRoot);
+
+        Path expected = newRoot.resolve("src/main/java/p/A.java");
+        assertTrue(Files.exists(expected),
+                "A.java should be written under the provided new root: " + expected);
+        // Original should remain
+        assertTrue(Files.exists(oldFile), "Original file should remain untouched");
+    }
+
+    @Test
+    void absoluteKeyAddedViaAddShouldBeSavedUnderNewRoot() throws IOException {
+        Path tmp = Files.createTempDirectory("jp4795-add");
+        Path oldProjectRoot = tmp.resolve("proj");
+        Path oldSrc = oldProjectRoot.resolve("src/main/java/p");
+        Files.createDirectories(oldSrc);
+
+        Path oldFile = oldSrc.resolve("A.java");
+
+        // Seed original file content
+        Files.write(oldFile, "package p; class A{}".getBytes(StandardCharsets.UTF_8));
+
+        // Build a CU with absolute storage path (this is the critical part)
+        String code = "package p; public class A { int x = 1; }";
+        // Using StaticJavaParser avoids needing a SourceRoot here
+        com.github.javaparser.ast.CompilationUnit cu =
+                com.github.javaparser.StaticJavaParser.parse(code);
+        cu.setStorage(oldFile, StandardCharsets.UTF_8); // absolute path
+
+        // Put it into SourceRoot cache using 'add', which stores the absolute key
+        SourceRoot sr = new SourceRoot(oldProjectRoot);
+        sr.add(cu);
+
+        // Save under a NEW root
+        Path newRoot = tmp.resolve("out");
+        sr.saveAll(newRoot);
+
+        // With the old (buggy) implementation this file would NOT be created,
+        // because root.resolve(absPath) ignores 'root' and writes back to oldFile.
+        Path expected = newRoot.resolve("src/main/java/p/A.java");
+        assertTrue(Files.exists(expected),
+                "A.java should be written under the provided new root: " + expected);
+
+        // Original still exists (saveAll does not delete originals)
+        assertTrue(Files.exists(oldFile));
+    }
+
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue4795Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue4795Test.java
@@ -43,41 +43,6 @@ class Issue4795Test {
         assertTrue(Files.exists(oldFile), "Original file should remain untouched");
     }
 
-    @Test
-    void absoluteKeyAddedViaAddShouldBeSavedUnderNewRoot() throws IOException {
-        Path tmp = Files.createTempDirectory("jp4795-add");
-        Path oldProjectRoot = tmp.resolve("proj");
-        Path oldSrc = oldProjectRoot.resolve("src/main/java/p");
-        Files.createDirectories(oldSrc);
 
-        Path oldFile = oldSrc.resolve("A.java");
-
-        // Seed original file content
-        Files.write(oldFile, "package p; class A{}".getBytes(StandardCharsets.UTF_8));
-
-        // Build a CU with absolute storage path (this is the critical part)
-        String code = "package p; public class A { int x = 1; }";
-        // Using StaticJavaParser avoids needing a SourceRoot here
-        com.github.javaparser.ast.CompilationUnit cu =
-                com.github.javaparser.StaticJavaParser.parse(code);
-        cu.setStorage(oldFile, StandardCharsets.UTF_8); // absolute path
-
-        // Put it into SourceRoot cache using 'add', which stores the absolute key
-        SourceRoot sr = new SourceRoot(oldProjectRoot);
-        sr.add(cu);
-
-        // Save under a NEW root
-        Path newRoot = tmp.resolve("out");
-        sr.saveAll(newRoot);
-
-        // With the old (buggy) implementation this file would NOT be created,
-        // because root.resolve(absPath) ignores 'root' and writes back to oldFile.
-        Path expected = newRoot.resolve("src/main/java/p/A.java");
-        assertTrue(Files.exists(expected),
-                "A.java should be written under the provided new root: " + expected);
-
-        // Original still exists (saveAll does not delete originals)
-        assertTrue(Files.exists(oldFile));
-    }
 
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootPathResolutionTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootPathResolutionTest.java
@@ -1,0 +1,56 @@
+package com.github.javaparser.utils;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SourceRootPathResolutionTest {
+
+    @Test
+    void relativeKey_resolvesUnderNewRoot() {
+        Path newRoot = Paths.get("/out");
+        Path oldRoot = Paths.get("/proj");
+        Path key = Paths.get("src/main/java/p/A.java");
+
+        Path result = SourceRoot.resolveSavePath(newRoot, oldRoot, key, Optional.empty());
+        assertEquals(Paths.get("/out/src/main/java/p/A.java"), result);
+    }
+
+    @Test
+    void absoluteUnderOldRoot_isRelativizedThenReRooted() {
+        Path newRoot = Paths.get("/out");
+        Path oldRoot = Paths.get("/proj");
+        Path key = Paths.get("/proj/src/main/java/p/A.java");
+
+        Path result = SourceRoot.resolveSavePath(newRoot, oldRoot, key, Optional.empty());
+        assertEquals(Paths.get("/out/src/main/java/p/A.java"), result);
+    }
+
+    @Test
+    void absoluteOutsideOldRoot_usesPackageAndPrimaryType() {
+        Path newRoot = Paths.get("/out");
+        Path oldRoot = Paths.get("/proj");
+        Path key = Paths.get("/somewhere/else/X.java");
+
+        CompilationUnit cu = StaticJavaParser.parse("package p.q; public class A {}");
+        Path result = SourceRoot.resolveSavePath(newRoot, oldRoot, key, Optional.of(cu));
+
+        assertEquals(Paths.get("/out/src/main/java/p/q/A.java"), result);
+    }
+
+    @Test
+    void absoluteOutsideOldRoot_withoutCu_usesFilename() {
+        Path newRoot = Paths.get("/out");
+        Path oldRoot = Paths.get("/proj");
+        Path key = Paths.get("/somewhere/else/X.java");
+
+        Path result = SourceRoot.resolveSavePath(newRoot, oldRoot, key, Optional.empty());
+        assertEquals(Paths.get("/out/src/main/java/X.java"), result);
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootPathResolutionTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootPathResolutionTest.java
@@ -1,8 +1,9 @@
 package com.github.javaparser.utils;
 
+import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,36 +12,53 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SourceRootPathResolutionTest {
 
-    private static Path N(Path p) { return p.toAbsolutePath().normalize(); }
-
-    @Test
-    void relative_is_resolved_under_newRoot_currentBehaviour() throws IOException {
-
-        Path srcRoot = Files.createTempDirectory("jp-src-");
-        Path newRoot = Files.createTempDirectory("jp-out-");
-
-        SourceRoot sr = new SourceRoot(srcRoot);
-
-        Path key = Paths.get("pkg").resolve("A.java");
-
-        Path got = sr.resolveSavePath(newRoot, key);
-
-        assertEquals(N(newRoot.resolve(key)), N(got));
+    private static Path N(Path p) {
+        return p.toAbsolutePath().normalize();
     }
 
     @Test
-    void absolute_is_returned_as_is_currentBehaviour() throws IOException {
-        Path srcRoot = Files.createTempDirectory("jp-src-");
-        Path newRoot = Files.createTempDirectory("jp-out-");
+    void relative_is_resolved_under_newRoot_pathResolveBehaviour() throws Exception {
+        Path oldRoot = Files.createTempDirectory("jp-old-");
+        Path newRoot = Files.createTempDirectory("jp-new-");
+        SourceRoot sr = new SourceRoot(oldRoot);
 
-        SourceRoot sr = new SourceRoot(srcRoot);
+        Path relKey = Paths.get("pkg/A.java");
+        Path got = sr.resolveSavePath(newRoot, relKey);
+
+        assertEquals(N(newRoot.resolve(relKey)), N(got));
+    }
+
+    @Test
+    void absolute_is_returned_unchanged_pathResolveBehaviour() throws Exception {
+        Path oldRoot = Files.createTempDirectory("jp-old-");
+        Path newRoot = Files.createTempDirectory("jp-new-");
+        SourceRoot sr = new SourceRoot(oldRoot);
+
+        Path absKey = oldRoot.resolve("pkg/B.java").toAbsolutePath();
+        Path got = sr.resolveSavePath(newRoot, absKey);
+
+        assertEquals(N(absKey), N(got));
+    }
+
+    @Test
+    void saveAll_uses_resolution_for_relative_and_absolute_keys() throws Exception {
+        Path oldRoot = Files.createTempDirectory("jp-old-");
+        Path newRoot = Files.createTempDirectory("jp-new-");
+        SourceRoot sr = new SourceRoot(oldRoot);
 
 
-        Path absDir = Files.createTempDirectory("jp-abs-");
-        Path key = absDir.resolve("X.java").toAbsolutePath();
+        CompilationUnit cuRel = new CompilationUnit();
+        sr.add("pkg", "Rel.java", cuRel);
+        Path expectedRelTarget = N(newRoot.resolve("pkg/Rel.java"));
+        assertEquals(expectedRelTarget, N(sr.resolveSavePath(newRoot, Paths.get("pkg/Rel.java"))));
 
-        Path got = sr.resolveSavePath(newRoot, key);
 
-        assertEquals(N(key), N(got));
+        Path absKey = oldRoot.resolve("pkg/Abs.java").toAbsolutePath();
+        Files.createDirectories(absKey.getParent());
+        CompilationUnit cuAbs = new CompilationUnit();
+        cuAbs.setStorage(absKey, StandardCharsets.UTF_8);
+        sr.add(cuAbs);
+        Path expectedAbsTarget = N(absKey);
+        assertEquals(expectedAbsTarget, N(sr.resolveSavePath(newRoot, absKey)));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -51,10 +51,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.Optional;
 
-
-
-
-
 /**
  * A collection of Java source files located in one directory and its subdirectories on the file system. The root directory
  * corresponds to the root of the package structure of the source files within. Files can be parsed and written back one
@@ -483,109 +479,40 @@ public class SourceRoot {
     }
 
     /**
-     * Computes the normalized output path under the given newRoot.
-     *
-     * Rules:
-     * - If the cache key is relative, resolve it under newRoot.
-     * - If the key is absolute and under oldRoot, relativize it against oldRoot and then resolve under newRoot.
-     * - If the key is absolute but outside oldRoot, derive a stable relative path:
-     *   use src/main/java/<package>/<PrimaryType>.java when unit is present,
-     *   otherwise use src/main/java/<filename>.
-     *
-     * Visibility: package-private for testability.
-     *
-     * @param newRoot the destination root directory
-     * @param oldRoot the original source root
-     * @param key     the cached path key (may be relative or absolute)
-     * @param unit    the compilation unit if available
-     * @return the resolved and normalized target path under newRoot
+     * Save all previously parsed files back to a new path.
+     * @param root the root of the java packages
+     * @param encoding the encoding to use while saving the file
      */
-
-
-    static Path resolveSavePath(Path newRoot, Path oldRoot, Path key, Optional<CompilationUnit> unit) {
-        // Normalize everything to be robust across platforms.
-        final Path normNewRoot = newRoot.normalize();
-        final Path normOldRoot = oldRoot.normalize();
-        final Path normKey     = key.normalize();
-
-        final Path absOld = normOldRoot.toAbsolutePath();
-        final Path absKey = normKey.toAbsolutePath();
-
-        // On Windows, a path like "\foo\bar" may not be "absolute" but still has a root.
-        final boolean hasRoot  = normKey.getRoot() != null;
-        final boolean underOld = absKey.startsWith(absOld);
-
-        final Path relative;
-        if (underOld) {
-            // Case 1: absolute key under the original root -> re-root by relativizing.
-            relative = absOld.relativize(absKey);
-        } else if (hasRoot) {
-            // Case 2: absolute (has root) but outside old root -> derive a stable relative path.
-            if (unit.isPresent()) {
-                CompilationUnit cu = unit.get();
-
-                // Prefer declared package path; empty string means default package.
-                String pkgPath = cu.getPackageDeclaration()
-                        .map(pd -> pd.getNameAsString().replace('.', '/'))
-                        .orElse("");
-
-                // Derive a sensible type name:
-                // 1) use primary type name if available,
-                // 2) otherwise use the first declared type's name,
-                // 3) finally fall back to "Unknown".
-                String typeName = cu.getPrimaryTypeName()
-                        .orElseGet(() -> cu.getPrimaryType()
-                                .map(t -> t.getNameAsString())
-                                .orElseGet(() -> cu.getTypes().isEmpty()
-                                        ? "Unknown"
-                                        : cu.getType(0).getNameAsString()));
-
-                relative = Paths.get("src/main/java").resolve(pkgPath).resolve(typeName + ".java");
-            } else {
-                // No CU available: at least preserve the filename under src/main/java.
-                relative = Paths.get("src/main/java").resolve(normKey.getFileName());
-            }
-        } else {
-            // Case 3: already relative -> keep as-is under the new root.
-            relative = normKey;
-        }
-
-        // Do not force absolute; tests expect a normalized path anchored at newRoot.
-        return normNewRoot.resolve(relative).normalize();
-    }
-
-
-    /**
-     * Saves all cached compilation units under the specified root directory.
-     *
-     * Path resolution:
-     * - Relative keys are resolved under the provided root.
-     * - Absolute keys under this SourceRoot's old root are relativized before resolving under the new root.
-     * - Absolute keys outside the old root use a stable derived path based on package and primary type name.
-     *
-     * @param root     the destination directory to save all files
-     * @param encoding the character encoding used when writing files
-     * @return this SourceRoot instance
-     */
-
     public SourceRoot saveAll(Path root, Charset encoding) {
         assertNotNull(root);
         Log.info("Saving all files (%s) to %s", cache::size, () -> root);
 
-        final Path oldRoot = getRoot();
-        for (Map.Entry<Path, ParseResult<CompilationUnit>> entry : cache.entrySet()) {
-            final Path key = entry.getKey();
-            final Optional<CompilationUnit> unit = entry.getValue().getResult();
-            final Path target = resolveSavePath(root, oldRoot, key, unit);
-
-            if (unit.isPresent()) {
+        for (Map.Entry<Path, ParseResult<CompilationUnit>> cu : cache.entrySet()) {
+            final Path target = resolveSavePath(root, cu.getKey());
+            if (cu.getValue().getResult().isPresent()) {
                 Log.trace("Saving %s", () -> target);
-                save(unit.get(), target, encoding);
+                save(cu.getValue().getResult().get(), target, encoding);
             }
         }
         return this;
     }
 
+    /**
+     * Computes the target path following Path.resolve semantics.
+     * This refactor-only version preserves current behaviour.
+     *
+     * @param newRoot the destination root directory
+     * @param key     the cached path key (relative or absolute)
+     * @return newRoot.resolve(key) (Path.resolve semantics)
+     */
+    Path resolveSavePath(Path newRoot, Path key) {
+        if (newRoot == null || key == null) {
+            throw new NullPointerException("newRoot/key must not be null");
+        }
+        return key.isAbsolute()
+                ? key.normalize()
+                : newRoot.resolve(key).normalize();
+    }
     /**
      * Save all previously parsed files back to a new path.
      * @param root the root of the java packages


### PR DESCRIPTION
This pull request resolves #4795
 by fixing inconsistent behavior in SourceRoot.saveAll() when handling absolute paths.
Previously, when a CompilationUnit had an absolute storage path, the method ignored the new root and saved the file to its original location.
This update ensures all files, whether relative or absolute  are saved under the specified new root consistently. 


