### PR TITLE
Fix CommentInserter crash on compact classes

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue4961Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue4961Test.java
@@ -1,0 +1,61 @@
+package com.github.javaparser;
+
+import static com.github.javaparser.utils.TestUtils.assertNoProblems;
+
+import com.github.javaparser.ast.CompilationUnit;
+import org.junit.jupiter.api.Test;
+
+public class Issue4961Test {
+
+    @Test
+    public void testIssue4961() {
+
+        String code = "// Support JEP 513: Flexible Constructor Bodies\n"
+                + "// https://youtrack.jetbrains.com/projects/IDEA/issues/IDEA-372971/Support-JEP-513-Flexible-Constructor-Bodies\n"
+                + "\n"
+                + "void main(String[] args) {\n"
+                + "    Employee e1 = new Employee(30, \"A123\");\n"
+                + "    e1.show();\n"
+                + "\n"
+                + "    // Employee Age: 30, Office ID: null\n"
+                + "    // Employee Age: 30, Office ID: A123\n"
+                + "}\n"
+                + "\n"
+                + "class Person {\n"
+                + "    final int age;\n"
+                + "\n"
+                + "    Person(int age) {\n"
+                + "        this.age = age;\n"
+                + "        show();\n"
+                + "    }\n"
+                + "\n"
+                + "    void show() {\n"
+                + "        System.out.println(\"Age: \" + age);\n"
+                + "    }\n"
+                + "}\n"
+                + "\n"
+                + "class Employee extends Person {\n"
+                + "    final String officeId;\n"
+                + "\n"
+                + "    Employee(int age, String officeId) {\n"
+                + "        super(validateAge(age));\n"
+                + "        this.officeId = officeId;\n"
+                + "    }\n"
+                + "\n"
+                + "    private static int validateAge(int age) {\n"
+                + "        if (age < 18 || age > 67)\n"
+                + "            throw new IllegalArgumentException(\"Invalid age: \" + age);\n"
+                + "        return age;\n"
+                + "    }\n"
+                + "\n"
+                + "    @Override\n"
+                + "    void show() {\n"
+                + "        System.out.println(\"Employee Age: \" + age + \", Office ID: \" + officeId);\n"
+                + "    }\n"
+                + "}";
+
+        JavaParser parser = new JavaParser();
+        ParseResult<CompilationUnit> result = parser.parse(code);
+        assertNoProblems(result);
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CompactClassDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/CompactClassDeclarationTest.java
@@ -21,8 +21,11 @@
 package com.github.javaparser.ast.body;
 
 import static com.github.javaparser.utils.TestParser.parseCompilationUnit;
+import static com.github.javaparser.utils.TestUtils.assertNoProblems;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
@@ -631,5 +634,23 @@ class CompactClassDeclarationTest {
         assertTrue(members.get(2).isMethodDeclaration());
         MethodDeclaration mainMethod = members.get(2).asMethodDeclaration();
         assertEquals("main", mainMethod.getNameAsString());
+    }
+
+    @Test
+    public void commentInCompactClassMethodBody() {
+        String code = "void foo() {\n" + "    // Some comment\n" + "    int x;\n" + "}";
+
+        JavaParser parser = new JavaParser();
+        ParseResult<CompilationUnit> result = parser.parse(code);
+        assertNoProblems(result);
+    }
+
+    @Test
+    public void trailingCommentInCompactClass() {
+        String code = "void foo() {\n" + "}\n" + "// Some comment";
+
+        JavaParser parser = new JavaParser();
+        ParseResult<CompilationUnit> result = parser.parse(code);
+        assertNoProblems(result);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
@@ -91,6 +91,11 @@ class CommentsInserter {
                         .collect(toList());
         boolean attributeToAnnotation = !(configuration.isIgnoreAnnotationsWhenAttributingComments());
         for (Node child : children) {
+            // Some child nodes of a compact class declaration may not have a range, so first check that the child
+            // in question does have a range.
+            if (!child.hasRange()) {
+                continue;
+            }
             TreeSet<Comment> commentsInsideChild = new TreeSet<>(NODE_BY_BEGIN_POSITION);
             commentsInsideChild.addAll(commentsToAttribute.stream()
                     .filter(comment -> comment.hasRange())


### PR DESCRIPTION
Fixes https://github.com/javaparser/javaparser/issues/4961.

The crash was caused by the CommentInserter attempting to attribute a comment to a node without a range which is now possible for compact classes (the SimpleName child of the compact class was the specific one causing the crash reported).