### PR TITLE
fix(grammar): allow text block ending in escaped backslash before closing """

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/TextBlockLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/TextBlockLiteralExprTest.java
@@ -21,6 +21,7 @@
 
 package com.github.javaparser.ast.expr;
 
+import static com.github.javaparser.utils.TestParser.parseExpression;
 import static com.github.javaparser.utils.TestParser.parseStatement;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -196,5 +197,30 @@ class TextBlockLiteralExprTest {
                 .findFirst(TextBlockLiteralExpr.class)
                 .get();
         assertEquals("\nHello\n" + "World", textBlock.translateEscapes());
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/javaparser/javaparser/issues/4894">issue #4894</a>.
+     * <p>
+     * A text block whose last content characters before the closing {@code """} are an
+     * escaped backslash ({@code \\}) on a separate line must parse successfully.
+     */
+    @Test
+    void textBlockEndingInDoubleBackslashOnSeparateLineParses() {
+        TextBlockLiteralExpr textBlock = parseExpression("\"\"\"\n" + "        foo\\\\\n" + "        \"\"\"");
+        assertEquals("foo\\\n", textBlock.translateEscapes());
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/javaparser/javaparser/issues/4894">issue #4894</a>.
+     * <p>
+     * Canonical failing form: an escaped backslash ({@code \\}) sits immediately adjacent
+     * to the closing {@code """} (no intervening newline)
+     */
+    @Test
+    void textBlockEndingInDoubleBackslashAdjacentToCloserParses() {
+        TextBlockLiteralExpr textBlock =
+                parseExpression("\"\"\"\n" + "        arbitrary text\n" + "        \\\\\"\"\"");
+        assertEquals("arbitrary text\n\\", textBlock.translateEscapes());
     }
 }

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -840,8 +840,13 @@ TOKEN :
 MORE: { <ENTER_TEXT_BLOCK: "\"\"\"" >: IN_TEXT_BLOCK }
 <IN_TEXT_BLOCK> TOKEN : { <TEXT_BLOCK_LITERAL: "\"\"\"" >: DEFAULT }
 // Need to recognize an escaped " to prevent it from parsing as "backslash doublequote" -
-// which might match that doublequote with following doublequotes.
-<IN_TEXT_BLOCK> MORE :{ <TEXT_BLOCK_CONTENT:  ( "\\" "\"" | ~[] ) > }
+// which might match that doublequote with following doublequotes. The ~[] is needed so the
+// backslash escape ("\\" followed by any character) atomically so
+// the escape's trailing character (most importantly, the " in \")
+// cannot be re-used as part of the closing """ delimiter. The first alternative
+// wins by JavaCC's longest-match rule whenever the current char is a backslash;
+// the second alternative is the fallback for ordinary text-block characters.
+<IN_TEXT_BLOCK> MORE :{ <TEXT_BLOCK_CONTENT:  ( "\\" ~[] | ~[] ) > }
 
 
 /* IDENTIFIERS */


### PR DESCRIPTION
Fixes #4894.

## Summary

A text block whose content ends in an escaped backslash (`\\`) immediately before
the closing `"""` failed to parse, e.g.:

```java
String s = """
    arbitrary text
    \\""";
```

produced `Lexical error ... Encountered: <EOF> after : ""`. `javac` accepts this
form per JLS §3.10.6. 

## Root cause

In `javaparser-core/src/main/javacc/java.jj`, the `TEXT_BLOCK_CONTENT` rule only
treated `\"` as an atomic escape:

```
<IN_TEXT_BLOCK> MORE : { <TEXT_BLOCK_CONTENT: ( "\\" "\"" | ~[] ) > }
```

Given input `\\"""`, JavaCC's longest-match consumed the first `\` as a 1-char
`~[]` match, then matched the second `\` together with the first `"` of the
closing delimiter as a 2-char `\"` escape — leaving only `""`, which can never
satisfy the 3-quote `TEXT_BLOCK_LITERAL` token. The lexer ran off the end of
input.

## Fix

Recognise *any* `\X` (backslash + any character) as a single atomic chunk:

```
<IN_TEXT_BLOCK> MORE : { <TEXT_BLOCK_CONTENT: ( "\\" ~[] | ~[] ) > }
```

So `\\` is now consumed as one unit and the closing `"""` stays intact. `\"`
continues to work (still a 2-char match, still wins over the 1-char fallback),
and bare `"` inside the block is unaffected because the 3-char
`TEXT_BLOCK_LITERAL` token outranks `~[]` at the closer.

## Tests

Two regression tests added in
`javaparser-core-testing/.../ast/expr/TextBlockLiteralExprTest.java`:

- `textBlockEndingInDoubleBackslashAdjacentToCloserParses` — canonical failing
  form from the issue (`\\` immediately before `"""`).
- `textBlockEndingInDoubleBackslashOnSeparateLineParses` — the `\\` on its own
  line variant, asserting both raw value and `translateEscapes()` output.