### PR TITLE
[JEP 513] Add support for flexible constructor bodies

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ConstructorDeclarationTest.java
@@ -21,8 +21,18 @@
 
 package com.github.javaparser.ast.body;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
+import static com.github.javaparser.Providers.provider;
+import static com.github.javaparser.utils.TestUtils.assertNoProblems;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.utils.LineSeparator;
 import org.junit.jupiter.api.Test;
 
@@ -34,5 +44,34 @@ class ConstructorDeclarationTest {
 
         assertEquals(
                 String.format("public Cons() {%1$s" + "    super();%1$s" + "}", LineSeparator.SYSTEM), cons.toString());
+    }
+
+    @Test
+    void explicitConstructorInvocationAfterFirstStatement() {
+        String code = "class Foo {\n" + "    public Foo() {\n"
+                + "        int x = 2;\n"
+                + "        super();\n"
+                + "        x = 3;\n"
+                + "    }\n"
+                + "}";
+
+        ParserConfiguration configuration =
+                new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        JavaParser parser = new JavaParser(configuration);
+        ParseResult<CompilationUnit> result = parser.parse(COMPILATION_UNIT, provider(code));
+        assertNoProblems(result);
+
+        CompilationUnit cu = result.getResult().get();
+
+        ConstructorDeclaration constructorDeclaration =
+                Navigator.demandNodeOfGivenClass(cu, ConstructorDeclaration.class);
+        NodeList<Statement> statements = constructorDeclaration.getBody().getStatements();
+
+        assertTrue(statements.get(0).isExpressionStmt());
+        assertTrue(statements.get(0).asExpressionStmt().getExpression().isVariableDeclarationExpr());
+        assertTrue(statements.get(1).isExplicitConstructorInvocationStmt());
+        assertFalse(statements.get(1).asExplicitConstructorInvocationStmt().isThis());
+        assertTrue(statements.get(2).isExpressionStmt());
+        assertTrue(statements.get(2).asExpressionStmt().getExpression().isAssignExpr());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java1_0ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java1_0ValidatorTest.java
@@ -139,4 +139,30 @@ class Java1_0ValidatorTest {
                 result,
                 "(line 1,col 1) Module imports are not supported Pay attention that this feature is supported starting from 'JAVA_25' language level. If you need that feature the language level must be configured in the configuration before parsing the source files.");
     }
