### PR TITLE
[JEP 467] Add support for MarkdownComments

### DIFF
--- a/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
+++ b/javaparser-core-metamodel-generator/src/main/java/com/github/javaparser/generator/metamodel/MetaModelGenerator.java
@@ -111,6 +111,7 @@ public class MetaModelGenerator extends AbstractGenerator {
             add(com.github.javaparser.ast.comments.BlockComment.class);
             add(com.github.javaparser.ast.comments.TraditionalJavadocComment.class);
             add(com.github.javaparser.ast.comments.LineComment.class);
+            add(com.github.javaparser.ast.comments.MarkdownComment.class);
 
             add(com.github.javaparser.ast.expr.ArrayAccessExpr.class);
             add(com.github.javaparser.ast.expr.ArrayCreationExpr.class);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavadocParserTest.java
@@ -167,21 +167,21 @@ class JavadocParserTest {
 
     @Test
     void startsWithAsteriskEmpty() {
-        assertEquals(-1, JavadocParser.startsWithAsterisk(""));
+        assertEquals(-1, JavadocParser.startsWithAsteriskOrMdSlash(""));
     }
 
     @Test
     void startsWithAsteriskNoAsterisk() {
-        assertEquals(-1, JavadocParser.startsWithAsterisk(" ciao"));
+        assertEquals(-1, JavadocParser.startsWithAsteriskOrMdSlash(" ciao"));
     }
 
     @Test
     void startsWithAsteriskAtTheBeginning() {
-        assertEquals(0, JavadocParser.startsWithAsterisk("* ciao"));
+        assertEquals(0, JavadocParser.startsWithAsteriskOrMdSlash("* ciao"));
     }
 
     @Test
     void startsWithAsteriskAfterSpaces() {
-        assertEquals(3, JavadocParser.startsWithAsterisk("   * ciao"));
+        assertEquals(3, JavadocParser.startsWithAsteriskOrMdSlash("   * ciao"));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.javadoc.Javadoc;
@@ -42,6 +43,7 @@ import com.github.javaparser.printer.configuration.Indentation;
 import com.github.javaparser.printer.configuration.Indentation.IndentType;
 import com.github.javaparser.printer.configuration.PrinterConfiguration;
 import com.github.javaparser.utils.LineSeparator;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class CommentTest {
@@ -222,5 +224,173 @@ class CommentTest {
         comment.setContent(b);
 
         verifyNoInteractions(observer);
+    }
+
+    @Test
+    void testSingleLineCommentContent() {
+        CompilationUnit cu = parse("class Test {\n" + "  // this is a single line comment\n"
+                + "  // and so is this\n"
+                + "  void test() {}\n"
+                + "}");
+
+        MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
+
+        Comment secondComment = testMethod.getComment().get();
+
+        assertEqualsStringIgnoringEol(" and so is this", secondComment.getContent());
+
+        List<Comment> orphanComments = cu.findFirst(TypeDeclaration.class).get().getOrphanComments();
+        assertEquals(1, orphanComments.size());
+        assertEqualsStringIgnoringEol(
+                " this is a single line comment", orphanComments.get(0).getContent());
+    }
+
+    @Test
+    void testJavadocCommentContent() {
+        String commentCode = "\n   * This is a regular {@code JavaDoc comment}\n   * @see some reference\n    ";
+        CompilationUnit cu = parse("class Test {\n" + "  /**" + commentCode + "*/\n" + "  void test() {}\n" + "}");
+
+        MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
+
+        assertTrue(testMethod.getJavadocComment().isPresent());
+
+        JavadocComment comment = testMethod.getJavadocComment().get();
+
+        assertEqualsStringIgnoringEol(commentCode, comment.getContent());
+    }
+
+    @Test
+    void testSingleMarkdownComment() {
+        String commentCode = "  /// This is a markdown comment test. It should\n" + "  /// /**\n"
+                + "  ///  * Handle multiline comments.\n"
+                + "  ///  */\n"
+                + "  ///  // and single line comments\n"
+                + "  ///\n"
+                + "  ///  and empty lines preceded by ///\n"
+                + "  ///  without issues\n";
+        CompilationUnit cu = parse("class Test {\n" + commentCode + "  void test() {}\n" + "}");
+
+        MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
+
+        assertTrue(testMethod.getComment().isPresent());
+        assertInstanceOf(MarkdownComment.class, testMethod.getComment().get());
+
+        MarkdownComment comment = testMethod.getComment().get().asMarkdownComment();
+
+        String expectedContent = "This is a markdown comment test. It should\n" + "/**\n"
+                + " * Handle multiline comments.\n"
+                + " */\n"
+                + " // and single line comments\n"
+                + "\n"
+                + " and empty lines preceded by ///\n"
+                + " without issues";
+        assertEquals(expectedContent, comment.getMarkdownContent());
+    }
+
+    @Test
+    void testMultipleMarkdownComments() {
+        String comment1Code = "  /// This is a markdown comment test. It should\n" + "  /// /**\n"
+                + "  ///  * Handle multiline comments.\n"
+                + "  ///  */\n"
+                + "  /// // and single line comments\n";
+        String comment2Code = "  ///\n" + "  /// and empty lines preceded by ///\n" + "  /// without issues\n";
+        CompilationUnit cu = parse("class Test {\n" + comment1Code + "\n" + comment2Code + "  void test() {}\n" + "}");
+
+        MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
+
+        assertTrue(testMethod.getComment().isPresent());
+        assertInstanceOf(MarkdownComment.class, testMethod.getComment().get());
+
+        MarkdownComment comment = testMethod.getComment().get().asMarkdownComment();
+
+        String comment2Expectation = "///\n" + "  /// and empty lines preceded by ///\n" + "  /// without issues\n";
+        assertEqualsStringIgnoringEol(comment2Expectation, comment.asString());
+
+        List<Comment> orphanComments = cu.findFirst(TypeDeclaration.class).get().getOrphanComments();
+
+        assertEquals(1, orphanComments.size());
+        assertInstanceOf(MarkdownComment.class, orphanComments.get(0));
+
+        String comment1Expectation = "/// This is a markdown comment test. It should\n" + "  /// /**\n"
+                + "  ///  * Handle multiline comments.\n"
+                + "  ///  */\n"
+                + "  /// // and single line comments\n";
+        assertEqualsStringIgnoringEol(comment1Expectation, orphanComments.get(0).asString());
+    }
+
+    @Test
+    void markdownCommentShouldNotHaveSingleLineContent() {
+        CompilationUnit cu = parse(
+                "class Test {\n" + "  /// this is a single-line markdown comment test\n" + "  void test() {}\n" + "}");
+
+        MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
+
+        assertTrue(testMethod.getComment().isPresent());
+        assertInstanceOf(MarkdownComment.class, testMethod.getComment().get());
+
+        MarkdownComment comment = testMethod.getComment().get().asMarkdownComment();
+
+        assertEqualsStringIgnoringEol("/// this is a single-line markdown comment test", comment.getContent());
+        assertEqualsStringIgnoringEol("this is a single-line markdown comment test", comment.getMarkdownContent());
+        assertEqualsStringIgnoringEol("/// this is a single-line markdown comment test\n", comment.asString());
+    }
+
+    @Test
+    void testSplitMarkdownComment1() {
+        String commentCode = "  /// This is a markdown comment test. It should\n" + "  /// /**\n"
+                + "  ///  * Handle multiline comments.\n"
+                + "  ///  */\n"
+                + "  // split by single line comments\n"
+                + "  ///\n"
+                + "  ///  and empty lines preceded by ///\n"
+                + "  ///  without issues\n";
+        CompilationUnit cu = parse("class Test {\n" + commentCode + "  void test() {}\n" + "}");
+
+        MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
+
+        assertTrue(testMethod.getComment().isPresent());
+        assertTrue(testMethod.getJavadocComment().isPresent());
+        assertInstanceOf(MarkdownComment.class, testMethod.getComment().get());
+
+        MarkdownComment comment = testMethod.getComment().get().asMarkdownComment();
+
+        String expectedMarkdownContent = "\n" + "and empty lines preceded by ///\n" + "without issues";
+        assertEquals(expectedMarkdownContent, comment.getMarkdownContent());
+
+        String expectedContent = "///\n  ///  and empty lines preceded by ///\n  ///  without issues";
+        assertEquals(expectedContent, comment.getContent());
+
+        List<Comment> orphanComments = cu.findFirst(TypeDeclaration.class).get().getOrphanComments();
+
+        assertEquals(2, orphanComments.size());
+
+        assertInstanceOf(MarkdownComment.class, orphanComments.get(0));
+        String expectedFirstOrphanContent =
+                "This is a markdown comment test. It should\n" + "/**\n" + " * Handle multiline comments.\n" + " */";
+        assertEqualsStringIgnoringEol(
+                expectedFirstOrphanContent,
+                orphanComments.get(0).asMarkdownComment().getMarkdownContent());
+
+        assertInstanceOf(LineComment.class, orphanComments.get(1));
+        assertEqualsStringIgnoringEol(
+                " split by single line comments", orphanComments.get(1).getContent());
+    }
+
+    @Test
+    void testTraditionalJavadocComment() {
+        CompilationUnit cu = parse("class Test {\n" + "  /**\n"
+                + "   * This is a traditional javadoc comment\n"
+                + "   */\n"
+                + "  void test() {}\n"
+                + "}");
+
+        MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
+
+        assertTrue(testMethod.getComment().isPresent());
+        assertInstanceOf(
+                TraditionalJavadocComment.class, testMethod.getComment().get());
+
+        String expectedContent = "\n   * This is a traditional javadoc comment\n   ";
+        assertEquals(expectedContent, testMethod.getComment().get().getContent());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -521,4 +521,17 @@ class PrettyPrintVisitorTest extends TestParser {
 
         assertEqualsStringIgnoringEol(expected, cu.toString());
     }
+
+    @Test
+    public void testMarkdownComment() {
+        String code = "class Foo {\n" + "\n"
+                + "    /// This is a markdown comment\n"
+                + "    /// for the foo method\n"
+                + "    void foo(Integer arg) {\n"
+                + "    }\n"
+                + "}\n";
+
+        CompilationUnit cu = parse(code);
+        assertEqualsStringIgnoringEol(code, cu.toString());
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -696,4 +696,29 @@ class PrettyPrinterTest {
         CompilationUnit cu = parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
+
+    @Test
+    public void testMarkdownComment() {
+        String code = "class Foo {\n" + "\n"
+                + "    /// This is a markdown comment\n"
+                + "    /// for the foo method\n"
+                + "    void foo(Integer arg) {\n"
+                + "    }\n"
+                + "}\n";
+
+        CompilationUnit cu = parse(code);
+        assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
+    }
+
+    @Test
+    public void testSingleLineComment() {
+        String code = "class Foo {\n" + "\n"
+                + "    // This is a single line comment for the foo method\n"
+                + "    void foo(Integer arg) {\n"
+                + "    }\n"
+                + "}\n";
+
+        CompilationUnit cu = parse(code);
+        assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/JavaParserAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavaParserAdapter.java
@@ -148,8 +148,8 @@ public class JavaParserAdapter {
         return handleResult(getParser().parseVariableDeclarationExpr(declaration));
     }
 
-    public Javadoc parseJavadoc(String content) {
-        return JavadocParser.parse(content);
+    public Javadoc parseJavadoc(String content, boolean isMarkdownComment) {
+        return JavadocParser.parse(content, isMarkdownComment);
     }
 
     public ExplicitConstructorInvocationStmt parseExplicitConstructorInvocationStmt(String statement) {

--- a/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/JavadocParser.java
@@ -44,11 +44,16 @@ class JavadocParser {
     private static Pattern BLOCK_PATTERN = Pattern.compile("^\\s*" + BLOCK_TAG_PREFIX, Pattern.MULTILINE);
 
     public static Javadoc parse(JavadocComment comment) {
-        return parse(comment.getContent());
+        return parse(comment.getContent(), comment.isMarkdownComment());
     }
 
     public static Javadoc parse(String commentContent) {
-        List<String> cleanLines = cleanLines(normalizeEolInTextBlock(commentContent, LineSeparator.SYSTEM));
+        return parse(commentContent, false);
+    }
+
+    public static Javadoc parse(String commentContent, boolean isMarkdownComment) {
+        List<String> cleanLines =
+                cleanLines(normalizeEolInTextBlock(commentContent, LineSeparator.SYSTEM), isMarkdownComment);
         int indexOfFirstBlockTag = cleanLines.stream()
                 .filter(JavadocParser::isABlockLine)
                 .map(cleanLines::indexOf)
@@ -75,7 +80,7 @@ class JavadocParser {
                     .map(s -> BLOCK_TAG_PREFIX + s)
                     .collect(Collectors.toList());
         }
-        Javadoc document = new Javadoc(JavadocDescription.parseText(descriptionText));
+        Javadoc document = new Javadoc(JavadocDescription.parseText(descriptionText), isMarkdownComment);
         blockLines.forEach(l -> document.addBlockTag(parseBlockTag(l)));
         return document;
     }
@@ -98,24 +103,24 @@ class JavadocParser {
         return string;
     }
 
-    private static List<String> cleanLines(String content) {
+    private static List<String> cleanLines(String content, boolean isMarkdownComment) {
         String[] lines = content.split(LineSeparator.SYSTEM.asRawString());
         if (lines.length == 0) {
             return Collections.emptyList();
         }
         List<String> cleanedLines = Arrays.stream(lines)
                 .map(l -> {
-                    int asteriskIndex = startsWithAsterisk(l);
-                    if (asteriskIndex == -1) {
+                    int asteriskOrLastMdSlashIndex = startsWithAsteriskOrMdSlash(l);
+                    if (asteriskOrLastMdSlashIndex == -1) {
                         return l;
                     }
-                    if (l.length() > (asteriskIndex + 1)) {
-                        char c = l.charAt(asteriskIndex + 1);
+                    if (l.length() > (asteriskOrLastMdSlashIndex + 1)) {
+                        char c = l.charAt(asteriskOrLastMdSlashIndex + 1);
                         if (c == ' ' || c == '\t') {
-                            return l.substring(asteriskIndex + 2);
+                            return l.substring(asteriskOrLastMdSlashIndex + 2);
                         }
                     }
-                    return l.substring(asteriskIndex + 1);
+                    return l.substring(asteriskOrLastMdSlashIndex + 1);
                 })
                 .collect(Collectors.toList());
         // lines containing only whitespace are normalized to empty lines
@@ -137,17 +142,26 @@ class JavadocParser {
         return cleanedLines;
     }
 
-    // Visible for testing
-    static int startsWithAsterisk(String line) {
-        if (line.startsWith("*")) {
-            return 0;
-        }
-        if ((line.startsWith(" ") || line.startsWith("\t")) && line.length() > 1) {
-            int res = startsWithAsterisk(line.substring(1));
-            if (res == -1) {
+    /**
+     * Given a line in a block or markdown comment, this method finds the index of the * or / at the start of the line.
+     * For markdown comments where lines start with ///, this would be the index of the third /. This is used to strip
+     * the relevant prefix string when cleaning lines as part of the Javadoc parsing process.
+     * It is made visible for testing
+     */
+    static int startsWithAsteriskOrMdSlash(String line) {
+        for (int i = 0, mdSlashCount = 0; i < line.length(); i++) {
+            char currentChar = line.charAt(i);
+            if (currentChar == '/') {
+                if (mdSlashCount == 2) {
+                    return i;
+                } else {
+                    mdSlashCount++;
+                }
+            } else if (currentChar == '*' && mdSlashCount == 0) {
+                return i;
+            } else if (currentChar != ' ' && currentChar != '\t') {
                 return -1;
             }
-            return 1 + res;
         }
         return -1;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -393,9 +393,9 @@ public final class StaticJavaParser {
      * @return Javadoc representing the content of the comment
      * @throws ParseProblemException if the source code has parser errors
      */
-    public static Javadoc parseJavadoc(@NotNull String content) {
+    public static Javadoc parseJavadoc(@NotNull String content, boolean isMarkdownComment) {
         Preconditions.checkNotNull(content, "Parameter content can't be null.");
-        return JavadocParser.parse(content);
+        return JavadocParser.parse(content, isMarkdownComment);
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/Comment.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
  * @author Julio Vilmar Gesser
  * @see BlockComment
  * @see LineComment
+ * @see MarkdownComment
  * @see TraditionalJavadocComment
  */
 public abstract class Comment extends Node {
@@ -237,6 +238,25 @@ public abstract class Comment extends Node {
     public String asString() {
         return getHeader() + getContent() + getFooter();
     }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public boolean isMarkdownComment() {
+        return false;
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public MarkdownComment asMarkdownComment() {
+        throw new IllegalStateException(
+                f("%s is not MarkdownComment, it is %s", this, this.getClass().getSimpleName()));
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public Optional<MarkdownComment> toMarkdownComment() {
+        return Optional.empty();
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public void ifMarkdownComment(Consumer<MarkdownComment> action) {}
 
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public boolean isTraditionalJavadocComment() {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/JavadocComment.java
@@ -89,6 +89,6 @@ public abstract class JavadocComment extends Comment {
     }
 
     public Javadoc parse() {
-        return parseJavadoc(getContent());
+        return parseJavadoc(getContent(), this.isMarkdownComment());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/MarkdownComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/MarkdownComment.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.ast.comments;
+
+import com.github.javaparser.TokenRange;
+import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.visitor.CloneVisitor;
+import com.github.javaparser.ast.visitor.GenericVisitor;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+import com.github.javaparser.metamodel.MarkdownCommentMetaModel;
+import com.github.javaparser.utils.LineSeparator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * https://openjdk.org/jeps/467 added support for markdown JavaDoc comments
+ * /// That are prefixed with ///
+ * /// Support `markdown` markup and references
+ * /// And supports substrings not allowed in regular block comments, e.g. *_no_space_here_/
+ * <p>
+ * While these comments could be seen as a series of single line comments, they are functionally block comments.
+ * The {@code MarkdownComment} class adds support for this, although special handling is required for the content
+ * of these comments, since the header is no longer only applied to the start of the comment, but rather to the
+ * start of each line.
+ */
+public class MarkdownComment extends JavadocComment {
+
+    private static Pattern markdownLinePattern = Pattern.compile("^\\s*///(.*)$");
+
+    public MarkdownComment() {
+        this(null, "empty");
+    }
+
+    @AllFieldsConstructor
+    public MarkdownComment(String content) {
+        this(null, content);
+    }
+
+    /**
+     * This constructor is used by the parser and is considered private.
+     */
+    @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
+    public MarkdownComment(TokenRange tokenRange, String content) {
+        super(tokenRange, content);
+        customInitialization();
+    }
+
+    /**
+     * Returns the Markdown content of this comment as defined in <a href="https://openjdk.org/jeps/467">JEP 467</a>:
+     * <blockquote cite="https://openjdk.org/jeps/467">
+     *     Because horizontal whitespace at the beginning and end of each line of Markdown text may be significant,
+     *     the content of a Markdown documentation comment is determined as follows:
+     *     -- Any leading whitespace and the three initial / characters are removed from each line.
+     *     -- The lines are shifted left, by removing leading whitespace characters, until the non-blank line with the
+     *        least leading whitespace has no remaining leading whitespace.
+     *     -- Additional leading whitespace and any trailing whitespace in each line is preserved, because it may be
+     *        significant. For example, whitespace at the beginning of a line may indicate an indented code block or the
+     *        continuation of a list item, and whitespace at the end of a line may indicate a hard line break.
+     *     </blockquote>
+     */
+    public String getMarkdownContent() {
+        String content = getContent();
+        // Start by isolating the lines to make calculating and stripping leading whitespace easier
+        ArrayList<String> commentLines = new ArrayList<>();
+        commentLines.addAll(Arrays.asList(content.split("(\r\n|\r|\n)")));
+        ArrayList<String> formattedLines = new ArrayList<>();
+        for (String line : commentLines) {
+            // Use pattern matching to strip leading whitespace followed by /// for each of the lines.
+            Matcher matcher = markdownLinePattern.matcher(line);
+            if (matcher.matches()) {
+                formattedLines.add(matcher.group(1));
+            } else {
+                formattedLines.add(line);
+            }
+        }
+        // Find the length of the shortest whitespace prefix for all the lines so that this can be stripped according
+        // to the Java specification. For example, treating . as whitespace in the example below, 2 spaces will be
+        // stripped:
+        // ///....prefix_length=4
+        // ///......prefix_length=8
+        // ///..prefix_length=2
+        int shortestWhitespacePrefix = Integer.MAX_VALUE;
+        for (String line : formattedLines) {
+            for (int i = 0; i < line.length(); i++) {
+                if (!Character.isWhitespace(line.charAt(i))) {
+                    shortestWhitespacePrefix = Math.min(shortestWhitespacePrefix, i);
+                    break;
+                }
+            }
+        }
+        StringBuilder contentBuilder = new StringBuilder();
+        LineSeparator lineSeparator = LineSeparator.detect(content);
+        // Reassemble the content with the whitespace prefix stripped and without adding back the /// removed by the
+        // pattern match above.
+        for (int i = 0; i < formattedLines.size(); i++) {
+            String line = formattedLines.get(i);
+            if (line.trim().isEmpty()) {
+                contentBuilder.append(line);
+            } else {
+                contentBuilder.append(line.substring(shortestWhitespacePrefix));
+            }
+            if (i != formattedLines.size() - 1) {
+                contentBuilder.append(lineSeparator.asRawString());
+            }
+        }
+        return contentBuilder.toString();
+    }
+
+    /**
+     * For other comment types, the header is the character sequence that starts the comment, i.e. /* for block
+     * comments and // for line comments and the footer is the character sequence that ends the comment, i.e. * / for
+     * block comments, but empty for line comments. These comments can then be reconstructed with
+     *   c.getHeader() + c.getContent() + c.getFooter().
+     * For Markdown comments, this model doesn't fit as well, since the header is now a character sequence that
+     * appears at the start of each line. For ease of use, the leading /// is now included in the comment content,
+     * returned by the getContent() method, while the getMarkdownContent() method returns the comment content with the
+     * leading /// stripped from each line.
+     *
+     * @return the empty string
+     */
+    @Override
+    public String getHeader() {
+        return "";
+    }
+
+    /**
+     * Markdown comments are not terminated by a specific character sequence, so just use the empty string as a footer.
+     * @return the empty string
+     */
+    @Override
+    public String getFooter() {
+        return "";
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.AcceptGenerator")
+    public <R, A> R accept(final GenericVisitor<R, A> v, final A arg) {
+        return v.visit(this, arg);
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.AcceptGenerator")
+    public <A> void accept(final VoidVisitor<A> v, final A arg) {
+        v.visit(this, arg);
+    }
+
+    @Override
+    public String asString() {
+        String content = getContent();
+        // Try to preserve line separators
+        String lineSeparator = getLineEndingStyle().asRawString();
+        String[] lines = content.split(lineSeparator);
+        StringBuilder builder = new StringBuilder();
+        for (String line : lines) {
+            builder.append(getHeader());
+            builder.append(line);
+            builder.append(lineSeparator);
+        }
+        return builder.toString();
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public boolean isMarkdownComment() {
+        return true;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public MarkdownComment asMarkdownComment() {
+        return this;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public Optional<MarkdownComment> toMarkdownComment() {
+        return Optional.of(this);
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
+    public void ifMarkdownComment(Consumer<MarkdownComment> action) {
+        action.accept(this);
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.CloneGenerator")
+    public MarkdownComment clone() {
+        return (MarkdownComment) accept(new CloneVisitor(), null);
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.GetMetaModelGenerator")
+    public MarkdownCommentMetaModel getMetaModel() {
+        return JavaParserMetaModel.markdownCommentMetaModel;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/comments/TraditionalJavadocComment.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/comments/TraditionalJavadocComment.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
- * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
  *
  * This file is part of JavaParser.
  *
@@ -73,7 +73,7 @@ public class TraditionalJavadocComment extends JavadocComment {
 
     @Override
     public Javadoc parse() {
-        return parseJavadoc(getContent());
+        return parseJavadoc(getContent(), false);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithJavadoc.java
@@ -23,6 +23,7 @@ package com.github.javaparser.ast.nodeTypes;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.Javadoc;
 import java.util.Optional;
@@ -59,8 +60,18 @@ public interface NodeWithJavadoc<N extends Node> {
     /**
      * Set a JavadocComment for this node
      */
+    @SuppressWarnings("unchecked")
+    default N setJavadocComment(String comment, boolean isMarkdownComment) {
+        JavadocComment javadocComment =
+                isMarkdownComment ? new MarkdownComment(comment) : new TraditionalJavadocComment(comment);
+        return setJavadocComment(javadocComment);
+    }
+
+    /**
+     * Set a JavadocComment for this node
+     */
     default N setJavadocComment(String comment) {
-        return setJavadocComment(new TraditionalJavadocComment(comment));
+        return setJavadocComment(comment, false);
     }
 
     default N setJavadocComment(JavadocComment comment) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/CloneVisitor.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -1371,6 +1372,16 @@ public class CloneVisitor implements GenericVisitor<Visitable, Object> {
         NodeList<Modifier> modifiers = cloneList(n.getModifiers(), arg);
         Comment comment = cloneNode(n.getComment(), arg);
         MatchAllPatternExpr r = new MatchAllPatternExpr(n.getTokenRange().orElse(null), modifiers);
+        r.setComment(comment);
+        n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
+        copyData(n, r);
+        return r;
+    }
+
+    @Override
+    public Visitable visit(final MarkdownComment n, final Object arg) {
+        Comment comment = cloneNode(n.getComment(), arg);
+        MarkdownComment r = new MarkdownComment(n.getTokenRange().orElse(null), n.getContent());
         r.setComment(comment);
         n.getOrphanComments().stream().map(Comment::clone).forEach(r::addOrphanComment);
         copyData(n, r);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/EqualsVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -1086,6 +1087,14 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Visitable> {
     public Boolean visit(final MatchAllPatternExpr n, final Visitable arg) {
         final MatchAllPatternExpr n2 = (MatchAllPatternExpr) arg;
         if (!nodesEquals(n.getModifiers(), n2.getModifiers())) return false;
+        if (!nodeEquals(n.getComment(), n2.getComment())) return false;
+        return true;
+    }
+
+    @Override
+    public Boolean visit(final MarkdownComment n, final Visitable arg) {
+        final MarkdownComment n2 = (MarkdownComment) arg;
+        if (!objEquals(n.getContent(), n2.getContent())) return false;
         if (!nodeEquals(n.getComment(), n2.getComment())) return false;
         return true;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericListVisitorAdapter.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -2032,6 +2033,17 @@ public abstract class GenericListVisitorAdapter<R, A> implements GenericVisitor<
             tmp = n.getModifiers().accept(this, arg);
             if (tmp != null) result.addAll(tmp);
         }
+        if (n.getComment().isPresent()) {
+            tmp = n.getComment().get().accept(this, arg);
+            if (tmp != null) result.addAll(tmp);
+        }
+        return result;
+    }
+
+    @Override
+    public List<R> visit(final MarkdownComment n, final A arg) {
+        List<R> result = new ArrayList<>();
+        List<R> tmp;
         if (n.getComment().isPresent()) {
             tmp = n.getComment().get().accept(this, arg);
             if (tmp != null) result.addAll(tmp);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -245,4 +246,6 @@ public interface GenericVisitor<R, A> {
     R visit(RecordPatternExpr n, A arg);
 
     R visit(MatchAllPatternExpr n, A arg);
+
+    R visit(MarkdownComment n, A arg);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorAdapter.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -1929,6 +1930,16 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
             result = n.getModifiers().accept(this, arg);
             if (result != null) return result;
         }
+        if (n.getComment().isPresent()) {
+            result = n.getComment().get().accept(this, arg);
+            if (result != null) return result;
+        }
+        return null;
+    }
+
+    @Override
+    public R visit(final MarkdownComment n, final A arg) {
+        R result;
         if (n.getComment().isPresent()) {
             result = n.getComment().get().accept(this, arg);
             if (result != null) return result;

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaults.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/GenericVisitorWithDefaults.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -557,6 +558,11 @@ public abstract class GenericVisitorWithDefaults<R, A> implements GenericVisitor
 
     @Override
     public R visit(final MatchAllPatternExpr n, final A arg) {
+        return defaultAction(n, arg);
+    }
+
+    @Override
+    public R visit(final MarkdownComment n, final A arg) {
         return defaultAction(n, arg);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/HashCodeVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -733,6 +734,12 @@ public class HashCodeVisitor implements GenericVisitor<Integer, Void> {
     @Override
     public Integer visit(final MatchAllPatternExpr n, final Void arg) {
         return (n.getModifiers().accept(this, arg)) * 31
+                + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
+    }
+
+    @Override
+    public Integer visit(final MarkdownComment n, final Void arg) {
+        return (n.getContent().hashCode()) * 31
                 + (n.getComment().isPresent() ? n.getComment().get().accept(this, arg) : 0);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ModifierVisitor.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -1322,6 +1323,13 @@ public class ModifierVisitor<A> implements GenericVisitor<Visitable, A> {
         NodeList<Modifier> modifiers = modifyList(n.getModifiers(), arg);
         Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         n.setModifiers(modifiers);
+        n.setComment(comment);
+        return n;
+    }
+
+    @Override
+    public Visitable visit(final MarkdownComment n, final A arg) {
+        Comment comment = n.getComment().map(s -> (Comment) s.accept(this, arg)).orElse(null);
         n.setComment(comment);
         return n;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -935,6 +936,13 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
     public Boolean visit(final MatchAllPatternExpr n, final Visitable arg) {
         final MatchAllPatternExpr n2 = (MatchAllPatternExpr) arg;
         if (!nodesEquals(n.getModifiers(), n2.getModifiers())) return false;
+        return true;
+    }
+
+    @Override
+    public Boolean visit(final MarkdownComment n, final Visitable arg) {
+        final MarkdownComment n2 = (MarkdownComment) arg;
+        if (!objEquals(n.getContent(), n2.getContent())) return false;
         return true;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -607,5 +608,10 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
     @Override
     public Integer visit(final MatchAllPatternExpr n, final Void arg) {
         return (n.getModifiers().accept(this, arg));
+    }
+
+    @Override
+    public Integer visit(final MarkdownComment n, final Void arg) {
+        return (n.getContent().hashCode());
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityEqualsVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -550,6 +551,11 @@ public class ObjectIdentityEqualsVisitor implements GenericVisitor<Boolean, Visi
 
     @Override
     public Boolean visit(final MatchAllPatternExpr n, final Visitable arg) {
+        return n == arg;
+    }
+
+    @Override
+    public Boolean visit(final MarkdownComment n, final Visitable arg) {
         return n == arg;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/ObjectIdentityHashCodeVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -462,6 +463,11 @@ public class ObjectIdentityHashCodeVisitor implements GenericVisitor<Integer, Vo
 
     @Override
     public Integer visit(final MatchAllPatternExpr n, final Void arg) {
+        return n.hashCode();
+    }
+
+    @Override
+    public Integer visit(final MarkdownComment n, final Void arg) {
         return n.hashCode();
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -240,4 +241,6 @@ public interface VoidVisitor<A> {
     void visit(RecordPatternExpr n, A arg);
 
     void visit(MatchAllPatternExpr n, A arg);
+
+    void visit(MarkdownComment n, A arg);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -764,6 +765,11 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     @Override
     public void visit(final MatchAllPatternExpr n, final A arg) {
         n.getModifiers().forEach(p -> p.accept(this, arg));
+        n.getComment().ifPresent(l -> l.accept(this, arg));
+    }
+
+    @Override
+    public void visit(final MarkdownComment n, final A arg) {
         n.getComment().ifPresent(l -> l.accept(this, arg));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaults.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorWithDefaults.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -551,6 +552,11 @@ public abstract class VoidVisitorWithDefaults<A> implements VoidVisitor<A> {
 
     @Override
     public void visit(final MatchAllPatternExpr n, final A arg) {
+        defaultAction(n, arg);
+    }
+
+    @Override
+    public void visit(final MarkdownComment n, final A arg) {
         defaultAction(n, arg);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/javadoc/Javadoc.java
@@ -21,6 +21,7 @@
 package com.github.javaparser.javadoc;
 
 import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.utils.LineSeparator;
@@ -41,9 +42,16 @@ public class Javadoc {
 
     private List<JavadocBlockTag> blockTags;
 
+    private boolean isMarkdownComment;
+
     public Javadoc(JavadocDescription description) {
         this.description = description;
         this.blockTags = new LinkedList<>();
+    }
+
+    public Javadoc(JavadocDescription description, boolean isMarkdownComment) {
+        this(description);
+        this.isMarkdownComment = isMarkdownComment;
     }
 
     public Javadoc addBlockTag(JavadocBlockTag blockTag) {
@@ -114,17 +122,22 @@ public class Javadoc {
         StringBuilder sb = new StringBuilder();
         sb.append(LineSeparator.SYSTEM);
         final String text = toText();
+        String commentPrefix = isMarkdownComment ? "/// " : " * ";
         if (!text.isEmpty()) {
             for (String line : text.split(LineSeparator.SYSTEM.asRawString())) {
                 sb.append(indentation);
-                sb.append(" * ");
+                sb.append(commentPrefix);
                 sb.append(line);
                 sb.append(LineSeparator.SYSTEM);
             }
         }
-        sb.append(indentation);
-        sb.append(" ");
-        return new TraditionalJavadocComment(sb.toString());
+        if (isMarkdownComment) {
+            return new MarkdownComment(sb.toString());
+        } else {
+            sb.append(indentation);
+            sb.append(" ");
+            return new TraditionalJavadocComment(sb.toString());
+        }
     }
 
     public JavadocDescription getDescription() {

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/JavaParserMetaModel.java
@@ -282,6 +282,7 @@ public final class JavaParserMetaModel {
         blockCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         traditionalJavadocCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         lineCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
+        markdownCommentMetaModel.getConstructorParameters().add(commentMetaModel.contentPropertyMetaModel);
         arrayAccessExprMetaModel.getConstructorParameters().add(arrayAccessExprMetaModel.namePropertyMetaModel);
         arrayAccessExprMetaModel.getConstructorParameters().add(arrayAccessExprMetaModel.indexPropertyMetaModel);
         arrayCreationExprMetaModel
@@ -573,6 +574,7 @@ public final class JavaParserMetaModel {
         nodeMetaModels.add(localClassDeclarationStmtMetaModel);
         nodeMetaModels.add(localRecordDeclarationStmtMetaModel);
         nodeMetaModels.add(longLiteralExprMetaModel);
+        nodeMetaModels.add(markdownCommentMetaModel);
         nodeMetaModels.add(markerAnnotationExprMetaModel);
         nodeMetaModels.add(matchAllPatternExprMetaModel);
         nodeMetaModels.add(memberValuePairMetaModel);
@@ -3126,6 +3128,10 @@ public final class JavaParserMetaModel {
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
     public static final LineCommentMetaModel lineCommentMetaModel =
             new LineCommentMetaModel(Optional.of(commentMetaModel));
+
+    @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
+    public static final MarkdownCommentMetaModel markdownCommentMetaModel =
+            new MarkdownCommentMetaModel(Optional.of(javadocCommentMetaModel));
 
     @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
     public static final ArrayAccessExprMetaModel arrayAccessExprMetaModel =

--- a/javaparser-core/src/main/java/com/github/javaparser/metamodel/MarkdownCommentMetaModel.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/metamodel/MarkdownCommentMetaModel.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.metamodel;
+
+import com.github.javaparser.ast.Generated;
+import com.github.javaparser.ast.comments.MarkdownComment;
+import java.util.Optional;
+
+/**
+ * This file, class, and its contents are completely generated based on:
+ * <ul>
+ *     <li>The contents and annotations within the package `com.github.javaparser.ast`, and</li>
+ *     <li>`ALL_NODE_CLASSES` within the class `com.github.javaparser.generator.metamodel.MetaModelGenerator`.</li>
+ * </ul>
+ *
+ * For this reason, any changes made directly to this file will be overwritten the next time generators are run.
+ */
+@Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
+public class MarkdownCommentMetaModel extends JavadocCommentMetaModel {
+
+    @Generated("com.github.javaparser.generator.metamodel.NodeMetaModelGenerator")
+    MarkdownCommentMetaModel(Optional<BaseNodeMetaModel> superBaseNodeMetaModel) {
+        super(
+                superBaseNodeMetaModel,
+                MarkdownComment.class,
+                "MarkdownComment",
+                "com.github.javaparser.ast.comments",
+                false,
+                false);
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -26,10 +26,7 @@ import static java.util.stream.Collectors.joining;
 
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
-import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.LineComment;
-import com.github.javaparser.ast.comments.TraditionalJavadocComment;
+import com.github.javaparser.ast.comments.*;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
@@ -1794,6 +1791,27 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
         // last line is not followed by a newline, and simply terminated with `*/`
         printer.print(lines[lines.length - 1]);
         printer.println(n.getFooter());
+    }
+
+    @Override
+    public void visit(final MarkdownComment n, final Void arg) {
+        if (!getOption(ConfigOption.PRINT_COMMENTS).isPresent()) {
+            return;
+        }
+        final String commentContent = normalizeEolInTextBlock(
+                n.getContent(),
+                getOption(ConfigOption.END_OF_LINE_CHARACTER).get().asString());
+        String[] lines = commentContent.split("\\R");
+        for (int i = 0; i < (lines.length - 1); i++) {
+            printer.print(n.getHeader());
+            printer.print(lines[i]);
+            // Avoids introducing indentation in markdown comments. ie: do not use println() as it would trigger
+            // indentation
+            // at the next print call.
+            printer.print(getOption(ConfigOption.END_OF_LINE_CHARACTER).get().asValue());
+        }
+        printer.print(n.getHeader());
+        printer.println(lines[lines.length - 1]);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -28,10 +28,7 @@ import static java.util.stream.Collectors.joining;
 
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
-import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.LineComment;
-import com.github.javaparser.ast.comments.TraditionalJavadocComment;
+import com.github.javaparser.ast.comments.*;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.nodeTypes.*;
@@ -1695,6 +1692,25 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
         // last line is not followed by a newline, and simply terminated with `*/`
         printer.print(lines[lines.length - 1]);
         printer.println(n.getFooter());
+    }
+
+    @Override
+    public void visit(final MarkdownComment n, final Void arg) {
+        if (configuration.isIgnoreComments()) {
+            return;
+        }
+        final String commentContent = normalizeEolInTextBlock(n.getContent(), configuration.getEndOfLineCharacter());
+        String[] lines = commentContent.split("\\R");
+        for (int i = 0; i < (lines.length - 1); i++) {
+            printer.print(n.getHeader());
+            printer.print(lines[i]);
+            // Avoids introducing indentation in markdown comments. ie: do not use println() as it would trigger
+            // indentation
+            // at the next print call.
+            printer.print(configuration.getEndOfLineCharacter());
+        }
+        printer.print(n.getHeader());
+        printer.println(lines[lines.length - 1]);
     }
 
     @Override

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -34,10 +34,7 @@ import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.comments.BlockComment;
-import com.github.javaparser.ast.comments.Comment;
-import com.github.javaparser.ast.comments.LineComment;
-import com.github.javaparser.ast.comments.TraditionalJavadocComment;
+import com.github.javaparser.ast.comments.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithVariables;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.ObservableProperty;
@@ -159,9 +156,7 @@ public class LexicalPreservingPrinter {
                 if (oldValue == null) {
                     // this case corresponds to the addition of a comment
                     // Find the position of the comment node and put in front of it the [...]
-                    int // Find the position of the comment node and put in front of it the [...]
-                            //
-                            index = parentNode.isPresent() ? nodeText.findChild(observedNode) : 0;
+                    int index = parentNode.isPresent() ? nodeText.findChild(observedNode) : 0;
                     /* Add the same indentation to the comment as the previous node
                      * for example if we want to add a comment on the body of the method declaration :
                      * Actual code
@@ -184,7 +179,9 @@ public class LexicalPreservingPrinter {
                      */
                     fixIndentOfAddedNode(nodeText, index - 1);
                     LineSeparator lineSeparator = observedNode.getLineEndingStyleOrDefault(LineSeparator.SYSTEM);
-                    nodeText.addElement(index++, makeCommentToken((Comment) newValue));
+                    for (TokenTextElement element : makeCommentTokens((Comment) newValue)) {
+                        nodeText.addElement(index++, element);
+                    }
                     nodeText.addToken(index, eolTokenKind(lineSeparator), lineSeparator.asRawString());
                     // code indentation after inserting an eol token may be wrong
                 } else if (newValue == null) {
@@ -193,8 +190,12 @@ public class LexicalPreservingPrinter {
                         if (((Comment) oldValue).isOrphan()) {
                             nodeText = getOrCreateNodeText(observedNode);
                         }
-                        int index = getIndexOfComment((Comment) oldValue, nodeText);
-                        nodeText.removeElement(index);
+                        Pair<Integer, Integer> indexAndCount =
+                                getIndexAndCountOfCommentTokens((Comment) oldValue, nodeText);
+                        int index = indexAndCount.a;
+                        for (int i = 0; i < indexAndCount.b; i++) {
+                            nodeText.removeElement(index);
+                        }
                         if (isCompleteLine(nodeText.getElements(), index)) {
                             removeAllExtraCharacters(nodeText.getElements(), index);
                         } else {
@@ -208,12 +209,20 @@ public class LexicalPreservingPrinter {
                     // this is a replacement of a comment
                     List<TokenTextElement> matchingTokens =
                             findTokenTextElementForComment((Comment) oldValue, nodeText);
-                    if (matchingTokens.size() != 1) {
+                    if ((oldValue instanceof MarkdownComment && matchingTokens.isEmpty())
+                            || (!(oldValue instanceof MarkdownComment) && matchingTokens.size() != 1)) {
                         throw new IllegalStateException("The matching comment to be replaced could not be found");
                     }
                     Comment newComment = (Comment) newValue;
-                    TokenTextElement matchingElement = matchingTokens.get(0);
-                    nodeText.replace(matchingElement.and(matchingElement.matchByRange()), makeCommentToken(newComment));
+                    TokenTextElement firstMatchingElement = matchingTokens.get(0);
+                    int index = nodeText.findElement(firstMatchingElement.and(firstMatchingElement.matchByRange()));
+                    // When replacing a MarkdownComment, all matching tokens must be removed before adding new ones
+                    for (int i = 0; i < matchingTokens.size(); i++) {
+                        nodeText.removeElement(index);
+                    }
+                    for (TokenTextElement newElement : makeCommentTokens(newComment)) {
+                        nodeText.addElement(index++, newElement);
+                    }
                 }
             }
             NodeText nodeText = getOrCreateNodeText(observedNode);
@@ -283,32 +292,78 @@ public class LexicalPreservingPrinter {
             }
         }
 
-        private TokenTextElement makeCommentToken(Comment newComment) {
-            if (newComment.isTraditionalJavadocComment()) {
-                return new TokenTextElement(
-                        JAVADOC_COMMENT, newComment.getHeader() + newComment.getContent() + newComment.getFooter());
+        /**
+         * Comments must be converted to TokenTextElements that the LPP can work with. For the other comments this is
+         * simple since there is a TokenType corresponding to them. A TokenTextElement can just be created from the
+         * header, footer, and content of the comment. This is not the case for MarkdownComments, however, since a
+         * MarkdownComment is made up of a sequence of whitespace and line comment tokens. This sequence is therefore
+         * manually reconstructed from the comment content.
+         */
+        private List<TokenTextElement> convertMarkdownCommentContentToTokens(MarkdownComment comment) {
+            ArrayList<TokenTextElement> tokens = new ArrayList<>();
+            String content = comment.getContent();
+            for (int i = 0; i < content.length(); i++) {
+                if (content.charAt(i) == '/') {
+                    int commentStart = i;
+                    while (i < content.length() - 1) {
+                        if (content.charAt(i + 1) == '\n' || content.charAt(i + 1) == '\r') {
+                            break;
+                        }
+                        i++;
+                    }
+                    tokens.add(new TokenTextElement(SINGLE_LINE_COMMENT, content.substring(commentStart, i + 1)));
+                } else if (content.charAt(i) == '\r') {
+                    if (i < content.length() - 1 && content.charAt(i + 1) == '\n') {
+                        tokens.add(new TokenTextElement(SPACE, "\r\n"));
+                        i++;
+                    } else {
+                        tokens.add(new TokenTextElement(SPACE, "\r"));
+                    }
+                } else if (Character.isWhitespace(content.charAt(i))) {
+                    tokens.add(new TokenTextElement(SPACE, Character.toString(content.charAt(i))));
+                } else {
+                    throw new IllegalArgumentException("Expected Markdown comment content format, but got " + comment);
+                }
             }
-            if (newComment.isLineComment()) {
-                return new TokenTextElement(SINGLE_LINE_COMMENT, newComment.getHeader() + newComment.getContent());
-            }
-            if (newComment.isBlockComment()) {
-                return new TokenTextElement(
-                        MULTI_LINE_COMMENT, newComment.getHeader() + newComment.getContent() + newComment.getFooter());
-            }
-            throw new UnsupportedOperationException(
-                    "Unknown type of comment: " + newComment.getClass().getSimpleName());
+            return tokens;
         }
 
-        private int getIndexOfComment(Comment oldValue, NodeText nodeText) {
+        private List<TokenTextElement> makeCommentTokens(Comment newComment) {
+            List<TokenTextElement> tokens = new ArrayList<>();
+            if (newComment.isJavadocComment()) {
+                TokenTextElement t = new TokenTextElement(
+                        JAVADOC_COMMENT, newComment.getHeader() + newComment.getContent() + newComment.getFooter());
+                tokens.add(t);
+            } else if (newComment.isLineComment()) {
+                TokenTextElement t =
+                        new TokenTextElement(SINGLE_LINE_COMMENT, newComment.getHeader() + newComment.getContent());
+                tokens.add(t);
+            } else if (newComment.isBlockComment()) {
+                TokenTextElement t = new TokenTextElement(
+                        MULTI_LINE_COMMENT, newComment.getHeader() + newComment.getContent() + newComment.getFooter());
+                tokens.add(t);
+            } else if (newComment.isMarkdownComment()) {
+                tokens.addAll(convertMarkdownCommentContentToTokens(newComment.asMarkdownComment()));
+            } else {
+                throw new UnsupportedOperationException(
+                        "Unknown type of comment: " + newComment.getClass().getSimpleName());
+            }
+            return tokens;
+        }
+
+        private Pair<Integer, Integer> getIndexAndCountOfCommentTokens(Comment oldValue, NodeText nodeText) {
             List<TokenTextElement> matchingTokens = findTokenTextElementForComment(oldValue, nodeText);
             if (!matchingTokens.isEmpty()) {
                 TextElement matchingElement = matchingTokens.get(0);
-                return nodeText.findElement(matchingElement.and(matchingElement.matchByRange()));
+                return new Pair<>(
+                        nodeText.findElement(matchingElement.and(matchingElement.matchByRange())),
+                        matchingTokens.size());
             }
             // If no matching TokenTextElements were found, we try searching through ChildTextElements as well
             List<ChildTextElement> matchingChilds = findChildTextElementForComment(oldValue, nodeText);
             ChildTextElement matchingChild = matchingChilds.get(0);
-            return nodeText.findElement(matchingChild.and(matchingChild.matchByRange()));
+            return new Pair<>(
+                    nodeText.findElement(matchingChild.and(matchingChild.matchByRange())), matchingChilds.size());
         }
 
         /*
@@ -383,6 +438,49 @@ public class LexicalPreservingPrinter {
                         .map(e -> (TokenTextElement) e)
                         .filter(t -> t.getText().equals(oldValue.asString()))
                         .collect(toList());
+            } else if (oldValue instanceof MarkdownComment) {
+                // Because a MarkdownComment consists of a sequence of tokens (as opposed to the other comment types
+                // which consist of a single token), all the tokens making up the MarkdownComment need to be found to
+                // be able to correctly replace or delete it.
+                matchingTokens = new ArrayList<>();
+                ArrayList<TextElement> maybeMatchingTokens = new ArrayList<>();
+                boolean inMatch = false;
+                String oldContent = oldValue.asMarkdownComment().getContent();
+                List<TextElement> textElements = nodeText.getElements();
+                for (TextElement textElement : textElements) {
+                    if (inMatch) {
+                        // If a matching start has been found, then add all following tokens to maybeMatchingTokens
+                        // until either a matching end is found, at which point the token range is added to
+                        // matchingTokens, or a non-whitespace, non-comment token is found at which point we know the
+                        // maybeMatchingTokens do not actually match the markdown comment (just some prefix of it), so
+                        // maybeMatchingTokens is cleared.
+                        maybeMatchingTokens.add(textElement);
+                        if (textElement.isToken(SINGLE_LINE_COMMENT) && oldContent.endsWith(textElement.expand())) {
+                            // We have a matching start and end, so check that the full text matches.
+                            StringBuilder sb = new StringBuilder();
+                            for (TextElement elem : maybeMatchingTokens) {
+                                sb.append(((TokenTextElement) elem).getText());
+                            }
+                            if (sb.toString().equals(oldContent)) {
+                                matchingTokens.addAll(maybeMatchingTokens.stream()
+                                        .map(e -> (TokenTextElement) e)
+                                        .collect(toList()));
+                                // Clear and continue, since multiple markdown comments may have the same content
+                                maybeMatchingTokens.clear();
+                                inMatch = false;
+                            } else {
+                                maybeMatchingTokens.clear();
+                                inMatch = false;
+                            }
+                        }
+                    } else if (textElement.isToken(SINGLE_LINE_COMMENT)
+                            && oldContent.startsWith(((TokenTextElement) textElement).getText())) {
+                        // Found a line comment that matches the first line of the markdown comment, so start looking
+                        // for the rest of the comment.
+                        maybeMatchingTokens.add(textElement);
+                        inMatch = true;
+                    }
+                }
             } else {
                 matchingTokens = nodeText.getElements().stream()
                         .filter(e -> e.isToken(SINGLE_LINE_COMMENT))
@@ -396,10 +494,9 @@ public class LexicalPreservingPrinter {
                     .filter(t -> (!t.getToken().hasRange() && !oldValue.hasRange())
                             || (t.getToken().hasRange()
                                     && oldValue.hasRange()
-                                    && t.getToken()
-                                            .getRange()
+                                    && oldValue.getRange()
                                             .get()
-                                            .equals(oldValue.getRange().get())))
+                                            .contains(t.getToken().getRange().get())))
                     .collect(toList());
         }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/NodeText.java
@@ -21,6 +21,7 @@
 package com.github.javaparser.printer.lexicalpreservation;
 
 import com.github.javaparser.ast.Node;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -160,6 +161,12 @@ class NodeText {
         int index = findElement(position, 0);
         elements.remove(index);
         elements.add(index, newElement);
+    }
+
+    void replace(TextElementMatcher position, Collection<? extends TextElement> newElements) {
+        int index = findElement(position, 0);
+        elements.remove(index);
+        elements.addAll(index, newElements);
     }
 
     //

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -200,6 +200,9 @@ TOKEN_MGR_DECLS :
     private Stack<Token> tokenWorkStack = new Stack<Token>();
     private boolean storeTokens;
     private boolean yieldSupported = false;
+    private ArrayDeque<Token> markdownCommentTokens = new ArrayDeque<Token>();
+    boolean expectMarkdownComment;
+    boolean expectEndOfMarkdownLine;
 
     void reset() {
         tokens = new ArrayList<JavaToken>();
@@ -232,12 +235,35 @@ TOKEN_MGR_DECLS :
         yieldSupported = true;
     }
 
+    private void createMarkdownComment() {
+        while (!markdownCommentTokens.isEmpty() && TokenTypes.isWhitespace(markdownCommentTokens.peekFirst().kind)) {
+            markdownCommentTokens.removeFirst();
+        }
+        if (!markdownCommentTokens.isEmpty()) {
+            MarkdownComment comment = createMarkdownCommentFromTokenList(markdownCommentTokens);
+            markdownCommentTokens.clear();
+
+            expectMarkdownComment = true;
+            expectEndOfMarkdownLine = false;
+
+            commentsCollection.addComment(comment);
+        }
+    }
+
     private void CommonTokenAction(Token token) {
         // Use an intermediary stack to avoid recursion, see issue 1003
         do {
             tokenWorkStack.push(token);
             token = token.specialToken;
         } while (token != null);
+
+        // A /// sequence only indicates the start of a markdown comment if it is only preceded by whitespace characters
+        // in the line. This variable is used to keep track of this.
+        expectMarkdownComment = true;
+        // A newline token only indicates the end of the markdown comment if it is not preceded by a line comment (e.g.
+        // the second of two consecutive newlines would end the comment). This variable keeps track of whether the next
+        // newline should end the markdown comment (if currently processing one).
+        expectEndOfMarkdownLine = false;
 
         // The stack is now filled with tokens in left-to-right order. Process them.
         while(!tokenWorkStack.empty()) {
@@ -252,9 +278,57 @@ TOKEN_MGR_DECLS :
                 homeToken = token.javaToken;
             }
 
-            if(TokenTypes.isComment(token.kind)) {
+            // While processing the list of tokens, markdown comments are constructed from consecutive line comments
+            // starting with ///. This is done using effectively a second state machine on top of the javacc. The core
+            // observation is that the start of a markdown comment line must be preceded by only whitespace. When
+            // the processing of the token stream starts, EXPECT_MARKDOWN_COMMENT = true since no non-whitespace tokens
+            // have been processed. Processing then proceeds as follows:
+            //  1. If a non-whitespace, non-line-comment token is read, then a markdown comment cannot start on that
+            //     line. Continue reading tokens until the newline while not expecting markdown comments.
+            //  2. If only whitespace tokens have been processed on a line, followed by a line comment starting with
+            //     ///, start processing a markdown comment.
+            //  3. While processing a markdown comment, add all whitespace tokens and line comments to the
+            //     markdownCommentTokens. These will be used to construct the markdown comment later.
+            //  4. If a newline is read while processing a markdown comment, then either the next line will continue
+            //     the comment (i.e. the newline is followed by only non-newline whitespace characters before the
+            //     next line comment starting with ///), or the markdown comment will be ended by another newline
+            //     or non-line-comment.
+            //  5. If the markdown comment is ended, use the markdownCommentTokens buffer to create the actual markdown
+            //     comment node.
+            if (TokenTypes.isEndOfLineToken(token.kind)) {
+                if (expectEndOfMarkdownLine) {
+                    // A newline is processed, but it's the first newline after a markdown comment line
+                    // (expectEndOfMarkdownComment is still true), so it does not end the comment yet.
+                    markdownCommentTokens.add(token);
+                    expectEndOfMarkdownLine = false;
+                } else {
+                    // A newline is processed, but it's not the first newline after a markdown comment line, so
+                    // create the comment now.
+                    createMarkdownComment();
+                }
+                // A new line is started, so until a non-whitespace non-line-comment token is processed, expect a new
+                // markdown comment.
+                expectMarkdownComment = true;
+            } else if (expectMarkdownComment && isMarkdownCommentLineCandidate(token)) {
+                // The next markdown line comment is processed, so add it to the buffer.
+                expectEndOfMarkdownLine = true;
+                markdownCommentTokens.add(token);
+            } else if (expectMarkdownComment && TokenTypes.isWhitespaceButNotEndOfLine(token.kind)) {
+                // Non-newline whitespace characters are always included in the token range for the markdown comment, so
+                // add them to the buffer
+                markdownCommentTokens.add(token);
+            } else if(TokenTypes.isComment(token.kind)) {
+                // A comment token is found, but not one that is a markdown line candidate (those are handled in an
+                // else above). This could be a line comment not starting with ///, or a block comment. At this point,
+                // end the markdown comment and handle the other comment separately.
+                createMarkdownComment();
                 Comment comment = createCommentFromToken(token);
                 commentsCollection.addComment(comment);
+            } else if (!TokenTypes.isWhitespace(token.kind)) {
+                // Any non-whitespace token ends the markdown comment. If the markdownCommentTokens buffer is empty or
+                // only contains whitespace, it is simply cleared.
+                expectMarkdownComment = false;
+                createMarkdownComment();
             }
         }
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/DefaultVisitorAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/DefaultVisitorAdapter.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.MarkdownComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
@@ -56,6 +57,11 @@ public class DefaultVisitorAdapter implements GenericVisitor<ResolvedType, Boole
 
     @Override
     public ResolvedType visit(BlockComment node, Boolean aBoolean) {
+        throw new UnsupportedOperationException(node.getClass().getCanonicalName());
+    }
+
+    @Override
+    public ResolvedType visit(MarkdownComment node, Boolean aBoolean) {
         throw new UnsupportedOperationException(node.getClass().getCanonicalName());
     }
 


### PR DESCRIPTION
Originally opened as https://github.com/javaparser/javaparser/pull/4875, but split into https://github.com/javaparser/javaparser/pull/4885 and https://github.com/johannescoetzee/javaparser/pull/3 (the latter opened and reviewed on my fork to see the diff compared to a local version of https://github.com/javaparser/javaparser/pull/4885)

# Original description

This PR will replace https://github.com/javaparser/javaparser/pull/4875. 

This PR adds support for Markdown comments as described in JEP 467. I ran into a few issues while implementing this, so the end result is a compromise between the ideal design and what is doable in a reasonable amount of time and without rewriting all of the comment handling (and requiring users to do the same).
 
## MarkdownComment node
As it is, this PR adds the `MarkdownComment` node, which is distinct from `JavadocComment`. I considered merging these under a common class, but in my opinion the benefits to doing so is far outweighed by the complexity of the change required. The `content` field of the `MarkdownComment` contains the raw text, including the `///` and leading spaces after the first line, which is somewhat consistent with how block comments are handled. Keeping this information is necessary for the pretty printer and LPP. 

It also contains a method `getMarkdownContent` which strips the leading whitespace, `///` and indents the remaining content consistent with the description provided in JEP 467. I suspect that this will be more useful to users than using the raw content.

## Parser changes
I initially tried updating the grammar to parse markdown comments as a single token, but ran into some difficulties doing this. From what I can see it looks like it should be possible, but would require manually manipulating the tokenizer input stream and I wasn't confident enough that this would work out to spend too much time on it. Instead, the `MarkdownComment` consists of a range of tokens starting with the first `SINGLE_LINE_COMMENT`, including all leading and trailing whitespace for the body and ending with the last `SINGLE_LINE_COMMENT`. The handling of all this is done in the `CommonTokenAction` method defined in `java.jj` which is added to the `GeneratedJavaParserTokenManager`. 

## Pretty printer and LPP
Support in the pretty printer is mostly a copy-paste of block comments are handled with only minor tweaks to account for the lack of `/**` and `*/`. Support for the LPP is more complicated since the assumption was made that a comment will always consist of a single token. I've updated the code handling adding, removing, and replacing comments to account for the possibility of having multiple tokens corresponding to the comment.

## Note on the implementation
I did consider implementing Markdown comment support as a PostProcessing pass as well, but thought it would end up being more complex. The main problem is that all but the last line comment before a method end up as orphan comments, so, to correctly reconstruct the markdown comments, it would necessary to connect these line comments by looking at token ranges and the tokens between them. While separating this logic from the parser would bring some benefit, I think it would be harder to reason about than the approach implemented in this PR where the token stream is being processed directly. It would also only work if tokens are saved (as far as I understand), which is a significant downside.