### PR TITLE
Fix: issue 4188 UnsolvedSymbolException resolving MethocCallExpr using MethodReferenceExpr

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/TypeExpr.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.TypeExprMetaModel;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -145,5 +146,21 @@ public class TypeExpr extends Expression implements NodeWithType<TypeExpr, Type>
     @Generated("com.github.javaparser.generator.core.node.TypeCastingGenerator")
     public Optional<TypeExpr> toTypeExpr() {
         return Optional.of(this);
+    }
+
+    /*
+     * https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.13
+     * Workaround to handle cases where a type should have been parsed as a primary expression.
+     * A change to the grammar should lead to the removal of this method.
+     * This is the case, for example, in the following reference expression ‘foo:convert’,
+     * where foo is an instance of the Foo class and convert is a method of the Foo class.
+     * foo should not be considered a type expression as String could be in the expression String::length.
+     * This method compares the type name (e.g. foo) with the name of a resolved type, e.g. Foo.
+     * If they are different, we consider it to be a primary expression.
+     */
+    public boolean isPrimaryExpr(ResolvedReferenceType type) {
+        return type.getTypeDeclaration().isPresent()
+                ? !type.getTypeDeclaration().get().getName().equals(getTypeAsString())
+                : false;
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4188Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4188Test.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2013-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import org.junit.jupiter.api.Test;
+
+public class Issue4188Test extends AbstractResolutionTest {
+
+    @Test
+    public void test() {
+
+        String code = "import java.util.Optional;\n"
+                + "\n"
+                + "public class MethodInvocation {\n"
+                + "\n"
+                + "    // Resolves successfully\n"
+                + "    public void staticMethodInvocation(Foo foo) {\n"
+                + "        Optional<Integer> priority = Optional.of(4);\n"
+                + "        priority.map(Foo::staticConvert).orElse(\"0\");\n"
+                + "    }\n"
+                + "\n"
+                + "    // Does not resolve\n"
+                + "    public void instanceMethodInvocation(Foo foo) {\n"
+                + "        Optional<Integer> priority = Optional.of(4);\n"
+                + "        priority.map(foo::convert).orElse(\"0\");\n"
+                + "    }\n"
+                + "\n"
+                + "    // Does not resolve\n"
+                + "    public void defaultMethodInvocation(Bar bar) {\n"
+                + "        Optional<Integer> priority = Optional.of(4);\n"
+                + "        priority.map(bar::convert).orElse(\"0\");\n"
+                + "    }\n"
+                + "\n"
+                + "    public static class Foo {\n"
+                + "        public String convert(int priority) {\n"
+                + "            return Integer.toString(priority);\n"
+                + "        }\n"
+                + "\n"
+                + "        public static String staticConvert(int priority) {\n"
+                + "            return Integer.toString(priority);\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n"
+                + "    public interface Bar {\n"
+                + "        default String convert(int priority) {\n"
+                + "            return Integer.toString(priority);\n"
+                + "        }\n"
+                + "    }\n"
+                + "}";
+        JavaParser parser = createParserWithResolver(defaultTypeSolver());
+        CompilationUnit cu = parser.parse(code).getResult().get();
+        cu.findAll(MethodCallExpr.class).forEach(MethodCallExpr::resolve);
+    }
+}


### PR DESCRIPTION

Fixes #4188 .

This PR improves the resolution of a reference expression of the form Primary,  followed by :: and a method name.".

JLS §15.13.1: "If the method reference expression has the form Primary :: [TypeArguments] Identifier"

 This is FORM 2: The scope is an expression (e.g., foo, myString, System.out)

CRITICAL: In this form, the expression is evaluated and becomes the BOUND RECEIVER at method reference creation time, not at invocation time.

The potentially applicable methods are the member methods of the type of the Primary that are not static

 For bound instance methods: ALL functional interface parameters map to method parameters
The receiver is NOT part of paramTypes - it's already bound to the expression result

Example from failing test:

    Foo foo = new Foo();
    Optional<Integer> priority = Optional.of(4);
    priority.map(foo::convert).orElse("0");

Analysis:
   - scope = foo (a Primary expression, not a type)
   - foo is evaluated → becomes bound receiver
   - map() expects Function<Integer, String>
   - paramTypes = [Integer] (from Function's parameter type)
  - convert(int) signature: takes 1 parameter
  - ALL paramTypes [Integer] go to method parameters
   - Match: convert(int) with [Integer] ✓
