### PR TITLE
Respect visibility in MethodResolution(fix #4969)

### DIFF
--- a/javaparser-core-testing/src/test/resources/com/github/javaparser/bulk_test_results/javaparser_test_results_javaparser_symbol_solver_testing_src_test_java.txt
+++ b/javaparser-core-testing/src/test/resources/com/github/javaparser/bulk_test_results/javaparser_test_results_javaparser_symbol_solver_testing_src_test_java.txt
@@ -1,1 +1,0 @@
-0 problems in 0 files

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/Context.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/Context.java
@@ -366,24 +366,25 @@ public interface Context {
      * We find the method declaration which is the best match for the given name and list of typeParametersValues.
      */
     default SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         // Default to solving within the parent context.
-        return solveMethodInParentContext(name, argumentsTypes, staticOnly);
+        return solveMethodInParentContext(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     default SymbolReference<ResolvedMethodDeclaration> solveMethodInParentContext(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         Optional<Context> optionalParentContext = getParent();
         if (!optionalParentContext.isPresent()) {
             return SymbolReference.unsolved();
         }
         // Delegate solving to the parent context.
-        return optionalParentContext.get().solveMethod(name, argumentsTypes, staticOnly);
+        return optionalParentContext.get().solveMethod(name, argumentsTypes, staticOnly,
+                invocationContext);
     }
 
     /**
      * Similar to solveMethod but we return a MethodUsage.
      * A MethodUsage corresponds to a MethodDeclaration plus the resolved type variables.
      */
-    Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes);
+    Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes, ResolvedReferenceTypeDeclaration invocationContext);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/Solver.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/Solver.java
@@ -21,6 +21,7 @@ package com.github.javaparser.resolution;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
@@ -43,9 +44,9 @@ public interface Solver {
 
     SymbolReference<? extends ResolvedTypeDeclaration> solveType(String name, Node node);
 
-    MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context);
+    MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context, ResolvedReferenceTypeDeclaration invocationContext);
 
-    MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node);
+    MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node, ResolvedReferenceTypeDeclaration invocationContext);
 
     ResolvedTypeDeclaration solveType(Type type);
 

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionCapability.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionCapability.java
@@ -21,6 +21,7 @@
 package com.github.javaparser.resolution.logic;
 
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.List;
@@ -28,5 +29,6 @@ import java.util.List;
 public interface MethodResolutionCapability {
 
     SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext);
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -20,6 +20,7 @@
  */
 package com.github.javaparser.resolution.logic;
 
