### PR TITLE
fix(grammar): allow empty component list in RecordPattern

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/PatternExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/PatternExprTest.java
@@ -193,6 +193,24 @@ public class PatternExprTest {
     }
 
     @Test
+    public void emptyRecordPatternListShouldWork() {
+        // JLS 14.30: RecordPattern = ReferenceType ( [ComponentPatternList] )
+        // The component list is optional — "Point()" is valid.
+        Expression expr = parseExpression("x instanceof Point()");
+
+        assertTrue(expr.isInstanceOfExpr());
+        InstanceOfExpr instanceOfExpr = expr.asInstanceOfExpr();
+        assertTrue(instanceOfExpr.getPattern().isPresent());
+
+        ComponentPatternExpr pattern = instanceOfExpr.getPattern().get();
+        assertTrue(pattern.isRecordPatternExpr());
+
+        RecordPatternExpr recordPattern = pattern.asRecordPatternExpr();
+        assertEquals("Point", recordPattern.getTypeAsString());
+        assertTrue(recordPattern.getPatternList().isEmpty());
+    }
+
+    @Test
     public void anUnnamedTypePatternShouldWork() {
         Expression expr = parseExpression("x instanceof Foo _");
 

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -3536,13 +3536,15 @@ NodeList<ComponentPatternExpr> PatternList():
 	NodeList<ComponentPatternExpr> ret = new NodeList<>();
 }
 {
-	"("
-    pattern = ComponentPatternExpression() { ret.add(pattern); }
-    (
-        ","
+    "("
+      [
         pattern = ComponentPatternExpression() { ret.add(pattern); }
-    )*
-	")"
+        (
+            ","
+            pattern = ComponentPatternExpression() { ret.add(pattern); }
+        )*
+      ]
+    ")"
     { return ret; }
 }
 


### PR DESCRIPTION
Per JLS 14.30, the component list in a RecordPattern is optional:
    RecordPattern: ReferenceType ( [ComponentPatternList] )
The PatternList() production in java.jj required at least one
component, causing a parse error on valid patterns like Point()
or case Pair() in switch expressions.
Wrap the content of PatternList() in an optional block [ ... ]
so that an empty parenthesised list produces an empty NodeList
rather than a parse failure. Also update the Javadoc comment to
match the JLS definition.
Add emptyRecordPatternListShouldWork() test to PatternExprTest
to cover the zero-component case.