+
+    @Test
+    void explicitConstructorInvocationAsFirstStatementAllowed() {
+        String code = "class Foo {\n" + "    public Foo() {\n"
+                + "        super();\n"
+                + "        int x = 2;\n"
+                + "    }\n"
+                + "}";
+
+        ParseResult<CompilationUnit> result = javaParser.parse(COMPILATION_UNIT, provider(code));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void explicitConstructorInvocationAfterFirstStatementNotAllowed() {
+        String code = "class Foo {\n" + "    public Foo() {\n"
+                + "        int x = 2;\n"
+                + "        super();\n"
+                + "    }\n"
+                + "}";
+
+        ParseResult<CompilationUnit> result = javaParser.parse(COMPILATION_UNIT, provider(code));
+        assertProblems(
+                result,
+                "(line 4,col 9) Flexible constructor bodies are not supported Pay attention that this feature is supported starting from 'JAVA_25' language level. If you need that feature the language level must be configured in the configuration before parsing the source files.");
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java25ValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/Java25ValidatorTest.java
@@ -29,6 +29,7 @@ import static com.github.javaparser.utils.TestUtils.assertNoProblems;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +46,18 @@ class Java25ValidatorTest {
     void moduleImportAllowed() {
         ParseResult<ImportDeclaration> result =
                 javaParser.parse(IMPORT_DECLARATION, provider("import module java.base;"));
+        assertNoProblems(result);
+    }
+
+    @Test
+    void explicitConstructorInvocationAfterFirstStatementAllowed() {
+        String code = "class Foo {\n" + "    public Foo() {\n"
+                + "        int x = 2;\n"
+                + "        super();\n"
+                + "    }\n"
+                + "}";
+
+        ParseResult<CompilationUnit> result = javaParser.parse(COMPILATION_UNIT, provider(code));
         assertNoProblems(result);
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -548,4 +548,16 @@ class PrettyPrintVisitorTest extends TestParser {
         CompilationUnit cu = parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
+
+    @Test
+    void printFlexibleConstructorBody() {
+        String code = "public class A {\n" + "\n"
+                + "    public A() {\n"
+                + "        int x;\n"
+                + "        super();\n"
+                + "    }\n"
+                + "}\n";
+        CompilationUnit cu = parse(code);
+        assertEqualsStringIgnoringEol(code, cu.toString());
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ConstructorDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ConstructorDeclarationTransformationsTest.java
@@ -25,10 +25,13 @@ import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
@@ -118,6 +121,33 @@ class ConstructorDeclarationTransformationsTest extends AbstractLexicalPreservin
     // ThrownExceptions
 
     // Body
+
+    @Test
+    void addingConstructorInvocationAsSecondStatement() {
+        ConstructorDeclaration cd = consider("public A() { int x; }");
+        cd.getBody().getStatements().add(new ExplicitConstructorInvocationStmt().setThis(false));
+        assertTransformedToString("public A() { int x; super();" + System.lineSeparator() + "}", cd);
+    }
+
+    @Test
+    void modifyingConstructorInvocationAsSecondStatement() {
+        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        ConstructorDeclaration cd = consider("public A() { int x; super(); }");
+        cd.getBody()
+                .getStatements()
+                .get(1)
+                .asExplicitConstructorInvocationStmt()
+                .setThis(true);
+        assertTransformedToString("public A() { int x; this(); }", cd);
+    }
+
+    @Test
+    void removingConstructorInvocationAsSecondStatement() {
+        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        ConstructorDeclaration cd = consider("public A() { int x; super(); }");
+        cd.getBody().getStatements().remove(1);
+        assertTransformedToString("public A() { int x; }", cd);
+    }
 
     // Annotations
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java25Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java25Validator.java
@@ -31,5 +31,6 @@ public class Java25Validator extends Java24Validator {
     public Java25Validator() {
         super();
         remove(noModuleImports);
+        remove(explicitConstructorInvocationMustBeFirstStatement);
     }
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1947,7 +1947,6 @@ CompactConstructorDeclaration CompactConstructorDeclaration(ModifierHolder modif
     SimpleName name;
     Pair<NodeList<Parameter>, ReceiverParameter> parameters = new Pair<NodeList<Parameter>, ReceiverParameter>(emptyNodeList(), null);
     NodeList<ReferenceType> throws_ = emptyNodeList();
-    ExplicitConstructorInvocationStmt exConsInv = null;
     NodeList<Statement> stmts = emptyNodeList();
     JavaToken begin = modifier.begin;
     JavaToken blockBegin = INVALID;
@@ -1964,17 +1963,10 @@ CompactConstructorDeclaration CompactConstructorDeclaration(ModifierHolder modif
         ("," throwType = AnnotatedReferenceType() { throws_ = add(throws_, throwType); })*
     ]
     "{" { blockBegin=token(); }
-    [
-        LOOKAHEAD(ExplicitConstructorInvocation())
-        exConsInv = ExplicitConstructorInvocation()
-    ]
     stmts = Statements()
     "}"
 
     {
-    if (exConsInv != null) {
-        stmts = prepend(stmts, exConsInv);
-    }
     return new CompactConstructorDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, typeParameters.list, name, throws_, new BlockStmt(range(blockBegin, token()), stmts));
 }
 }
@@ -2513,9 +2505,11 @@ Name ReceiverParameterId():
  *         TypeIdentifier
  * }</pre>
  * https://docs.oracle.com/javase/specs/jls/se15/html/jls-8.html#jls-8.8.7
+ * https://docs.oracle.com/javase/specs/jls/se25/html/jls-8.html#jls-ConstructorBody
  * <pre>{@code
  *     ConstructorBody:
- *         { [ExplicitConstructorInvocation] [BlockStatements] }
+ *         { [BlockStatements] ConstructorInvocation [BlockStatements] }
+ *         { [BlockStatements] }
  * }</pre>
  * https://docs.oracle.com/javase/specs/jls/se15/html/jls-8.html#jls-8.8.7.1
  * <pre>{@code
@@ -2532,7 +2526,6 @@ ConstructorDeclaration ConstructorDeclaration(ModifierHolder modifier):
     SimpleName name;
     Pair<NodeList<Parameter>, ReceiverParameter> parameters = new Pair<NodeList<Parameter>, ReceiverParameter>(emptyNodeList(), null);
     NodeList<ReferenceType> throws_ = emptyNodeList();
-    ExplicitConstructorInvocationStmt exConsInv = null;
     NodeList<Statement> stmts = emptyNodeList();
     JavaToken begin = modifier.begin;
     JavaToken blockBegin = INVALID;
@@ -2549,17 +2542,10 @@ ConstructorDeclaration ConstructorDeclaration(ModifierHolder modifier):
         ("," throwType = AnnotatedReferenceType() { throws_ = add(throws_, throwType); })*
     ]
     "{" { blockBegin=token(); }
-    [
-        LOOKAHEAD(ExplicitConstructorInvocation())
-        exConsInv = ExplicitConstructorInvocation()
-    ]
     stmts = Statements()
     "}"
 
     {
-        if (exConsInv != null) {
-            stmts = prepend(stmts, exConsInv);
-        }
         return new ConstructorDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, typeParameters.list, name, parameters.a, throws_, new BlockStmt(range(blockBegin, token()), stmts), parameters.b);
     }
 }
@@ -4568,6 +4554,15 @@ Statement BlockStatement():
             expr = VariableDeclarationExpression()
             ";"
             { ret = new ExpressionStmt(range(expr, token()), expr); }
+         |
+            // In Java >= 25, explicit constructor invocations are allowed anywhere in the body of a constructor
+            // Adding support for that here isn't 100% correct, since this would allow multiple constructor invocations
+            // in a constructor body or block not in a constructor body, but handling this correctly would require
+            // larger changes through the grammar due to simplifications made elsewhere.
+            // Handling it here should not be a problem since we assume input code compiles. The compiler would have
+            // already caught the incorrect cases above.
+            LOOKAHEAD( ExplicitConstructorInvocation() )
+            ret = ExplicitConstructorInvocation()
          |
             ret = Statement()
         )


### PR DESCRIPTION
Fixes https://github.com/javaparser/javaparser/issues/4849
Replaces https://github.com/javaparser/javaparser/pull/4903

This PR removes the restriction that explicit constructor invocations must appear as the first statement in a constructor body. See https://openjdk.org/jeps/513 for more details regarding the motivations behind this change.

The grammar change was inspired by https://github.com/javaparser/javaparser/pull/4903 opened by @rpx99, although I did add my own comment explaining why handling it this way should be fine, even if it isn't 100% correct according to the JLS (we handle compiling code correctly, but also parse some non-compiling code without reporting errors; if users choose to parse non-compiling code, then they will need to do their own validation according to their needs).

I've also included a simplified validator compared to https://github.com/javaparser/javaparser/pull/4903 with validator tests and AST tests.

Finally, I've also included pretty printer and LPP tests, but didn't need to update either of those to support this.