+import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.resolution.MethodAmbiguityException;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.TypeSolver;
@@ -28,6 +29,7 @@ import com.github.javaparser.resolution.model.LambdaArgumentTypePlaceholder;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.resolution.types.*;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -83,7 +85,7 @@ public class MethodResolutionLogic {
             // method, the lambda cannot implement that interface.
             if (lambdaPlaceholder.getParameterCount().isPresent()
                     && functionalInterface.getNoParams()
-                            != lambdaPlaceholder.getParameterCount().get()) {
+                    != lambdaPlaceholder.getParameterCount().get()) {
                 return true;
             }
             // If the lambda method has a block body then:
@@ -111,7 +113,6 @@ public class MethodResolutionLogic {
      * Note that "needle" refers to that value being used as a search/query term to match against.
      *
      * @return true, if the given ResolvedMethodDeclaration matches the given name/types (normally obtained from a MethodUsage)
-     *
      * @see {@link MethodResolutionLogic#isApplicable(MethodUsage, String, List, TypeSolver)}
      */
     private static boolean isApplicable(
@@ -159,8 +160,8 @@ public class MethodResolutionLogic {
                 // Confirm all of these grouped "trailing" arguments have the required type -- if not, this is not a
                 // valid type. (Maybe this is also done later..?)
                 for (int variadicArgumentIndex = countOfMethodParametersDeclared;
-                        variadicArgumentIndex < countOfNeedleArgumentsPassed;
-                        variadicArgumentIndex++) {
+                     variadicArgumentIndex < countOfNeedleArgumentsPassed;
+                     variadicArgumentIndex++) {
                     ResolvedType currentArgumentType = needleArgumentTypes.get(variadicArgumentIndex);
                     ResolvedType variadicComponentType =
                             expectedVariadicParameterType.asArrayType().getComponentType();
@@ -193,7 +194,7 @@ public class MethodResolutionLogic {
             ResolvedType actualArgumentType = needleArgumentTypes.get(i);
             if (actualArgumentType instanceof LambdaArgumentTypePlaceholder
                     && isConflictingLambdaType(
-                            (LambdaArgumentTypePlaceholder) actualArgumentType, expectedDeclaredType)) {
+                    (LambdaArgumentTypePlaceholder) actualArgumentType, expectedDeclaredType)) {
                 return false;
             }
             if ((expectedDeclaredType.isTypeVariable() && !(expectedDeclaredType.isWildcard()))
@@ -215,7 +216,7 @@ public class MethodResolutionLogic {
             }
             boolean isAssignableWithoutSubstitution = expectedDeclaredType.isAssignableBy(actualArgumentType)
                     || (methodDeclaration.getParam(i).isVariadic()
-                            && convertToVariadicParameter(expectedDeclaredType).isAssignableBy(actualArgumentType));
+                    && convertToVariadicParameter(expectedDeclaredType).isAssignableBy(actualArgumentType));
             if (!isAssignableWithoutSubstitution
                     && expectedDeclaredType.isReferenceType()
                     && actualArgumentType.isReferenceType()) {
@@ -250,13 +251,13 @@ public class MethodResolutionLogic {
                     if (actualArgumentType.isConstraint()
                             && withWildcardTolerance
                             && (actualArgumentType.asConstraintType().getBound().isTypeVariable()
-                                    || (!actualArgumentType
-                                                    .asConstraintType()
-                                                    .getBound()
-                                                    .isTypeVariable()
-                                            && expectedDeclaredType.isAssignableBy(actualArgumentType
-                                                    .asConstraintType()
-                                                    .getBound())))) {
+                            || (!actualArgumentType
+                            .asConstraintType()
+                            .getBound()
+                            .isTypeVariable()
+                            && expectedDeclaredType.isAssignableBy(actualArgumentType
+                            .asConstraintType()
+                            .getBound())))) {
                         needForWildCardTolerance = true;
                         continue;
                     }
@@ -324,7 +325,7 @@ public class MethodResolutionLogic {
             ResolvedType actualArgumentType = needleArgumentTypes.get(lastNeedleArgumentIndex);
             boolean finalArgumentIsArray = actualArgumentType.isArray()
                     && expectedVariadicParameterType.isAssignableBy(
-                            actualArgumentType.asArrayType().getComponentType());
+                    actualArgumentType.asArrayType().getComponentType());
             if (finalArgumentIsArray) {
                 // Treat as an array of values -- in which case the expected parameter type is the common type of this
                 // array.
@@ -507,17 +508,16 @@ public class MethodResolutionLogic {
      * Checks if a method usage is applicable for a given method name and parameter
      * types. This method performs type compatibility checking including generic
      * type variable substitution.
-     *
+     * <p>
      * Note the specific naming here -- parameters are part of the method
      * declaration, while arguments are the values passed when calling a method.
      * Note that "needle" refers to that value being used as a search/query term to
      * match against.
      *
      * @return true, if the given MethodUsage matches the given name/types (normally
-     *         obtained from a ResolvedMethodDeclaration)
-     *
+     * obtained from a ResolvedMethodDeclaration)
      * @see {@link MethodResolutionLogic#isApplicable(ResolvedMethodDeclaration, String, List, TypeSolver)}
-     *      }
+     * }
      * @see {@link MethodResolutionLogic#isApplicable(ResolvedMethodDeclaration, String, List, TypeSolver, boolean)}
      */
     public static boolean isApplicable(
@@ -694,10 +694,10 @@ public class MethodResolutionLogic {
                 // Check boxing/unboxing compatibility with all type variations
                 isApplicable = isBoxingCompatibleWithTypeSolver(expectedArgumentType, actualArgumentType, typeSolver)
                         || isBoxingCompatibleWithTypeSolver(
-                                expectedTypeWithSubstitutions, actualArgumentType, typeSolver)
+                        expectedTypeWithSubstitutions, actualArgumentType, typeSolver)
                         || isBoxingCompatibleWithTypeSolver(expectedTypeWithInference, actualArgumentType, typeSolver)
                         || isBoxingCompatibleWithTypeSolver(
-                                expectedTypeWithoutSubstitutions, actualArgumentType, typeSolver);
+                        expectedTypeWithoutSubstitutions, actualArgumentType, typeSolver);
             }
             if (!isApplicable) {
                 return false;
@@ -799,29 +799,29 @@ public class MethodResolutionLogic {
 
     /**
      * Substitutes type variables from the declaring type into the method signature.
-     *
+     * <p>
      * This method handles the case where a method is inherited from a generic ancestor,
      * and the method signature contains type variables from that ancestor that need to
      * be replaced with the type variables (or concrete types) of the current declaring type.
-     *
+     * <p>
      * Example scenario:
      * - Iterable<T> declares: forEach(Consumer<? super T> action)
      * - Collection<E> extends Iterable<E>
      * - List<E> extends Collection<E>
-     *
+     * <p>
      * When we call List<String>.forEach(...):
      * 1. The method signature initially references Iterable's type variable 'T'
      * 2. This needs to be substituted through the inheritance chain:
-     *    - In Collection<E>: T -> E (Iterable<T> becomes Iterable<E>)
-     *    - In List<E>: E remains E
-     *    - In List<String>: E -> String
+     * - In Collection<E>: T -> E (Iterable<T> becomes Iterable<E>)
+     * - In List<E>: E remains E
+     * - In List<String>: E -> String
      * 3. Final result: forEach(Consumer<? super String> action)
-     *
+     * <p>
      * Without this substitution, we would be comparing incompatible type variables
      * and the method resolution would fail.
      *
      * @param methodUsage the method usage whose signature needs type variable substitution
-     * @param typeSolver the type solver for resolving types during substitution
+     * @param typeSolver  the type solver for resolving types during substitution
      * @return a new MethodUsage with type variables properly substituted
      */
     private static MethodUsage substituteDeclaringTypeParameters(MethodUsage methodUsage, TypeSolver typeSolver) {
@@ -867,18 +867,18 @@ public class MethodResolutionLogic {
 
     /**
      * Recursively substitutes type variables within a type structure.
-     *
+     * <p>
      * This method performs deep substitution of type variables, handling various
      * type structures including:
      * - Simple type variables (T, E, K, V, etc.)
      * - Wildcards with type variable bounds (? super T, ? extends E)
      * - Parameterized types with type variables (List<T>, Map<K, V>)
      * - Nested combinations of the above (Consumer<? super T>, List<List<E>>)
-     *
+     * <p>
      * The substitution is based on a mapping between type parameter declarations
      * (the formal parameters as declared, e.g., <T> in class Foo<T>) and their
      * actual type arguments (the concrete types used, e.g., String in Foo<String>).
-     *
+     * <p>
      * Example transformations:
      * - T -> String (when typeParams contains T and typeArgs contains String)
      * - ? super T -> ? super String
@@ -886,9 +886,9 @@ public class MethodResolutionLogic {
      * - List<T> -> List<String>
      * - Map<K, V> -> Map<String, Integer> (with appropriate mappings)
      *
-     * @param type the type in which to substitute type variables
+     * @param type       the type in which to substitute type variables
      * @param typeParams the list of type parameter declarations (formal parameters)
-     * @param typeArgs the list of actual type arguments to substitute in
+     * @param typeArgs   the list of actual type arguments to substitute in
      * @return a new type with all matching type variables substituted
      */
     private static ResolvedType substituteTypeVariables(
@@ -987,13 +987,14 @@ public class MethodResolutionLogic {
             List<ResolvedMethodDeclaration> methods,
             String name,
             List<ResolvedType> argumentsTypes,
-            TypeSolver typeSolver) {
+            TypeSolver typeSolver,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         SymbolReference<ResolvedMethodDeclaration> res =
-                findMostApplicable(methods, name, argumentsTypes, typeSolver, false);
+                findMostApplicable(methods, name, argumentsTypes, typeSolver, false, invocationContext);
         if (res.isSolved()) {
             return res;
         }
-        return findMostApplicable(methods, name, argumentsTypes, typeSolver, true);
+        return findMostApplicable(methods, name, argumentsTypes, typeSolver, true, invocationContext);
     }
 
     public static SymbolReference<ResolvedMethodDeclaration> findMostApplicable(
@@ -1001,7 +1002,42 @@ public class MethodResolutionLogic {
             String name,
             List<ResolvedType> argumentsTypes,
             TypeSolver typeSolver,
-            boolean wildcardTolerance) {
+            boolean wildcardTolerance,
+            ResolvedReferenceTypeDeclaration invocationContext) {
+
+        if (invocationContext != null) {
+            List<ResolvedMethodDeclaration> resolvedMethods = new ArrayList<>(methods);
+            for (ResolvedMethodDeclaration method : resolvedMethods) {
+                final AccessSpecifier methodAccess = method.accessSpecifier();
+                final ResolvedReferenceTypeDeclaration containerType = method.declaringType();
+                final boolean invocationIsInternal =
+                        containerType.internalTypes().stream()
+                                .anyMatch(it ->
+                                        Objects.equals(it.getQualifiedName(), invocationContext.getQualifiedName()));
+                final boolean sameType = invocationContext.getQualifiedName().equals(containerType.getQualifiedName());
+                final boolean samePackage = containerType.getPackageName().equals(invocationContext.getPackageName());
+
+                if (invocationIsInternal) {
+                    // inner classes can see anything in their surrounding class continue;
+                    continue;
+                }
+
+                if (methodAccess == AccessSpecifier.PRIVATE && !sameType) {
+                    methods.remove(method);
+                    continue;
+                }
+
+                if (methodAccess == AccessSpecifier.PROTECTED && !(containerType.isAssignableBy(invocationContext) || samePackage)) {
+                    methods.remove(method);
+                    continue;
+                }
+
+                if (methodAccess == AccessSpecifier.NONE && !samePackage) {
+                    methods.remove(method);
+                }
+            }
+        }
+
         // Only consider methods with a matching name
         // Filters out duplicate ResolvedMethodDeclaration by their signature.
         // Checks if ResolvedMethodDeclaration is applicable to argumentsTypes.
@@ -1315,8 +1351,8 @@ public class MethodResolutionLogic {
     }
 
     public static SymbolReference<ResolvedMethodDeclaration> solveMethodInType(
-            ResolvedTypeDeclaration typeDeclaration, String name, List<ResolvedType> argumentsTypes) {
-        return solveMethodInType(typeDeclaration, name, argumentsTypes, false);
+            ResolvedTypeDeclaration typeDeclaration, String name, List<ResolvedType> argumentsTypes, ResolvedReferenceTypeDeclaration invocationContext) {
+        return solveMethodInType(typeDeclaration, name, argumentsTypes, false, invocationContext);
     }
 
     // TODO: Replace TypeDeclaration.solveMethod
@@ -1324,9 +1360,9 @@ public class MethodResolutionLogic {
             ResolvedTypeDeclaration typeDeclaration,
             String name,
             List<ResolvedType> argumentsTypes,
-            boolean staticOnly) {
+            boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         if (typeDeclaration instanceof MethodResolutionCapability) {
-            return ((MethodResolutionCapability) typeDeclaration).solveMethod(name, argumentsTypes, staticOnly);
+            return ((MethodResolutionCapability) typeDeclaration).solveMethod(name, argumentsTypes, staticOnly, invocationContext);
         }
         throw new UnsupportedOperationException(typeDeclaration.getClass().getCanonicalName());
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/MethodUsageResolutionCapability.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/MethodUsageResolutionCapability.java
@@ -23,6 +23,7 @@ package com.github.javaparser.symbolsolver.core.resolution;
 
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.List;
 import java.util.Optional;
@@ -32,5 +33,5 @@ public interface MethodUsageResolutionCapability {
             String name,
             List<ResolvedType> argumentTypes,
             Context invocationContext,
-            List<ResolvedType> typeParameters);
+            List<ResolvedType> typeParameters, ResolvedReferenceTypeDeclaration callContext);
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -21,10 +21,6 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel;
 
-import static com.github.javaparser.resolution.Navigator.demandParentNode;
-import static com.github.javaparser.resolution.model.SymbolReference.solved;
-import static com.github.javaparser.resolution.model.SymbolReference.unsolved;
-
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.DataKey;
 import com.github.javaparser.ast.Node;
@@ -34,6 +30,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ForEachStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.resolution.*;
 import com.github.javaparser.resolution.declarations.*;
@@ -51,8 +48,13 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.github.javaparser.utils.Log;
+
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.github.javaparser.resolution.Navigator.demandParentNode;
+import static com.github.javaparser.resolution.model.SymbolReference.solved;
+import static com.github.javaparser.resolution.model.SymbolReference.unsolved;
 
 /**
  * Class to be used by final users to solve symbols for JavaParser ASTs.
@@ -63,8 +65,10 @@ public class JavaParserFacade {
 
     // Start of static class
 
-    private static final DataKey<ResolvedType> TYPE_WITH_LAMBDAS_RESOLVED = new DataKey<ResolvedType>() {};
-    private static final DataKey<ResolvedType> TYPE_WITHOUT_LAMBDAS_RESOLVED = new DataKey<ResolvedType>() {};
+    private static final DataKey<ResolvedType> TYPE_WITH_LAMBDAS_RESOLVED = new DataKey<ResolvedType>() {
+    };
+    private static final DataKey<ResolvedType> TYPE_WITHOUT_LAMBDAS_RESOLVED = new DataKey<ResolvedType>() {
+    };
 
     private static final Map<TypeSolver, JavaParserFacade> instances = new WeakHashMap<>();
 
@@ -130,8 +134,15 @@ public class JavaParserFacade {
                 .orElseThrow(() -> new IllegalArgumentException(expr.getClass().getCanonicalName()));
     }
 
+    @SuppressWarnings("rawtypes")
+    public static ResolvedReferenceTypeDeclaration find(Expression methodCallExpr) {
+        Optional<Node> parent = methodCallExpr.getParentNode();
+        Optional<TypeDeclaration> typeDeclaration = methodCallExpr.findAncestor(TypeDeclaration.class);
+        return typeDeclaration.map(TypeDeclaration::resolve).orElse(null);
+    }
+
     public SymbolReference<ResolvedMethodDeclaration> solve(MethodCallExpr methodCallExpr) {
-        return solve(methodCallExpr, true);
+        return solve(methodCallExpr, true, find(methodCallExpr));
     }
 
     public SymbolReference<ResolvedMethodDeclaration> solve(MethodReferenceExpr methodReferenceExpr) {
@@ -316,14 +327,15 @@ public class JavaParserFacade {
     /**
      * Given a method call find out to which method declaration it corresponds.
      */
-    public SymbolReference<ResolvedMethodDeclaration> solve(MethodCallExpr methodCallExpr, boolean solveLambdas) {
+    public SymbolReference<ResolvedMethodDeclaration> solve(MethodCallExpr methodCallExpr, boolean solveLambdas,
+                                                            ResolvedReferenceTypeDeclaration invocationContext) {
         List<ResolvedType> argumentTypes = new LinkedList<>();
         List<LambdaArgumentTypePlaceholder> placeholders = new LinkedList<>();
 
         solveArguments(methodCallExpr, methodCallExpr.getArguments(), solveLambdas, argumentTypes, placeholders);
 
         SymbolReference<ResolvedMethodDeclaration> res = JavaParserFactory.getContext(methodCallExpr, typeSolver)
-                .solveMethod(methodCallExpr.getName().getId(), argumentTypes, false);
+                .solveMethod(methodCallExpr.getName().getId(), argumentTypes, false, invocationContext);
         for (LambdaArgumentTypePlaceholder placeholder : placeholders) {
             placeholder.setMethod(res);
         }
@@ -338,7 +350,7 @@ public class JavaParserFacade {
         // pass empty argument list to be populated
         List<ResolvedType> argumentTypes = new LinkedList<>();
         return JavaParserFactory.getContext(methodReferenceExpr, typeSolver)
-                .solveMethod(methodReferenceExpr.getIdentifier(), argumentTypes, false);
+                .solveMethod(methodReferenceExpr.getIdentifier(), argumentTypes, false, find(methodReferenceExpr));
     }
 
     public SymbolReference<ResolvedAnnotationDeclaration> solve(AnnotationExpr annotationExpr) {
@@ -753,19 +765,19 @@ public class JavaParserFacade {
             if (parent instanceof BodyDeclaration) {
                 if (parent instanceof TypeDeclaration
                         && ((TypeDeclaration<?>) parent)
-                                .getFullyQualifiedName()
-                                .orElse("")
-                                .endsWith(className)) {
+                        .getFullyQualifiedName()
+                        .orElse("")
+                        .endsWith(className)) {
                     return parent;
                 }
                 detachFlag = true;
             }
             if (parent instanceof ObjectCreationExpr
                     && ((ObjectCreationExpr) parent)
-                            .getType()
-                            .getName()
-                            .asString()
-                            .equals(className)) {
+                    .getType()
+                    .getName()
+                    .asString()
+                    .equals(className)) {
                 if (detachFlag) {
                     return parent;
                 }
@@ -776,9 +788,8 @@ public class JavaParserFacade {
     /**
      * Convert a {@link Type} into the corresponding {@link ResolvedType}.
      *
-     * @param type      The type to be converted.
-     * @param context   The current context.
-     *
+     * @param type    The type to be converted.
+     * @param context The current context.
      * @return The type resolved.
      */
     protected ResolvedType convertToUsage(Type type, Context context) {
@@ -792,7 +803,6 @@ public class JavaParserFacade {
      * Convert a {@link Type} into the corresponding {@link ResolvedType}.
      *
      * @param type The type to be converted.
-     *
      * @return The type resolved.
      */
     public ResolvedType convertToUsage(Type type) {
@@ -836,7 +846,7 @@ public class JavaParserFacade {
         }
         Context context = JavaParserFactory.getContext(call, typeSolver);
         Optional<MethodUsage> methodUsage =
-                context.solveMethodAsUsage(call.getName().getId(), params);
+                context.solveMethodAsUsage(call.getName().getId(), params, null);
         if (!methodUsage.isPresent()) {
             throw new UnsolvedSymbolException("Method '" + call.getName() + "' cannot be resolved in context " + call
                     + " (line: " + call.getRange().map(r -> "" + r.begin.line).orElse("??") + ") " + context
@@ -893,9 +903,7 @@ public class JavaParserFacade {
      * Convert a {@link Class} into the corresponding {@link ResolvedType}.
      *
      * @param clazz The class to be converted.
-     *
      * @return The class resolved.
-     *
      * @deprecated instead consider SymbolSolver.classToResolvedType(Class<?> clazz)
      */
     @Deprecated

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -29,6 +29,7 @@ import static com.github.javaparser.resolution.Navigator.demandParentNode;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -752,7 +753,8 @@ public class TypeExtractor extends DefaultVisitorAdapter {
         if (parentNode instanceof MethodCallExpr) {
             MethodCallExpr callExpr = (MethodCallExpr) parentNode;
             int pos = getParamPos(node);
-            SymbolReference<ResolvedMethodDeclaration> refMethod = facade.solve(callExpr, false);
+            SymbolReference<ResolvedMethodDeclaration> refMethod = facade.solve(callExpr, false,
+                    JavaParserFacade.find(callExpr));
             if (!refMethod.isSolved()) {
                 throw new UnsolvedSymbolException(
                         parentNode.toString(), callExpr.getName().getId());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -282,8 +282,8 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
      * A MethodUsage corresponds to a MethodDeclaration plus the resolved type variables.
      */
     @Override
-    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
-        SymbolReference<ResolvedMethodDeclaration> methodSolved = solveMethod(name, argumentsTypes, false);
+    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes, ResolvedReferenceTypeDeclaration invocationContext) {
+        SymbolReference<ResolvedMethodDeclaration> methodSolved = solveMethod(name, argumentsTypes, false, invocationContext);
         if (methodSolved.isSolved()) {
             ResolvedMethodDeclaration methodDeclaration = methodSolved.getCorrespondingDeclaration();
             if (!(methodDeclaration instanceof TypeVariableResolutionCapability)) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractMethodLikeDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractMethodLikeDeclarationContext.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.resolution.SymbolDeclarator;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
@@ -125,8 +126,8 @@ public abstract class AbstractMethodLikeDeclarationContext<
 
     @Override
     public final SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnnotationDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnnotationDeclarationContext.java
@@ -64,8 +64,8 @@ public class AnnotationDeclarationContext extends AbstractJavaParserContext<Anno
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     ///

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnonymousClassDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnonymousClassDeclarationContext.java
@@ -60,7 +60,8 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         List<ResolvedMethodDeclaration> candidateMethods = myDeclaration.getDeclaredMethods().stream()
                 .filter(m -> m.getName().equals(name) && (!staticOnly || m.isStatic()))
                 .collect(Collectors.toList());
@@ -69,7 +70,7 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
             for (ResolvedReferenceType ancestor : myDeclaration.getAncestors()) {
                 ancestor.getTypeDeclaration().ifPresent(ancestorTypeDeclaration -> {
                     SymbolReference<ResolvedMethodDeclaration> res = MethodResolutionLogic.solveMethodInType(
-                            ancestorTypeDeclaration, name, argumentsTypes, staticOnly);
+                            ancestorTypeDeclaration, name, argumentsTypes, staticOnly, invocationContext);
 
                     // consider methods from superclasses and only default methods from interfaces :
                     // not true, we should keep abstract as a valid candidate
@@ -86,7 +87,7 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
         if (candidateMethods.isEmpty()) {
             SymbolReference<ResolvedMethodDeclaration> parentSolution = getParent()
                     .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
-                    .solveMethod(name, argumentsTypes, staticOnly);
+                    .solveMethod(name, argumentsTypes, staticOnly, invocationContext);
             if (parentSolution.isSolved()) {
                 candidateMethods.add(parentSolution.getCorrespondingDeclaration());
             }
@@ -96,13 +97,13 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
         if (candidateMethods.isEmpty()
                 && myDeclaration.getSuperTypeDeclaration().isInterface()) {
             SymbolReference<ResolvedMethodDeclaration> res = MethodResolutionLogic.solveMethodInType(
-                    new ReflectionClassDeclaration(Object.class, typeSolver), name, argumentsTypes, false);
+                    new ReflectionClassDeclaration(Object.class, typeSolver), name, argumentsTypes, false, invocationContext);
             if (res.isSolved()) {
                 candidateMethods.add(res.getCorrespondingDeclaration());
             }
         }
 
-        return MethodResolutionLogic.findMostApplicable(candidateMethods, name, argumentsTypes, typeSolver);
+        return MethodResolutionLogic.findMostApplicable(candidateMethods, name, argumentsTypes, typeSolver, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CatchClauseContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CatchClauseContext.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.resolution.SymbolDeclarator;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.Value;
@@ -74,9 +75,10 @@ public class CatchClauseContext extends AbstractJavaParserContext<CatchClause> {
 
     @Override
     public final SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
@@ -104,8 +104,9 @@ public class ClassOrInterfaceDeclarationContext extends AbstractJavaParserContex
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
+        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     public SymbolReference<ResolvedConstructorDeclaration> solveConstructor(List<ResolvedType> argumentsTypes) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -320,7 +320,8 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         for (ImportDeclaration importDecl : wrappedNode.getImports()) {
             if (importDecl.isStatic()) {
                 if (importDecl.isAsterisk()) {
@@ -342,7 +343,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
 
                     ResolvedTypeDeclaration ref = typeSolver.solveType(importString);
                     SymbolReference<ResolvedMethodDeclaration> method =
-                            MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true);
+                            MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true, invocationContext);
                     if (method.isSolved()) {
                         return method;
                     }
@@ -353,7 +354,7 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
                         String typeName = getType(qName);
                         ResolvedTypeDeclaration ref = typeSolver.solveType(typeName);
                         SymbolReference<ResolvedMethodDeclaration> method =
-                                MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true);
+                                MethodResolutionLogic.solveMethodInType(ref, name, argumentsTypes, true, invocationContext);
                         if (method.isSolved()) {
                             return method;
                         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ContextHelper.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ContextHelper.java
@@ -23,6 +23,7 @@ package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionCapability;
@@ -43,11 +44,11 @@ public class ContextHelper {
             String name,
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameters) {
+            List<ResolvedType> typeParameters, ResolvedReferenceTypeDeclaration callContext) {
 
         if (typeDeclaration instanceof MethodUsageResolutionCapability) {
             return ((MethodUsageResolutionCapability) typeDeclaration)
-                    .solveMethodAsUsage(name, argumentsTypes, invokationContext, typeParameters);
+                    .solveMethodAsUsage(name, argumentsTypes, invokationContext, typeParameters, callContext);
         }
         throw new UnsupportedOperationException(typeDeclaration.toString());
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
@@ -73,8 +73,8 @@ public class EnumDeclarationContext extends AbstractJavaParserContext<EnumDeclar
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     ///

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/FieldAccessContext.java
@@ -77,9 +77,9 @@ public class FieldAccessContext extends ExpressionContext<FieldAccessExpr> {
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> parameterTypes, boolean staticOnly) {
+            String name, List<ResolvedType> parameterTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         return JavaParserFactory.getContext(demandParentNode(wrappedNode), typeSolver)
-                .solveMethod(name, parameterTypes, false);
+                .solveMethod(name, parameterTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForEachStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForEachStatementContext.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ForEachStmt;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -60,9 +61,9 @@ public class ForEachStatementContext extends StatementContext<ForEachStmt> {
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ForStatementContext.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithStatements;
 import com.github.javaparser.ast.stmt.ForStmt;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -124,9 +125,9 @@ public class ForStatementContext extends StatementContext<ForStmt> {
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -256,7 +256,8 @@ public class JavaParserTypeDeclarationAdapter {
     }
 
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
 
         // Begin by locating methods declared "here"
         List<ResolvedMethodDeclaration> candidateMethods = typeDeclaration.getDeclaredMethods().stream()
@@ -282,7 +283,7 @@ public class JavaParserTypeDeclarationAdapter {
                     // not true, we should keep abstract as a valid candidate
                     // abstract are removed in MethodResolutionLogic.isApplicable is necessary
                     SymbolReference<ResolvedMethodDeclaration> res = MethodResolutionLogic.solveMethodInType(
-                            ancestorTypeDeclaration.get(), name, argumentsTypes, staticOnly);
+                            ancestorTypeDeclaration.get(), name, argumentsTypes, staticOnly, invocationContext);
                     if (res.isSolved()) {
                         candidateMethods.add(res.getCorrespondingDeclaration());
                     }
@@ -298,7 +299,7 @@ public class JavaParserTypeDeclarationAdapter {
         if (candidateMethods.isEmpty() && !staticOnly) {
             SymbolReference<ResolvedMethodDeclaration> parentSolution = context.getParent()
                     .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
-                    .solveMethod(name, argumentsTypes, staticOnly);
+                    .solveMethod(name, argumentsTypes, staticOnly, invocationContext);
             if (parentSolution.isSolved()) {
                 candidateMethods.add(parentSolution.getCorrespondingDeclaration());
             }
@@ -307,13 +308,13 @@ public class JavaParserTypeDeclarationAdapter {
         // if is interface and candidate method list is empty, we should check the Object Methods
         if (candidateMethods.isEmpty() && typeDeclaration.isInterface()) {
             SymbolReference<ResolvedMethodDeclaration> res = MethodResolutionLogic.solveMethodInType(
-                    typeSolver.getSolvedJavaLangObject(), name, argumentsTypes, false);
+                    typeSolver.getSolvedJavaLangObject(), name, argumentsTypes, false, invocationContext);
             if (res.isSolved()) {
                 candidateMethods.add(res.getCorrespondingDeclaration());
             }
         }
 
-        return MethodResolutionLogic.findMostApplicable(candidateMethods, name, argumentsTypes, typeSolver);
+        return MethodResolutionLogic.findMostApplicable(candidateMethods, name, argumentsTypes, typeSolver, invocationContext);
     }
 
     public SymbolReference<ResolvedConstructorDeclaration> solveConstructor(List<ResolvedType> argumentsTypes) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -38,6 +38,7 @@ import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.SymbolDeclarator;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.logic.FunctionalInterfaceLogic;
@@ -233,9 +234,10 @@ public class LambdaExprContext extends ExpressionContext<LambdaExpr> {
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -77,7 +77,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
     }
 
     @Override
-    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
+    public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes, ResolvedReferenceTypeDeclaration invocationContext) {
         ResolvedType typeOfScope;
         if (wrappedNode.hasScope()) {
             Expression scope = wrappedNode.getScope().get();
@@ -87,7 +87,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
                 SymbolReference<ResolvedTypeDeclaration> ref = solveType(className);
                 if (ref.isSolved()) {
                     SymbolReference<ResolvedMethodDeclaration> m = MethodResolutionLogic.solveMethodInType(
-                            ref.getCorrespondingDeclaration(), name, argumentsTypes);
+                            ref.getCorrespondingDeclaration(), name, argumentsTypes, invocationContext);
                     if (m.isSolved()) {
                         MethodUsage methodUsage = new MethodUsage(m.getCorrespondingDeclaration());
                         methodUsage = resolveMethodTypeParametersFromExplicitList(typeSolver, methodUsage);
@@ -123,7 +123,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
             argumentsTypes.set(i, updatedArgumentType);
         }
 
-        return solveMethodAsUsage(typeOfScope, name, argumentsTypes, this);
+        return solveMethodAsUsage(typeOfScope, name, argumentsTypes, this, invocationContext);
     }
 
     private MethodUsage resolveMethodTypeParametersFromExplicitList(TypeSolver typeSolver, MethodUsage methodUsage) {
@@ -148,7 +148,8 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         Collection<ResolvedReferenceTypeDeclaration> rrtds = findTypeDeclarations(wrappedNode.getScope());
 
         if (rrtds.isEmpty()) {
@@ -161,7 +162,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
 
         for (ResolvedReferenceTypeDeclaration rrtd : rrtds) {
             SymbolReference<ResolvedMethodDeclaration> res =
-                    MethodResolutionLogic.solveMethodInType(rrtd, name, argumentsTypes, false);
+                    MethodResolutionLogic.solveMethodInType(rrtd, name, argumentsTypes, false, invocationContext);
             if (res.isSolved()) {
                 return res;
             }
@@ -175,7 +176,9 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
     ///
 
     private Optional<MethodUsage> solveMethodAsUsage(
-            ResolvedReferenceType refType, String name, List<ResolvedType> argumentsTypes, Context invokationContext) {
+            ResolvedReferenceType refType, String name,
+            List<ResolvedType> argumentsTypes, Context invokationContext,
+            ResolvedReferenceTypeDeclaration callContext) {
         if (!refType.getTypeDeclaration().isPresent()) {
             return Optional.empty();
         }
@@ -185,7 +188,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
                 name,
                 argumentsTypes,
                 invokationContext,
-                refType.typeParametersValues());
+                refType.typeParametersValues(), callContext);
         if (ref.isPresent()) {
             MethodUsage methodUsage = ref.get();
 
@@ -479,7 +482,8 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
     }
 
     private Optional<MethodUsage> solveMethodAsUsage(
-            ResolvedTypeVariable tp, String name, List<ResolvedType> argumentsTypes, Context invokationContext) {
+            ResolvedTypeVariable tp, String name, List<ResolvedType> argumentsTypes, Context invokationContext,
+            ResolvedReferenceTypeDeclaration callContext) {
         List<ResolvedTypeParameterDeclaration.Bound> bounds =
                 tp.asTypeParameter().getBounds();
 
@@ -495,7 +499,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
 
         for (ResolvedTypeParameterDeclaration.Bound bound : bounds) {
             Optional<MethodUsage> methodUsage =
-                    solveMethodAsUsage(bound.getType(), name, argumentsTypes, invokationContext);
+                    solveMethodAsUsage(bound.getType(), name, argumentsTypes, invokationContext, callContext);
             if (methodUsage.isPresent()) {
                 return methodUsage;
             }
@@ -505,33 +509,35 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
     }
 
     private Optional<MethodUsage> solveMethodAsUsage(
-            ResolvedType type, String name, List<ResolvedType> argumentsTypes, Context invokationContext) {
+            ResolvedType type, String name, List<ResolvedType> argumentsTypes, Context invokationContext,
+            ResolvedReferenceTypeDeclaration callContext) {
         if (type instanceof ResolvedReferenceType) {
-            return solveMethodAsUsage((ResolvedReferenceType) type, name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage((ResolvedReferenceType) type, name, argumentsTypes, invokationContext, callContext);
         }
         if (type instanceof LazyType) {
-            return solveMethodAsUsage(type.asReferenceType(), name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage(type.asReferenceType(), name, argumentsTypes, invokationContext, callContext);
         }
         if (type instanceof ResolvedTypeVariable) {
-            return solveMethodAsUsage((ResolvedTypeVariable) type, name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage((ResolvedTypeVariable) type, name, argumentsTypes, invokationContext, callContext);
         }
         if (type instanceof ResolvedWildcard) {
             ResolvedWildcard wildcardUsage = (ResolvedWildcard) type;
             if (wildcardUsage.isSuper()) {
-                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext);
+                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext, callContext);
             }
             if (wildcardUsage.isExtends()) {
-                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext);
+                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext, callContext);
             }
             return solveMethodAsUsage(
                     new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject()),
                     name,
                     argumentsTypes,
-                    invokationContext);
+                    invokationContext,
+                    callContext);
         }
         if (type instanceof ResolvedLambdaConstraintType) {
             ResolvedLambdaConstraintType constraintType = (ResolvedLambdaConstraintType) type;
-            return solveMethodAsUsage(constraintType.getBound(), name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage(constraintType.getBound(), name, argumentsTypes, invokationContext, callContext);
         }
         if (type instanceof ResolvedArrayType) {
             // An array inherits methods from Object not from it's component type
@@ -539,12 +545,13 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
                     new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject()),
                     name,
                     argumentsTypes,
-                    invokationContext);
+                    invokationContext,
+                    callContext);
         }
         if (type instanceof ResolvedUnionType) {
             Optional<ResolvedReferenceType> commonAncestor = type.asUnionType().getCommonAncestor();
             if (commonAncestor.isPresent()) {
-                return solveMethodAsUsage(commonAncestor.get(), name, argumentsTypes, invokationContext);
+                return solveMethodAsUsage(commonAncestor.get(), name, argumentsTypes, invokationContext, callContext);
             }
             throw new UnsupportedOperationException("no common ancestor available for " + type.describe());
         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
@@ -61,7 +61,7 @@ public class MethodReferenceExprContext extends ExpressionContext<MethodReferenc
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         if ("new".equals(name)) {
             throw new UnsupportedOperationException("Constructor calls not yet resolvable");
         }
@@ -80,12 +80,12 @@ public class MethodReferenceExprContext extends ExpressionContext<MethodReferenc
 
         for (ResolvedReferenceTypeDeclaration rrtd : rrtds) {
             SymbolReference<ResolvedMethodDeclaration> firstResAttempt =
-                    MethodResolutionLogic.solveMethodInType(rrtd, name, argumentsTypes, false);
+                    MethodResolutionLogic.solveMethodInType(rrtd, name, argumentsTypes, false, invocationContext);
             if (firstResAttempt.isSolved()) {
                 return firstResAttempt;
             }
             SymbolReference<ResolvedMethodDeclaration> secondResAttempt =
-                    MethodResolutionLogic.solveMethodInType(rrtd, name, Collections.emptyList(), false);
+                    MethodResolutionLogic.solveMethodInType(rrtd, name, Collections.emptyList(), false, invocationContext);
             if (secondResAttempt.isSolved()) {
                 return secondResAttempt;
             }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ObjectCreationContext.java
@@ -72,8 +72,8 @@ public class ObjectCreationContext extends ExpressionContext<ObjectCreationExpr>
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         return JavaParserFactory.getContext(demandParentNode(wrappedNode), typeSolver)
-                .solveMethod(name, argumentsTypes, false);
+                .solveMethod(name, argumentsTypes, false, invocationContext);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/RecordDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/RecordDeclarationContext.java
@@ -104,9 +104,9 @@ public class RecordDeclarationContext extends AbstractJavaParserContext<RecordDe
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         SymbolReference<ResolvedMethodDeclaration> resolvedExplicitMethod =
-                javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
+                javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly, invocationContext);
 
         if (!resolvedExplicitMethod.isSolved() && argumentsTypes.isEmpty()) {
             // If the method could not be resolved and has no arguments, then it could be an implicit getter for

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/StatementContext.java
@@ -32,6 +32,7 @@ import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.SymbolDeclarator;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.Value;
@@ -317,9 +318,10 @@ public class StatementContext<N extends Statement> extends AbstractJavaParserCon
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 
     public List<TypePatternExpr> getIntroducedTypePatterns() {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/SwitchEntryContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/SwitchEntryContext.java
@@ -100,9 +100,9 @@ public class SwitchEntryContext extends AbstractJavaParserContext<SwitchEntry> {
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/TryWithResourceContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/TryWithResourceContext.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.Value;
@@ -88,9 +89,9 @@ public class TryWithResourceContext extends StatementContext<TryStmt> {
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         // TODO: Document why staticOnly is forced to be false.
-        return solveMethodInParentContext(name, argumentsTypes, false);
+        return solveMethodInParentContext(name, argumentsTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -91,8 +91,9 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return getContext().solveMethod(name, argumentsTypes, staticOnly);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     @Override
@@ -100,8 +101,9 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
             String name,
             List<ResolvedType> argumentTypes,
             Context invocationContext,
-            List<ResolvedType> typeParameters) {
-        return getContext().solveMethodAsUsage(name, argumentTypes);
+            List<ResolvedType> typeParameters,
+            ResolvedReferenceTypeDeclaration callContext) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, callContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -155,9 +155,10 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
     /// Public methods
     ///
 
-    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> parameterTypes) {
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> parameterTypes,
+                                                                  ResolvedReferenceTypeDeclaration invocationContext) {
         Context ctx = getContext();
-        return ctx.solveMethod(name, parameterTypes, false);
+        return ctx.solveMethod(name, parameterTypes, false, invocationContext);
     }
 
     @Override
@@ -165,8 +166,8 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
             String name,
             List<ResolvedType> argumentTypes,
             Context invocationContext,
-            List<ResolvedType> typeParameters) {
-        return getContext().solveMethodAsUsage(name, argumentTypes);
+            List<ResolvedType> typeParameters, ResolvedReferenceTypeDeclaration callContext) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, callContext);
     }
 
     /**
@@ -330,8 +331,9 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return getContext().solveMethod(name, argumentsTypes, staticOnly);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -190,7 +190,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> argumentTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameters) {
+            List<ResolvedType> typeParameters, ResolvedReferenceTypeDeclaration callContext) {
         if (VALUES.equals(name) && argumentTypes.isEmpty()) {
             return Optional.of(new MethodUsage(new JavaParserEnumDeclaration.ValuesMethod(this, typeSolver)));
         }
@@ -201,12 +201,12 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
                 return Optional.of(new MethodUsage(new JavaParserEnumDeclaration.ValueOfMethod(this, typeSolver)));
             }
         }
-        return getContext().solveMethodAsUsage(name, argumentTypes);
+        return getContext().solveMethodAsUsage(name, argumentTypes, callContext);
     }
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
         if (VALUES.equals(name) && argumentsTypes.isEmpty()) {
             return SymbolReference.solved(new JavaParserEnumDeclaration.ValuesMethod(this, typeSolver));
         }
@@ -217,7 +217,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
                 return SymbolReference.solved(new JavaParserEnumDeclaration.ValueOfMethod(this, typeSolver));
             }
         }
-        return getContext().solveMethod(name, argumentsTypes, staticOnly);
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -281,8 +281,8 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return getContext().solveMethod(name, argumentsTypes, staticOnly);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     @Override
@@ -290,8 +290,8 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> argumentTypes,
             Context invocationContext,
-            List<ResolvedType> typeParameters) {
-        return getContext().solveMethodAsUsage(name, argumentTypes);
+            List<ResolvedType> typeParameters, ResolvedReferenceTypeDeclaration callContext) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, callContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserRecordDeclaration.java
@@ -203,9 +203,10 @@ public class JavaParserRecordDeclaration extends AbstractTypeDeclaration
     /// Public methods
     ///
 
-    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> parameterTypes) {
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> parameterTypes,
+                                                                  ResolvedReferenceTypeDeclaration invocationContext) {
         Context ctx = getContext();
-        return ctx.solveMethod(name, parameterTypes, false);
+        return ctx.solveMethod(name, parameterTypes, false, invocationContext);
     }
 
     @Override
@@ -213,8 +214,8 @@ public class JavaParserRecordDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> argumentTypes,
             Context invocationContext,
-            List<ResolvedType> typeParameters) {
-        return getContext().solveMethodAsUsage(name, argumentTypes);
+            List<ResolvedType> typeParameters, ResolvedReferenceTypeDeclaration callContext) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, callContext);
     }
 
     /**
@@ -393,9 +394,10 @@ public class JavaParserRecordDeclaration extends AbstractTypeDeclaration
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
 
-        return getContext().solveMethod(name, argumentsTypes, staticOnly);
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
@@ -56,8 +56,8 @@ public class JavaParserTypeParameter extends AbstractTypeDeclaration implements 
         return Collections.emptySet();
     }
 
-    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> parameterTypes) {
-        return getContext().solveMethod(name, parameterTypes, false);
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(String name, List<ResolvedType> parameterTypes, ResolvedReferenceTypeDeclaration invocationContext) {
+        return getContext().solveMethod(name, parameterTypes, false, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistClassDeclaration.java
@@ -135,7 +135,7 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
             String name,
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
         return JavassistUtils.solveMethodAsUsage(
                 name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }
@@ -190,8 +190,8 @@ public class JavassistClassDeclaration extends AbstractClassDeclaration
     @Override
     @Deprecated
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass, invocationContext);
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistEnumDeclaration.java
@@ -179,8 +179,8 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass, invocationContext);
     }
 
     @Override
@@ -188,7 +188,7 @@ public class JavassistEnumDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
         return JavassistUtils.solveMethodAsUsage(
                 name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistInterfaceDeclaration.java
@@ -98,7 +98,7 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
         return JavassistUtils.solveMethodAsUsage(
                 name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }
@@ -106,8 +106,8 @@ public class JavassistInterfaceDeclaration extends AbstractTypeDeclaration
     @Override
     @Deprecated
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass,invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclaration.java
@@ -135,7 +135,7 @@ public class JavassistRecordDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
         return JavassistUtils.solveMethodAsUsage(
                 name, argumentsTypes, typeSolver, invokationContext, typeParameterValues, this, ctClass);
     }
@@ -347,7 +347,7 @@ public class JavassistRecordDeclaration extends AbstractTypeDeclaration
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass);
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return JavassistUtils.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, ctClass, invocationContext);
     }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistUtils.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistUtils.java
@@ -82,7 +82,7 @@ class JavassistUtils {
             ancestor.getTypeDeclaration()
                     .flatMap(superClassTypeDeclaration -> ancestor.getTypeDeclaration())
                     .flatMap(interfaceTypeDeclaration -> ContextHelper.solveMethodAsUsage(
-                            interfaceTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues))
+                            interfaceTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues, null))//XXX
                     .ifPresent(methods::add);
         }
 
@@ -95,7 +95,8 @@ class JavassistUtils {
             boolean staticOnly,
             TypeSolver typeSolver,
             ResolvedReferenceTypeDeclaration scopeType,
-            CtClass ctClass) {
+            CtClass ctClass,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         List<ResolvedMethodDeclaration> candidates = new ArrayList<>();
         Predicate<CtMethod> staticOnlyCheck = m -> !staticOnly || java.lang.reflect.Modifier.isStatic(m.getModifiers());
         for (CtMethod method : ctClass.getDeclaredMethods()) {
@@ -117,7 +118,7 @@ class JavassistUtils {
             Optional<ResolvedReferenceTypeDeclaration> ancestorTypeDeclOpt = ancestorRefType.getTypeDeclaration();
             if (ancestorTypeDeclOpt.isPresent()) {
                 SymbolReference<ResolvedMethodDeclaration> ancestorMethodRef = MethodResolutionLogic.solveMethodInType(
-                        ancestorTypeDeclOpt.get(), name, argumentsTypes, staticOnly);
+                        ancestorTypeDeclOpt.get(), name, argumentsTypes, staticOnly, invocationContext);
                 if (ancestorMethodRef.isSolved()) {
                     candidates.add(ancestorMethodRef.getCorrespondingDeclaration());
                 }
@@ -126,7 +127,7 @@ class JavassistUtils {
             }
         }
 
-        return MethodResolutionLogic.findMostApplicable(candidates, name, argumentsTypes, typeSolver);
+        return MethodResolutionLogic.findMostApplicable(candidates, name, argumentsTypes, typeSolver, invocationContext);
     }
 
     static ResolvedType signatureTypeToType(

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclaration.java
@@ -193,7 +193,7 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration
             final String name,
             final List<ResolvedType> parameterTypes,
             final Context invokationContext,
-            final List<ResolvedType> typeParameterValues) {
+            final List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
         Optional<MethodUsage> res = ReflectionMethodResolutionLogic.solveMethodAsUsage(
                 name, parameterTypes, typeSolver, invokationContext, typeParameterValues, this, clazz);
         if (res.isPresent()) {
@@ -226,8 +226,8 @@ public class ReflectionAnnotationDeclaration extends AbstractTypeDeclaration
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            final String name, final List<ResolvedType> argumentsTypes, final boolean staticOnly) {
-        return ReflectionMethodResolutionLogic.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, clazz);
+            final String name, final List<ResolvedType> argumentsTypes, final boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return ReflectionMethodResolutionLogic.solveMethod(name, argumentsTypes, staticOnly, typeSolver, this, clazz, invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -143,7 +143,8 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
     @Override
     @Deprecated
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         Predicate<Method> staticFilter = m -> !staticOnly || (staticOnly && Modifier.isStatic(m.getModifiers()));
 
         List<ResolvedMethodDeclaration> candidateSolvedMethods = new ArrayList<>();
@@ -171,7 +172,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
         // Next consider methods declared within extended superclasses.
         getSuperClass().flatMap(ResolvedReferenceType::getTypeDeclaration).ifPresent(superClassTypeDeclaration -> {
             SymbolReference<ResolvedMethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(
-                    superClassTypeDeclaration, name, argumentsTypes, staticOnly);
+                    superClassTypeDeclaration, name, argumentsTypes, staticOnly, invocationContext);
             if (ref.isSolved()) {
                 candidateSolvedMethods.add(ref.getCorrespondingDeclaration());
             }
@@ -181,7 +182,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
         for (ResolvedReferenceType interfaceDeclaration : getInterfaces()) {
             interfaceDeclaration.getTypeDeclaration().ifPresent(interfaceTypeDeclaration -> {
                 SymbolReference<ResolvedMethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(
-                        interfaceTypeDeclaration, name, argumentsTypes, staticOnly);
+                        interfaceTypeDeclaration, name, argumentsTypes, staticOnly, invocationContext);
                 if (ref.isSolved()) {
                     candidateSolvedMethods.add(ref.getCorrespondingDeclaration());
                 }
@@ -195,7 +196,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
         if (candidateSolvedMethods.isEmpty()) {
             return SymbolReference.unsolved();
         }
-        return MethodResolutionLogic.findMostApplicable(candidateSolvedMethods, name, argumentsTypes, typeSolver);
+        return MethodResolutionLogic.findMostApplicable(candidateSolvedMethods, name, argumentsTypes, typeSolver, invocationContext);
     }
 
     @Override
@@ -213,7 +214,8 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
             String name,
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues,
+            ResolvedReferenceTypeDeclaration callContext) {
         List<MethodUsage> methodUsages = new ArrayList<>();
 
         List<Method> allMethods = Arrays.stream(clazz.getDeclaredMethods())
@@ -244,7 +246,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
         getSuperClass().ifPresent(superClass -> {
             superClass.getTypeDeclaration().ifPresent(superClassTypeDeclaration -> {
                 ContextHelper.solveMethodAsUsage(
-                                superClassTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues)
+                                superClassTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues, callContext)
                         .ifPresent(methodUsages::add);
             });
         });
@@ -254,7 +256,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
                     .getTypeDeclaration()
                     .flatMap(superClassTypeDeclaration -> interfaceDeclaration.getTypeDeclaration())
                     .flatMap(interfaceTypeDeclaration -> ContextHelper.solveMethodAsUsage(
-                            interfaceTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues))
+                            interfaceTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues, callContext))
                     .ifPresent(methodUsages::add);
         }
         Optional<MethodUsage> ref =

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionEnumDeclaration.java
@@ -198,8 +198,8 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> parameterTypes, boolean staticOnly) {
-        return ReflectionMethodResolutionLogic.solveMethod(name, parameterTypes, staticOnly, typeSolver, this, clazz);
+            String name, List<ResolvedType> parameterTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return ReflectionMethodResolutionLogic.solveMethod(name, parameterTypes, staticOnly, typeSolver, this, clazz, invocationContext);
     }
 
     @Override
@@ -207,7 +207,7 @@ public class ReflectionEnumDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> parameterTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
         Optional<MethodUsage> res = ReflectionMethodResolutionLogic.solveMethodAsUsage(
                 name, parameterTypes, typeSolver, invokationContext, typeParameterValues, this, clazz);
         if (res.isPresent()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -108,8 +108,8 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
     @Override
     @Deprecated
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> parameterTypes, boolean staticOnly) {
-        return ReflectionMethodResolutionLogic.solveMethod(name, parameterTypes, staticOnly, typeSolver, this, clazz);
+            String name, List<ResolvedType> parameterTypes, boolean staticOnly, ResolvedReferenceTypeDeclaration invocationContext) {
+        return ReflectionMethodResolutionLogic.solveMethod(name, parameterTypes, staticOnly, typeSolver, this, clazz, invocationContext);
     }
 
     @Override
@@ -143,17 +143,18 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
      * This method first resolves the basic method signature, then performs generic type inference
      * based on the actual parameter types provided at the call site.
      *
-     * @param name the method name to resolve
-     * @param parameterTypes the actual parameter types at the call site
-     * @param invokationContext the context where the method is invoked
+     * @param name                the method name to resolve
+     * @param parameterTypes      the actual parameter types at the call site
+     * @param invokationContext   the context where the method is invoked
      * @param typeParameterValues explicit type parameter values (if any)
+     * @param callContext
      * @return an Optional containing the resolved MethodUsage with inferred types, or empty if resolution fails
      */
     public Optional<MethodUsage> solveMethodAsUsage(
             String name,
             List<ResolvedType> parameterTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
 
         Optional<MethodUsage> res = ReflectionMethodResolutionLogic.solveMethodAsUsage(
                 name, parameterTypes, typeSolver, invokationContext, typeParameterValues, this, clazz);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
@@ -52,7 +52,8 @@ class ReflectionMethodResolutionLogic {
             boolean staticOnly,
             TypeSolver typeSolver,
             ResolvedReferenceTypeDeclaration scopeType,
-            Class clazz) {
+            Class clazz,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         List<ResolvedMethodDeclaration> methods = new ArrayList<>();
         Predicate<Method> staticOnlyCheck = m -> !staticOnly || (staticOnly && Modifier.isStatic(m.getModifiers()));
         for (Method method : clazz.getMethods()) {
@@ -67,7 +68,7 @@ class ReflectionMethodResolutionLogic {
         for (ResolvedReferenceType ancestor : scopeType.getAncestors()) {
             ancestor.getTypeDeclaration().ifPresent(ancestorTypeDeclaration -> {
                 SymbolReference<ResolvedMethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(
-                        ancestorTypeDeclaration, name, parameterTypes, staticOnly);
+                        ancestorTypeDeclaration, name, parameterTypes, staticOnly, invocationContext);
                 if (ref.isSolved()) {
                     methods.add(ref.getCorrespondingDeclaration());
                 }
@@ -79,13 +80,13 @@ class ReflectionMethodResolutionLogic {
                     new ReferenceTypeImpl(new ReflectionClassDeclaration(Object.class, typeSolver));
             objectClass.getTypeDeclaration().ifPresent(objectTypeDeclaration -> {
                 SymbolReference<ResolvedMethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(
-                        objectTypeDeclaration, name, parameterTypes, staticOnly);
+                        objectTypeDeclaration, name, parameterTypes, staticOnly, invocationContext);
                 if (ref.isSolved()) {
                     methods.add(ref.getCorrespondingDeclaration());
                 }
             });
         }
-        return MethodResolutionLogic.findMostApplicable(methods, name, parameterTypes, typeSolver);
+        return MethodResolutionLogic.findMostApplicable(methods, name, parameterTypes, typeSolver, invocationContext);
     }
 
     static Optional<MethodUsage> solveMethodAsUsage(
@@ -123,7 +124,7 @@ class ReflectionMethodResolutionLogic {
                 ResolvedReferenceTypeDeclaration ancestorTypeDeclaration =
                         ancestor.getTypeDeclaration().get();
                 SymbolReference<ResolvedMethodDeclaration> ref =
-                        MethodResolutionLogic.solveMethodInType(ancestorTypeDeclaration, name, argumentsTypes);
+                        MethodResolutionLogic.solveMethodInType(ancestorTypeDeclaration, name, argumentsTypes, null); //XXX
                 if (ref.isSolved()) {
                     ResolvedMethodDeclaration correspondingDeclaration = ref.getCorrespondingDeclaration();
                     MethodUsage methodUsage =
@@ -139,7 +140,7 @@ class ReflectionMethodResolutionLogic {
                     .getTypeDeclaration();
             if (optionalObjectClass.isPresent()) {
                 SymbolReference<ResolvedMethodDeclaration> ref =
-                        MethodResolutionLogic.solveMethodInType(optionalObjectClass.get(), name, argumentsTypes);
+                        MethodResolutionLogic.solveMethodInType(optionalObjectClass.get(), name, argumentsTypes, null);//XXX
                 if (ref.isSolved()) {
                     MethodUsage usage = replaceParams(
                             typeParameterValues, optionalObjectClass.get(), ref.getCorrespondingDeclaration());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
@@ -148,7 +148,8 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
     @Override
     @Deprecated
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-            String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+            ResolvedReferenceTypeDeclaration invocationContext) {
         Predicate<Method> staticFilter = m -> !staticOnly || (staticOnly && Modifier.isStatic(m.getModifiers()));
 
         List<ResolvedMethodDeclaration> candidateSolvedMethods = new ArrayList<>();
@@ -176,7 +177,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
         // Next consider methods declared within extended superclasses.
         getSuperClass().flatMap(ResolvedReferenceType::getTypeDeclaration).ifPresent(superClassTypeDeclaration -> {
             SymbolReference<ResolvedMethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(
-                    superClassTypeDeclaration, name, argumentsTypes, staticOnly);
+                    superClassTypeDeclaration, name, argumentsTypes, staticOnly, invocationContext);
             if (ref.isSolved()) {
                 candidateSolvedMethods.add(ref.getCorrespondingDeclaration());
             }
@@ -186,7 +187,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
         for (ResolvedReferenceType interfaceDeclaration : getInterfaces()) {
             interfaceDeclaration.getTypeDeclaration().ifPresent(interfaceTypeDeclaration -> {
                 SymbolReference<ResolvedMethodDeclaration> ref = MethodResolutionLogic.solveMethodInType(
-                        interfaceTypeDeclaration, name, argumentsTypes, staticOnly);
+                        interfaceTypeDeclaration, name, argumentsTypes, staticOnly, invocationContext);
                 if (ref.isSolved()) {
                     candidateSolvedMethods.add(ref.getCorrespondingDeclaration());
                 }
@@ -200,7 +201,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
         if (candidateSolvedMethods.isEmpty()) {
             return SymbolReference.unsolved(ResolvedMethodDeclaration.class);
         }
-        return MethodResolutionLogic.findMostApplicable(candidateSolvedMethods, name, argumentsTypes, typeSolver);
+        return MethodResolutionLogic.findMostApplicable(candidateSolvedMethods, name, argumentsTypes, typeSolver, invocationContext);
     }
 
     @Override
@@ -217,7 +218,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
             String name,
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
-            List<ResolvedType> typeParameterValues) {
+            List<ResolvedType> typeParameterValues, ResolvedReferenceTypeDeclaration callContext) {
         List<MethodUsage> methodUsages = new ArrayList<>();
 
         List<Method> allMethods = Arrays.stream(clazz.getDeclaredMethods())
@@ -248,7 +249,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
         getSuperClass().ifPresent(superClass -> {
             superClass.getTypeDeclaration().ifPresent(superClassTypeDeclaration -> {
                 ContextHelper.solveMethodAsUsage(
-                                superClassTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues)
+                                superClassTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues, callContext)
                         .ifPresent(methodUsages::add);
             });
         });
@@ -258,7 +259,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
                     .getTypeDeclaration()
                     .flatMap(superClassTypeDeclaration -> interfaceDeclaration.getTypeDeclaration())
                     .flatMap(interfaceTypeDeclaration -> ContextHelper.solveMethodAsUsage(
-                            interfaceTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues))
+                            interfaceTypeDeclaration, name, argumentsTypes, invokationContext, typeParameterValues, callContext))
                     .ifPresent(methodUsages::add);
         }
         Optional<MethodUsage> ref =

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/SymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/SymbolSolver.java
@@ -93,8 +93,8 @@ public class SymbolSolver implements Solver {
     }
 
     @Override
-    public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context) {
-        SymbolReference<ResolvedMethodDeclaration> decl = context.solveMethod(methodName, argumentsTypes, false);
+    public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Context context, ResolvedReferenceTypeDeclaration invocationContext) {
+        SymbolReference<ResolvedMethodDeclaration> decl = context.solveMethod(methodName, argumentsTypes, false, invocationContext);
         if (!decl.isSolved()) {
             throw new UnsolvedSymbolException(context.toString(), methodName);
         }
@@ -102,8 +102,8 @@ public class SymbolSolver implements Solver {
     }
 
     @Override
-    public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node) {
-        return solveMethod(methodName, argumentsTypes, JavaParserFactory.getContext(node, typeSolver));
+    public MethodUsage solveMethod(String methodName, List<ResolvedType> argumentsTypes, Node node, ResolvedReferenceTypeDeclaration invocationContext) {
+        return solveMethod(methodName, argumentsTypes, JavaParserFactory.getContext(node, typeSolver), invocationContext);
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2953Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2953Test.java
@@ -49,7 +49,7 @@ public class Issue2953Test {
 
         JavassistEnumDeclaration enumA = (JavassistEnumDeclaration) typeResolver.solveType("foo.A");
         SymbolReference<ResolvedMethodDeclaration> method =
-                enumA.solveMethod("equalByCode", Arrays.asList(ResolvedPrimitiveType.INT), false);
+                enumA.solveMethod("equalByCode", Arrays.asList(ResolvedPrimitiveType.INT), false, null); // XXX
         assertTrue(method.isSolved());
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4969Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4969Test.java
@@ -1,0 +1,34 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ *
+ * @author Alexander Weigl
+ * @version 1 (3/8/26)
+ */
+public class Issue4969Test {
+    @Test
+    void preferVisibleMethods() throws FileNotFoundException {
+        JavaSymbolSolver symbolSolver = new JavaSymbolSolver(new ReflectionTypeSolver());
+        ParserConfiguration config = new ParserConfiguration().setSymbolResolver(symbolSolver);
+        JavaParser javaParser = new JavaParser(config);
+
+        CompilationUnit cu = javaParser.parse(new File("src/test/resources/issue4969/A.java")).getResult().get();
+        MethodCallExpr expr = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration decl = expr.resolve();
+
+        assertEquals("A.m(long)", decl.getQualifiedSignature());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -1149,27 +1149,27 @@ class JavaParserClassDeclarationTest extends AbstractResolutionTest {
 
         SymbolReference<ResolvedMethodDeclaration> res;
 
-        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of());
+        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isStatic()",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         res = constructorDeclaration.solveMethod(
                 "isThrows",
-                ImmutableList.of(ReflectionFactory.typeUsageFor(RuntimeException.class.getClass(), typeSolverNewCode)));
+                ImmutableList.of(ReflectionFactory.typeUsageFor(RuntimeException.class.getClass(), typeSolverNewCode)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         res = constructorDeclaration.solveMethod(
-                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(String.class, typeSolverNewCode)));
+                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(String.class, typeSolverNewCode)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.String)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         // This is solved because it is raw
         res = constructorDeclaration.solveMethod(
-                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(Class.class, typeSolverNewCode)));
+                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(Class.class, typeSolverNewCode)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
@@ -1182,10 +1182,10 @@ class JavaParserClassDeclarationTest extends AbstractResolutionTest {
 
         SymbolReference<ResolvedMethodDeclaration> res;
 
-        res = constructorDeclaration.solveMethod("unexistingMethod", ImmutableList.of());
+        res = constructorDeclaration.solveMethod("unexistingMethod", ImmutableList.of(), null);
         assertFalse(res.isSolved());
 
-        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN));
+        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN), null);
         assertFalse(res.isSolved());
     }
 
@@ -1202,7 +1202,7 @@ class JavaParserClassDeclarationTest extends AbstractResolutionTest {
                 (ResolvedReferenceType) ReflectionFactory.typeUsageFor(Class.class, typeSolverNewCode);
         ResolvedReferenceType classOfStringType = (ResolvedReferenceType) rawClassType.replaceTypeVariables(
                 rawClassType.getTypeDeclaration().get().getTypeParameters().get(0), stringType);
-        res = constructorDeclaration.solveMethod("isThrows", ImmutableList.of(classOfStringType));
+        res = constructorDeclaration.solveMethod("isThrows", ImmutableList.of(classOfStringType), null);
         assertFalse(res.isSolved());
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -1032,27 +1032,27 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest
 
         SymbolReference<ResolvedMethodDeclaration> res;
 
-        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of());
+        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isStatic()",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         res = constructorDeclaration.solveMethod(
                 "isThrows",
-                ImmutableList.of(ReflectionFactory.typeUsageFor(RuntimeException.class.getClass(), typeSolver)));
+                ImmutableList.of(ReflectionFactory.typeUsageFor(RuntimeException.class.getClass(), typeSolver)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         res = constructorDeclaration.solveMethod(
-                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(String.class, typeSolver)));
+                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(String.class, typeSolver)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.String)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         // This is solved because it is raw
         res = constructorDeclaration.solveMethod(
-                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(Class.class, typeSolver)));
+                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(Class.class, typeSolver)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
@@ -1065,10 +1065,10 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest
 
         SymbolReference<ResolvedMethodDeclaration> res;
 
-        res = constructorDeclaration.solveMethod("unexistingMethod", ImmutableList.of());
+        res = constructorDeclaration.solveMethod("unexistingMethod", ImmutableList.of(), null);
         assertEquals(false, res.isSolved());
 
-        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN));
+        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN), null);
         assertEquals(false, res.isSolved());
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -1081,27 +1081,27 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
 
         SymbolReference<ResolvedMethodDeclaration> res;
 
-        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of());
+        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithModifiers.isStatic()",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         res = constructorDeclaration.solveMethod(
                 "isThrows",
-                ImmutableList.of(ReflectionFactory.typeUsageFor(RuntimeException.class.getClass(), typeSolver)));
+                ImmutableList.of(ReflectionFactory.typeUsageFor(RuntimeException.class.getClass(), typeSolver)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         res = constructorDeclaration.solveMethod(
-                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(String.class, typeSolver)));
+                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(String.class, typeSolver)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.String)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
 
         // This is solved because it is raw
         res = constructorDeclaration.solveMethod(
-                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(Class.class, typeSolver)));
+                "isThrows", ImmutableList.of(ReflectionFactory.typeUsageFor(Class.class, typeSolver)), null);
         assertEquals(
                 "com.github.javaparser.ast.nodeTypes.NodeWithThrowable.isThrows(java.lang.Class<? extends java.lang.Throwable>)",
                 res.getCorrespondingDeclaration().getQualifiedSignature());
@@ -1114,10 +1114,10 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
 
         SymbolReference<ResolvedMethodDeclaration> res;
 
-        res = constructorDeclaration.solveMethod("unexistingMethod", ImmutableList.of());
+        res = constructorDeclaration.solveMethod("unexistingMethod", ImmutableList.of(), null);
         assertEquals(false, res.isSolved());
 
-        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN));
+        res = constructorDeclaration.solveMethod("isStatic", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN), null);
         assertEquals(false, res.isSolved());
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserRecordDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserRecordDeclarationTest.java
@@ -391,7 +391,7 @@ public class JavaParserRecordDeclarationTest {
                 (JavaParserRecordDeclaration) recordDeclaration.resolve();
 
         SymbolReference<ResolvedMethodDeclaration> symbol =
-                resolvedRecordDeclaration.solveMethod("s", Collections.emptyList());
+                resolvedRecordDeclaration.solveMethod("s", Collections.emptyList(), null);
         assertTrue(symbol.isSolved());
         ResolvedMethodDeclaration resolvedCall = symbol.getCorrespondingDeclaration();
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistRecordDeclarationTest.java
@@ -388,7 +388,7 @@ class JavassistRecordDeclarationTest extends AbstractTypeDeclarationTest {
         JavassistRecordDeclaration compilationUnit = (JavassistRecordDeclaration) typeSolver.solveType("box.Box");
         ResolvedType functionType = new SymbolSolver(typeSolver).classToResolvedType(Function.class);
         SymbolReference<ResolvedMethodDeclaration> method =
-                compilationUnit.solveMethod("map", Collections.singletonList(functionType), false);
+                compilationUnit.solveMethod("map", Collections.singletonList(functionType), false, null);
         assertTrue(method.isSolved());
         assertEquals(
                 "box.Box.map(java.util.function.Function<T, U>)",

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionAnnotationDeclarationTest.java
@@ -81,7 +81,7 @@ class ReflectionAnnotationDeclarationTest {
         ReflectionAnnotationDeclaration annotation =
                 (ReflectionAnnotationDeclaration) typeSolver.solveType(WithValue.class.getCanonicalName());
         final SymbolReference<ResolvedMethodDeclaration> symbolReference =
-                annotation.solveMethod("value", Collections.emptyList(), false);
+                annotation.solveMethod("value", Collections.emptyList(), false, null);
         assertEquals("value", symbolReference.getCorrespondingDeclaration().getName());
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -235,7 +235,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         TypeSolver typeSolver = new CombinedTypeSolver(new JarTypeSolver(pathToJar), new ReflectionTypeSolver(true));
         Solver symbolSolver = new SymbolSolver(typeSolver);
 
-        MethodUsage ref = symbolSolver.solveMethod("getTypes", Collections.emptyList(), callToGetTypes);
+        MethodUsage ref = symbolSolver.solveMethod("getTypes", Collections.emptyList(), callToGetTypes, null);
 
         assertEquals("getTypes", ref.getName());
         assertEquals(
@@ -254,7 +254,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         Path pathToJar = adaptPath("src/test/resources/javaparser-core-2.1.0.jar");
         TypeSolver typeSolver = new CombinedTypeSolver(new JarTypeSolver(pathToJar), new ReflectionTypeSolver(true));
         Solver symbolSolver = new SymbolSolver(typeSolver);
-        MethodUsage ref = symbolSolver.solveMethod("stream", Collections.emptyList(), callToStream);
+        MethodUsage ref = symbolSolver.solveMethod("stream", Collections.emptyList(), callToStream, null);
 
         assertEquals("stream", ref.getName());
         assertEquals("java.util.Collection", ref.declaringType().getQualifiedName());
@@ -271,7 +271,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         TypeSolver typeSolver = new CombinedTypeSolver(
                 new ReflectionTypeSolver(), new JavaParserTypeSolver(src, new LeanParserConfiguration()));
         Solver symbolSolver = new SymbolSolver(typeSolver);
-        MethodUsage ref = symbolSolver.solveMethod("trim", Collections.emptyList(), callToTrim);
+        MethodUsage ref = symbolSolver.solveMethod("trim", Collections.emptyList(), callToTrim, null);
 
         assertEquals("trim", ref.getName());
         assertEquals("java.lang.String", ref.declaringType().getQualifiedName());
@@ -332,7 +332,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
 
         TypeSolver typeSolver = new ReflectionTypeSolver();
         Solver symbolSolver = new SymbolSolver(typeSolver);
-        MethodUsage ref = symbolSolver.solveMethod("isEmpty", Collections.emptyList(), call);
+        MethodUsage ref = symbolSolver.solveMethod("isEmpty", Collections.emptyList(), call, null);
 
         assertEquals("isEmpty", ref.getName());
         assertEquals("java.lang.String", ref.declaringType().getQualifiedName());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/DefaultPackageTest.java
@@ -143,7 +143,8 @@ class DefaultPackageTest {
 
         @Override
         public SymbolReference<ResolvedMethodDeclaration> solveMethod(
-                String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+                String name, List<ResolvedType> argumentsTypes, boolean staticOnly,
+                ResolvedReferenceTypeDeclaration invocationContext) {
             throw new UnsupportedOperationException();
         }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/ClassOrInterfaceDeclarationContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/ClassOrInterfaceDeclarationContextResolutionTest.java
@@ -346,7 +346,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = Navigator.demandClass(cu, "A");
         Context context = new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, typeSolver);
 
-        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo0", ImmutableList.of(), false);
+        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo0", ImmutableList.of(), false, null); // XXX
         assertEquals(true, ref.isSolved());
         assertEquals("A", ref.getCorrespondingDeclaration().declaringType().getName());
         assertEquals(0, ref.getCorrespondingDeclaration().getNumberOfParams());
@@ -358,7 +358,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = Navigator.demandClass(cu, "A");
         Context context = new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, typeSolver);
 
-        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo1", ImmutableList.of(), false);
+        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo1", ImmutableList.of(), false, null); // XXX
         assertEquals(true, ref.isSolved());
         assertEquals("A", ref.getCorrespondingDeclaration().declaringType().getName());
         assertEquals(0, ref.getCorrespondingDeclaration().getNumberOfParams());
@@ -370,7 +370,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = Navigator.demandClass(cu, "A");
         Context context = new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, typeSolver);
 
-        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo2", ImmutableList.of(), false);
+        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo2", ImmutableList.of(), false, null); //XXX
         assertEquals(true, ref.isSolved());
         assertEquals("Super", ref.getCorrespondingDeclaration().declaringType().getName());
         assertEquals(0, ref.getCorrespondingDeclaration().getNumberOfParams());
@@ -384,7 +384,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
 
         ResolvedType intType = ResolvedPrimitiveType.INT;
 
-        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo3", ImmutableList.of(intType), false);
+        SymbolReference<ResolvedMethodDeclaration> ref = context.solveMethod("foo3", ImmutableList.of(intType), false, null); // XXX
         assertEquals(true, ref.isSolved());
         assertEquals("A", ref.getCorrespondingDeclaration().declaringType().getName());
         assertEquals(1, ref.getCorrespondingDeclaration().getNumberOfParams());
@@ -399,7 +399,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
         ResolvedType stringType = new ReferenceTypeImpl(new ReflectionClassDeclaration(String.class, typeSolver));
 
         SymbolReference<ResolvedMethodDeclaration> ref =
-                context.solveMethod("foo4", ImmutableList.of(stringType), false);
+                context.solveMethod("foo4", ImmutableList.of(stringType), false, null); //XXX
         assertEquals(true, ref.isSolved());
         assertEquals("A", ref.getCorrespondingDeclaration().declaringType().getName());
         assertEquals(1, ref.getCorrespondingDeclaration().getNumberOfParams());
@@ -412,7 +412,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
             ClassOrInterfaceDeclaration classOrInterfaceDeclaration = Navigator.demandClass(cu, "A");
             Context context = new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, typeSolver);
             SymbolReference<ResolvedMethodDeclaration> ref =
-                    context.solveMethod("foo5", ImmutableList.of(NullType.INSTANCE), false);
+                    context.solveMethod("foo5", ImmutableList.of(NullType.INSTANCE), false, null); // XX
         });
     }
 
@@ -423,7 +423,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
         Context context =
                 new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, new ReflectionTypeSolver());
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo0", ImmutableList.of());
+        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo0", ImmutableList.of(), null); // XX
         assertEquals(true, ref.isPresent());
         assertEquals("A", ref.get().declaringType().getName());
         assertEquals(0, ref.get().getNoParams());
@@ -436,7 +436,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
         Context context =
                 new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, new ReflectionTypeSolver());
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo1", ImmutableList.of());
+        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo1", ImmutableList.of(), null ); //XXX
         assertEquals(true, ref.isPresent());
         assertEquals("A", ref.get().declaringType().getName());
         assertEquals(0, ref.get().getNoParams());
@@ -449,7 +449,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
         Context context =
                 new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, new ReflectionTypeSolver());
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo2", ImmutableList.of());
+        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo2", ImmutableList.of(), null); //XXX
         assertEquals(true, ref.isPresent());
         assertEquals("Super", ref.get().declaringType().getName());
         assertEquals(0, ref.get().getNoParams());
@@ -464,7 +464,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
 
         ResolvedType intType = ResolvedPrimitiveType.INT;
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo3", ImmutableList.of(intType));
+        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo3", ImmutableList.of(intType), null); // XXX
         assertEquals(true, ref.isPresent());
         assertEquals("A", ref.get().declaringType().getName());
         assertEquals(1, ref.get().getNoParams());
@@ -479,7 +479,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
 
         ResolvedType stringType = new ReferenceTypeImpl(new ReflectionClassDeclaration(String.class, typeSolver));
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo4", ImmutableList.of(stringType));
+        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo4", ImmutableList.of(stringType), null); //XX
         assertEquals(true, ref.isPresent());
         assertEquals("A", ref.get().declaringType().getName());
         assertEquals(1, ref.get().getNoParams());
@@ -492,7 +492,7 @@ class ClassOrInterfaceDeclarationContextResolutionTest extends AbstractResolutio
             ClassOrInterfaceDeclaration classOrInterfaceDeclaration = Navigator.demandClass(cu, "A");
             Context context =
                     new ClassOrInterfaceDeclarationContext(classOrInterfaceDeclaration, new ReflectionTypeSolver());
-            Optional<MethodUsage> ref = context.solveMethodAsUsage("foo5", ImmutableList.of(NullType.INSTANCE));
+            Optional<MethodUsage> ref = context.solveMethodAsUsage("foo5", ImmutableList.of(NullType.INSTANCE), null); //XXX
         });
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/CompilationUnitContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/CompilationUnitContextResolutionTest.java
@@ -227,7 +227,7 @@ class CompilationUnitContextResolutionTest extends AbstractResolutionTest {
         Context context = new CompilationUnitContext(cu, typeSolver);
 
         SymbolReference<ResolvedMethodDeclaration> ref =
-                context.solveMethod("assertFalse", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN), false);
+                context.solveMethod("assertFalse", ImmutableList.of(ResolvedPrimitiveType.BOOLEAN), false, null);
         assertEquals(true, ref.isSolved());
         assertEquals("assertFalse", ref.getCorrespondingDeclaration().getName());
         assertEquals(1, ref.getCorrespondingDeclaration().getNumberOfParams());
@@ -249,7 +249,7 @@ class CompilationUnitContextResolutionTest extends AbstractResolutionTest {
         Context context = new CompilationUnitContext(cu, typeSolver);
 
         SymbolReference<ResolvedMethodDeclaration> ref =
-                context.solveMethod("assertEquals", ImmutableList.of(NullType.INSTANCE, NullType.INSTANCE), false);
+                context.solveMethod("assertEquals", ImmutableList.of(NullType.INSTANCE, NullType.INSTANCE), false, null);
         assertEquals(true, ref.isSolved());
         assertEquals("assertEquals", ref.getCorrespondingDeclaration().getName());
         assertEquals(2, ref.getCorrespondingDeclaration().getNumberOfParams());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
@@ -80,7 +80,7 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
 
         Context context = new MethodCallExprContext(methodCallExpr, typeSolver);
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo", Collections.emptyList());
+        Optional<MethodUsage> ref = context.solveMethodAsUsage("foo", Collections.emptyList(), null); //XX
         assertTrue(ref.isPresent());
         assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
     }
@@ -101,7 +101,7 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
 
         MethodCallExprContext context = new MethodCallExprContext(methodCallExpr, typeSolver);
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, Collections.emptyList());
+        Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, Collections.emptyList(), null); //XXX
         assertTrue(ref.isPresent());
         assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
         assertEquals(
@@ -132,7 +132,7 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
         List<ResolvedType> argumentsTypes = new ArrayList<>();
         argumentsTypes.add(new ReferenceTypeImpl(stringType));
 
-        Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, argumentsTypes);
+        Optional<MethodUsage> ref = context.solveMethodAsUsage(callMethodName, argumentsTypes, null ); //XXX
         assertTrue(ref.isPresent());
         assertEquals("MethodCalls", ref.get().declaringType().getQualifiedName());
         assertEquals(

--- a/javaparser-symbol-solver-testing/src/test/resources/issue4969/A.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue4969/A.java
@@ -1,0 +1,12 @@
+final class A {
+    public  byte m(long i) { return 2; }
+
+    private int m(int i) { return 1; }
+}
+
+final class B {
+    static int callM() {
+        A a = new A();
+        return a.m(1);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <maven.compiler.release>8</maven.compiler.release>
         <byte-buddy.version>1.18.7-jdk5</byte-buddy.version>
         <argLine>-javaagent:'${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar'</argLine>
         <build.timestamp>2026-01-10T00:00:00Z</build.timestamp>


### PR DESCRIPTION
Fixes issue #4969. 

The resolution of methods now respects their visibility. For example, calling `m(5)` should resolve to `m(long)` if the sibling method `m(int)` is not visible from the caller context. 

This patch extends the `solveMethod` interface with an additional caller context (`ResolvedReferenceTypeDeclaration`). The final visibility resolution is done in `MethodResolutionLogic#findMostApplicable`).

Side edit: `<maven.compiler.release>8</maven.compiler.release>` makes it compile under modern JDK.




Original patch by @unp1 
