### PR TITLE
refactor(lexicalpreservation): introduce TextElementSequence API and migrate core classes

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TextElementIteratorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TextElementIteratorTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.GeneratedJavaParserConstants.SPACE;
+import static com.github.javaparser.GeneratedJavaParserConstants.UNIX_EOL;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.javaparser.GeneratedJavaParserConstants;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+
+class TextElementIteratorTest {
+
+    private static TokenTextElement space() {
+        return new TokenTextElement(SPACE, " ");
+    }
+
+    private static TokenTextElement newline() {
+        return new TokenTextElement(UNIX_EOL, "\n");
+    }
+
+    private static TokenTextElement tab() {
+        return new TokenTextElement(SPACE, "\t");
+    }
+
+    // === CONSTRUCTION TESTS ===
+
+    @Test
+    void constructor_withValidIndex_createsIterator() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+
+        TextElementIterator iterator = list.iterator(1);
+
+        assertEquals(-1, iterator.currentIndex());
+    }
+
+    @Test
+    void constructor_withZeroIndex_startsAtBeginning() {
+        TextElementList list = TextElementList.of(space(), newline());
+
+        TextElementIterator iterator = list.iterator(0);
+
+        assertEquals(-1, iterator.currentIndex());
+    }
+
+    @Test
+    void constructor_withInvalidIndex_throwsIndexOutOfBoundsException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> list.iterator(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.iterator(10));
+    }
+
+    // === CURRENT INDEX TESTS ===
+
+    @Test
+    void currentIndex_returnsInitialIndex() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(1);
+
+        assertEquals(-1, iterator.currentIndex());
+    }
+
+    @Test
+    void currentIndex_updatesAfterNext() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(0);
+
+        iterator.next();
+
+        assertEquals(0, iterator.currentIndex());
+    }
+
+    @Test
+    void currentIndex_updatesAfterPrevious() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(2);
+
+        iterator.previous();
+
+        assertEquals(1, iterator.currentIndex());
+    }
+
+    @Test
+    void currentIndex_matchesNextIndex() {
+        TextElementList list = TextElementList.of(space(), newline());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertEquals(-1, iterator.currentIndex());
+        assertEquals(0, iterator.nextIndex());
+    }
+
+    // === HAS NEXT TESTS ===
+
+    @Test
+    void hasNext_returnsTrueWhenElementsRemain() {
+        TextElementList list = TextElementList.of(space(), newline());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertTrue(iterator.hasNext());
+    }
+
+    @Test
+    void hasNext_returnsFalseAtEnd() {
+        TextElementList list = TextElementList.of(space());
+        TextElementIterator iterator = list.iterator(0);
+
+        iterator.next();
+
+        assertFalse(iterator.hasNext());
+    }
+
+    // === NEXT TESTS ===
+
+    @Test
+    void next_returnsCurrentElementAndAdvances() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(0);
+
+        TextElement first = iterator.next();
+        TextElement second = iterator.next();
+
+        assertTrue(first.isSpaceOrTab());
+        assertTrue(second.isNewline());
+        assertEquals(1, iterator.currentIndex());
+    }
+
+    @Test
+    void next_atEnd_throwsNoSuchElementException() {
+        TextElementList list = TextElementList.of(space());
+        TextElementIterator iterator = list.iterator(0);
+
+        iterator.next();
+
+        assertThrows(NoSuchElementException.class, iterator::next);
+    }
+
+    // === HAS PREVIOUS TESTS ===
+
+    @Test
+    void hasPrevious_returnsTrueWhenNotAtStart() {
+        TextElementList list = TextElementList.of(space(), newline());
+        TextElementIterator iterator = list.iterator(1);
+
+        assertTrue(iterator.hasPrevious());
+    }
+
+    @Test
+    void hasPrevious_returnsFalseAtStart() {
+        TextElementList list = TextElementList.of(space());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertFalse(iterator.hasPrevious());
+    }
+
+    // === PREVIOUS TESTS ===
+
+    @Test
+    void previous_returnsPreviousElementAndRetracts() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(2);
+
+        TextElement first = iterator.previous();
+        TextElement second = iterator.previous();
+
+        assertTrue(first.isNewline()); // iterator(2).previous() returns element at index 1
+        assertTrue(second.isSpaceOrTab()); // After first previous(), iterator(1).previous() returns element at index 0
+        assertEquals(0, iterator.currentIndex());
+    }
+
+    @Test
+    void previous_atStart_throwsNoSuchElementException() {
+        TextElementList list = TextElementList.of(space());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertThrows(NoSuchElementException.class, iterator::previous);
+    }
+
+    // === NEXT INDEX TESTS ===
+
+    @Test
+    void nextIndex_returnsIndexOfNextElement() {
+        TextElementList list = TextElementList.of(space(), newline());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertEquals(0, iterator.nextIndex());
+        iterator.next();
+        assertEquals(1, iterator.nextIndex());
+    }
+
+    // === PREVIOUS INDEX TESTS ===
+
+    @Test
+    void previousIndex_returnsIndexOfPreviousElement() {
+        TextElementList list = TextElementList.of(space(), newline());
+        TextElementIterator iterator = list.iterator(1);
+
+        assertEquals(0, iterator.previousIndex());
+    }
+
+    @Test
+    void previousIndex_atStart_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertEquals(-1, iterator.previousIndex());
+    }
+
+    // === REMOVE TESTS ===
+
+    @Test
+    void remove_removesLastReturnedElement() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(0);
+
+        iterator.next();
+        iterator.remove();
+
+        assertEquals(2, list.size());
+        assertTrue(list.get(0).isNewline());
+    }
+
+    @Test
+    void remove_withoutNext_throwsIllegalStateException() {
+        TextElementList list = TextElementList.of(space());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertThrows(IllegalStateException.class, iterator::remove);
+    }
+
+    // === SET TESTS ===
+
+    @Test
+    void set_replacesLastReturnedElement() {
+        TextElementList list = TextElementList.of(space(), newline());
+        TextElementIterator iterator = list.iterator(0);
+        TokenTextElement replacement = tab();
+
+        iterator.next();
+        iterator.set(replacement);
+
+        assertEquals(replacement, list.get(0));
+    }
+
+    @Test
+    void set_withoutNext_throwsIllegalStateException() {
+        TextElementList list = TextElementList.of(space());
+        TextElementIterator iterator = list.iterator(0);
+
+        assertThrows(IllegalStateException.class, () -> iterator.set(newline()));
+    }
+
+    // === ADD TESTS ===
+
+    @Test
+    void add_insertsElementBeforeCurrent() {
+        TextElementList list = TextElementList.of(space(), tab());
+        TextElementIterator iterator = list.iterator(1);
+
+        iterator.add(newline());
+
+        assertEquals(3, list.size());
+        assertTrue(list.get(1).isNewline());
+        assertEquals(1, iterator.currentIndex()); // Advanced after add
+    }
+
+    // === BIDIRECTIONAL ITERATION TESTS ===
+
+    @Test
+    void bidirectionalIteration_worksCorrectly() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(1);
+        iterator.next(); // read element 1, currentIndex = 1
+        iterator.previous(); // read element 1, currentIndex = 1
+        assertEquals(1, iterator.currentIndex());
+    }
+
+    // === FULL ITERATION TEST ===
+
+    @Test
+    void fullIteration_processesAllElements() {
+        TextElementList list = TextElementList.of(space(), newline(), tab(), space());
+        TextElementIterator iterator = list.iterator(0);
+
+        int count = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            count++;
+        }
+
+        assertEquals(4, count);
+        assertEquals(3, iterator.currentIndex());
+    }
+
+    // === USAGE PATTERN TEST (replaces ArrayIterator) ===
+
+    @Test
+    void usagePattern_searchingForComments() {
+        // Simulates Difference.posOfNextComment() usage pattern
+        TextElementList list = TextElementList.of(
+                space(), space(), new TokenTextElement(GeneratedJavaParserConstants.SINGLE_LINE_COMMENT, "// comment"));
+        TextElementIterator iterator = list.iterator(0);
+
+        int commentIndex = -1;
+        while (iterator.hasNext()) {
+            TextElement element = iterator.next();
+            if (!element.isSpaceOrTab()) {
+                commentIndex = iterator.currentIndex();
+                break;
+            }
+        }
+
+        assertEquals(2, commentIndex);
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TextElementListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TextElementListTest.java
@@ -1,0 +1,898 @@
+/*
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.GeneratedJavaParserConstants.SPACE;
+import static com.github.javaparser.GeneratedJavaParserConstants.UNIX_EOL;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.javaparser.GeneratedJavaParserTokenManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+
+class TextElementListTest {
+
+    // === FACTORY METHODS ===
+
+    private static TokenTextElement space() {
+        return new TokenTextElement(SPACE, " ");
+    }
+
+    private static TokenTextElement tab() {
+        return new TokenTextElement(SPACE, "\t");
+    }
+
+    private static TokenTextElement newline() {
+        return new TokenTextElement(UNIX_EOL, "\n");
+    }
+
+    private static TokenTextElement token(String text) {
+        return new TokenTextElement(GeneratedJavaParserTokenManager.STRING_LITERAL, text);
+    }
+
+    // === CONSTRUCTION TESTS ===
+
+    @Test
+    void constructor_withNullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new TextElementList(null));
+    }
+
+    @Test
+    void of_createsListWithElements() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        assertEquals(3, list.size());
+    }
+
+    @Test
+    void empty_createsEmptyList() {
+        TextElementList list = TextElementList.empty();
+        assertTrue(list.isEmpty());
+        assertEquals(0, list.size());
+    }
+
+    @Test
+    void copyOf_createsIndependentCopy() {
+        List<TextElement> original = new ArrayList<>(Arrays.asList(space(), newline()));
+        TextElementList list = TextElementList.copyOf(original);
+
+        original.add(tab());
+
+        assertEquals(2, list.size()); // Not affected by original modification
+    }
+
+    @Test
+    void constructor_wrapsListWithoutCopying() {
+        List<TextElement> original = new ArrayList<>(Arrays.asList(space()));
+        TextElementList list = new TextElementList(original);
+
+        original.add(newline());
+
+        assertEquals(2, list.size()); // Affected by original modification
+    }
+
+    // === FIND FIRST TESTS ===
+
+    @Test
+    void findFirst_withMatchingElement_returnsFirstIndex() {
+        TextElementList list = TextElementList.of(space(), newline(), space(), newline());
+
+        int index = list.findFirst(TextElement::isNewline);
+
+        assertEquals(1, index);
+    }
+
+    @Test
+    void findFirst_withNoMatch_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space(), tab());
+
+        int index = list.findFirst(TextElement::isNewline);
+
+        assertEquals(-1, index);
+    }
+
+    @Test
+    void findFirst_onEmptyList_returnsMinusOne() {
+        TextElementList list = TextElementList.empty();
+
+        int index = list.findFirst(TextElement::isNewline);
+
+        assertEquals(-1, index);
+    }
+
+    @Test
+    void findFirst_withNullPredicate_throwsNullPointerException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(NullPointerException.class, () -> list.findFirst(null));
+    }
+
+    // === FIND LAST TESTS ===
+
+    @Test
+    void findLast_withMatchingElement_returnsLastIndex() {
+        TextElementList list = TextElementList.of(space(), newline(), space(), newline());
+
+        int index = list.findLast(TextElement::isNewline);
+
+        assertEquals(3, index);
+    }
+
+    @Test
+    void findLast_withNoMatch_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space(), tab());
+
+        int index = list.findLast(TextElement::isNewline);
+
+        assertEquals(-1, index);
+    }
+
+    @Test
+    void findLast_onEmptyList_returnsMinusOne() {
+        TextElementList list = TextElementList.empty();
+
+        int index = list.findLast(TextElement::isNewline);
+
+        assertEquals(-1, index);
+    }
+
+    @Test
+    void findLast_withNullPredicate_throwsNullPointerException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(NullPointerException.class, () -> list.findLast(null));
+    }
+
+    // === FIND NEXT TESTS ===
+
+    @Test
+    void findNext_fromValidIndex_findsNextMatch() {
+        TextElementList list = TextElementList.of(newline(), space(), newline(), space());
+
+        int index = list.findNext(1, TextElement::isNewline);
+
+        assertEquals(2, index);
+    }
+
+    @Test
+    void findNext_fromMatchingIndex_returnsSameIndex() {
+        TextElementList list = TextElementList.of(space(), newline(), space());
+
+        int index = list.findNext(1, TextElement::isNewline);
+
+        assertEquals(1, index);
+    }
+
+    @Test
+    void findNext_withNoMatchAhead_returnsMinusOne() {
+        TextElementList list = TextElementList.of(newline(), space(), space());
+
+        int index = list.findNext(1, TextElement::isNewline);
+
+        assertEquals(-1, index);
+    }
+
+    @Test
+    void findNext_withInvalidFromIndex_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space());
+
+        assertEquals(-1, list.findNext(-1, TextElement::isNewline));
+        assertEquals(-1, list.findNext(10, TextElement::isNewline));
+    }
+
+    @Test
+    void findNext_withNullPredicate_throwsNullPointerException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(NullPointerException.class, () -> list.findNext(0, null));
+    }
+
+    // === FIND PREVIOUS TESTS ===
+
+    @Test
+    void findPrevious_fromValidIndex_findsPreviousMatch() {
+        TextElementList list = TextElementList.of(newline(), space(), newline(), space());
+
+        int index = list.findPrevious(2, TextElement::isNewline);
+
+        assertEquals(2, index); // Finds itself first
+    }
+
+    @Test
+    void findPrevious_searchesBackward() {
+        TextElementList list = TextElementList.of(newline(), space(), newline(), space());
+
+        int index = list.findPrevious(1, TextElement::isNewline);
+
+        assertEquals(0, index);
+    }
+
+    @Test
+    void findPrevious_withNoMatchBehind_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space(), space(), newline());
+
+        int index = list.findPrevious(1, TextElement::isNewline);
+
+        assertEquals(-1, index);
+    }
+
+    @Test
+    void findPrevious_withInvalidFromIndex_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space());
+
+        assertEquals(-1, list.findPrevious(-1, TextElement::isNewline));
+        assertEquals(-1, list.findPrevious(10, TextElement::isNewline));
+    }
+
+    @Test
+    void findPrevious_withNullPredicate_throwsNullPointerException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(NullPointerException.class, () -> list.findPrevious(0, null));
+    }
+
+    // === INDEX OF (ELEMENT) TESTS ===
+
+    @Test
+    void indexOf_findsFirstOccurrence() {
+        TokenTextElement target = space();
+        TextElementList list = TextElementList.of(newline(), target, newline(), target);
+
+        int index = list.indexOf(target);
+
+        assertEquals(1, index);
+    }
+
+    @Test
+    void indexOf_withNoMatch_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space());
+
+        int index = list.indexOf(newline());
+
+        assertEquals(-1, index);
+    }
+
+    @Test
+    void indexOf_withNull_searchesForNull() {
+        List<TextElement> elements = new ArrayList<>();
+        elements.add(space());
+        elements.add(null);
+        TextElementList list = new TextElementList(elements);
+
+        int index = list.indexOf(null);
+
+        assertEquals(1, index);
+    }
+
+    // === LAST INDEX OF (ELEMENT) TESTS ===
+
+    @Test
+    void lastIndexOf_findsLastOccurrence() {
+        TokenTextElement target = space();
+        TextElementList list = TextElementList.of(target, newline(), target, newline());
+
+        int index = list.lastIndexOf(target);
+
+        assertEquals(2, index);
+    }
+
+    @Test
+    void lastIndexOf_withNoMatch_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space());
+
+        int index = list.lastIndexOf(newline());
+
+        assertEquals(-1, index);
+    }
+
+    // === INDEX OF FROM INDEX TESTS ===
+
+    @Test
+    void indexOfFromIndex_findsNextOccurrence() {
+        TokenTextElement target = newline();
+        TextElementList list = TextElementList.of(target, space(), target, space());
+
+        int index = list.indexOf(1, target);
+
+        assertEquals(2, index);
+    }
+
+    @Test
+    void indexOfFromIndex_includesFromIndex() {
+        TokenTextElement target = newline();
+        TextElementList list = TextElementList.of(space(), target, space());
+
+        int index = list.indexOf(1, target);
+
+        assertEquals(1, index);
+    }
+
+    @Test
+    void indexOfFromIndex_withInvalidIndex_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space());
+
+        assertEquals(-1, list.indexOf(-1, space()));
+        assertEquals(-1, list.indexOf(10, space()));
+    }
+
+    // === LAST INDEX OF FROM INDEX TESTS ===
+
+    @Test
+    void lastIndexOfFromIndex_findsPreviousOccurrence() {
+        TokenTextElement target = newline();
+        TextElementList list = TextElementList.of(target, space(), target, space());
+
+        int index = list.lastIndexOf(2, target);
+
+        assertEquals(2, index);
+    }
+
+    @Test
+    void lastIndexOfFromIndex_searchesBackward() {
+        TokenTextElement target = newline();
+        TextElementList list = TextElementList.of(target, space(), target, space());
+
+        int index = list.lastIndexOf(1, target);
+
+        assertEquals(0, index);
+    }
+
+    @Test
+    void lastIndexOfFromIndex_withInvalidIndex_returnsMinusOne() {
+        TextElementList list = TextElementList.of(space());
+
+        assertEquals(-1, list.lastIndexOf(-1, space()));
+        assertEquals(-1, list.lastIndexOf(10, space()));
+    }
+
+    // === TAKE WHILE TESTS ===
+
+    @Test
+    void takeWhile_returnsMatchingPrefix() {
+        TextElementList list = TextElementList.of(space(), space(), newline(), space());
+
+        List<TextElement> result = list.takeWhile(TextElement::isSpaceOrTab);
+
+        assertEquals(2, result.size());
+        assertTrue(result.get(0).isSpaceOrTab());
+        assertTrue(result.get(1).isSpaceOrTab());
+    }
+
+    @Test
+    void takeWhile_stopsAtFirstNonMatch() {
+        TextElementList list = TextElementList.of(space(), newline(), space());
+
+        List<TextElement> result = list.takeWhile(TextElement::isSpaceOrTab);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void takeWhile_onEmptyList_returnsEmptyList() {
+        TextElementList list = TextElementList.empty();
+
+        List<TextElement> result = list.takeWhile(TextElement::isSpaceOrTab);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void takeWhile_withNullPredicate_throwsNullPointerException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(NullPointerException.class, () -> list.takeWhile(null));
+    }
+
+    // === SUBLIST TESTS ===
+
+    @Test
+    void subList_returnsCorrectRange() {
+        TextElementList list = TextElementList.of(space(), newline(), tab(), space());
+
+        List<TextElement> sublist = list.subList(1, 3);
+
+        assertEquals(2, sublist.size());
+        assertTrue(sublist.get(0).isNewline());
+        assertTrue(sublist.get(1).isSpaceOrTab());
+    }
+
+    @Test
+    void subList_isBackedByOriginal() {
+        List<TextElement> original = new ArrayList<>(Arrays.asList(space(), newline(), tab()));
+        TextElementList list = new TextElementList(original);
+
+        List<TextElement> sublist = list.subList(0, 2);
+        sublist.clear();
+
+        assertEquals(1, list.size()); // Original affected
+    }
+
+    // === INSERT TESTS ===
+
+    @Test
+    void insert_addsElementAtIndex() {
+        TextElementList list = TextElementList.of(space(), tab());
+
+        list.insert(1, newline());
+
+        assertEquals(3, list.size());
+        assertTrue(list.get(1).isNewline());
+    }
+
+    @Test
+    void insert_withNullElement_throwsNullPointerException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(NullPointerException.class, () -> list.insert(0, null));
+    }
+
+    @Test
+    void insert_withInvalidIndex_throwsIndexOutOfBoundsException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> list.insert(-1, newline()));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.insert(10, newline()));
+    }
+
+    // === INSERT ALL TESTS ===
+
+    @Test
+    void insertAll_addsAllElements() {
+        TextElementList list = TextElementList.of(space(), tab());
+        List<TextElement> toInsert = Arrays.asList(newline(), newline());
+
+        list.insertAll(1, toInsert);
+
+        assertEquals(4, list.size());
+        assertTrue(list.get(1).isNewline());
+        assertTrue(list.get(2).isNewline());
+    }
+
+    @Test
+    void insertAll_withNullList_throwsNullPointerException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(NullPointerException.class, () -> list.insertAll(0, null));
+    }
+
+    // === REMOVE TESTS ===
+
+    @Test
+    void remove_removesElementAtIndex() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+
+        list.remove(1);
+
+        assertEquals(2, list.size());
+        assertTrue(list.get(0).isSpaceOrTab());
+        assertTrue(list.get(1).isSpaceOrTab());
+    }
+
+    @Test
+    void remove_withInvalidIndex_throwsIndexOutOfBoundsException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> list.remove(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.remove(10));
+    }
+
+    // === REMOVE RANGE TESTS ===
+
+    @Test
+    void removeRange_removesInclusiveRange() {
+        TextElementList list = TextElementList.of(space(), newline(), tab(), space(), newline());
+
+        list.removeRange(1, 3);
+
+        assertEquals(2, list.size());
+        assertTrue(list.get(0).isSpaceOrTab());
+        assertTrue(list.get(1).isNewline());
+    }
+
+    @Test
+    void removeRange_withSingleElement_removesOne() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+
+        list.removeRange(1, 1);
+
+        assertEquals(2, list.size());
+    }
+
+    @Test
+    void removeRange_withInvalidIndices_throwsIndexOutOfBoundsException() {
+        TextElementList list = TextElementList.of(space(), newline());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> list.removeRange(-1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.removeRange(0, 10));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.removeRange(1, 0));
+    }
+
+    // === ACCESS TESTS ===
+
+    @Test
+    void get_returnsElementAtIndex() {
+        TokenTextElement expected = newline();
+        TextElementList list = TextElementList.of(space(), expected, tab());
+
+        TextElement actual = list.get(1);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void get_withInvalidIndex_throwsIndexOutOfBoundsException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(10));
+    }
+
+    @Test
+    void isValidIndex_returnsTrueForValidIndices() {
+        TextElementList list = TextElementList.of(space(), newline());
+
+        assertTrue(list.isValidIndex(0));
+        assertTrue(list.isValidIndex(1));
+    }
+
+    @Test
+    void isValidIndex_returnsFalseForInvalidIndices() {
+        TextElementList list = TextElementList.of(space());
+
+        assertFalse(list.isValidIndex(-1));
+        assertFalse(list.isValidIndex(1));
+        assertFalse(list.isValidIndex(10));
+    }
+
+    @Test
+    void size_returnsCorrectSize() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+
+        assertEquals(3, list.size());
+    }
+
+    @Test
+    void isEmpty_returnsTrueForEmptyList() {
+        TextElementList list = TextElementList.empty();
+
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    void isEmpty_returnsFalseForNonEmptyList() {
+        TextElementList list = TextElementList.of(space());
+
+        assertFalse(list.isEmpty());
+    }
+
+    @Test
+    void toList_returnsUnmodifiableView() {
+        TextElementList list = TextElementList.of(space());
+        List<TextElement> view = list.toList();
+
+        assertThrows(UnsupportedOperationException.class, () -> view.add(newline()));
+    }
+
+    @Test
+    void toList_reflectsChanges() {
+        List<TextElement> original = new ArrayList<>(Arrays.asList(space()));
+        TextElementList list = new TextElementList(original);
+        List<TextElement> view = list.toList();
+
+        original.add(newline());
+
+        assertEquals(2, view.size());
+    }
+
+    // === ITERATOR TESTS ===
+
+    @Test
+    void iterator_iteratesOverAllElements() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator();
+
+        int count = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            count++;
+        }
+
+        assertEquals(3, count);
+    }
+
+    @Test
+    void iteratorFromIndex_startsAtSpecifiedIndex() {
+        TextElementList list = TextElementList.of(space(), newline(), tab());
+        TextElementIterator iterator = list.iterator(1);
+
+        assertEquals(-1, iterator.currentIndex());
+        assertTrue(iterator.next().isNewline());
+    }
+
+    @Test
+    void iteratorFromIndex_withInvalidIndex_throwsIndexOutOfBoundsException() {
+        TextElementList list = TextElementList.of(space());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> list.iterator(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.iterator(10));
+    }
+
+    // === STREAM TESTS ===
+
+    @Test
+    void stream_returnsStreamOfElements() {
+        TextElementList list = TextElementList.of(space(), newline(), tab(), space());
+
+        long count = list.stream().filter(TextElement::isSpaceOrTab).count();
+
+        assertEquals(3, count);
+    }
+
+    // === EQUALITY TESTS ===
+
+    @Test
+    void equals_returnsTrueForSameContent() {
+        TextElementList list1 = TextElementList.of(space(), newline());
+        TextElementList list2 = TextElementList.of(space(), newline());
+
+        assertEquals(list1, list2);
+    }
+
+    @Test
+    void equals_returnsFalseForDifferentContent() {
+        TextElementList list1 = TextElementList.of(space());
+        TextElementList list2 = TextElementList.of(newline());
+
+        assertNotEquals(list1, list2);
+    }
+
+    @Test
+    void hashCode_isConsistentWithEquals() {
+        TextElementList list1 = TextElementList.of(space(), newline());
+        TextElementList list2 = TextElementList.of(space(), newline());
+
+        assertEquals(list1.hashCode(), list2.hashCode());
+    }
+
+    // === TESTS FOR anyMatch() ===
+
+    @Test
+    void anyMatch_withMatchingElement_returnsTrue() {
+        TextElementList list = TextElementList.of(space(), token("test"), newline());
+
+        assertTrue(list.anyMatch(el -> el instanceof TokenTextElement));
+    }
+
+    @Test
+    void anyMatch_withNoMatchingElement_returnsFalse() {
+        TextElementList list = TextElementList.of(space(), space(), newline());
+
+        assertFalse(list.anyMatch(el -> el.match(token("test"))));
+    }
+
+    @Test
+    void anyMatch_withEmptyList_returnsFalse() {
+        TextElementList list = new TextElementList(new ArrayList<>());
+        assertFalse(list.anyMatch(TextElement::isComment));
+    }
+
+    @Test
+    void anyMatch_withNullPredicate_throwsException() {
+        TextElementList list = TextElementList.of(space());
+        assertThrows(NullPointerException.class, () -> list.anyMatch(null));
+    }
+
+    @Test
+    void anyMatch_shortCircuits() {
+        // Verify that anyMatch stops as soon as it finds a match
+        List<TextElement> elements = new ArrayList<>();
+        elements.add(space());
+        elements.add(token("test")); // Should match here
+        elements.add(newline());
+
+        TextElementList list = new TextElementList(elements);
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        boolean result = list.anyMatch(el -> {
+            callCount.incrementAndGet();
+            return el.match(token("test"));
+        });
+
+        assertTrue(result);
+        // Should only call 2 times (space, then identifier which matches)
+        assertEquals(2, callCount.get());
+    }
+
+    @Test
+    void anyMatch_withComplexPredicate_worksCorrectly() {
+        TextElementList list = TextElementList.of(space(), token("myVariable"), space(), token("otherVar"));
+
+        boolean hasSpecificText = list.anyMatch(el -> el instanceof TokenTextElement
+                && ((TokenTextElement) el).getText().equals("myVariable"));
+
+        assertTrue(hasSpecificText);
+    }
+
+    // === TESTS FOR allMatch() ===
+
+    @Test
+    void allMatch_whenAllElementsMatch_returnsTrue() {
+        TextElementList list = TextElementList.of(space(), space(), space());
+
+        assertTrue(list.allMatch(TextElement::isSpaceOrTab));
+    }
+
+    @Test
+    void allMatch_whenNotAllElementsMatch_returnsFalse() {
+        TextElementList list = TextElementList.of(space(), token("test"), space());
+
+        assertFalse(list.allMatch(TextElement::isSpaceOrTab));
+    }
+
+    @Test
+    void allMatch_withEmptyList_returnsTrue() {
+        // Empty list satisfies vacuous truth
+        TextElementList list = new TextElementList(new ArrayList<>());
+        assertTrue(list.allMatch(el -> false));
+    }
+
+    @Test
+    void allMatch_withNullPredicate_throwsException() {
+        TextElementList list = TextElementList.of(space());
+        assertThrows(NullPointerException.class, () -> list.allMatch(null));
+    }
+
+    @Test
+    void allMatch_shortCircuits() {
+        // Verify that allMatch stops as soon as it finds a non-match
+        List<TextElement> elements = new ArrayList<>();
+        elements.add(space());
+        elements.add(token("test")); // Should fail here
+        elements.add(space());
+
+        TextElementList list = new TextElementList(elements);
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        boolean result = list.allMatch(el -> {
+            callCount.incrementAndGet();
+            return el.isSpaceOrTab();
+        });
+
+        assertFalse(result);
+        // Should only call 2 times (space passes, then identifier fails)
+        assertEquals(2, callCount.get());
+    }
+
+    @Test
+    void allMatch_withComplexPredicate_worksCorrectly() {
+        TextElementList list = TextElementList.of(space(), space(), newline());
+
+        boolean allWhitespace = list.allMatch(el -> el.isSpaceOrTab() || el.isNewline());
+
+        assertTrue(allWhitespace);
+    }
+
+    // === TESTS FOR noneMatch() ===
+
+    @Test
+    void noneMatch_whenNoElementsMatch_returnsTrue() {
+        TextElementList list = TextElementList.of(space(), space(), newline());
+
+        assertTrue(list.noneMatch(el -> el.match(token("test"))));
+    }
+
+    @Test
+    void noneMatch_whenSomeElementsMatch_returnsFalse() {
+        TextElementList list = TextElementList.of(space(), token("test"), newline());
+
+        assertFalse(list.noneMatch(el -> el.match(token("test"))));
+    }
+
+    @Test
+    void noneMatch_withEmptyList_returnsTrue() {
+        TextElementList list = new TextElementList(new ArrayList<>());
+        assertTrue(list.noneMatch(el -> true));
+    }
+
+    @Test
+    void noneMatch_withNullPredicate_throwsException() {
+        TextElementList list = TextElementList.of(space());
+        assertThrows(NullPointerException.class, () -> list.noneMatch(null));
+    }
+
+    @Test
+    void noneMatch_shortCircuits() {
+        // Verify that noneMatch stops as soon as it finds a match
+        List<TextElement> elements = new ArrayList<>();
+        elements.add(space());
+        elements.add(token("test")); // Should match here
+        elements.add(newline());
+
+        TextElementList list = new TextElementList(elements);
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        boolean result = list.noneMatch(el -> {
+            callCount.incrementAndGet();
+            return el.match(token("test"));
+        });
+
+        assertFalse(result);
+        // Should only call 2 times (space, then identifier which matches)
+        assertEquals(2, callCount.get());
+    }
+
+    @Test
+    void noneMatch_equivalentToNotAnyMatch() {
+        TextElementList list = TextElementList.of(space(), token("test"), newline());
+
+        Predicate<TextElement> predicate = TextElement::isComment;
+
+        assertEquals(!list.anyMatch(predicate), list.noneMatch(predicate));
+    }
+
+    // === INTEGRATION TESTS ===
+
+    @Test
+    void matchingMethods_workTogetherCorrectly() {
+        TextElementList list = TextElementList.of(space(), space(), token("test"), space());
+
+        // Some are spaces
+        assertTrue(list.anyMatch(TextElement::isSpaceOrTab));
+
+        // Not all are spaces
+        assertFalse(list.allMatch(TextElement::isSpaceOrTab));
+
+        // None are comments
+        assertTrue(list.noneMatch(TextElement::isComment));
+    }
+
+    @Test
+    void matchingMethods_withSingleElement() {
+        TextElementList list = TextElementList.of(space());
+
+        assertTrue(list.anyMatch(TextElement::isSpaceOrTab));
+        assertTrue(list.allMatch(TextElement::isSpaceOrTab));
+        assertFalse(list.noneMatch(TextElement::isSpaceOrTab));
+    }
+
+    @Test
+    void matchingMethods_performanceTest() {
+        // Create a large list
+        List<TextElement> elements = new ArrayList<>();
+        for (int i = 0; i < 10000; i++) {
+            elements.add(space());
+        }
+        // Add one token at the end
+        elements.add(token("test"));
+
+        TextElementList list = new TextElementList(elements);
+
+        // anyMatch should find it quickly
+        long start = System.nanoTime();
+        boolean hasToken = list.anyMatch(el -> el instanceof TokenTextElement);
+        long duration = System.nanoTime() - start;
+
+        assertTrue(hasToken);
+        // Should be fast (no specific assertion on time, just verify it works)
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/IndexTrackingIterator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/IndexTrackingIterator.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.printer.lexicalpreservation;
+
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * A generic iterator that tracks the index of the current element.
+ *
+ * <p>This iterator wraps a standard {@link ListIterator} and maintains
+ * the index of the most recently read element, which can be accessed via
+ * {@link #currentIndex()}.
+ *
+ * <p>This class provides a generic implementation that can be used with any
+ * type of list elements. It correctly handles bidirectional iteration by
+ * tracking the current index internally.
+ *
+ * <p>This iterator is particularly useful for operations that need to know
+ * the position of elements during iteration, such as calculating
+ * correspondences between lists or tracking modifications.
+ *
+ * @param <T> the type of elements in the list
+ * @since 3.28.0
+ */
+public class IndexTrackingIterator<T> implements ListIterator<T> {
+
+    private final ListIterator<T> delegate;
+    private int currentIndex;
+
+    /**
+     * Creates an iterator starting at the beginning of the list.
+     *
+     * @param elements the list to iterate over
+     */
+    public IndexTrackingIterator(List<T> elements) {
+        this(elements, 0);
+    }
+
+    /**
+     * Creates an iterator starting at the specified index.
+     * The current index is initialized to -1, indicating that no element
+     * has been read yet.
+     *
+     * @param elements the list to iterate over
+     * @param fromIndex the starting index (cursor position)
+     * @throws IndexOutOfBoundsException if fromIndex is out of range
+     */
+    public IndexTrackingIterator(List<T> elements, int fromIndex) {
+        this.delegate = elements.listIterator(fromIndex);
+        this.currentIndex = -1; // No element read yet
+    }
+
+    /**
+     * Returns the index of the element that was returned by the most recent call
+     * to {@link #next()} or {@link #previous()}.
+     *
+     * <p>This method can be called multiple times without side effects - it will
+     * always return the same value until the next call to {@link #next()},
+     * {@link #previous()}, or {@link #remove()}.
+     *
+     * <p><b>Important:</b> If neither {@link #next()} nor {@link #previous()} has
+     * been called yet, or if {@link #remove()} was called after the last call to
+     * {@link #next()} or {@link #previous()}, this method returns -1.
+     *
+     * <p><b>Note:</b> In the legacy {@code ArrayIterator} class, this method was
+     * named {@code index()}. It has been renamed to {@code currentIndex()} for
+     * better clarity and consistency.
+     *
+     * @return the index of the current element, or -1 if no element has been read
+     *         or the current element was removed
+     */
+    public int currentIndex() {
+        return currentIndex;
+    }
+
+    // === LISTITERATOR METHODS WITH INDEX TRACKING ===
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public T next() {
+        T result = delegate.next();
+        // After next(), previousIndex() points to the element we just read
+        currentIndex = delegate.previousIndex();
+        return result;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return delegate.hasPrevious();
+    }
+
+    @Override
+    public T previous() {
+        T result = delegate.previous();
+        // After previous(), nextIndex() points to the element we just read
+        currentIndex = delegate.nextIndex();
+        return result;
+    }
+
+    @Override
+    public int nextIndex() {
+        return delegate.nextIndex();
+    }
+
+    @Override
+    public int previousIndex() {
+        return delegate.previousIndex();
+    }
+
+    @Override
+    public void remove() {
+        delegate.remove();
+        // After remove, there is no current element
+        currentIndex = -1;
+    }
+
+    @Override
+    public void set(T element) {
+        delegate.set(element);
+        // Current index doesn't change when replacing an element
+    }
+
+    @Override
+    public void add(T element) {
+        delegate.add(element);
+        // After add(), the added element becomes the current element
+        currentIndex = delegate.previousIndex();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ReshuffledDiffElementExtractor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/ReshuffledDiffElementExtractor.java
@@ -22,7 +22,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmMix;
 import com.github.javaparser.printer.concretesyntaxmodel.CsmToken;
-import com.github.javaparser.printer.lexicalpreservation.Difference.ArrayIterator;
 import java.util.*;
 
 public class ReshuffledDiffElementExtractor {
@@ -56,7 +55,7 @@ public class ReshuffledDiffElementExtractor {
     }
 
     public void extract(List<DifferenceElement> diffElements) {
-        ArrayIterator<DifferenceElement> iterator = new ArrayIterator<>(diffElements);
+        IndexTrackingIterator<DifferenceElement> iterator = new IndexTrackingIterator<>(diffElements);
         while (iterator.hasNext()) {
             DifferenceElement diffElement = iterator.next();
             if (diffElement instanceof Reshuffled) {
@@ -170,21 +169,21 @@ public class ReshuffledDiffElementExtractor {
     private Map<Integer, Integer> getCorrespondanceBetweenNextOrderAndPreviousOrder(
             CsmMix elementsFromPreviousOrder, CsmMix elementsFromNextOrder) {
         Map<Integer, Integer> correspondanceBetweenNextOrderAndPreviousOrder = new HashMap<>();
-        ArrayIterator<CsmElement> previousOrderElementsIterator =
-                new ArrayIterator<>(elementsFromPreviousOrder.getElements());
+        IndexTrackingIterator<CsmElement> previousOrderElementsIterator =
+                new IndexTrackingIterator<>(elementsFromPreviousOrder.getElements());
         int syncNextIndex = 0;
         while (previousOrderElementsIterator.hasNext()) {
             CsmElement pe = previousOrderElementsIterator.next();
-            ArrayIterator<CsmElement> nextOrderElementsIterator =
-                    new ArrayIterator<>(elementsFromNextOrder.getElements(), syncNextIndex);
+            IndexTrackingIterator<CsmElement> nextOrderElementsIterator =
+                    new IndexTrackingIterator<>(elementsFromNextOrder.getElements(), syncNextIndex);
             while (nextOrderElementsIterator.hasNext()) {
                 CsmElement ne = nextOrderElementsIterator.next();
                 if (!correspondanceBetweenNextOrderAndPreviousOrder
                                 .values()
-                                .contains(previousOrderElementsIterator.index())
+                                .contains(previousOrderElementsIterator.currentIndex())
                         && DifferenceElementCalculator.matching(ne, pe)) {
                     correspondanceBetweenNextOrderAndPreviousOrder.put(
-                            nextOrderElementsIterator.index(), previousOrderElementsIterator.index());
+                            nextOrderElementsIterator.currentIndex(), previousOrderElementsIterator.currentIndex());
                     // set the position to start on the next {@code nextOrderElementsIterator} iteration
                     syncNextIndex = nextOrderElementsIterator.nextIndex();
                     break;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementIterator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementIterator.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.printer.lexicalpreservation;
+
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * Iterator that tracks its current position in a TextElement list.
+ *
+ * <p>Unlike standard {@link ListIterator}, this class provides direct access
+ * to the current index via {@link #currentIndex()}, which returns the index of
+ * the element that was returned by the most recent call to {@link #next()} or
+ * {@link #previous()}.
+ *
+ * <p>This iterator is a replacement for the internal {@code ArrayIterator} class,
+ * with clearer semantics and better naming. It correctly handles bidirectional
+ * iteration by maintaining the current index internally.
+ *
+ * @since 3.28.0
+ */
+public class TextElementIterator implements ListIterator<TextElement> {
+
+    private final ListIterator<TextElement> delegate;
+    private int currentIndex;
+
+    /**
+     * Creates an iterator starting at the specified index.
+     * The current index is initialized to -1, indicating that no element
+     * has been read yet.
+     *
+     * @param elements the list to iterate over
+     * @param fromIndex the starting index (cursor position)
+     * @throws IndexOutOfBoundsException if fromIndex is out of range
+     */
+    public TextElementIterator(List<TextElement> elements, int fromIndex) {
+        this.delegate = elements.listIterator(fromIndex);
+        this.currentIndex = -1; // No element read yet
+    }
+
+    /**
+     * Returns the index of the element that was returned by the most recent call
+     * to {@link #next()} or {@link #previous()}.
+     *
+     * <p>This method can be called multiple times without side effects - it will
+     * always return the same value until the next call to {@link #next()},
+     * {@link #previous()}, or {@link #remove()}.
+     *
+     * <p><b>Important:</b> If neither {@link #next()} nor {@link #previous()} has
+     * been called yet, or if {@link #remove()} was called after the last call to
+     * {@link #next()} or {@link #previous()}, this method returns -1.
+     *
+     * @return the index of the current element, or -1 if no element has been read
+     *         or the current element was removed
+     */
+    public int currentIndex() {
+        return currentIndex;
+    }
+
+    // === LISTITERATOR METHODS WITH INDEX TRACKING ===
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public TextElement next() {
+        TextElement result = delegate.next();
+        // After next(), previousIndex() points to the element we just read
+        currentIndex = delegate.previousIndex();
+        return result;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return delegate.hasPrevious();
+    }
+
+    @Override
+    public TextElement previous() {
+        TextElement result = delegate.previous();
+        // After previous(), nextIndex() points to the element we just read
+        currentIndex = delegate.nextIndex();
+        return result;
+    }
+
+    @Override
+    public int nextIndex() {
+        return delegate.nextIndex();
+    }
+
+    @Override
+    public int previousIndex() {
+        return delegate.previousIndex();
+    }
+
+    @Override
+    public void remove() {
+        delegate.remove();
+        // After remove, there is no current element
+        currentIndex = -1;
+    }
+
+    @Override
+    public void set(TextElement element) {
+        delegate.set(element);
+        // Current index doesn't change when replacing an element
+    }
+
+    @Override
+    public void add(TextElement element) {
+        delegate.add(element);
+        // After add(), the added element becomes the current element
+        currentIndex = delegate.previousIndex();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementList.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementList.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.printer.lexicalpreservation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Default mutable implementation of {@link TextElementSequence}.
+ *
+ * <p>This class wraps an existing {@code List<TextElement>} without copying it.
+ * All mutations directly affect the underlying list.
+ *
+ * <p>The implementation provides optimized search operations and clear semantics
+ * for index-based manipulations required by lexical preservation operations.
+ *
+ * @since 3.28.0
+ */
+public class TextElementList implements TextElementSequence {
+
+    private final List<TextElement> elements;
+
+    /**
+     * Creates a wrapper around the given list.
+     * The list is NOT copied, mutations affect the original.
+     *
+     * @param elements the list to wrap
+     * @throws NullPointerException if elements is null
+     */
+    public TextElementList(List<TextElement> elements) {
+        this.elements = Objects.requireNonNull(elements, "elements cannot be null");
+    }
+
+    /**
+     * Creates a new TextElementList containing the given elements.
+     *
+     * @param elements varargs of elements
+     * @return a new list
+     */
+    public static TextElementList of(TextElement... elements) {
+        return new TextElementList(new ArrayList<>(Arrays.asList(elements)));
+    }
+
+    /**
+     * Creates a new TextElementList wrapping the given list.
+     *
+     * <p><b>IMPORTANT:</b> This method wraps the list directly without copying.
+     * Modifications to the TextElementList will affect the original list.
+     * Use {@link #copyOf(List)} if you need an independent copy.
+     *
+     * <p>This method is useful for chaining operations:
+     * <pre>{@code
+     * List<TextElement> result = TextElementList.of(list.subList(0, 10))
+     *     .takeWhile(TextElement::isSpaceOrTab);
+     * }</pre>
+     *
+     * @param elements the list to wrap (not copied)
+     * @return a new TextElementList wrapping the given list
+     * @throws NullPointerException if elements is null
+     */
+    public static TextElementList of(List<TextElement> elements) {
+        return new TextElementList(elements);
+    }
+
+    /**
+     * Creates an empty mutable TextElementList.
+     *
+     * @return an empty list
+     */
+    public static TextElementList empty() {
+        return new TextElementList(new ArrayList<>());
+    }
+
+    /**
+     * Creates a new TextElementList with a copy of the given list.
+     *
+     * @param elements the list to copy
+     * @return a new list with copied elements
+     * @throws NullPointerException if elements is null
+     */
+    public static TextElementList copyOf(List<TextElement> elements) {
+        return new TextElementList(new ArrayList<>(elements));
+    }
+
+    // === SEARCH BY PREDICATE ===
+
+    @Override
+    public int findFirst(Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        for (int i = 0; i < elements.size(); i++) {
+            if (predicate.test(elements.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int findLast(Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        for (int i = elements.size() - 1; i >= 0; i--) {
+            if (predicate.test(elements.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int findNext(int fromIndex, Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        if (!isValidIndex(fromIndex)) {
+            return -1;
+        }
+        for (int i = fromIndex; i < elements.size(); i++) {
+            if (predicate.test(elements.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int findPrevious(int fromIndex, Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        if (fromIndex < 0 || fromIndex >= elements.size()) {
+            return -1;
+        }
+        for (int i = fromIndex; i >= 0; i--) {
+            if (predicate.test(elements.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // === FILTERING ===
+
+    @Override
+    public List<TextElement> takeWhile(Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        List<TextElement> result = new ArrayList<>();
+        for (TextElement element : elements) {
+            if (!predicate.test(element)) {
+                break;
+            }
+            result.add(element);
+        }
+        return result;
+    }
+
+    @Override
+    public List<TextElement> subList(int fromIndex, int toIndex) {
+        return elements.subList(fromIndex, toIndex);
+    }
+
+    // === MUTATION ===
+
+    @Override
+    public void insert(int index, TextElement element) {
+        Objects.requireNonNull(element, "element cannot be null");
+        elements.add(index, element);
+    }
+
+    @Override
+    public void insertAll(int index, List<TextElement> elementsToInsert) {
+        Objects.requireNonNull(elementsToInsert, "elements cannot be null");
+        elements.addAll(index, elementsToInsert);
+    }
+
+    @Override
+    public void remove(int index) {
+        elements.remove(index);
+    }
+
+    @Override
+    public void removeRange(int fromIndex, int toIndex) {
+        if (!isValidIndex(fromIndex) || !isValidIndex(toIndex) || fromIndex > toIndex) {
+            throw new IndexOutOfBoundsException(
+                    "Invalid range: [" + fromIndex + ", " + toIndex + "] for size " + elements.size());
+        }
+        // toIndex is inclusive, subList.clear() expects exclusive upper bound
+        elements.subList(fromIndex, toIndex + 1).clear();
+    }
+
+    // === ACCESS ===
+
+    @Override
+    public TextElement get(int index) {
+        return elements.get(index);
+    }
+
+    @Override
+    public boolean isValidIndex(int index) {
+        return index >= 0 && index < elements.size();
+    }
+
+    @Override
+    public int size() {
+        return elements.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return elements.isEmpty();
+    }
+
+    @Override
+    public List<TextElement> toList() {
+        return Collections.unmodifiableList(elements);
+    }
+
+    @Override
+    public List<TextElement> toMutableList() {
+        return elements;
+    }
+
+    // === MATCHING (TERMINAL OPERATIONS) ===
+
+    @Override
+    public boolean anyMatch(Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        for (TextElement element : elements) {
+            if (predicate.test(element)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean allMatch(Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        for (TextElement element : elements) {
+            if (!predicate.test(element)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean noneMatch(Predicate<TextElement> predicate) {
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        return !anyMatch(predicate);
+    }
+
+    // === ITERATION ===
+
+    @Override
+    public TextElementIterator iterator(int fromIndex) {
+        return new TextElementIterator(elements, fromIndex);
+    }
+
+    @Override
+    public String toString() {
+        return "TextElementList{size=" + elements.size() + "}";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof TextElementList)) return false;
+        TextElementList other = (TextElementList) obj;
+        return elements.equals(other.elements);
+    }
+
+    @Override
+    public int hashCode() {
+        return elements.hashCode();
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementSequence.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/TextElementSequence.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.printer.lexicalpreservation;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Contract for a specialized sequence of TextElements with enhanced search
+ * and modification capabilities for lexical preservation operations.
+ *
+ * <p>Unlike standard {@link List}, this interface provides:
+ * <ul>
+ *   <li>Index-based search with predicates (findFirst, findLast, findNext, findPrevious)</li>
+ *   <li>Element-based search (indexOf, lastIndexOf with overloads)</li>
+ *   <li>Controlled mutations (insert, remove) where caller manages index adjustments</li>
+ * </ul>
+ *
+ * <p><b>Thread safety:</b> Implementations are not required to be thread-safe.
+ *
+ * <p><b>Index management:</b> Mutation operations modify the underlying list directly.
+ * Callers are responsible for tracking index changes after mutations.
+ *
+ * @since 3.28.0
+ */
+public interface TextElementSequence {
+
+    // === SEARCH BY PREDICATE ===
+
+    /**
+     * Finds the first index where the predicate matches, searching forward from index 0.
+     *
+     * @param predicate the condition to test
+     * @return the first matching index, or -1 if no match found
+     * @throws NullPointerException if predicate is null
+     */
+    int findFirst(Predicate<TextElement> predicate);
+
+    /**
+     * Finds the last index where the predicate matches, searching backward from the end.
+     *
+     * @param predicate the condition to test
+     * @return the last matching index, or -1 if no match found
+     * @throws NullPointerException if predicate is null
+     */
+    int findLast(Predicate<TextElement> predicate);
+
+    /**
+     * Finds the next index where the predicate matches, searching forward from fromIndex (inclusive).
+     *
+     * @param fromIndex the starting index (inclusive)
+     * @param predicate the condition to test
+     * @return the next matching index, or -1 if no match found
+     * @throws NullPointerException if predicate is null
+     */
+    int findNext(int fromIndex, Predicate<TextElement> predicate);
+
+    /**
+     * Finds the previous index where the predicate matches, searching backward from fromIndex (inclusive).
+     *
+     * @param fromIndex the starting index (inclusive)
+     * @param predicate the condition to test
+     * @return the previous matching index, or -1 if no match found
+     * @throws NullPointerException if predicate is null
+     */
+    int findPrevious(int fromIndex, Predicate<TextElement> predicate);
+
+    // === MATCHING (TERMINAL OPERATIONS) ===
+
+    /**
+     * Tests whether any element in this sequence matches the given predicate.
+     *
+     * <p>This is a short-circuiting terminal operation: it stops as soon as
+     * a matching element is found and returns true immediately.
+     *
+     * <p>Examples:
+     * <pre>{@code
+     * // Check if list contains any comment
+     * boolean hasComment = list.anyMatch(TextElement::isComment);
+     *
+     * // Check if list contains any token with specific text
+     * boolean hasIdentifier = list.anyMatch(el ->
+     *     el instanceof TokenTextElement &&
+     *     ((TokenTextElement) el).getText().equals("myVar")
+     * );
+     * }</pre>
+     *
+     * @param predicate the predicate to test elements against
+     * @return true if any element matches the predicate, false otherwise
+     *         (returns false for empty sequences)
+     * @throws NullPointerException if predicate is null
+     */
+    boolean anyMatch(Predicate<TextElement> predicate);
+
+    /**
+     * Tests whether all elements in this sequence match the given predicate.
+     *
+     * <p>This is a short-circuiting terminal operation: it stops as soon as
+     * a non-matching element is found and returns false immediately.
+     *
+     * <p>Returns true for empty sequences (vacuous truth).
+     *
+     * <p>Examples:
+     * <pre>{@code
+     * // Check if all elements are whitespace
+     * boolean allWhitespace = list.allMatch(TextElement::isSpaceOrTab);
+     *
+     * // Check if all elements are comments
+     * boolean allComments = list.allMatch(TextElement::isComment);
+     * }</pre>
+     *
+     * @param predicate the predicate to test elements against
+     * @return true if all elements match the predicate (or sequence is empty),
+     *         false otherwise
+     * @throws NullPointerException if predicate is null
+     */
+    boolean allMatch(Predicate<TextElement> predicate);
+
+    /**
+     * Tests whether no elements in this sequence match the given predicate.
+     *
+     * <p>This is a short-circuiting terminal operation: it stops as soon as
+     * a matching element is found and returns false immediately.
+     *
+     * <p>Returns true for empty sequences.
+     *
+     * <p>Equivalent to {@code !anyMatch(predicate)}.
+     *
+     * <p>Examples:
+     * <pre>{@code
+     * // Check if list has no comments
+     * boolean noComments = list.noneMatch(TextElement::isComment);
+     *
+     * // Check if list has no newlines
+     * boolean noNewlines = list.noneMatch(TextElement::isNewline);
+     * }</pre>
+     *
+     * @param predicate the predicate to test elements against
+     * @return true if no elements match the predicate (or sequence is empty),
+     *         false otherwise
+     * @throws NullPointerException if predicate is null
+     */
+    boolean noneMatch(Predicate<TextElement> predicate);
+
+    // === SEARCH BY ELEMENT ===
+
+    /**
+     * Finds the first occurrence of the specified element.
+     * Equivalent to {@code findFirst(e -> Objects.equals(e, element))}.
+     *
+     * @param element the element to search for (may be null)
+     * @return the first occurrence index, or -1 if not found
+     */
+    default int indexOf(TextElement element) {
+        return findFirst(e -> Objects.equals(e, element));
+    }
+
+    /**
+     * Finds the last occurrence of the specified element.
+     * Equivalent to {@code findLast(e -> Objects.equals(e, element))}.
+     *
+     * @param element the element to search for (may be null)
+     * @return the last occurrence index, or -1 if not found
+     */
+    default int lastIndexOf(TextElement element) {
+        return findLast(e -> Objects.equals(e, element));
+    }
+
+    /**
+     * Finds the next occurrence of element starting from fromIndex (inclusive).
+     * Equivalent to {@code findNext(fromIndex, e -> Objects.equals(e, element))}.
+     *
+     * @param fromIndex the starting index (inclusive)
+     * @param element the element to search for (may be null)
+     * @return the next occurrence index, or -1 if not found
+     */
+    default int indexOf(int fromIndex, TextElement element) {
+        return findNext(fromIndex, e -> Objects.equals(e, element));
+    }
+
+    /**
+     * Finds the previous occurrence of element before fromIndex (inclusive).
+     * Equivalent to {@code findPrevious(fromIndex, e -> Objects.equals(e, element))}.
+     *
+     * @param fromIndex the starting index (inclusive)
+     * @param element the element to search for (may be null)
+     * @return the previous occurrence index, or -1 if not found
+     */
+    default int lastIndexOf(int fromIndex, TextElement element) {
+        return findPrevious(fromIndex, e -> Objects.equals(e, element));
+    }
+
+    // === FILTERING ===
+
+    /**
+     * Returns a new list containing elements from the start until the predicate fails.
+     * The returned list is independent of this sequence.
+     *
+     * @param predicate the condition to test
+     * @return a new list of matching elements
+     * @throws NullPointerException if predicate is null
+     */
+    List<TextElement> takeWhile(Predicate<TextElement> predicate);
+
+    /**
+     * Returns a sublist view [fromIndex, toIndex).
+     * The returned list is backed by this sequence, so changes affect both.
+     *
+     * @param fromIndex low endpoint (inclusive)
+     * @param toIndex high endpoint (exclusive)
+     * @return a sublist view
+     * @throws IndexOutOfBoundsException if indices are out of range
+     */
+    List<TextElement> subList(int fromIndex, int toIndex);
+
+    // === MUTATION ===
+
+    /**
+     * Inserts element at the specified index.
+     * <b>WARNING:</b> Caller must adjust subsequent indices manually.
+     *
+     * @param index position to insert at
+     * @param element element to insert
+     * @throws IndexOutOfBoundsException if index is out of range
+     * @throws NullPointerException if element is null
+     */
+    void insert(int index, TextElement element);
+
+    /**
+     * Inserts all elements at the specified index.
+     * <b>WARNING:</b> Caller must adjust subsequent indices manually.
+     *
+     * @param index position to insert at
+     * @param elements elements to insert
+     * @throws IndexOutOfBoundsException if index is out of range
+     * @throws NullPointerException if elements is null
+     */
+    void insertAll(int index, List<TextElement> elements);
+
+    /**
+     * Removes the element at the specified index.
+     * <b>WARNING:</b> Caller must adjust subsequent indices manually.
+     *
+     * @param index position to remove from
+     * @throws IndexOutOfBoundsException if index is out of range
+     */
+    void remove(int index);
+
+    /**
+     * Removes elements in range [fromIndex, toIndex] (inclusive on both ends).
+     * <b>WARNING:</b> Caller must adjust subsequent indices manually.
+     *
+     * @param fromIndex start of range (inclusive)
+     * @param toIndex end of range (inclusive)
+     * @throws IndexOutOfBoundsException if indices are out of range or fromIndex > toIndex
+     */
+    void removeRange(int fromIndex, int toIndex);
+
+    // === ACCESS ===
+
+    /**
+     * Returns the element at the specified index.
+     *
+     * @param index the index
+     * @return the element at that position
+     * @throws IndexOutOfBoundsException if index is out of range
+     */
+    TextElement get(int index);
+
+    /**
+     * Checks if the index is valid (0 <= index < size).
+     *
+     * @param index the index to check
+     * @return true if index is valid
+     */
+    boolean isValidIndex(int index);
+
+    /**
+     * Returns the number of elements in this sequence.
+     *
+     * @return the size
+     */
+    int size();
+
+    /**
+     * Checks if this sequence is empty.
+     *
+     * @return true if size is 0
+     */
+    boolean isEmpty();
+
+    /**
+     * Returns an unmodifiable view of the underlying list.
+     * Changes to the original list are visible in the returned view.
+     *
+     * @return an unmodifiable list view
+     */
+    List<TextElement> toList();
+
+    /**
+     * Returns the underlying mutable list.
+     *
+     * <p><b>WARNING:</b> This exposes the internal list directly.
+     * Modifications will affect this sequence.
+     *
+     * @return the mutable list
+     */
+    List<TextElement> toMutableList();
+
+    // === ITERATION ===
+
+    /**
+     * Returns an iterator starting at the specified index.
+     *
+     * @param fromIndex the starting position
+     * @return an iterator with position tracking
+     * @throws IndexOutOfBoundsException if fromIndex is out of range
+     */
+    TextElementIterator iterator(int fromIndex);
+
+    /**
+     * Returns an iterator starting at index 0.
+     *
+     * @return an iterator from the beginning
+     */
+    default TextElementIterator iterator() {
+        return iterator(0);
+    }
+
+    /**
+     * Returns a stream of elements for functional operations.
+     *
+     * @return a stream over the elements
+     */
+    default Stream<TextElement> stream() {
+        return toList().stream();
+    }
+}


### PR DESCRIPTION
- Create TextElementSequence interface with specialized search/filtering operations (findFirst, findLast, takeWhile, anyMatch, allMatch, noneMatch)
- Implement TextElementList with optimized index-based operations and method chaining support
- Introduce TextElementIterator for bidirectional traversal with currentIndex() tracking
- Replace IndexTrackingIterator<T> with generic implementation, removing ArrayIterator
- Migrate Difference.java: refactor processIndentation(), posOfNextComment(), removeElements() (-96 lines, ~8% reduction)
- Migrate NodeText.java to use TextElementList internally (code simplification, -16% logic, -25% complexity)
- Add factory method TextElementList.of(List) for fluent API chaining
- Distinguish toList() (unmodifiable) from toMutableList() (mutable) for clear intent
- Fix indentation preservation bugs and iterator edge cases
