### PR TITLE
Fix parsing of multiple patterns in switch case labels (issue #4996)

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue4996Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue4996Test.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser;
+
+import static com.github.javaparser.utils.TestUtils.assertNoProblems;
+
+import org.junit.jupiter.api.Test;
+
+public class Issue4996Test {
+
+    @Test
+    public void testIssue4996() {
+        String code =
+                "public class Main {\n" +
+                        "    public static void main(String[] args) {\n" +
+                        "        Object str = \"string\";\n" +
+                        "\n" +
+                        "        switch (str) {\n" +
+                        "            case String _, Integer _ -> f();\n" +
+                        "            default -> g();\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "\n" +
+                        "    private static void f() {\n" +
+                        "        System.out.println(\"f\");\n" +
+                        "    }\n" +
+                        "\n" +
+                        "    private static void g() {\n" +
+                        "        System.out.println(\"g\");\n" +
+                        "    }\n" +
+                        "}";
+
+        ParserConfiguration config = new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_22);
+        JavaParser parser = new JavaParser(config);
+        assertNoProblems(parser.parse(code));
+    }
+}

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -4859,6 +4859,11 @@ SwitchEntry SwitchEntry():
             */
             LOOKAHEAD(PatternExpression())
             label = PatternExpression() { labels = add(labels, label); }
+            (
+                LOOKAHEAD("," PatternExpression())
+                ","
+                label = PatternExpression() { labels = add(labels, label); }
+            )*
             [
               "when"
               guard = ConditionalExpression()


### PR DESCRIPTION
Fixes #4996 .

The JavaCC grammar only allowed a single PatternExpression per case label,
causing a parse error on valid Java 22+ syntax such as:
    case String _, Integer _ -> ...
Extended the SwitchEntry grammar rule to accept one or more comma-separated
PatternExpression nodes using a targeted LOOKAHEAD to avoid ambiguity with
the existing multi-constant case branch (case A, B ->).
