### PR TITLE
Add support for Java 23 and Java 24

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java23ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java23ValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator;
+
+import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
+import static com.github.javaparser.ParseStart.STATEMENT;
+import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_23;
+import static com.github.javaparser.Providers.provider;
+import static com.github.javaparser.utils.TestUtils.assertNoProblems;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.stmt.Statement;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for Java 23 language level support.
+ * Tests basic functionality inherited from Java 22.
+ *
+ * @see <a href="https://openjdk.org/projects/jdk/23/">https://openjdk.org/projects/jdk/23/</a>
+ */
+class Java23ValidatorTest {
+
+    private final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_23));
+
+    @Test
+    void basicParsing() {
+        ParseResult<CompilationUnit> result = javaParser.parse(
+                COMPILATION_UNIT, provider("class X { void m() { System.out.println(\"Hello\"); } }"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void yieldStatementSupported() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("yield 42;"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void switchExpressionSupported() {
+        ParseResult<Statement> result = javaParser.parse(
+                STATEMENT,
+                provider("int result = switch(x) { case 1 -> 10; case 2 -> 20; default -> 0; };"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void recordsSupported() {
+        ParseResult<CompilationUnit> result =
+                javaParser.parse(COMPILATION_UNIT, provider("record Point(int x, int y) {}"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void textBlocksSupported() {
+        ParseResult<CompilationUnit> result = javaParser.parse(
+                COMPILATION_UNIT, provider("class X { String s = \"\"\"\n    Hello\n    World\n    \"\"\"; }"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void unnamedVariablesFromJava22Supported() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int _ = 42;"));
+        assertNoProblems(result);
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java23ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java23ValidatorTest.java
@@ -46,8 +46,8 @@ class Java23ValidatorTest {
 
     @Test
     void basicParsing() {
-        ParseResult<CompilationUnit> result = javaParser.parse(
-                COMPILATION_UNIT, provider("class X { void m() { System.out.println(\"Hello\"); } }"));
+        ParseResult<CompilationUnit> result =
+                javaParser.parse(COMPILATION_UNIT, provider("class X { void m() { System.out.println(\"Hello\"); } }"));
         assertNoProblems(result);
     }
 
@@ -60,8 +60,7 @@ class Java23ValidatorTest {
     @Test
     void switchExpressionSupported() {
         ParseResult<Statement> result = javaParser.parse(
-                STATEMENT,
-                provider("int result = switch(x) { case 1 -> 10; case 2 -> 20; default -> 0; };"));
+                STATEMENT, provider("int result = switch(x) { case 1 -> 10; case 2 -> 20; default -> 0; };"));
         assertNoProblems(result);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java24ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java24ValidatorTest.java
@@ -46,8 +46,8 @@ class Java24ValidatorTest {
 
     @Test
     void basicParsing() {
-        ParseResult<CompilationUnit> result = javaParser.parse(
-                COMPILATION_UNIT, provider("class X { void m() { System.out.println(\"Hello\"); } }"));
+        ParseResult<CompilationUnit> result =
+                javaParser.parse(COMPILATION_UNIT, provider("class X { void m() { System.out.println(\"Hello\"); } }"));
         assertNoProblems(result);
     }
 
@@ -60,8 +60,7 @@ class Java24ValidatorTest {
     @Test
     void switchExpressionSupported() {
         ParseResult<Statement> result = javaParser.parse(
-                STATEMENT,
-                provider("int result = switch(x) { case 1 -> 10; case 2 -> 20; default -> 0; };"));
+                STATEMENT, provider("int result = switch(x) { case 1 -> 10; case 2 -> 20; default -> 0; };"));
         assertNoProblems(result);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java24ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java24ValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator;
+
+import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
+import static com.github.javaparser.ParseStart.STATEMENT;
+import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_24;
+import static com.github.javaparser.Providers.provider;
+import static com.github.javaparser.utils.TestUtils.assertNoProblems;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.stmt.Statement;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for Java 24 language level support.
+ * Tests basic functionality inherited from Java 23.
+ *
+ * @see <a href="https://openjdk.org/projects/jdk/24/">https://openjdk.org/projects/jdk/24/</a>
+ */
+class Java24ValidatorTest {
+
+    private final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_24));
+
+    @Test
+    void basicParsing() {
+        ParseResult<CompilationUnit> result = javaParser.parse(
+                COMPILATION_UNIT, provider("class X { void m() { System.out.println(\"Hello\"); } }"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void yieldStatementSupported() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("yield 42;"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void switchExpressionSupported() {
+        ParseResult<Statement> result = javaParser.parse(
+                STATEMENT,
+                provider("int result = switch(x) { case 1 -> 10; case 2 -> 20; default -> 0; };"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void recordsSupported() {
+        ParseResult<CompilationUnit> result =
+                javaParser.parse(COMPILATION_UNIT, provider("record Point(int x, int y) {}"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void textBlocksSupported() {
+        ParseResult<CompilationUnit> result = javaParser.parse(
+                COMPILATION_UNIT, provider("class X { String s = \"\"\"\n    Hello\n    World\n    \"\"\"; }"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void unnamedVariablesFromJava22Supported() {
+        ParseResult<Statement> result = javaParser.parse(STATEMENT, provider("int _ = 42;"));
+        assertNoProblems(result);
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -186,7 +186,15 @@ public class ParserConfiguration {
         /**
          * Java 22
          */
-        JAVA_22(new Java22Validator(), new Java22PostProcessor());
+        JAVA_22(new Java22Validator(), new Java22PostProcessor()),
+        /**
+         * Java 23
+         */
+        JAVA_23(new Java23Validator(), new Java23PostProcessor()),
+        /**
+         * Java 24
+         */
+        JAVA_24(new Java24Validator(), new Java24PostProcessor());
 
         /**
          * Does no post processing or validation. Only for people wanting the fastest parsing.
@@ -208,7 +216,7 @@ public class ParserConfiguration {
         /**
          * The newest Java features supported.
          */
-        public static LanguageLevel BLEEDING_EDGE = JAVA_22;
+        public static LanguageLevel BLEEDING_EDGE = JAVA_24;
 
         final Validator validator;
 
@@ -229,7 +237,9 @@ public class ParserConfiguration {
             JAVA_19,
             JAVA_20,
             JAVA_21,
-            JAVA_22
+            JAVA_22,
+            JAVA_23,
+            JAVA_24
         };
 
         LanguageLevel(Validator validator, PostProcessors postProcessor) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java23Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java23Validator.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.validator.language_level_validations;
 
 /**
@@ -27,6 +26,7 @@ package com.github.javaparser.ast.validator.language_level_validations;
  * so this validator simply extends Java 22.
  */
 public class Java23Validator extends Java22Validator {
+
     public Java23Validator() {
         super();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java23Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java23Validator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.language_level_validations;
+
+/**
+ * Validator for Java 23 language features.
+ * Java 23 does not introduce new syntax changes that affect parsing,
+ * so this validator simply extends Java 22.
+ */
+public class Java23Validator extends Java22Validator {
+    public Java23Validator() {
+        super();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java24Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java24Validator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.language_level_validations;
+
+/**
+ * Validator for Java 24 language features.
+ * Java 24 does not introduce new syntax changes that affect parsing,
+ * so this validator simply extends Java 23.
+ */
+public class Java24Validator extends Java23Validator {
+    public Java24Validator() {
+        super();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java24Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java24Validator.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.validator.language_level_validations;
 
 /**
@@ -27,6 +26,7 @@ package com.github.javaparser.ast.validator.language_level_validations;
  * so this validator simply extends Java 23.
  */
 public class Java24Validator extends Java23Validator {
+
     public Java24Validator() {
         super();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java23PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java23PostProcessor.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.validator.postprocessors;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java23PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java23PostProcessor.java
@@ -25,5 +25,4 @@ package com.github.javaparser.ast.validator.postprocessors;
  * Post-processor for Java 23 language features.
  * Java 23 does not introduce new syntax changes requiring post-processing.
  */
-public class Java23PostProcessor extends Java22PostProcessor {
-}
+public class Java23PostProcessor extends Java22PostProcessor {}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java23PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java23PostProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Post-processor for Java 23 language features.
+ * Java 23 does not introduce new syntax changes requiring post-processing.
+ */
+public class Java23PostProcessor extends Java22PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java24PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java24PostProcessor.java
@@ -18,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser.ast.validator.postprocessors;
 
 /**

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java24PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java24PostProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.validator.postprocessors;
+
+/**
+ * Post-processor for Java 24 language features.
+ * Java 24 does not introduce new syntax changes requiring post-processing.
+ */
+public class Java24PostProcessor extends Java23PostProcessor {
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java24PostProcessor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/postprocessors/Java24PostProcessor.java
@@ -25,5 +25,4 @@ package com.github.javaparser.ast.validator.postprocessors;
  * Post-processor for Java 24 language features.
  * Java 24 does not introduce new syntax changes requiring post-processing.
  */
-public class Java24PostProcessor extends Java23PostProcessor {
-}
+public class Java24PostProcessor extends Java23PostProcessor {}


### PR DESCRIPTION
## Summary
Adds language level support for Java 23 and Java 24.

## Changes
- Added `Java23Validator` and `Java24Validator` (extend `Java22Validator`)
- Added `Java23PostProcessor` and `Java24PostProcessor` (extend `Java22PostProcessor`)
- Added `JAVA_23` and `JAVA_24` enum entries to `ParserConfiguration`
- Updated `BLEEDING_EDGE` to `JAVA_24`
- Extended `yieldSupport` array to include Java 23 and 24
- Added comprehensive tests for both language levels

## Notes
- Neither Java 23 nor Java 24 introduce syntax changes that affect parsing
- The validators and post-processors simply extend Java 22 counterparts
- Java 25 support with JEPs 511, 512, and 513 will be handled in separate PRs

## Related Issues
Closes #4699

## Testing
All existing tests pass + new validator tests for Java 23/24