### PR TITLE
Refactor comment hierarchy in preparation for MarkdownComments

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentEqualsVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentEqualsVisitorGenerator.java
@@ -48,7 +48,7 @@ public class NoCommentEqualsVisitorGenerator extends VisitorGenerator {
 
         if (!(node.equals(JavaParserMetaModel.lineCommentMetaModel)
                 || node.equals(JavaParserMetaModel.blockCommentMetaModel)
-                || node.equals(JavaParserMetaModel.javadocCommentMetaModel))) {
+                || node.equals(JavaParserMetaModel.traditionalJavadocCommentMetaModel))) {
 
             body.addStatement(f("final %s n2 = (%s) arg;", node.getTypeName(), node.getTypeName()));
 

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
@@ -52,7 +52,7 @@ public class NoCommentHashCodeVisitorGenerator extends VisitorGenerator {
         final List<PropertyMetaModel> propertyMetaModels = node.getAllPropertyMetaModels();
         if (node.equals(JavaParserMetaModel.lineCommentMetaModel)
                 || node.equals(JavaParserMetaModel.blockCommentMetaModel)
-                || node.equals(JavaParserMetaModel.javadocCommentMetaModel)
+                || node.equals(JavaParserMetaModel.traditionalJavadocCommentMetaModel)
                 || propertyMetaModels.isEmpty()) {
             builder.append("0");
         } else {

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/AbstractGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/AbstractGenerator.java
@@ -33,7 +33,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -121,8 +121,8 @@ public abstract class AbstractGenerator {
             // Attempt to retain any existing javadoc.
 
             // TODO: Confirm what is done with normal comments...
-            Optional<JavadocComment> callableJavadocComment = callable.getJavadocComment();
-            Optional<JavadocComment> existingCallableJavadocComment = existingCallable.getJavadocComment();
+            Optional<TraditionalJavadocComment> callableJavadocComment = callable.getJavadocComment();
+            Optional<TraditionalJavadocComment> existingCallableJavadocComment = existingCallable.getJavadocComment();
 
             Optional<Comment> callableComment = callable.getComment();
             Optional<Comment> existingCallableComment = existingCallable.getComment();

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/AbstractGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/AbstractGenerator.java
@@ -33,7 +33,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.TraditionalJavadocComment;
+import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -121,8 +121,8 @@ public abstract class AbstractGenerator {
             // Attempt to retain any existing javadoc.
 
             // TODO: Confirm what is done with normal comments...
-            Optional<TraditionalJavadocComment> callableJavadocComment = callable.getJavadocComment();
-            Optional<TraditionalJavadocComment> existingCallableJavadocComment = existingCallable.getJavadocComment();
+            Optional<JavadocComment> callableJavadocComment = callable.getJavadocComment();
+            Optional<JavadocComment> existingCallableJavadocComment = existingCallable.getJavadocComment();
 
             Optional<Comment> callableComment = callable.getComment();
             Optional<Comment> existingCallableComment = existingCallable.getComment();

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
@@ -108,7 +108,7 @@ public class MetaModelGenerator extends AbstractGenerator {
 
             add(com.github.javaparser.ast.comments.Comment.class); // First, as it is the base of other comment types
             add(com.github.javaparser.ast.comments.BlockComment.class);
-            add(com.github.javaparser.ast.comments.JavadocComment.class);
+            add(com.github.javaparser.ast.comments.TraditionalJavadocComment.class);
             add(com.github.javaparser.ast.comments.LineComment.class);
 
             add(com.github.javaparser.ast.expr.ArrayAccessExpr.class);

--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
@@ -107,6 +107,7 @@ public class MetaModelGenerator extends AbstractGenerator {
             add(com.github.javaparser.ast.body.VariableDeclarator.class);
 
             add(com.github.javaparser.ast.comments.Comment.class); // First, as it is the base of other comment types
+            add(com.github.javaparser.ast.comments.JavadocComment.class);
             add(com.github.javaparser.ast.comments.BlockComment.class);
             add(com.github.javaparser.ast.comments.TraditionalJavadocComment.class);
             add(com.github.javaparser.ast.comments.LineComment.class);

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
@@ -139,8 +139,7 @@ public class CommentParsingSteps {
 
     @Then("Javadoc comment $position is \"$expectedContent\"")
     public void thenJavadocCommentIs(int position, String expectedContent) {
-        TraditionalJavadocComment commentUnderTest =
-                getCommentAt(commentsCollection.getJavadocComments(), position - 1);
+        JavadocComment commentUnderTest = getCommentAt(commentsCollection.getJavadocComments(), position - 1);
 
         assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/CommentParsingSteps.java
@@ -139,7 +139,8 @@ public class CommentParsingSteps {
 
     @Then("Javadoc comment $position is \"$expectedContent\"")
     public void thenJavadocCommentIs(int position, String expectedContent) {
-        JavadocComment commentUnderTest = getCommentAt(commentsCollection.getJavadocComments(), position - 1);
+        TraditionalJavadocComment commentUnderTest =
+                getCommentAt(commentsCollection.getJavadocComments(), position - 1);
 
         assertThat(commentUnderTest.getContent(), is(equalToCompressingWhiteSpace(expectedContent)));
     }

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ExistenceOfParentNodeVerifier.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/steps/ExistenceOfParentNodeVerifier.java
@@ -32,8 +32,8 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
@@ -280,7 +280,7 @@ class ExistenceOfParentNodeVerifier {
         }
 
         @Override
-        public void visit(JavadocComment n, Void arg) {
+        public void visit(TraditionalJavadocComment n, Void arg) {
             super.visit(n, arg);
         }
 

--- a/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/visitors/PositionTestVisitor.java
+++ b/javaparser-core-testing-bdd/src/test/java/com/github/javaparser/visitors/PositionTestVisitor.java
@@ -33,8 +33,8 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
@@ -294,7 +294,7 @@ public class PositionTestVisitor extends VoidVisitorAdapter<Object> {
     }
 
     @Override
-    public void visit(final JavadocComment n, final Object arg) {
+    public void visit(final TraditionalJavadocComment n, final Object arg) {
         doTest(n);
         super.visit(n, arg);
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -35,8 +35,8 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -86,7 +86,7 @@ class NodeTest {
     @Test
     void hasJavaDocCommentPositiveCaseWithSetComment() {
         ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration(new NodeList<>(), false, "Foo");
-        decl.setComment(new JavadocComment("A comment"));
+        decl.setComment(new TraditionalJavadocComment("A comment"));
         assertTrue(decl.hasJavaDocComment());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadocTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadocTest.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import org.junit.jupiter.api.Test;
 
 class NodeWithJavadocTest {
@@ -50,7 +50,7 @@ class NodeWithJavadocTest {
     @Test
     void removeJavaDocPositiveCase() {
         ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration(new NodeList<>(), false, "Foo");
-        decl.setComment(new JavadocComment("A comment"));
+        decl.setComment(new TraditionalJavadocComment("A comment"));
         assertTrue(decl.removeJavaDocComment());
         assertFalse(decl.getComment().isPresent());
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapterTest.java
@@ -28,8 +28,8 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -1133,7 +1133,7 @@ class GenericListVisitorAdapterTest {
     void visit_GivenJavadocComment() {
         // Given
         Object argument = mock(Object.class);
-        JavadocComment node = mock(JavadocComment.class);
+        TraditionalJavadocComment node = mock(TraditionalJavadocComment.class);
 
         // When
         Mockito.when(node.getComment()).thenReturn(Optional.of(mock(Comment.class)));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/GenericVisitorAdapterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/GenericVisitorAdapterTest.java
@@ -28,8 +28,8 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -1131,7 +1131,7 @@ public class GenericVisitorAdapterTest {
     void visit_GivenJavadocComment() {
         // Given
         Object argument = mock(Object.class);
-        JavadocComment node = mock(JavadocComment.class);
+        TraditionalJavadocComment node = mock(TraditionalJavadocComment.class);
 
         // When
         Mockito.when(node.getComment()).thenReturn(Optional.of(mock(Comment.class)));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaultsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaultsTest.java
@@ -29,8 +29,8 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -364,7 +364,7 @@ class GenericVisitorWithDefaultsTest {
 
     @Test
     void testThatVisitWithJavadocCommentAsParameterCallDefaultAction() {
-        Node node = visitor.visit(mock(JavadocComment.class), argument);
+        Node node = visitor.visit(mock(TraditionalJavadocComment.class), argument);
         assertNodeVisitDefaultAction(node);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
@@ -30,8 +30,8 @@ import static org.mockito.Mockito.*;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -468,7 +468,7 @@ class HashCodeVisitorTest {
 
     @Test
     void testVisitJavadocComment() {
-        JavadocComment node = spy(new JavadocComment());
+        TraditionalJavadocComment node = spy(new TraditionalJavadocComment());
         HashCodeVisitor.hashCode(node);
         verify(node, times(1)).getContent();
         verify(node, times(1)).getComment();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
@@ -30,8 +30,8 @@ import static org.mockito.Mockito.*;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -65,7 +65,7 @@ class NoCommentHashCodeVisitorTest {
 
     @Test
     void testJavadocCommentDoesNotHaveHashCode() {
-        JavadocComment node = spy(new JavadocComment());
+        TraditionalJavadocComment node = spy(new TraditionalJavadocComment());
         assertEquals(0, NoCommentHashCodeVisitor.hashCode(node));
 
         verify(node).accept(isA(NoCommentHashCodeVisitor.class), isNull());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitorTest.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -180,8 +180,8 @@ class ObjectIdentityEqualsVisitorTest {
 
     @Test
     void equals_GivenJavadocComment() {
-        Node nodeA = new JavadocComment();
-        Node nodeB = new JavadocComment();
+        Node nodeA = new TraditionalJavadocComment();
+        Node nodeB = new TraditionalJavadocComment();
 
         Assertions.assertTrue(ObjectIdentityEqualsVisitor.equals(nodeA, nodeA));
         Assertions.assertFalse(ObjectIdentityEqualsVisitor.equals(nodeA, nodeB));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitorTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.spy;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -294,7 +294,7 @@ class ObjectIdentityHashCodeVisitorTest {
 
     @Test
     void testVisitJavadocComment() {
-        JavadocComment node = spy(new JavadocComment());
+        TraditionalJavadocComment node = spy(new TraditionalJavadocComment());
         assertEquals(node.hashCode(), ObjectIdentityHashCodeVisitor.hashCode(node));
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaultsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaultsTest.java
@@ -28,8 +28,8 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -362,7 +362,7 @@ class VoidVisitorWithDefaultsTest {
 
     @Test
     void testThatVisitWithJavadocCommentAsParameterCallDefaultAction() {
-        visitor.visit(mock(JavadocComment.class), argument);
+        visitor.visit(mock(TraditionalJavadocComment.class), argument);
         assertNodeVisitDefaultAction();
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
@@ -25,7 +25,7 @@ import static com.github.javaparser.StaticJavaParser.parse;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -43,7 +43,7 @@ class JavadocExtractorTest {
             CompilationUnit cu = parse(file);
             new VoidVisitorAdapter<Object>() {
                 @Override
-                public void visit(JavadocComment n, Object arg) {
+                public void visit(TraditionalJavadocComment n, Object arg) {
                     super.visit(n, arg);
                     n.parse();
                 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.javadoc.description.JavadocDescriptionElement;
 import com.github.javaparser.javadoc.description.JavadocInlineTag;
@@ -67,7 +67,7 @@ class JavadocTest {
     @Test
     void toCommentForEmptyJavadoc() {
         Javadoc javadoc = new Javadoc(new JavadocDescription());
-        assertEquals(new JavadocComment("" + LineSeparator.SYSTEM + "\t\t "), javadoc.toComment("\t\t"));
+        assertEquals(new TraditionalJavadocComment("" + LineSeparator.SYSTEM + "\t\t "), javadoc.toComment("\t\t"));
     }
 
     @Test
@@ -75,7 +75,7 @@ class JavadocTest {
         Javadoc javadoc =
                 new Javadoc(JavadocDescription.parseText("first line" + LineSeparator.SYSTEM + "second line"));
         assertEquals(
-                new JavadocComment("" + LineSeparator.SYSTEM + "\t\t * first line" + LineSeparator.SYSTEM
+                new TraditionalJavadocComment("" + LineSeparator.SYSTEM + "\t\t * first line" + LineSeparator.SYSTEM
                         + "\t\t * second line" + LineSeparator.SYSTEM + "\t\t "),
                 javadoc.toComment("\t\t"));
     }
@@ -86,7 +86,7 @@ class JavadocTest {
                 new Javadoc(JavadocDescription.parseText("first line" + LineSeparator.SYSTEM + "second line"));
         javadoc.addBlockTag("foo", "something useful");
         assertEquals(
-                new JavadocComment("" + LineSeparator.SYSTEM + "\t\t * first line" + LineSeparator.SYSTEM
+                new TraditionalJavadocComment("" + LineSeparator.SYSTEM + "\t\t * first line" + LineSeparator.SYSTEM
                         + "\t\t * second line" + LineSeparator.SYSTEM + "\t\t * " + LineSeparator.SYSTEM
                         + "\t\t * @foo something useful" + LineSeparator.SYSTEM + "\t\t "),
                 javadoc.toComment("\t\t"));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
@@ -75,6 +75,7 @@ class YamlPrinterTest {
         YamlPrinter yamlPrinter = new YamlPrinter(true);
         CompilationUnit computationUnit = parse(code);
         String output = yamlPrinter.output(computationUnit);
-        assertEqualsStringIgnoringEol(read("yamlParsingJavadocWithQuoteAndNewline.yaml"), output);
+        assertEqualsStringIgnoringEol(
+                read("yamlParsingJavadocWithQuoteAndNewline.yaml").trim(), output);
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceElementCalculatorTest.java
@@ -34,7 +34,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.*;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -216,7 +216,7 @@ class DifferenceElementCalculatorTest extends AbstractLexicalPreservingTest {
         considerExample("AnnotationDeclaration_Example3_original");
         AnnotationDeclaration annotationDeclaration = (AnnotationDeclaration) cu.getType(0);
         CsmElement element = ConcreteSyntaxModel.forClass(annotationDeclaration.getClass());
-        JavadocComment comment = new JavadocComment("Cool this annotation!");
+        TraditionalJavadocComment comment = new TraditionalJavadocComment("Cool this annotation!");
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmOriginal =
                 new LexicalDifferenceCalculator().calculatedSyntaxModelForNode(element, annotationDeclaration);
         LexicalDifferenceCalculator.CalculatedSyntaxModel csmChanged = new LexicalDifferenceCalculator()

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculatorTest.java
@@ -37,7 +37,7 @@ import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -226,7 +226,7 @@ class LexicalDifferenceCalculatorTest extends AbstractLexicalPreservingTest {
         considerExample("AnnotationDeclaration_Example3_original");
         AnnotationDeclaration annotationDeclaration = (AnnotationDeclaration) cu.getType(0);
         CsmElement element = ConcreteSyntaxModel.forClass(annotationDeclaration.getClass());
-        JavadocComment comment = new JavadocComment("Cool this annotation!");
+        TraditionalJavadocComment comment = new TraditionalJavadocComment("Cool this annotation!");
         LexicalDifferenceCalculator.CalculatedSyntaxModel csm = new LexicalDifferenceCalculator()
                 .calculatedSyntaxModelAfterPropertyChange(
                         element, annotationDeclaration, ObservableProperty.COMMENT, null, comment);

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/printer/PrettyPrintVisitor_prettyprinted
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/printer/PrettyPrintVisitor_prettyprinted
@@ -24,7 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/printer/PrettyPrintVisitor_prettyprinted
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/printer/PrettyPrintVisitor_prettyprinted
@@ -24,7 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.TraditionalJavadocComment;
+import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeArguments;

--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/printer/yamlParsingJavadocWithQuoteAndNewline.yaml
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/printer/yamlParsingJavadocWithQuoteAndNewline.yaml
@@ -5,7 +5,7 @@ root(Type=CompilationUnit):
             isInterface: "false"
             name(Type=SimpleName): 
                 identifier: "Dog"
-            comment(Type=JavadocComment): 
+            comment(Type=TraditionalJavadocComment): 
                 content: "\n * \" this comment contains a quote and newlines\n "
             modifiers: 
                 - modifier(Type=Modifier): 

--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -22,7 +22,7 @@ package com.github.javaparser;
 
 import static com.github.javaparser.utils.Utils.*;
 
-import com.github.javaparser.ast.comments.TraditionalJavadocComment;
+import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.github.javaparser.javadoc.description.JavadocDescription;
@@ -43,7 +43,7 @@ class JavadocParser {
 
     private static Pattern BLOCK_PATTERN = Pattern.compile("^\\s*" + BLOCK_TAG_PREFIX, Pattern.MULTILINE);
 
-    public static Javadoc parse(TraditionalJavadocComment comment) {
+    public static Javadoc parse(JavadocComment comment) {
         return parse(comment.getContent());
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -22,7 +22,7 @@ package com.github.javaparser;
 
 import static com.github.javaparser.utils.Utils.*;
 
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.github.javaparser.javadoc.description.JavadocDescription;
@@ -43,7 +43,7 @@ class JavadocParser {
 
     private static Pattern BLOCK_PATTERN = Pattern.compile("^\\s*" + BLOCK_TAG_PREFIX, Pattern.MULTILINE);
 
-    public static Javadoc parse(JavadocComment comment) {
+    public static Javadoc parse(TraditionalJavadocComment comment) {
         return parse(comment.getContent());
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/CompilationUnit.java
@@ -32,7 +32,7 @@ import static com.github.javaparser.utils.Utils.assertNotNull;
 import com.github.javaparser.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.modules.ModuleDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
@@ -193,7 +193,7 @@ public class CompilationUnit extends Node {
      * If there is no comment, an empty list is returned.
      *
      * @return list with all comments of this compilation unit.
-     * @see JavadocComment
+     * @see TraditionalJavadocComment
      * @see com.github.javaparser.ast.comments.LineComment
      * @see com.github.javaparser.ast.comments.BlockComment
      */

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -41,7 +41,7 @@ import java.util.function.Consumer;
  * @author Julio Vilmar Gesser
  * @see BlockComment
  * @see LineComment
- * @see JavadocComment
+ * @see TraditionalJavadocComment
  */
 public abstract class Comment extends Node {
 
@@ -187,21 +187,22 @@ public abstract class Comment extends Node {
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public boolean isJavadocComment() {
+    public boolean isTraditionalJavadocComment() {
         return false;
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public JavadocComment asJavadocComment() {
-        throw new IllegalStateException(
-                f("%s is not JavadocComment, it is %s", this, this.getClass().getSimpleName()));
+    public TraditionalJavadocComment asTraditionalJavadocComment() {
+        throw new IllegalStateException(f(
+                "%s is not TraditionalJavadocComment, it is %s",
+                this, this.getClass().getSimpleName()));
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifBlockComment(Consumer<BlockComment> action) {}
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public void ifJavadocComment(Consumer<JavadocComment> action) {}
+    public void ifTraditionalJavadocComment(Consumer<TraditionalJavadocComment> action) {}
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifLineComment(Consumer<LineComment> action) {}
@@ -212,7 +213,7 @@ public abstract class Comment extends Node {
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public Optional<JavadocComment> toJavadocComment() {
+    public Optional<TraditionalJavadocComment> toTraditionalJavadocComment() {
         return Optional.empty();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -187,22 +187,21 @@ public abstract class Comment extends Node {
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public boolean isTraditionalJavadocComment() {
+    public boolean isJavadocComment() {
         return false;
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public TraditionalJavadocComment asTraditionalJavadocComment() {
-        throw new IllegalStateException(f(
-                "%s is not TraditionalJavadocComment, it is %s",
-                this, this.getClass().getSimpleName()));
+    public JavadocComment asJavadocComment() {
+        throw new IllegalStateException(
+                f("%s is not JavadocComment, it is %s", this, this.getClass().getSimpleName()));
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifBlockComment(Consumer<BlockComment> action) {}
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public void ifTraditionalJavadocComment(Consumer<TraditionalJavadocComment> action) {}
+    public void ifJavadocComment(Consumer<JavadocComment> action) {}
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public void ifLineComment(Consumer<LineComment> action) {}
@@ -213,7 +212,7 @@ public abstract class Comment extends Node {
     }
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public Optional<TraditionalJavadocComment> toTraditionalJavadocComment() {
+    public Optional<JavadocComment> toJavadocComment() {
         return Optional.empty();
     }
 
@@ -238,4 +237,24 @@ public abstract class Comment extends Node {
     public String asString() {
         return getHeader() + getContent() + getFooter();
     }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public boolean isTraditionalJavadocComment() {
+        return false;
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public TraditionalJavadocComment asTraditionalJavadocComment() {
+        throw new IllegalStateException(f(
+                "%s is not TraditionalJavadocComment, it is %s",
+                this, this.getClass().getSimpleName()));
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public Optional<TraditionalJavadocComment> toTraditionalJavadocComment() {
+        return Optional.empty();
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public void ifTraditionalJavadocComment(Consumer<TraditionalJavadocComment> action) {}
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsCollection.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsCollection.java
@@ -55,10 +55,10 @@ public class CommentsCollection {
                 .collect(Collectors.toCollection(() -> new TreeSet<>(NODE_BY_BEGIN_POSITION)));
     }
 
-    public Set<TraditionalJavadocComment> getJavadocComments() {
+    public Set<JavadocComment> getJavadocComments() {
         return comments.stream()
-                .filter(comment -> comment instanceof TraditionalJavadocComment)
-                .map(comment -> (TraditionalJavadocComment) comment)
+                .filter(comment -> comment instanceof JavadocComment)
+                .map(comment -> (JavadocComment) comment)
                 .collect(Collectors.toCollection(() -> new TreeSet<>(NODE_BY_BEGIN_POSITION)));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsCollection.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/CommentsCollection.java
@@ -55,10 +55,10 @@ public class CommentsCollection {
                 .collect(Collectors.toCollection(() -> new TreeSet<>(NODE_BY_BEGIN_POSITION)));
     }
 
-    public Set<JavadocComment> getJavadocComments() {
+    public Set<TraditionalJavadocComment> getJavadocComments() {
         return comments.stream()
-                .filter(comment -> comment instanceof JavadocComment)
-                .map(comment -> (JavadocComment) comment)
+                .filter(comment -> comment instanceof TraditionalJavadocComment)
+                .map(comment -> (TraditionalJavadocComment) comment)
                 .collect(Collectors.toCollection(() -> new TreeSet<>(NODE_BY_BEGIN_POSITION)));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
- * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
  *
  * This file is part of JavaParser.
  *
@@ -26,27 +26,20 @@ import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.AllFieldsConstructor;
 import com.github.javaparser.ast.Generated;
 import com.github.javaparser.ast.visitor.CloneVisitor;
-import com.github.javaparser.ast.visitor.GenericVisitor;
-import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.metamodel.TraditionalJavadocCommentMetaModel;
+import com.github.javaparser.metamodel.JavadocCommentMetaModel;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-/**
- * A Javadoc comment. {@code /∗∗ a comment ∗/}
- *
- * @author Julio Vilmar Gesser
- */
-public class TraditionalJavadocComment extends JavadocComment {
+public abstract class JavadocComment extends Comment {
 
-    public TraditionalJavadocComment() {
+    public JavadocComment() {
         this(null, "empty");
     }
 
     @AllFieldsConstructor
-    public TraditionalJavadocComment(String content) {
+    public JavadocComment(String content) {
         this(null, content);
     }
 
@@ -54,71 +47,48 @@ public class TraditionalJavadocComment extends JavadocComment {
      * This constructor is used by the parser and is considered private.
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public TraditionalJavadocComment(TokenRange tokenRange, String content) {
+    public JavadocComment(TokenRange tokenRange, String content) {
         super(tokenRange, content);
         customInitialization();
     }
 
     @Override
-    @Generated("com.github.javaparser.generator.core.node.AcceptGenerator")
-    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
-        return v.visit(this, arg);
-    }
-
-    @Override
-    @Generated("com.github.javaparser.generator.core.node.AcceptGenerator")
-    public <A> void accept(final VoidVisitor<A> v, final A arg) {
-        v.visit(this, arg);
-    }
-
-    @Override
-    public Javadoc parse() {
-        return parseJavadoc(getContent());
-    }
-
-    @Override
-    @Generated("com.github.javaparser.generator.core.node.CloneGenerator")
-    public TraditionalJavadocComment clone() {
-        return (TraditionalJavadocComment) accept(new CloneVisitor(), null);
-    }
-
-    @Override
-    @Generated("com.github.javaparser.generator.core.node.GetMetaModelGenerator")
-    public TraditionalJavadocCommentMetaModel getMetaModel() {
-        return JavaParserMetaModel.traditionalJavadocCommentMetaModel;
-    }
-
-    @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public boolean isTraditionalJavadocComment() {
+    public boolean isJavadocComment() {
         return true;
     }
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public TraditionalJavadocComment asTraditionalJavadocComment() {
+    public JavadocComment asJavadocComment() {
         return this;
     }
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public void ifTraditionalJavadocComment(Consumer<TraditionalJavadocComment> action) {
-        action.accept(this);
-    }
-
-    @Override
-    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public Optional<TraditionalJavadocComment> toTraditionalJavadocComment() {
+    public Optional<JavadocComment> toJavadocComment() {
         return Optional.of(this);
     }
 
     @Override
-    public String getHeader() {
-        return "/**";
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public void ifJavadocComment(Consumer<JavadocComment> action) {
+        action.accept(this);
     }
 
     @Override
-    public String getFooter() {
-        return "*/";
+    @Generated("com.github.javaparser.generator.core.node.CloneGenerator")
+    public JavadocComment clone() {
+        return (JavadocComment) accept(new CloneVisitor(), null);
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.GetMetaModelGenerator")
+    public JavadocCommentMetaModel getMetaModel() {
+        return JavaParserMetaModel.javadocCommentMetaModel;
+    }
+
+    public Javadoc parse() {
+        return parseJavadoc(getContent());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/TraditionalJavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/TraditionalJavadocComment.java
@@ -30,7 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
-import com.github.javaparser.metamodel.JavadocCommentMetaModel;
+import com.github.javaparser.metamodel.TraditionalJavadocCommentMetaModel;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -39,14 +39,14 @@ import java.util.function.Consumer;
  *
  * @author Julio Vilmar Gesser
  */
-public class JavadocComment extends Comment {
+public class TraditionalJavadocComment extends Comment {
 
-    public JavadocComment() {
+    public TraditionalJavadocComment() {
         this(null, "empty");
     }
 
     @AllFieldsConstructor
-    public JavadocComment(String content) {
+    public TraditionalJavadocComment(String content) {
         this(null, content);
     }
 
@@ -54,7 +54,7 @@ public class JavadocComment extends Comment {
      * This constructor is used by the parser and is considered private.
      */
     @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
-    public JavadocComment(TokenRange tokenRange, String content) {
+    public TraditionalJavadocComment(TokenRange tokenRange, String content) {
         super(tokenRange, content);
         customInitialization();
     }
@@ -77,37 +77,37 @@ public class JavadocComment extends Comment {
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.CloneGenerator")
-    public JavadocComment clone() {
-        return (JavadocComment) accept(new CloneVisitor(), null);
+    public TraditionalJavadocComment clone() {
+        return (TraditionalJavadocComment) accept(new CloneVisitor(), null);
     }
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.GetMetaModelGenerator")
-    public JavadocCommentMetaModel getMetaModel() {
-        return JavaParserMetaModel.javadocCommentMetaModel;
+    public TraditionalJavadocCommentMetaModel getMetaModel() {
+        return JavaParserMetaModel.traditionalJavadocCommentMetaModel;
     }
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public boolean isJavadocComment() {
+    public boolean isTraditionalJavadocComment() {
         return true;
     }
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public JavadocComment asJavadocComment() {
+    public TraditionalJavadocComment asTraditionalJavadocComment() {
         return this;
     }
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public void ifJavadocComment(Consumer<JavadocComment> action) {
+    public void ifTraditionalJavadocComment(Consumer<TraditionalJavadocComment> action) {
         action.accept(this);
     }
 
     @Override
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
-    public Optional<JavadocComment> toJavadocComment() {
+    public Optional<TraditionalJavadocComment> toTraditionalJavadocComment() {
         return Optional.of(this);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
@@ -22,7 +22,7 @@ package com.github.javaparser.ast.nodeTypes;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.Javadoc;
 import java.util.Optional;
 
@@ -41,9 +41,10 @@ public interface NodeWithJavadoc<N extends Node> {
      *
      * @return The JavadocComment for this node wrapped in an optional as it may be absent.
      */
-    default Optional<JavadocComment> getJavadocComment() {
-        return getComment().filter(comment -> comment instanceof JavadocComment).map(comment ->
-                (JavadocComment) comment);
+    default Optional<TraditionalJavadocComment> getJavadocComment() {
+        return getComment()
+                .filter(comment -> comment instanceof TraditionalJavadocComment)
+                .map(comment -> (TraditionalJavadocComment) comment);
     }
 
     /**
@@ -52,7 +53,7 @@ public interface NodeWithJavadoc<N extends Node> {
      * @return The Javadoc for this node wrapped in an optional as it may be absent.
      */
     default Optional<Javadoc> getJavadoc() {
-        return getJavadocComment().map(JavadocComment::parse);
+        return getJavadocComment().map(TraditionalJavadocComment::parse);
     }
 
     /**
@@ -62,10 +63,10 @@ public interface NodeWithJavadoc<N extends Node> {
      */
     @SuppressWarnings("unchecked")
     default N setJavadocComment(String comment) {
-        return setJavadocComment(new JavadocComment(comment));
+        return setJavadocComment(new TraditionalJavadocComment(comment));
     }
 
-    default N setJavadocComment(JavadocComment comment) {
+    default N setJavadocComment(TraditionalJavadocComment comment) {
         setComment(comment);
         return (N) this;
     }
@@ -83,6 +84,6 @@ public interface NodeWithJavadoc<N extends Node> {
     }
 
     default boolean hasJavaDocComment() {
-        return getComment().isPresent() && getComment().get() instanceof JavadocComment;
+        return getComment().isPresent() && getComment().get() instanceof TraditionalJavadocComment;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast.nodeTypes;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.comments.Comment;
+import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.Javadoc;
 import java.util.Optional;
@@ -41,10 +42,9 @@ public interface NodeWithJavadoc<N extends Node> {
      *
      * @return The JavadocComment for this node wrapped in an optional as it may be absent.
      */
-    default Optional<TraditionalJavadocComment> getJavadocComment() {
-        return getComment()
-                .filter(comment -> comment instanceof TraditionalJavadocComment)
-                .map(comment -> (TraditionalJavadocComment) comment);
+    default Optional<JavadocComment> getJavadocComment() {
+        return getComment().filter(comment -> comment instanceof JavadocComment).map(comment ->
+                (JavadocComment) comment);
     }
 
     /**
@@ -53,20 +53,17 @@ public interface NodeWithJavadoc<N extends Node> {
      * @return The Javadoc for this node wrapped in an optional as it may be absent.
      */
     default Optional<Javadoc> getJavadoc() {
-        return getJavadocComment().map(TraditionalJavadocComment::parse);
+        return getJavadocComment().map(JavadocComment::parse);
     }
 
     /**
-     * Use this to store additional information to this node.
-     *
-     * @param comment to be set
+     * Set a JavadocComment for this node
      */
-    @SuppressWarnings("unchecked")
     default N setJavadocComment(String comment) {
         return setJavadocComment(new TraditionalJavadocComment(comment));
     }
 
-    default N setJavadocComment(TraditionalJavadocComment comment) {
+    default N setJavadocComment(JavadocComment comment) {
         setComment(comment);
         return (N) this;
     }
@@ -84,6 +81,6 @@ public interface NodeWithJavadoc<N extends Node> {
     }
 
     default boolean hasJavaDocComment() {
-        return getComment().isPresent() && getComment().get() instanceof TraditionalJavadocComment;
+        return getComment().isPresent() && getComment().get() instanceof JavadocComment;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -24,8 +24,8 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -302,9 +302,10 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
     }
 
     @Override
-    public Visitable visit(final JavadocComment n, final Object arg) {
+    public Visitable visit(final TraditionalJavadocComment n, final Object arg) {
         Comment comment = cloneNode(n.getComment(), arg);
-        JavadocComment r = new JavadocComment(n.getTokenRange().orElse(null), n.getContent());
+        TraditionalJavadocComment r =
+                new TraditionalJavadocComment(n.getTokenRange().orElse(null), n.getContent());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
         copyData(n, r);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -314,8 +314,8 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     }
 
     @Override
-    public Boolean visit(final JavadocComment n, final Visitable arg) {
-        final JavadocComment n2 = (JavadocComment) arg;
+    public Boolean visit(final TraditionalJavadocComment n, final Visitable arg) {
+        final TraditionalJavadocComment n2 = (TraditionalJavadocComment) arg;
         if (!objEquals(n.getContent(), n2.getContent())) return false;
         if (!nodeEquals(n.getComment(), n2.getComment())) return false;
         return true;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -910,7 +910,7 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
     }
 
     @Override
-    public List<R> visit(final JavadocComment n, final A arg) {
+    public List<R> visit(final TraditionalJavadocComment n, final A arg) {
         List<R> result = new ArrayList<>();
         List<R> tmp;
         if (n.getComment().isPresent()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -75,7 +75,7 @@ public interface GenericVisitor<R, A> {
 
     R visit(InitializerDeclaration n, A arg);
 
-    R visit(JavadocComment n, A arg);
+    R visit(TraditionalJavadocComment n, A arg);
 
     // - Type ----------------------------------------------
     R visit(ClassOrInterfaceType n, A arg);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -786,7 +786,7 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     }
 
     @Override
-    public R visit(final JavadocComment n, final A arg) {
+    public R visit(final TraditionalJavadocComment n, final A arg) {
         R result;
         if (n.getComment().isPresent()) {
             result = n.getComment().get().accept(this, arg);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaults.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaults.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -236,7 +236,7 @@ public abstract class GenericVisitorWithDefaults<R, A> implements GenericVisitor
     }
 
     @Override
-    public R visit(final JavadocComment n, final A arg) {
+    public R visit(final TraditionalJavadocComment n, final A arg) {
         return defaultAction(n, arg);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -334,7 +334,7 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
                 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
     }
 
-    public Integer visit(final JavadocComment n, final Void arg) {
+    public Integer visit(final TraditionalJavadocComment n, final Void arg) {
         return (n.getContent().hashCode()) * 31
                 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -27,8 +27,8 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -590,7 +590,7 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
     }
 
     @Override
-    public Visitable visit(final JavadocComment n, final A arg) {
+    public Visitable visit(final TraditionalJavadocComment n, final A arg) {
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
         return n;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -252,7 +252,7 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     }
 
     @Override
-    public Boolean visit(final JavadocComment n, final Visitable arg) {
+    public Boolean visit(final TraditionalJavadocComment n, final Visitable arg) {
         return true;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -280,7 +280,7 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
         return (n.getElements().accept(this, arg)) * 31 + (n.getAnnotations().accept(this, arg));
     }
 
-    public Integer visit(final JavadocComment n, final Void arg) {
+    public Integer visit(final TraditionalJavadocComment n, final Void arg) {
         return 0;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NodeFinderVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NodeFinderVisitor.java
@@ -42,8 +42,8 @@ import com.github.javaparser.ast.body.ReceiverParameter;
 import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.ArrayAccessExpr;
 import com.github.javaparser.ast.expr.ArrayCreationExpr;
 import com.github.javaparser.ast.expr.ArrayInitializerExpr;
@@ -971,7 +971,7 @@ public class NodeFinderVisitor extends VoidVisitorAdapter<Range> {
     }
 
     @Override
-    public void visit(final JavadocComment n, final Range arg) {
+    public void visit(final TraditionalJavadocComment n, final Range arg) {
         if (n.getComment().isPresent()) {
             n.getComment().get().accept(this, arg);
             if (selectedNode != null) return;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -124,7 +124,7 @@ public class ObjectIdentityEqualsVisitor implements GenericVisitor<Boolean, Visi
     }
 
     @Override
-    public Boolean visit(final JavadocComment n, final Visitable arg) {
+    public Boolean visit(final TraditionalJavadocComment n, final Visitable arg) {
         return n == arg;
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -210,7 +210,7 @@ public class ObjectIdentityHashCodeVisitor implements GenericVisitor<Integer, Vo
         return n.hashCode();
     }
 
-    public Integer visit(final JavadocComment n, final Void arg) {
+    public Integer visit(final TraditionalJavadocComment n, final Void arg) {
         return n.hashCode();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -123,7 +123,7 @@ public interface VoidVisitor<A> {
 
     void visit(IntersectionType n, A arg);
 
-    void visit(JavadocComment n, A arg);
+    void visit(TraditionalJavadocComment n, A arg);
 
     void visit(LabeledStmt n, A arg);
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -323,7 +323,7 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     }
 
     @Override
-    public void visit(final JavadocComment n, final A arg) {
+    public void visit(final TraditionalJavadocComment n, final A arg) {
         n.getComment().ifPresent(l -> l.accept(this, arg));
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaults.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaults.java
@@ -23,8 +23,8 @@ package com.github.javaparser.ast.visitor;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -237,7 +237,7 @@ public abstract class VoidVisitorWithDefaults<A> implements VoidVisitor<A> {
     }
 
     @Override
-    public void visit(final JavadocComment n, final A arg) {
+    public void visit(final TraditionalJavadocComment n, final A arg) {
         defaultAction(n, arg);
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
@@ -20,6 +20,7 @@
  */
 package com.github.javaparser.javadoc;
 
+import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.utils.LineSeparator;
@@ -96,14 +97,14 @@ public class Javadoc {
     /**
      * Create a JavadocComment, by formatting the text of the Javadoc using no indentation (expecting the pretty printer to do the formatting.)
      */
-    public TraditionalJavadocComment toComment() {
+    public JavadocComment toComment() {
         return toComment("");
     }
 
     /**
      * Create a JavadocComment, by formatting the text of the Javadoc using the given indentation.
      */
-    public TraditionalJavadocComment toComment(String indentation) {
+    public JavadocComment toComment(String indentation) {
         for (char c : indentation.toCharArray()) {
             if (!Character.isWhitespace(c)) {
                 throw new IllegalArgumentException(

--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
@@ -20,7 +20,7 @@
  */
 package com.github.javaparser.javadoc;
 
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.utils.LineSeparator;
 import java.util.LinkedList;
@@ -96,14 +96,14 @@ public class Javadoc {
     /**
      * Create a JavadocComment, by formatting the text of the Javadoc using no indentation (expecting the pretty printer to do the formatting.)
      */
-    public JavadocComment toComment() {
+    public TraditionalJavadocComment toComment() {
         return toComment("");
     }
 
     /**
      * Create a JavadocComment, by formatting the text of the Javadoc using the given indentation.
      */
-    public JavadocComment toComment(String indentation) {
+    public TraditionalJavadocComment toComment(String indentation) {
         for (char c : indentation.toCharArray()) {
             if (!Character.isWhitespace(c)) {
                 throw new IllegalArgumentException(
@@ -123,7 +123,7 @@ public class Javadoc {
         }
         sb.append(indentation);
         sb.append(" ");
-        return new JavadocComment(sb.toString());
+        return new TraditionalJavadocComment(sb.toString());
     }
 
     public JavadocDescription getDescription() {

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -278,6 +278,7 @@ public final class JavaParserMetaModel {
                 .getConstructorParameters()
                 .add(variableDeclaratorMetaModel.initializerPropertyMetaModel);
         commentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
+        javadocCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         blockCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         traditionalJavadocCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         lineCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
@@ -563,6 +564,7 @@ public final class JavaParserMetaModel {
         nodeMetaModels.add(instanceOfExprMetaModel);
         nodeMetaModels.add(integerLiteralExprMetaModel);
         nodeMetaModels.add(intersectionTypeMetaModel);
+        nodeMetaModels.add(javadocCommentMetaModel);
         nodeMetaModels.add(labeledStmtMetaModel);
         nodeMetaModels.add(lambdaExprMetaModel);
         nodeMetaModels.add(lineCommentMetaModel);
@@ -3110,12 +3112,16 @@ public final class JavaParserMetaModel {
     public static final CommentMetaModel commentMetaModel = new CommentMetaModel(Optional.of(nodeMetaModel));
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
+    public static final JavadocCommentMetaModel javadocCommentMetaModel =
+            new JavadocCommentMetaModel(Optional.of(commentMetaModel));
+
+    @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
     public static final BlockCommentMetaModel blockCommentMetaModel =
             new BlockCommentMetaModel(Optional.of(commentMetaModel));
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
     public static final TraditionalJavadocCommentMetaModel traditionalJavadocCommentMetaModel =
-            new TraditionalJavadocCommentMetaModel(Optional.of(commentMetaModel));
+            new TraditionalJavadocCommentMetaModel(Optional.of(javadocCommentMetaModel));
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
     public static final LineCommentMetaModel lineCommentMetaModel =

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -279,7 +279,7 @@ public final class JavaParserMetaModel {
                 .add(variableDeclaratorMetaModel.initializerPropertyMetaModel);
         commentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         blockCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
-        javadocCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
+        traditionalJavadocCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         lineCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         arrayAccessExprMetaModel.getConstructorParameters().add(arrayAccessExprMetaModel.namePropertyMetaModel);
         arrayAccessExprMetaModel.getConstructorParameters().add(arrayAccessExprMetaModel.indexPropertyMetaModel);
@@ -563,7 +563,6 @@ public final class JavaParserMetaModel {
         nodeMetaModels.add(instanceOfExprMetaModel);
         nodeMetaModels.add(integerLiteralExprMetaModel);
         nodeMetaModels.add(intersectionTypeMetaModel);
-        nodeMetaModels.add(javadocCommentMetaModel);
         nodeMetaModels.add(labeledStmtMetaModel);
         nodeMetaModels.add(lambdaExprMetaModel);
         nodeMetaModels.add(lineCommentMetaModel);
@@ -613,6 +612,7 @@ public final class JavaParserMetaModel {
         nodeMetaModels.add(textBlockLiteralExprMetaModel);
         nodeMetaModels.add(thisExprMetaModel);
         nodeMetaModels.add(throwStmtMetaModel);
+        nodeMetaModels.add(traditionalJavadocCommentMetaModel);
         nodeMetaModels.add(tryStmtMetaModel);
         nodeMetaModels.add(typeDeclarationMetaModel);
         nodeMetaModels.add(typeExprMetaModel);
@@ -3114,8 +3114,8 @@ public final class JavaParserMetaModel {
             new BlockCommentMetaModel(Optional.of(commentMetaModel));
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
-    public static final JavadocCommentMetaModel javadocCommentMetaModel =
-            new JavadocCommentMetaModel(Optional.of(commentMetaModel));
+    public static final TraditionalJavadocCommentMetaModel traditionalJavadocCommentMetaModel =
+            new TraditionalJavadocCommentMetaModel(Optional.of(commentMetaModel));
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
     public static final LineCommentMetaModel lineCommentMetaModel =

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavadocCommentMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavadocCommentMetaModel.java
@@ -21,7 +21,8 @@
 package com.github.javaparser.metamodel;
 
 import com.github.javaparser.ast.Generated;
-import com.github.javaparser.ast.comments.TraditionalJavadocComment;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.comments.JavadocComment;
 import java.util.Optional;
 
 /**
@@ -34,16 +35,27 @@ import java.util.Optional;
  * For this reason, any changes made directly to this file will be overwritten the next time generators are run.
  */
 @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
-public class TraditionalJavadocCommentMetaModel extends JavadocCommentMetaModel {
+public class JavadocCommentMetaModel extends CommentMetaModel {
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
-    TraditionalJavadocCommentMetaModel(Optional<BaseNodeMetaModel> superBaseNodeMetaModel) {
+    JavadocCommentMetaModel(Optional<BaseNodeMetaModel> superBaseNodeMetaModel) {
         super(
                 superBaseNodeMetaModel,
-                TraditionalJavadocComment.class,
-                "TraditionalJavadocComment",
+                JavadocComment.class,
+                "JavadocComment",
                 "com.github.javaparser.ast.comments",
-                false,
+                true,
                 false);
+    }
+
+    @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
+    protected JavadocCommentMetaModel(
+            Optional<BaseNodeMetaModel> superNodeMetaModel,
+            Class<? extends Node> type,
+            String name,
+            String packageName,
+            boolean isAbstract,
+            boolean hasWildcard) {
+        super(superNodeMetaModel, type, name, packageName, isAbstract, hasWildcard);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/TraditionalJavadocCommentMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/TraditionalJavadocCommentMetaModel.java
@@ -21,7 +21,7 @@
 package com.github.javaparser.metamodel;
 
 import com.github.javaparser.ast.Generated;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import java.util.Optional;
 
 /**
@@ -34,14 +34,14 @@ import java.util.Optional;
  * For this reason, any changes made directly to this file will be overwritten the next time generators are run.
  */
 @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
-public class JavadocCommentMetaModel extends CommentMetaModel {
+public class TraditionalJavadocCommentMetaModel extends CommentMetaModel {
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
-    JavadocCommentMetaModel(Optional<BaseNodeMetaModel> superBaseNodeMetaModel) {
+    TraditionalJavadocCommentMetaModel(Optional<BaseNodeMetaModel> superBaseNodeMetaModel) {
         super(
                 superBaseNodeMetaModel,
-                JavadocComment.class,
-                "JavadocComment",
+                TraditionalJavadocComment.class,
+                "TraditionalJavadocComment",
                 "com.github.javaparser.ast.comments",
                 false,
                 false);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -28,8 +28,8 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
@@ -438,7 +438,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
     }
 
     @Override
-    public void visit(final JavadocComment n, final Void arg) {
+    public void visit(final TraditionalJavadocComment n, final Void arg) {
         printOrphanCommentsBeforeThisChildNode(n);
         if (getOption(ConfigOption.PRINT_COMMENTS).isPresent()
                 && getOption(ConfigOption.PRINT_JAVADOC).isPresent()) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -30,8 +30,8 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.nodeTypes.*;
@@ -376,7 +376,7 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
     }
 
     @Override
-    public void visit(final JavadocComment n, final Void arg) {
+    public void visit(final TraditionalJavadocComment n, final Void arg) {
         printOrphanCommentsBeforeThisChildNode(n);
         if (configuration.isPrintComments() && configuration.isPrintJavadoc()) {
             printer.println(n.getHeader());

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -36,8 +36,8 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.nodeTypes.NodeWithVariables;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.ObservableProperty;
@@ -284,7 +284,7 @@ public class LexicalPreservingPrinter {
         }
 
         private TokenTextElement makeCommentToken(Comment newComment) {
-            if (newComment.isJavadocComment()) {
+            if (newComment.isTraditionalJavadocComment()) {
                 return new TokenTextElement(
                         JAVADOC_COMMENT, newComment.getHeader() + newComment.getContent() + newComment.getFooter());
             }
@@ -371,7 +371,7 @@ public class LexicalPreservingPrinter {
 
         private List<TokenTextElement> findTokenTextElementForComment(Comment oldValue, NodeText nodeText) {
             List<TokenTextElement> matchingTokens;
-            if (oldValue instanceof JavadocComment) {
+            if (oldValue instanceof TraditionalJavadocComment) {
                 matchingTokens = nodeText.getElements().stream()
                         .filter(e -> e.isToken(JAVADOC_COMMENT))
                         .map(e -> (TokenTextElement) e)
@@ -597,10 +597,11 @@ public class LexicalPreservingPrinter {
             interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
             return;
         }
-        if (node instanceof JavadocComment) {
-            Comment comment = (JavadocComment) node;
+        if (node instanceof TraditionalJavadocComment) {
+            Comment comment = (TraditionalJavadocComment) node;
             nodeText.addToken(
-                    JAVADOC_COMMENT, comment.getHeader() + ((JavadocComment) node).getContent() + comment.getFooter());
+                    JAVADOC_COMMENT,
+                    comment.getHeader() + ((TraditionalJavadocComment) node).getContent() + comment.getFooter());
             return;
         }
         if (node instanceof BlockComment) {

--- a/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserTokenManagerBase.java
+++ b/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserTokenManagerBase.java
@@ -23,7 +23,7 @@ package com.github.javaparser;
 
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
 
 import static com.github.javaparser.GeneratedJavaParserConstants.*;
@@ -47,7 +47,7 @@ abstract class GeneratedJavaParserTokenManagerBase {
     static Comment createCommentFromToken(Token token) {
         String commentText = token.image;
         if (token.kind == JAVADOC_COMMENT) {
-            return new JavadocComment(tokenRange(token), commentText.substring(3, commentText.length() - 2));
+            return new TraditionalJavadocComment(tokenRange(token), commentText.substring(3, commentText.length() - 2));
         } else if (token.kind == MULTI_LINE_COMMENT) {
             return new BlockComment(tokenRange(token), commentText.substring(2, commentText.length() - 2));
         } else if (token.kind == SINGLE_LINE_COMMENT) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/DefaultVisitorAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/DefaultVisitorAdapter.java
@@ -24,8 +24,8 @@ package com.github.javaparser.symbolsolver.javaparsermodel;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
@@ -115,7 +115,7 @@ public class DefaultVisitorAdapter implements GenericVisitor<ResolvedType, Boole
     }
 
     @Override
-    public ResolvedType visit(JavadocComment node, Boolean aBoolean) {
+    public ResolvedType visit(TraditionalJavadocComment node, Boolean aBoolean) {
         throw new UnsupportedOperationException(node.getClass().getCanonicalName());
     }
 


### PR DESCRIPTION
This PR introduces the comment hierarchy refactor which I added in some of the later commits in https://github.com/javaparser/javaparser/pull/4875. 