### PR TITLE
fix(FunctionalInterfaceLogic): return empty() for non-reference types (#3625)

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/FunctionalInterfaceLogic.java
@@ -42,15 +42,36 @@ public final class FunctionalInterfaceLogic {
 
     /**
      * Get the functional method defined by the type, if any.
+     *
+     * <p>Per JLS §9.8, a functional interface is always an <em>interface</em>, which is a reference
+     * type. Primitive types, array types, and void can therefore never be functional interfaces.
+     * Passing such a type returns {@link Optional#empty()} immediately without throwing an exception.
+     *
+     * <p>Note: bounded type variables ({@code <T extends Runnable>}) and intersection types
+     * ({@code Runnable & Serializable}) are not handled here and also return {@link Optional#empty()}.
+     * Supporting those cases is a separate, more complex enhancement (see JLS §15.27.3).
+     *
+     * @param type the resolved type to inspect — may be any {@link ResolvedType} subclass
+     * @return the single abstract method of the functional interface, or empty if the type is not
+     *     a functional interface or is not a reference type at all
+     * @see <a href="https://github.com/javaparser/javaparser/issues/3625">Issue #3625</a>
      */
     public static Optional<MethodUsage> getFunctionalMethod(ResolvedType type) {
+        // Guard added to fix issue #3625:
+        // asReferenceType() throws UnsupportedOperationException on non-reference types
+        // (e.g. ResolvedArrayType, ResolvedPrimitiveType). Since a functional interface is by
+        // definition an interface — a reference type — returning empty() here is both safe
+        // and semantically correct.
+        if (!type.isReferenceType()) {
+            return Optional.empty();
+        }
         Optional<ResolvedReferenceTypeDeclaration> optionalTypeDeclaration =
                 type.asReferenceType().getTypeDeclaration();
         if (!optionalTypeDeclaration.isPresent()) {
             return Optional.empty();
         }
         ResolvedReferenceTypeDeclaration typeDeclaration = optionalTypeDeclaration.get();
-        if (type.isReferenceType() && typeDeclaration.isInterface()) {
+        if (typeDeclaration.isInterface()) {
             return getFunctionalMethod(typeDeclaration);
         }
         return Optional.empty();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/logic/FunctionalInterfaceLogicTest.java
@@ -31,6 +31,8 @@ import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedInterfaceDeclaration;
 import com.github.javaparser.resolution.logic.FunctionalInterfaceLogic;
+import com.github.javaparser.resolution.types.ResolvedArrayType;
+import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.symbolsolver.AbstractSymbolResolutionTest;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserInterfaceDeclaration;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
@@ -283,6 +285,38 @@ class FunctionalInterfaceLogicTest extends AbstractSymbolResolutionTest {
                 new JavaParserInterfaceDeclaration(classOrInterfaceDecl, typeSolver);
         Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(resolvedDecl);
         assertTrue(methodUsage.isPresent());
+    }
+
+    /*
+     * Regression tests for https://github.com/javaparser/javaparser/issues/3625
+     *
+     * Before the fix, getFunctionalMethod(ResolvedType) called asReferenceType() without first
+     * checking whether the type actually was a reference type. Passing a primitive or an array
+     * caused an UnsupportedOperationException to be thrown instead of returning Optional.empty().
+     *
+     * Since a functional interface must be an interface (JLS §9.8), which is always a reference
+     * type, returning empty() for these types is semantically correct, not just a safe fallback.
+     */
+
+    /**
+     * A primitive type (e.g. int) is not a reference type and therefore can never be a functional
+     * interface. The method must return empty() instead of throwing UnsupportedOperationException.
+     */
+    @Test
+    void getFunctionalMethodReturnEmptyForPrimitiveType() {
+        Optional<MethodUsage> methodUsage = FunctionalInterfaceLogic.getFunctionalMethod(ResolvedPrimitiveType.INT);
+        assertFalse(methodUsage.isPresent());
+    }
+
+    /**
+     * An array type (e.g. int[]) is not a reference type and therefore can never be a functional
+     * interface. The method must return empty() instead of throwing UnsupportedOperationException.
+     */
+    @Test
+    void getFunctionalMethodReturnEmptyForArrayType() {
+        Optional<MethodUsage> methodUsage =
+                FunctionalInterfaceLogic.getFunctionalMethod(new ResolvedArrayType(ResolvedPrimitiveType.INT));
+        assertFalse(methodUsage.isPresent());
     }
 
     @Test


### PR DESCRIPTION

Fixes #3625.

getFunctionalMethod(ResolvedType) called asReferenceType() unconditionally,
throwing UnsupportedOperationException when the type was not a reference type
(e.g. ResolvedArrayType, ResolvedPrimitiveType).
Per JLS §9.8, a functional interface is always an interface, which is a
reference type. Arrays and primitives can therefore never be functional
interfaces, so returning Optional.empty() for them is semantically correct.
Fix: move the isReferenceType() guard to the top of the method, before any
call to asReferenceType(). The now-redundant isReferenceType() condition on
the inner if-statement is removed as a consequence.
Add two regression tests covering ResolvedPrimitiveType and ResolvedArrayType
to prevent future regressions.
