### PR TITLE
Enforce JLS §14.11.1 language-level rules for multi-pattern case labels

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue4996Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue4996Test.java
@@ -17,39 +17,95 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-
 package com.github.javaparser;
 
 import static com.github.javaparser.utils.TestUtils.assertNoProblems;
+import static com.github.javaparser.utils.TestUtils.assertProblems;
 
 import org.junit.jupiter.api.Test;
 
 public class Issue4996Test {
 
+    // Template: case label is on line 4, col 13; first pattern starts at col 18; second at col 28.
+    private static final String SWITCH_TEMPLATE = "public class Main {\n"
+            + "    void m(Object o) {\n"
+            + "        switch (o) {\n"
+            + "            %s\n"
+            + "            default -> {}\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+
+    private static final String UPGRADE_SUFFIX =
+            " Pay attention that this feature is supported starting from 'JAVA_22' language level."
+                    + " If you need that feature the language level must be configured in the"
+                    + " configuration before parsing the source files.";
+
+    private static JavaParser parserFor(ParserConfiguration.LanguageLevel level) {
+        return new JavaParser(new ParserConfiguration().setLanguageLevel(level));
+    }
+
+    private static String switchWith(String caseLabel) {
+        return String.format(SWITCH_TEMPLATE, caseLabel);
+    }
+
     @Test
     public void testIssue4996() {
-        String code =
-                "public class Main {\n" +
-                        "    public static void main(String[] args) {\n" +
-                        "        Object str = \"string\";\n" +
-                        "\n" +
-                        "        switch (str) {\n" +
-                        "            case String _, Integer _ -> f();\n" +
-                        "            default -> g();\n" +
-                        "        }\n" +
-                        "    }\n" +
-                        "\n" +
-                        "    private static void f() {\n" +
-                        "        System.out.println(\"f\");\n" +
-                        "    }\n" +
-                        "\n" +
-                        "    private static void g() {\n" +
-                        "        System.out.println(\"g\");\n" +
-                        "    }\n" +
-                        "}";
+        String code = "public class Main {\n" + "    public static void main(String[] args) {\n"
+                + "        Object str = \"string\";\n"
+                + "\n"
+                + "        switch (str) {\n"
+                + "            case String _, Integer _ -> f();\n"
+                + "            default -> g();\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n"
+                + "    private static void f() {\n"
+                + "        System.out.println(\"f\");\n"
+                + "    }\n"
+                + "\n"
+                + "    private static void g() {\n"
+                + "        System.out.println(\"g\");\n"
+                + "    }\n"
+                + "}";
 
-        ParserConfiguration config = new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_22);
+        ParserConfiguration config =
+                new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_22);
         JavaParser parser = new JavaParser(config);
         assertNoProblems(parser.parse(code));
+    }
+
+    @Test
+    public void multiPatternWithThreePatternsAcceptedInJava22() {
+        assertNoProblems(parserFor(ParserConfiguration.LanguageLevel.JAVA_22)
+                .parse(switchWith("case String _, Integer _, Long _ -> {}")));
+    }
+
+    @Test
+    public void multiPatternRejectedInJava21() {
+        // _ is a reserved keyword in Java 21, so named variables are used here.
+        assertProblems(
+                parserFor(ParserConfiguration.LanguageLevel.JAVA_21)
+                        .parse(switchWith("case String s, Integer i -> {}")),
+                "(line 4,col 13) Multiple patterns in case labels not supported." + UPGRADE_SUFFIX);
+    }
+
+    @Test
+    public void multiPatternWithNamedVarRejectedInJava22() {
+        // JLS §14.11.1: patterns in a multi-pattern case may not declare named variables.
+        // Error is reported at the position of the offending pattern.
+        assertProblems(
+                parserFor(ParserConfiguration.LanguageLevel.JAVA_22)
+                        .parse(switchWith("case String s, Integer _ -> {}")),
+                "(line 4,col 18) Multiple patterns in case labels may not declare any pattern variables.");
+    }
+
+    @Test
+    public void multiPatternBothNamedVarsRejectedInJava22() {
+        assertProblems(
+                parserFor(ParserConfiguration.LanguageLevel.JAVA_22)
+                        .parse(switchWith("case String s, Integer i -> {}")),
+                "(line 4,col 18) Multiple patterns in case labels may not declare any pattern variables.",
+                "(line 4,col 28) Multiple patterns in case labels may not declare any pattern variables.");
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java1_0Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java1_0Validator.java
@@ -266,6 +266,19 @@ public class Java1_0Validator extends Validators {
         }
     });
 
