### PR TITLE
Fix: issue 4949 Parsing issue in switch with yield with Java 25 parser configuration

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ParserConfiguration.java
@@ -215,12 +215,12 @@ public class ParserConfiguration {
         /**
          * The latest Java version that is available.
          */
-        public static LanguageLevel CURRENT = JAVA_18;
+        public static LanguageLevel CURRENT = JAVA_25;
 
         /**
          * The newest Java features supported.
          */
-        public static LanguageLevel BLEEDING_EDGE = JAVA_24;
+        public static LanguageLevel BLEEDING_EDGE = JAVA_25;
 
         final Validator validator;
 
@@ -243,7 +243,8 @@ public class ParserConfiguration {
             JAVA_21,
             JAVA_22,
             JAVA_23,
-            JAVA_24
+            JAVA_24,
+            JAVA_25
         };
 
         LanguageLevel(Validator validator, PostProcessors postProcessor) {


### PR DESCRIPTION

Fixes #4949 .

Support for the yield statement must be added for each version of Java that supports it.