### PR TITLE
Fix #4864: Correct toString() output in ReflectionRecordDeclaration

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
@@ -205,7 +205,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionClassDeclaration{" + "clazz=" + getId() + '}';
+        return getClass().getSimpleName() + "{" + "clazz=" + getId() + '}';
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
@@ -396,4 +396,18 @@ class ReflectionRecordDeclarationTest extends AbstractSymbolResolutionTest {
                 Navigator.findMethodCall(cu.getResult().get(), "value").get();
         assertEquals("java.lang.Integer", valueCall.calculateResolvedType().describe());
     }
+
+    @Test
+    @EnabledForJreRange(min = org.junit.jupiter.api.condition.JRE.JAVA_17)
+    void testToStringShouldUseCorrectClassName() {
+        ReflectionRecordDeclaration decl =
+                (ReflectionRecordDeclaration) typeSolver.solveType("box.Box");
+
+        String result = decl.toString();
+        System.out.println("toString() output = " + result);
+
+        assertTrue(result.contains("ReflectionRecordDeclaration"),
+                "Expected 'ReflectionRecordDeclaration' in toString(), but got: " + result);
+    }
+
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
@@ -400,14 +400,13 @@ class ReflectionRecordDeclarationTest extends AbstractSymbolResolutionTest {
     @Test
     @EnabledForJreRange(min = org.junit.jupiter.api.condition.JRE.JAVA_17)
     void testToStringShouldUseCorrectClassName() {
-        ReflectionRecordDeclaration decl =
-                (ReflectionRecordDeclaration) typeSolver.solveType("box.Box");
+        ReflectionRecordDeclaration decl = (ReflectionRecordDeclaration) typeSolver.solveType("box.Box");
 
         String result = decl.toString();
         System.out.println("toString() output = " + result);
 
-        assertTrue(result.contains("ReflectionRecordDeclaration"),
+        assertTrue(
+                result.contains("ReflectionRecordDeclaration"),
                 "Expected 'ReflectionRecordDeclaration' in toString(), but got: " + result);
     }
-
 }


### PR DESCRIPTION
### Fixes
Fixes #4864  

### Test
- Added a new test case `testToStringShouldUseCorrectClassName()` in `ReflectionRecordDeclarationTest`

### Details
- Use getClass().getSimpleName() to update toString() to print "ReflectionRecordDeclaration" instead of "ReflectionClassDeclaration"
