### PR TITLE
Include source file path in failed ParseResult when parsing via SourceRoot #4786

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParser.java
@@ -225,6 +225,7 @@ public final class JavaParser {
     public ParseResult<CompilationUnit> parse(final Path path) throws IOException {
         ParseResult<CompilationUnit> result =
                 parse(COMPILATION_UNIT, provider(path, configuration.getCharacterEncoding()));
+        result.setSourcePath(path);
         result.getResult().ifPresent(cu -> cu.setStorage(path, configuration.getCharacterEncoding()));
         return result;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -131,7 +131,8 @@ public class SourceRoot {
         final Path path = root.resolve(relativePath);
         Log.trace("Parsing %s", () -> path);
         final ParseResult<CompilationUnit> result = new JavaParser(configuration)
-                .parse(COMPILATION_UNIT, provider(path, configuration.getCharacterEncoding()));
+                .parse(COMPILATION_UNIT, provider(path, configuration.getCharacterEncoding()))
+                .setSourcePath(path);
         result.getResult().ifPresent(cu -> cu.setStorage(path, configuration.getCharacterEncoding()));
         cache.put(relativePath, result);
         return result;
@@ -277,7 +278,8 @@ public class SourceRoot {
         Path localPath = root.relativize(absolutePath);
         Log.trace("Parsing %s", () -> localPath);
         ParseResult<CompilationUnit> result = new JavaParser(configuration)
-                .parse(COMPILATION_UNIT, provider(absolutePath, configuration.getCharacterEncoding()));
+                .parse(COMPILATION_UNIT, provider(absolutePath, configuration.getCharacterEncoding()))
+                .setSourcePath(absolutePath);
         result.getResult().ifPresent(cu -> cu.setStorage(absolutePath, configuration.getCharacterEncoding()));
         switch (callback.process(localPath, absolutePath, result)) {
             case SAVE:

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -20,8 +20,6 @@
  */
 package com.github.javaparser.utils;
 
-import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
-import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.utils.CodeGenerationUtils.*;
 import static com.github.javaparser.utils.Utils.assertNotNull;
 import static java.nio.file.FileVisitResult.*;
@@ -130,10 +128,7 @@ public class SourceRoot {
         }
         final Path path = root.resolve(relativePath);
         Log.trace("Parsing %s", () -> path);
-        final ParseResult<CompilationUnit> result = new JavaParser(configuration)
-                .parse(COMPILATION_UNIT, provider(path, configuration.getCharacterEncoding()))
-                .setSourcePath(path);
-        result.getResult().ifPresent(cu -> cu.setStorage(path, configuration.getCharacterEncoding()));
+        final ParseResult<CompilationUnit> result = new JavaParser(configuration).parse(path);
         cache.put(relativePath, result);
         return result;
     }
@@ -277,10 +272,7 @@ public class SourceRoot {
             throws IOException {
         Path localPath = root.relativize(absolutePath);
         Log.trace("Parsing %s", () -> localPath);
-        ParseResult<CompilationUnit> result = new JavaParser(configuration)
-                .parse(COMPILATION_UNIT, provider(absolutePath, configuration.getCharacterEncoding()))
-                .setSourcePath(absolutePath);
-        result.getResult().ifPresent(cu -> cu.setStorage(absolutePath, configuration.getCharacterEncoding()));
+        ParseResult<CompilationUnit> result = new JavaParser(configuration).parse(absolutePath);
         switch (callback.process(localPath, absolutePath, result)) {
             case SAVE:
                 result.getResult().ifPresent(cu -> save(cu, absolutePath));


### PR DESCRIPTION
Fixes #4786.
Problem: Failed parses from SourceRoot.tryToParse() don’t indicate which file failed (ParseResult has Problems but no file path).
Change: ParseResult now carries an internal sourcePath set by SourceRoot; on failures, ParseResult.toString() includes “for <absolute-path>”. Successful parses still set CompilationUnit storage as before.
Tests: Added issues/Issue4786Test to reproduce the “file content is only ‘\u’” failure and assert diagnostics include the absolute file path.
Compatibility: Backward compatible.