### PR TITLE
Add first optimization for solving types in a block context

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import java.lang.reflect.Field;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -435,6 +436,486 @@ class NodeListTest extends AbstractLexicalPreservingTest {
                     iterator.next();
                 });
             }
+        }
+    }
+
+    @Nested
+    class FastIndexOfTest {
+
+        private boolean getIndicesInvalidated(NodeList<?> list) throws Exception {
+            Field field = NodeList.class.getDeclaredField("indicesInvalidated");
+            field.setAccessible(true);
+            return (boolean) field.get(list);
+        }
+
+        @Test
+        void basicLookup() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(1, list.fastIndexOf(b));
+            assertEquals(2, list.fastIndexOf(c));
+        }
+
+        @Test
+        void returnsMinusOneForAbsentNode() {
+            Name a = new Name("a");
+            NodeList<Name> list = nodeList(a);
+
+            assertEquals(-1, list.fastIndexOf(new Name("z")));
+        }
+
+        @Test
+        void returnsMinusOneForNonNodeObject() {
+            NodeList<Name> list = nodeList(new Name("a"));
+
+            assertEquals(-1, list.fastIndexOf("not a node"));
+        }
+
+        @Test
+        void afterAppend() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a);
+            list.add(b);
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(1, list.fastIndexOf(b));
+        }
+
+        @Test
+        void afterAddFirst() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a);
+            list.addFirst(b);
+
+            assertEquals(0, list.fastIndexOf(b));
+            assertEquals(1, list.fastIndexOf(a));
+        }
+
+        @Test
+        void afterInsertInMiddle() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, c);
+            list.add(1, b);
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(1, list.fastIndexOf(b));
+            assertEquals(2, list.fastIndexOf(c));
+        }
+
+        @Test
+        void afterRemoveLast() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+            list.removeLast();
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(1, list.fastIndexOf(b));
+            assertEquals(-1, list.fastIndexOf(c));
+        }
+
+        @Test
+        void afterRemoveFirst() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+            list.removeFirst();
+
+            assertEquals(-1, list.fastIndexOf(a));
+            assertEquals(0, list.fastIndexOf(b));
+            assertEquals(1, list.fastIndexOf(c));
+        }
+
+        @Test
+        void afterRemoveMiddleByIndex() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+            list.remove(1);
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(-1, list.fastIndexOf(b));
+            assertEquals(1, list.fastIndexOf(c));
+        }
+
+        @Test
+        void afterRemoveByReference() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.remove(a);
+
+            assertEquals(-1, list.fastIndexOf(a));
+            assertEquals(0, list.fastIndexOf(b));
+        }
+
+        @Test
+        void afterSet() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            Name z = new Name("z");
+            NodeList<Name> list = nodeList(a, b, c);
+            list.set(1, z);
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(-1, list.fastIndexOf(b));
+            assertEquals(2, list.fastIndexOf(c));
+            assertEquals(1, list.fastIndexOf(z));
+        }
+
+        @Test
+        void afterSort() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(c, a, b);
+            list.sort(Comparator.comparing(Name::asString));
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(1, list.fastIndexOf(b));
+            assertEquals(2, list.fastIndexOf(c));
+        }
+
+        @Test
+        void afterClear() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.clear();
+
+            assertEquals(-1, list.fastIndexOf(a));
+            assertEquals(-1, list.fastIndexOf(b));
+        }
+
+        @Test
+        void afterReplaceAll() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.replaceAll(n -> new Name(n.asString().toUpperCase()));
+
+            // Original nodes are no longer in the list
+            assertEquals(-1, list.fastIndexOf(a));
+            assertEquals(-1, list.fastIndexOf(b));
+            // New nodes are findable
+            assertEquals(0, list.fastIndexOf(list.get(0)));
+            assertEquals(1, list.fastIndexOf(list.get(1)));
+        }
+
+        @Test
+        void usesEquality() {
+            Name a1 = new Name("a");
+            Name a2 = new Name("a");
+            assertEquals(a1, a2);
+            assertNotSame(a1, a2);
+
+            NodeList<Name> list = nodeList(a1);
+
+            assertEquals(0, list.fastIndexOf(a1));
+            assertEquals(0, list.fastIndexOf(a2));
+        }
+
+        @Test
+        void duplicateEqualNodesDistinguished() {
+            Name a1 = new Name("a");
+            Name a2 = new Name("a");
+            Name b = new Name("b");
+            assertEquals(a1, a2);
+            assertNotSame(a1, a2);
+
+            NodeList<Name> list = nodeList(a1, b, a2);
+
+            // fastIndexOf finds the actual reference's position, not the first equals match
+            assertEquals(0, list.fastIndexOf(a1));
+            assertEquals(2, list.fastIndexOf(a2));
+            // indexOf always returns the first equals match
+            assertEquals(0, list.indexOf(a1));
+            assertEquals(0, list.indexOf(a2));
+        }
+
+        @Test
+        void consistentWithIndexOfAfterMultipleMutations() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            Name d = new Name("d");
+            Name e = new Name("e");
+            Name z = new Name("z");
+            NodeList<Name> list = nodeList(a, b, c);
+
+            list.add(d);
+            list.addFirst(e);
+            list.remove(b);
+            list.set(2, z);
+
+            for (int i = 0; i < list.size(); i++) {
+                Name node = list.get(i);
+                assertEquals(i, list.fastIndexOf(node), "fastIndexOf mismatch for node at position " + i);
+            }
+        }
+
+        @Test
+        void repeatedCallsWithoutMutation() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+
+            for (int i = 0; i < 5; i++) {
+                assertEquals(0, list.fastIndexOf(a));
+                assertEquals(1, list.fastIndexOf(b));
+                assertEquals(2, list.fastIndexOf(c));
+            }
+        }
+
+        @Test
+        void onEmptyList() {
+            NodeList<Name> list = nodeList();
+
+            assertEquals(-1, list.fastIndexOf(new Name("a")));
+        }
+
+        @Test
+        void onSingleElementList() {
+            Name a = new Name("a");
+            NodeList<Name> list = nodeList(a);
+
+            assertEquals(0, list.fastIndexOf(a));
+            assertEquals(-1, list.fastIndexOf(new Name("z")));
+        }
+
+        @Test
+        void freshListHasValidatedIndices() throws Exception {
+            NodeList<Name> list = nodeList(new Name("a"), new Name("b"));
+
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void fastIndexOfResetsInvalidatedFlag() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(b);
+            list.addFirst(a);
+            assertTrue(getIndicesInvalidated(list));
+
+            list.fastIndexOf(a);
+
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void appendDoesNotInvalidate() throws Exception {
+            Name a = new Name("a");
+            NodeList<Name> list = nodeList(a);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.add(new Name("b"));
+
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void multipleAppendsDoNotInvalidate() throws Exception {
+            Name a = new Name("a");
+            NodeList<Name> list = nodeList(a);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.add(new Name("b"));
+            list.add(new Name("c"));
+            list.add(new Name("d"));
+
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void addFirstInvalidates() throws Exception {
+            Name a = new Name("a");
+            NodeList<Name> list = nodeList(a);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.addFirst(new Name("b"));
+
+            assertTrue(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void insertInMiddleInvalidates() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.add(1, new Name("c"));
+
+            assertTrue(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void removeLastDoesNotInvalidate() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.removeLast();
+
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void removeFirstInvalidates() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.removeFirst();
+
+            assertTrue(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void removeMiddleInvalidates() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.remove(1);
+
+            assertTrue(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void setDoesNotInvalidate() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.set(0, new Name("z"));
+
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void sortInvalidates() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(b, a);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.sort(Comparator.comparing(Name::asString));
+
+            assertTrue(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void fastIndexOfAfterInvalidationResetsFlag() throws Exception {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+
+            list.addFirst(new Name("c"));
+            assertTrue(getIndicesInvalidated(list));
+
+            list.fastIndexOf(a);
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        // --- nodeListIndex field tests ---
+
+        @Test
+        void nodeListIndexSetCorrectlyAfterFastIndexOf() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+            list.fastIndexOf(a);
+
+            assertEquals(0, a.getNodeListIndex());
+            assertEquals(1, b.getNodeListIndex());
+            assertEquals(2, c.getNodeListIndex());
+        }
+
+        @Test
+        void nodeListIndexClearedOnRemoval() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            NodeList<Name> list = nodeList(a, b);
+            list.fastIndexOf(a);
+
+            list.remove(a);
+
+            assertEquals(-1, a.getNodeListIndex());
+        }
+
+        @Test
+        void nodeListIndexUpdatedOnReplacement() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name z = new Name("z");
+            NodeList<Name> list = nodeList(a, b);
+            list.fastIndexOf(a);
+
+            list.set(0, z);
+
+            assertEquals(-1, a.getNodeListIndex());
+            assertEquals(0, z.getNodeListIndex());
+            assertEquals(1, b.getNodeListIndex());
+        }
+
+        @Test
+        void appendSetsCorrectNodeListIndex() throws Exception {
+            Name a = new Name("a");
+            NodeList<Name> list = nodeList(a);
+            list.fastIndexOf(a);
+
+            Name b = new Name("b");
+            list.add(b);
+
+            assertEquals(0, a.getNodeListIndex());
+            assertEquals(1, b.getNodeListIndex());
+            assertFalse(getIndicesInvalidated(list));
+        }
+
+        @Test
+        void nodeListIndexClearedOnRemoveByIndex() {
+            Name a = new Name("a");
+            Name b = new Name("b");
+            Name c = new Name("c");
+            NodeList<Name> list = nodeList(a, b, c);
+            list.fastIndexOf(a);
+
+            Name removed = list.remove(1);
+
+            assertSame(b, removed);
+            assertEquals(-1, b.getNodeListIndex());
         }
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Node.java
@@ -34,10 +34,7 @@ import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.LineComment;
-import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
-import com.github.javaparser.ast.nodeTypes.NodeWithRange;
-import com.github.javaparser.ast.nodeTypes.NodeWithScope;
-import com.github.javaparser.ast.nodeTypes.NodeWithTokenRange;
+import com.github.javaparser.ast.nodeTypes.*;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.observer.PropagatingAstObserver;
@@ -198,6 +195,9 @@ public abstract class Node
 
     @InternalProperty
     private Parsedness parsed = PARSED;
+
+    @InternalProperty
+    private int nodeListIndex = -1;
 
     protected Node(TokenRange tokenRange) {
         setTokenRange(tokenRange);
@@ -1298,5 +1298,22 @@ public abstract class Node
         return node.getParentNode().isPresent()
                 && (isPhantom(node.getParentNode().get())
                         || inPhantomNode(node.getParentNode().get(), levels - 1));
+    }
+
+    /**
+     * This method exists only for internal use in NodeList and should be considered effectively private.
+     * It may be removed or the behaviour changed at any time.
+     */
+    public Node setNodeListIndex(int nodeListIndex) {
+        this.nodeListIndex = nodeListIndex;
+        return this;
+    }
+
+    /**
+     * This method exists only for internal use in NodeList and should be considered effectively private.
+     * It may be removed or the behaviour changed at any time.
+     */
+    public int getNodeListIndex() {
+        return nodeListIndex;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/NodeList.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast;
 
 import com.github.javaparser.HasParentNode;
 import com.github.javaparser.ast.observer.AstObserver;
+import com.github.javaparser.ast.observer.AstObserverAdapter;
 import com.github.javaparser.ast.observer.Observable;
 import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
@@ -52,7 +53,7 @@ public class NodeList<N extends Node>
 
     private Node parentNode;
 
-    private final List<AstObserver> observers = new ArrayList<>();
+    private final List<AstObserver> observers = new ArrayList<>(Collections.singletonList(new NodeListIndexObserver()));
 
     public NodeList() {
         parentNode = null;
@@ -61,6 +62,8 @@ public class NodeList<N extends Node>
     public NodeList(Collection<N> n) {
         this.addAll(n);
     }
+
+    private boolean indicesInvalidated = true;
 
     @SafeVarargs
     public NodeList(N... n) {
@@ -72,6 +75,17 @@ public class NodeList<N extends Node>
         notifyElementAdded(innerList.size(), node);
         own(node);
         return innerList.add(node);
+    }
+
+    private void invalidateIndices() {
+        indicesInvalidated = true;
+    }
+
+    private void resetIndices() {
+        for (int i = 0; i < innerList.size(); i++) {
+            innerList.get(i).setNodeListIndex(i);
+        }
+        indicesInvalidated = false;
     }
 
     private void own(N node) {
@@ -102,18 +116,21 @@ public class NodeList<N extends Node>
     public static <X extends Node> NodeList<X> nodeList(X... nodes) {
         final NodeList<X> nodeList = new NodeList<>();
         Collections.addAll(nodeList, nodes);
+        nodeList.resetIndices();
         return nodeList;
     }
 
     public static <X extends Node> NodeList<X> nodeList(Collection<X> nodes) {
         final NodeList<X> nodeList = new NodeList<>();
         nodeList.addAll(nodes);
+        nodeList.resetIndices();
         return nodeList;
     }
 
     public static <X extends Node> NodeList<X> nodeList(NodeList<X> nodes) {
         final NodeList<X> nodeList = new NodeList<>();
         nodeList.addAll(nodes);
+        nodeList.resetIndices();
         return nodeList;
     }
 
@@ -167,6 +184,7 @@ public class NodeList<N extends Node>
 
     @Override
     public void sort(Comparator<? super N> comparator) {
+        invalidateIndices();
         innerList.sort(comparator);
     }
 
@@ -434,6 +452,41 @@ public class NodeList<N extends Node>
     }
 
     /**
+     * This method is an optimized version of indexOf which uses the nodeListIndex field of
+     * Nodes to find the index of the given Node (if the given Object is a Node) in constant
+     * time in some cases where the argument o is a reference to one of the Nodes in the list.
+     * <br/>
+     * Unlike the regular indexOf method, this is not guaranteed to return the first index at which
+     * {@code nodeList.get(n) == o}. If a node {@code A(0)} means a node == A with index 0, then for
+     * the list {@code NodeList(A(0), B(1), A(2))}, {@code nodeList.indexOf(A(2)) => 0} while
+     * {@code nodeList.fastIndexOf(A(2)) => 2}. This is the desired behaviour in many cases, however.
+     * <br/>
+     * Note: If the list is modified, the {@code nodeListIndex} fields of the contained nodes are invalidated,
+     * and are then reset when this method is called. This is a linear-time, mutating operation, so
+     * this method is NOT thread safe. This operation is also not safe when used in conjunction with
+     * `NodeList.sublist` or aliases of the list in general.
+     */
+    public int fastIndexOf(Object o) {
+        if (indicesInvalidated) {
+            // If indices are currently invalidated, start by resetting the indices of the nodes in the list. If
+            // `o` is a reference to a node in the list (which is the intended use-case), then the nodeListIndex
+            // of that node will also be reset, so the lookup below will still work.
+            resetIndices();
+        }
+        if (o instanceof Node) {
+            int index = ((Node) o).getNodeListIndex();
+            if (index >= 0 && index < innerList.size()) {
+                Node candidate = innerList.get(index);
+                // Use structural equality to use the fast path in more cases.
+                if (candidate.equals(o)) {
+                    return index;
+                }
+            }
+        }
+        return innerList.indexOf(o);
+    }
+
+    /**
      * @see java.util.List#lastIndexOf(java.lang.Object)
      */
     @Override
@@ -561,6 +614,49 @@ public class NodeList<N extends Node>
     @Override
     public String toString() {
         return innerList.stream().map(Node::toString).collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private class NodeListIndexObserver extends AstObserverAdapter {
+
+        @Override
+        public void listChange(NodeList<?> observedNode, ListChangeType type, int index, Node nodeAddedOrRemoved) {
+            if (type == ListChangeType.ADDITION) {
+                handleAddition(index, nodeAddedOrRemoved);
+            } else if (type == ListChangeType.REMOVAL) {
+                handleRemoval(index, nodeAddedOrRemoved);
+            } else {
+                throw new IllegalArgumentException("NodeListIndexObserver does not handle type " + type);
+            }
+        }
+
+        @Override
+        public void listReplacement(NodeList<?> observedNode, int index, Node oldNode, Node newNode) {
+            if (oldNode != null) {
+                oldNode.setNodeListIndex(-1);
+            }
+            if (newNode != null) {
+                newNode.setNodeListIndex(index);
+            }
+        }
+
+        private void handleAddition(int index, Node node) {
+            if (node != null) node.setNodeListIndex(index);
+            // If the node is added at the end of the list, just set its index and don't invalidate indices
+            // for the rest of the list
+            if (index != innerList.size()) {
+                invalidateIndices();
+            }
+        }
+
+        private void handleRemoval(int index, Node node) {
+            if (node != null) {
+                node.setNodeListIndex(-1);
+            }
+            // If the last node in the list is removed, don't invalidate the whole list
+            if (index != innerList.size() - 1) {
+                invalidateIndices();
+            }
+        }
     }
 
     protected class NodeListIterator implements ListIterator<N> {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
@@ -81,7 +81,7 @@ public class BlockStmtContext extends StatementContext<BlockStmt> {
      */
     @Override
     public List<TypePatternExpr> typePatternExprsExposedToChild(Node child) {
-        int position = wrappedNode.getStatements().indexOf(child);
+        int position = wrappedNode.getStatements().fastIndexOf(child);
         if (position == -1) {
             throw new RuntimeException();
         }


### PR DESCRIPTION
This is related to https://github.com/javaparser/javaparser/issues/4975 and fixes the first issue causing slowdowns in `BlockStmtContext`. 

This PR adds an optimized `indexOf` method to `NodeList` which relies on a new `nodeListIndex` field in `Node` which is used to look up the node at the given index in the node list directly. If that node equals the given node, then the index is found and a linear search is not necessary. 

This solution to the problem has some downsides. Since it relies on the `nodeListIndex` field in the `Node`, adding a node to multiple node lists or using `fastIndexOf` on sublists of a list is likely to cause incorrect behavior and there is not a good mechanism to handle these cases. This means that `fastIndexOf` should not be used as a general purpose method, but in most "regular" use-cases (in particular where it's used in `BlockStmtContext`), it is easy to avoid these issues as regular list mutations (adding, removing, and replacing elements) are handled. 

Another issue with this approach is that `Node` now has this `nodeListIndex` field which doesn't make sense when viewed only from the context of the `Node` class. It needs the context of the completely separate `NodeList` class to be understood. The alternative I mentioned in the linked issue of adding an `order` field or something to AST nodes solves the issue of not making sense, but will likely run into many of the other issues mentioned.

I also considered other ways of implementing this that don't require this `nodeListIndex` field in `Node`. The most obvious idea is to keep some sort of hashmap of `Node -> indices at which equal nodes exist`, but this has a memory cost and introduces a much more difficult problem to solve, namely that of figuring out which of the indices at which the equal node exists is actually the correct one.

A possible change to this implementation that makes it even less generally useful but perhaps less confusing would be to change the logic to:
```
int fastIndexOf(Object o) {
  if (indicesInvalidated) resetIndices();
  if (o instanceof Node) {
    int index = ((Node) o).getNodeListIndex();
    // Specifically check reference equality
    if (nodeList.get(index) == o) {
      return index;
    }
  }
  // Only return if exact match is found
  return -1;
}
```

This would mean the method can only be used by providing reference to an item in the list, not an equal copy.