### PR TITLE
Add UnaryExpr, BinaryExpr, and some record/enum tests to improve overall test coverage

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/TypeDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/TypeDeclarationTest.java
@@ -25,8 +25,13 @@ import static com.github.javaparser.utils.TestParser.parseBodyDeclaration;
 import static com.github.javaparser.utils.TestParser.parseCompilationUnit;
 import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.junit.jupiter.api.Test;
 
 class TypeDeclarationTest {
@@ -75,6 +80,58 @@ class TypeDeclarationTest {
     @Test
     void qualifiedNameOfDetachedClassIsEmpty() {
         assertFQN("?", parseBodyDeclaration("class X{}"));
+    }
+
+    /**
+     * "module" became a keyword in Java 9, but can still be used as an identifier
+     * in certain contexts. This test verifies the AST for an enum named "module"
+     * that also uses "module" as a return type and in a field access expression.
+     */
+    @Test
+    void enumWithModuleAsName() {
+        String s = "enum module {\n"
+                + "  FOO;\n"
+                + "\n"
+                + "  module foo() {\n"
+                + "    return module.FOO;\n"
+                + "  }\n"
+                + "}\n";
+
+        CompilationUnit cu = parseCompilationUnit(s);
+
+        // Verify there is exactly one enum declaration
+        assertEquals(1, cu.findAll(EnumDeclaration.class).size());
+
+        EnumDeclaration enumDecl = cu.findFirst(EnumDeclaration.class).get();
+        assertEquals("module", enumDecl.getNameAsString());
+
+        // Verify the enum has one constant "FOO"
+        assertEquals(1, enumDecl.getEntries().size());
+        EnumConstantDeclaration constant = enumDecl.getEntries().get(0);
+        assertEquals("FOO", constant.getNameAsString());
+
+        // Verify the enum has one method "foo"
+        assertEquals(1, enumDecl.getMembers().size());
+        assertTrue(enumDecl.getMembers().get(0).isMethodDeclaration());
+
+        MethodDeclaration method = enumDecl.getMembers().get(0).asMethodDeclaration();
+        assertEquals("foo", method.getNameAsString());
+
+        // Verify the return type is "module"
+        assertInstanceOf(ClassOrInterfaceType.class, method.getType());
+        assertEquals("module", method.getType().asClassOrInterfaceType().getNameAsString());
+
+        // Verify the method body contains a return statement
+        assertTrue(method.getBody().isPresent());
+        assertEquals(1, method.getBody().get().getStatements().size());
+        assertTrue(method.getBody().get().getStatements().get(0).isReturnStmt());
+
+        ReturnStmt returnStmt = method.getBody().get().getStatements().get(0).asReturnStmt();
+        assertTrue(returnStmt.getExpression().isPresent());
+
+        // Verify the return expression is a field access "module.FOO"
+        assertTrue(returnStmt.getExpression().get().isFieldAccessExpr());
+        assertEquals("module.FOO", returnStmt.getExpression().get().toString());
     }
 
     void assertFQN(String fqn, Node node) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/UnaryExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/UnaryExprTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.ast.expr;
 
+import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -37,6 +38,190 @@ class UnaryExprTest {
     @BeforeEach
     void initParser() {
         StaticJavaParser.setConfiguration(new ParserConfiguration());
+    }
+
+    @Test
+    void unaryPlusTest() {
+        Expression e = parseExpression("+x");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.PLUS, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void unaryMinusTest() {
+        Expression e = parseExpression("-x");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.MINUS, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void prefixIncrementTest() {
+        Expression e = parseExpression("++x");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void prefixDecrementTest() {
+        Expression e = parseExpression("--x");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.PREFIX_DECREMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void logicalComplementTest() {
+        Expression e = parseExpression("!flag");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.LOGICAL_COMPLEMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("flag", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void bitwiseComplementTest() {
+        Expression e = parseExpression("~x");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.BITWISE_COMPLEMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void postfixIncrementTest() {
+        Expression e = parseExpression("x++");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.POSTFIX_INCREMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void postfixDecrementTest() {
+        Expression e = parseExpression("x--");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.POSTFIX_DECREMENT, unary.getOperator());
+
+        assertInstanceOf(NameExpr.class, unary.getExpression());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void nestedUnaryTest() {
+        Expression e = parseExpression("!!flag");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr outerUnary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.LOGICAL_COMPLEMENT, outerUnary.getOperator());
+
+        assertInstanceOf(UnaryExpr.class, outerUnary.getExpression());
+        UnaryExpr innerUnary = outerUnary.getExpression().asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.LOGICAL_COMPLEMENT, innerUnary.getOperator());
+
+        assertInstanceOf(NameExpr.class, innerUnary.getExpression());
+        assertEquals("flag", innerUnary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void unaryWithMethodCallTest() {
+        Expression e = parseExpression("!obj.isValid()");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.LOGICAL_COMPLEMENT, unary.getOperator());
+
+        assertInstanceOf(MethodCallExpr.class, unary.getExpression());
+        MethodCallExpr methodCall = unary.getExpression().asMethodCallExpr();
+        assertEquals("isValid", methodCall.getNameAsString());
+
+        assertInstanceOf(NameExpr.class, methodCall.getScope().get());
+        assertEquals("obj", methodCall.getScope().get().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void unaryWithArrayAccessTest() {
+        Expression e = parseExpression("++array[i]");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, unary.getOperator());
+
+        assertInstanceOf(ArrayAccessExpr.class, unary.getExpression());
+        ArrayAccessExpr arrayAccess = unary.getExpression().asArrayAccessExpr();
+
+        assertInstanceOf(NameExpr.class, arrayAccess.getName());
+        assertEquals("array", arrayAccess.getName().asNameExpr().getNameAsString());
+
+        assertInstanceOf(NameExpr.class, arrayAccess.getIndex());
+        assertEquals("i", arrayAccess.getIndex().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void unaryWithFieldAccessTest() {
+        Expression e = parseExpression("-obj.value");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr unary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.MINUS, unary.getOperator());
+
+        assertInstanceOf(FieldAccessExpr.class, unary.getExpression());
+        FieldAccessExpr fieldAccess = unary.getExpression().asFieldAccessExpr();
+        assertEquals("value", fieldAccess.getNameAsString());
+
+        assertInstanceOf(NameExpr.class, fieldAccess.getScope());
+        assertEquals("obj", fieldAccess.getScope().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void mixedPrefixAndPostfixTest() {
+        Expression e = parseExpression("++(x--)");
+        assertInstanceOf(UnaryExpr.class, e);
+        UnaryExpr prefixUnary = e.asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, prefixUnary.getOperator());
+
+        assertInstanceOf(EnclosedExpr.class, prefixUnary.getExpression());
+        EnclosedExpr enclosed = prefixUnary.getExpression().asEnclosedExpr();
+
+        assertInstanceOf(UnaryExpr.class, enclosed.getInner());
+        UnaryExpr postfixUnary = enclosed.getInner().asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.POSTFIX_DECREMENT, postfixUnary.getOperator());
+
+        assertInstanceOf(NameExpr.class, postfixUnary.getExpression());
+        assertEquals("x", postfixUnary.getExpression().asNameExpr().getNameAsString());
+    }
+
+    @Test
+    void unaryInBinaryExprTest() {
+        Expression e = parseExpression("-x + y");
+        assertInstanceOf(BinaryExpr.class, e);
+        BinaryExpr binary = e.asBinaryExpr();
+        assertEquals(BinaryExpr.Operator.PLUS, binary.getOperator());
+
+        assertInstanceOf(UnaryExpr.class, binary.getLeft());
+        UnaryExpr unary = binary.getLeft().asUnaryExpr();
+        assertEquals(UnaryExpr.Operator.MINUS, unary.getOperator());
+        assertEquals("x", unary.getExpression().asNameExpr().getNameAsString());
+
+        assertInstanceOf(NameExpr.class, binary.getRight());
+        assertEquals("y", binary.getRight().asNameExpr().getNameAsString());
     }
 
     @Test


### PR DESCRIPTION
While working on https://github.com/javaparser/javaparser/pull/4929 and the upcoming compact class PR I added the following tests. These are mostly sanity-checks that already passed and aren't strictly related to either of those changes, but are still worth having for the sake of overall test coverage to potentially catch future regressions. I think it makes more sense to add as a separate PR instead of including this in either of the other PRs, distracting from the main purpose of those.

These tests are mostly AI-generated, but I did verify them myself and fixed a few issues manually.