### PR TITLE
Fix grammar ambiguities causing crashes when using `assert` and `module` as names

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/UnaryExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/UnaryExprTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2025 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.ast.expr;
+
+import static com.github.javaparser.StaticJavaParser.parseStatement;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.stmt.AssertStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UnaryExprTest {
+    @BeforeEach
+    void initParser() {
+        StaticJavaParser.setConfiguration(new ParserConfiguration());
+    }
+
+    @Test
+    void unaryInAssertStatementTest() {
+        Statement stmt = parseStatement("assert ++counter == 1 : \"Counter should be incremented\";");
+        assertInstanceOf(AssertStmt.class, stmt);
+        AssertStmt assertStmt = stmt.asAssertStmt();
+
+        assertInstanceOf(BinaryExpr.class, assertStmt.getCheck());
+        BinaryExpr condition = assertStmt.getCheck().asBinaryExpr();
+        assertEquals(BinaryExpr.Operator.EQUALS, condition.getOperator());
+
+        assertInstanceOf(UnaryExpr.class, condition.getLeft());
+        UnaryExpr unary = condition.getLeft().asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("counter", unary.getExpression().asNameExpr().getNameAsString());
+
+        assertInstanceOf(IntegerLiteralExpr.class, condition.getRight());
+        assertEquals("1", condition.getRight().asIntegerLiteralExpr().getValue());
+
+        assertInstanceOf(StringLiteralExpr.class, assertStmt.getMessage().get());
+        assertEquals(
+                "Counter should be incremented",
+                assertStmt.getMessage().get().asStringLiteralExpr().getValue());
+    }
+
+    @Test
+    void postfixIncrementOnAssertIdentifierTest() {
+        // Note: "assert" as an identifier is only valid in Java < 1.4 In modern Java,
+        // "assert" is a keyword. However, "assert" as an identifier is still supported
+        // for backward compatibility
+        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0);
+
+        Statement stmt = parseStatement("assert++;");
+        assertInstanceOf(ExpressionStmt.class, stmt);
+        ExpressionStmt exprStmt = stmt.asExpressionStmt();
+
+        assertInstanceOf(UnaryExpr.class, exprStmt.getExpression());
+        UnaryExpr unary = exprStmt.getExpression().asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.POSTFIX_INCREMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("assert", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void prefixIncrementOnAssertIdentifierTest() {
+        // Note: "assert" as an identifier is only valid in Java < 1.4 In modern Java,
+        // "assert" is a keyword. However, "assert" as an identifier is still supported
+        // for backward compatibility
+        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0);
+
+        Statement stmt = parseStatement("++assert;");
+        assertInstanceOf(ExpressionStmt.class, stmt);
+        ExpressionStmt exprStmt = stmt.asExpressionStmt();
+
+        assertInstanceOf(UnaryExpr.class, exprStmt.getExpression());
+        UnaryExpr unary = exprStmt.getExpression().asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("assert", unary.getExpression().asNameExpr().getNameAsString());
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
@@ -22,8 +22,7 @@
 package com.github.javaparser.ast.imports;
 
 import static com.github.javaparser.StaticJavaParser.parseImport;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
@@ -69,5 +68,20 @@ class ImportDeclarationTest {
         ImportDeclaration i = parseImport("import module java.base;");
         assertEquals("java.base", i.getNameAsString());
         assertTrue(i.isModule());
+    }
+
+    @Test
+    void modulePackageImport() {
+        ImportDeclaration i = parseImport("import module.base.Foo;");
+        assertEquals("module.base.Foo", i.getNameAsString());
+        assertFalse(i.isModule());
+    }
+
+    @Test
+    void staticModulePackageImport() {
+        ImportDeclaration i = parseImport("import static module.base.Foo;");
+        assertEquals("module.base.Foo", i.getNameAsString());
+        assertFalse(i.isModule());
+        assertTrue(i.isStatic());
     }
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -4393,7 +4393,7 @@ Statement Statement():
     try {
         (
             LOOKAHEAD(2) ret = LabeledStatement()
-            | ret = AssertStatement()
+            | LOOKAHEAD(3) ret = AssertStatement()
             | LOOKAHEAD(3) ret = YieldStatement()
             | ret = Block()
             | ret = EmptyStatement()

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1282,8 +1282,13 @@ ImportDeclaration ImportDeclaration():
 {
     "import" {begin = token();}
     [ "static" { isStatic = true; } ]
-    [ "module" { isModule = true; }]
-    name = Name()
+    (
+        LOOKAHEAD(3)
+        "module" { isModule = true; }
+        name = Name()
+      |
+        name = Name()
+    )
     [ "." "*" { isAsterisk = true; } ] ";"
     { return new ImportDeclaration(range(begin, token()), name, isStatic, isAsterisk, isModule); }
 }


### PR DESCRIPTION
Fixes https://github.com/javaparser/javaparser/issues/4928

There are two different bugs here, but I decided to include them in one issue/PR since the fix for both is quite simple and they are related.

## Problem 1

In Java < 1.4, `assert` is not yet a keyword and can therefore be used as a regular identifier. There is an ambiguity in the grammar that causes a parse error when attempting to parse the statement:
```java
assert++;
```

It is very unlikely that any JavaParser user would encounter this error in practice given the fact that this is only valid code for Java 1-3, but I don't see any potential negative consequences for the fix.

The parser currently tries to parse this as an `assert` statement followed by a `PREFIX_INCREMENT` UnaryExpr. Parsing the UnaryExpr then fails since there is no expression following the `++`.

This is fixed by adding a lookahead for the `assert` statement to check whether the `++` is followed by an expression or not.

## Problem 2

`module` is a conditional keyword that can still be used as a package name.  https://github.com/javaparser/javaparser/pull/4910 introduced a new grammar ambiguity causing a parse error when attempting to parse an import statement for a package starting with `module`:
```java
import module.Foo
```

The parser attempts to parse this as a module import `import module .Foo` and crashes when attempting to parse the name since a name cannot start with `.`.

The fix is to consider two cases separately:
- either there is a `module` token followed by a name
- or there is just a name

Once these are separate cases, a lookahead can be used to figure out which of these should be applied