### PR TITLE
Fix #4864: Correct toString() output in ReflectionRecordDeclaration

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -200,7 +200,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionClassDeclaration{" + "clazz=" + getId() + '}';
+        return getClass().getSimpleName() + "{" + "clazz=" + getId() + '}';
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -114,7 +114,7 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionInterfaceDeclaration{" + "clazz=" + clazz.getCanonicalName() + '}';
+        return getClass().getSimpleName() + "{" + "clazz=" + clazz.getCanonicalName() + '}';
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
@@ -74,7 +74,7 @@ public class ReflectionMethodDeclaration implements ResolvedMethodDeclaration, T
 
     @Override
     public String toString() {
-        return "ReflectionMethodDeclaration{" + "method=" + method + '}';
+        return getClass().getSimpleName() + "{" + "method=" + method + '}';
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionParameterDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionParameterDeclaration.java
@@ -69,7 +69,7 @@ public class ReflectionParameterDeclaration implements ResolvedParameterDeclarat
 
     @Override
     public String toString() {
-        return "ReflectionParameterDeclaration{" + "type=" + type + ", name=" + name + '}';
+        return getClass().getSimpleName() + "{" + "type=" + type + ", name=" + name + '}';
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
@@ -205,7 +205,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionClassDeclaration{" + "clazz=" + getId() + '}';
+        return getClass().getSimpleName() + "{" + "clazz=" + getId() + '}';
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
@@ -118,7 +118,7 @@ public class ReflectionTypeParameter implements ResolvedTypeParameterDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionTypeParameter{" + "typeVariable=" + typeVariable + '}';
+        return getClass().getSimpleName() + "{" + "typeVariable=" + typeVariable + '}';
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4864Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4864Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.reflectionmodel.*;
+import java.lang.reflect.Method;
+import java.lang.reflect.TypeVariable;
+import org.junit.jupiter.api.Test;
+
+public class Issue4864Test {
+    private final TypeSolver typeSolver = null;
+
+    @Test
+    void testReflectionInterfaceDeclarationToString() {
+        ReflectionInterfaceDeclaration decl = new ReflectionInterfaceDeclaration(Runnable.class, typeSolver);
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionInterfaceDeclaration"));
+        assertTrue(output.contains("clazz=java.lang.Runnable"));
+    }
+
+    @Test
+    void testReflectionClassDeclarationToString() {
+        ReflectionClassDeclaration decl = new ReflectionClassDeclaration(String.class, typeSolver);
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionClassDeclaration"));
+        assertTrue(output.contains("clazz="));
+        assertTrue(output.contains("java.lang.String"));
+    }
+
+    @Test
+    void testReflectionParameterDeclarationToString() {
+        ReflectionParameterDeclaration decl =
+                new ReflectionParameterDeclaration(String.class, String.class, typeSolver, false, "param1");
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionParameterDeclaration"));
+        assertTrue(output.contains("type=class java.lang.String"));
+        assertTrue(output.contains("name=param1"));
+    }
+
+    @Test
+    void testReflectionTypeParameterToString() {
+        TypeVariable<Class<Comparable>> typeVar = Comparable.class.getTypeParameters()[0];
+        ReflectionTypeParameter param = new ReflectionTypeParameter(typeVar, true, typeSolver);
+        String output = param.toString();
+
+        assertTrue(output.contains("ReflectionTypeParameter"));
+        assertTrue(output.contains("typeVariable="));
+        assertTrue(output.contains("T"));
+    }
+
+    @Test
+    void testReflectionMethodDeclarationToString() throws NoSuchMethodException {
+        Method method = String.class.getMethod("substring", int.class, int.class);
+        ReflectionMethodDeclaration decl = new ReflectionMethodDeclaration(method, typeSolver);
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionMethodDeclaration"));
+        assertTrue(output.contains("method=public java.lang.String java.lang.String.substring(int,int)"));
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
@@ -396,4 +396,16 @@ class ReflectionRecordDeclarationTest extends AbstractSymbolResolutionTest {
                 Navigator.findMethodCall(cu.getResult().get(), "value").get();
         assertEquals("java.lang.Integer", valueCall.calculateResolvedType().describe());
     }
+
+    @Test
+    @EnabledForJreRange(min = org.junit.jupiter.api.condition.JRE.JAVA_17)
+    void testToStringShouldUseCorrectClassName() {
+        ReflectionRecordDeclaration decl = (ReflectionRecordDeclaration) typeSolver.solveType("box.Box");
+
+        String result = decl.toString();
+
+        assertTrue(
+                result.contains("ReflectionRecordDeclaration"),
+                "Expected 'ReflectionRecordDeclaration' in toString(), but got: " + result);
+    }
 }


### PR DESCRIPTION
### Fixes
Fixes #4864  

### Test
- Added a new test case `testToStringShouldUseCorrectClassName()` in `ReflectionRecordDeclarationTest`

### Details
- Use getClass().getSimpleName() to update toString() to print "ReflectionRecordDeclaration" instead of "ReflectionClassDeclaration"
