### PR TITLE
Add SPACE_BEFORE_SWITCH_PAREN option to pretty printer

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -698,6 +698,23 @@ class PrettyPrinterTest {
     }
 
     @Test
+    public void testSwitchWithSpaceBeforeParen() {
+        String code = "class Foo {\n" + "\n"
+                + "    void foo(Integer arg) {\n"
+                + "        switch (foo) {\n"
+                + "            case 1 ->\n"
+                + "                System.out.println(1);\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        CompilationUnit cu = parse(code);
+        PrinterConfiguration config = new DefaultPrinterConfiguration();
+        config.addOption(new DefaultConfigurationOption(ConfigOption.SPACE_BEFORE_SWITCH_PAREN));
+        assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter(config).print(cu));
+    }
+
+    @Test
     public void testMarkdownComment() {
         String code = "class Foo {\n" + "\n"
                 + "    /// This is a markdown comment\n"

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -1382,7 +1382,11 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
 
     private void printSwitchNode(SwitchNode n, Void arg) {
         printComment(n.getComment(), arg);
-        printer.print("switch(");
+        printer.print("switch");
+        if (getOption(ConfigOption.SPACE_BEFORE_SWITCH_PAREN).isPresent()) {
+            printer.print(" ");
+        }
+        printer.print("(");
         n.getSelector().accept(this, arg);
         printer.println(") {");
         if (n.getEntries() != null) {

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/configuration/DefaultPrinterConfiguration.java
@@ -54,6 +54,16 @@ public class DefaultPrinterConfiguration implements PrinterConfiguration {
         COLUMN_ALIGN_PARAMETERS(Boolean.class),
         COLUMN_ALIGN_FIRST_METHOD_CHAIN(Boolean.class),
         /**
+         * Insert a space before the opening parenthesis of a switch statement if true, don't if false
+         * <pre>{@code
+         * switch (x) {            switch(x) {
+         * case 1:                 case 1:
+         *     return y;               return y;
+         * }                       }
+         * }<pre>
+         */
+        SPACE_BEFORE_SWITCH_PAREN(Boolean.class),
+        /**
          * Indent the case when it is true, don't if false
          * <pre>{@code
          * switch(x) {            switch(x) {


### PR DESCRIPTION
Introduce a new configuration option, `SPACE_BEFORE_SWITCH_PAREN`, to the DefaultPrettyPrinter to allow fine-grained control over switch statement formatting. When enabled, the printer will insert a space between the `switch` keyword and its opening parenthesis.