+    final Validator noMultiPatternCaseLabels = new SingleNodeTypeValidator<>(SwitchEntry.class, (n, reporter) -> {
+        long patternCount = n.getLabels().stream()
+                .filter(Expression::isComponentPatternExpr)
+                .count();
+        if (patternCount > 1) {
+            reporter.report(
+                    n,
+                    new UpgradeJavaMessage(
+                            "Multiple patterns in case labels not supported.",
+                            ParserConfiguration.LanguageLevel.JAVA_22));
+        }
+    });
+
     final Validator noRecordPatterns = new TreeVisitorValidator((node, reporter) -> {
         if (node instanceof RecordPatternExpr) {
             reporter.report(
@@ -333,6 +346,7 @@ public class Java1_0Validator extends Validators {
         add(noPermitsListInClasses);
         add(noSwitchNullDefault);
         add(noSwitchPatterns);
+        add(noMultiPatternCaseLabels);
         add(noRecordPatterns);
         add(noModuleImports);
         add(explicitConstructorInvocationMustBeFirstStatement);

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java22Validator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/Java22Validator.java
@@ -25,10 +25,13 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ForStmt;
+import com.github.javaparser.ast.stmt.SwitchEntry;
 import com.github.javaparser.ast.validator.ProblemReporter;
 import com.github.javaparser.ast.validator.SingleNodeTypeValidator;
 import com.github.javaparser.ast.validator.Validator;
 import com.github.javaparser.resolution.Navigator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This validator validates according to Java 22 syntax rules.
@@ -85,6 +88,29 @@ public class Java22Validator extends Java21Validator {
                 }
             });
 
+    final Validator noNamedVarsInMultiPatternCase = new SingleNodeTypeValidator<>(SwitchEntry.class, (n, reporter) -> {
+        List<Expression> patternLabels = n.getLabels().stream()
+                .filter(Expression::isComponentPatternExpr)
+                .collect(Collectors.toList());
+        if (patternLabels.size() > 1) {
+            patternLabels.stream()
+                    .filter(Java22Validator::declaresNamedPatternVar)
+                    .forEach(label -> reporter.report(
+                            label, "Multiple patterns in case labels may not declare any pattern variables."));
+        }
+    });
+
+    private static boolean declaresNamedPatternVar(Expression expr) {
+        if (expr instanceof TypePatternExpr) {
+            return !((TypePatternExpr) expr).getName().getIdentifier().equals("_");
+        }
+        if (expr instanceof RecordPatternExpr) {
+            return ((RecordPatternExpr) expr)
+                    .getPatternList().stream().anyMatch(Java22Validator::declaresNamedPatternVar);
+        }
+        return false;
+    }
+
     private boolean reportNoParent(Node node, ProblemReporter reporter) {
         if (node.getParentNode().isPresent()) {
             return false;
@@ -97,7 +123,9 @@ public class Java22Validator extends Java21Validator {
     public Java22Validator() {
         super();
         remove(underscoreKeywordValidator);
+        remove(noMultiPatternCaseLabels);
         add(unnamedVarOnlyWhereAllowedByJep456);
         add(matchAllPatternNotTopLevel);
+        add(noNamedVarsInMultiPatternCase);
     }
 }


### PR DESCRIPTION
Multiple patterns per case label (case A _, B _ ->) were introduced in
Java 22 (JEP 456). Two validation rules are added to enforce the spec:
- noMultiPatternCaseLabels (Java1_0Validator): rejects multi-pattern case
  labels below Java 22, since the feature did not exist before.
- noNamedVarsInMultiPatternCase (Java22Validator): rejects any case label
  that combines multiple patterns where at least one declares a named
  pattern variable (e.g. case String s, Integer _ ->), as required by
  JLS §14.11.1.
Test cases cover all four scenarios: valid unnamed patterns, rejection
below Java 22, and the two named-variable violations.
