### PR TITLE
fix: resolve constructor parameter type for lambda in ObjectCreationExpr

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -656,8 +656,29 @@ public class TypeExtractor extends DefaultVisitorAdapter {
         }
         if (parentNode instanceof ObjectCreationExpr) {
             ObjectCreationExpr expr = (ObjectCreationExpr) parentNode;
-            ResolvedType result = expr.getType().resolve();
-
+            // Determine the position of this lambda in the constructor's argument list.
+            // We need the *constructor parameter type* at that position (e.g. Runnable for
+            // Thread(Runnable target)), NOT the type of the object being constructed (e.g.
+            // Thread). The previous implementation incorrectly called expr.getType().resolve(),
+            // which returned the constructed type itself. When that type is not a functional
+            // interface, resolveLambda() fails to find a functional method and returns a wrong
+            // result. See: https://github.com/javaparser/javaparser/issues/3626
+            int pos = expr.getArgumentPosition(node, EXCLUDE_ENCLOSED_EXPR);
+            SymbolReference<ResolvedConstructorDeclaration> refConstructor = facade.solve(expr);
+            if (!refConstructor.isSolved()) {
+                throw new UnsolvedSymbolException(
+                        parentNode.toString(), expr.getType().getName().getId());
+            }
+            // ResolvedConstructorDeclaration extends ResolvedMethodLikeDeclaration, so
+            // getMethodsExplicitAndVariadicParameterType works uniformly for both methods
+            // and constructors.
+            ResolvedType result = MethodResolutionLogic.getMethodsExplicitAndVariadicParameterType(
+                    refConstructor.getCorrespondingDeclaration(), pos);
+            // A lambda may be passed as a vararg argument; in that case the resolved type is
+            // an array — unwrap it to obtain the component (functional interface) type.
+            if (result.isArray()) {
+                result = result.asArrayType().getComponentType();
+            }
             if (solveLambdas) {
                 result = resolveLambda(node, result);
             }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
@@ -432,4 +432,62 @@ class LambdaResolutionTest extends AbstractResolutionTest {
         ResolvedType s1Type = JavaParserFacade.get(typeSolver).getType(s1Expr);
         assertEquals("? super java.lang.String", s1Type.describe());
     }
+
+    // --- Tests for issue #3626 ---
+    // When a lambda is passed as a constructor argument, TypeExtractor must resolve the type
+    // of the *constructor parameter* (e.g. Runnable), not the type of the constructed object
+    // (e.g. Thread). The two tests below cover a built-in JDK class and a user-defined class.
+
+    /**
+     * A lambda passed to {@code new Thread(Runnable)} must resolve to {@code java.lang.Runnable},
+     * not to {@code java.lang.Thread}.
+     *
+     * <p>Before the fix, {@code TypeExtractor} called {@code expr.getType().resolve()} on the
+     * {@code ObjectCreationExpr}, which returned the constructed type ({@code Thread}) instead of
+     * the functional-interface parameter type ({@code Runnable}).
+     *
+     * @see <a href="https://github.com/javaparser/javaparser/issues/3626">issue #3626</a>
+     */
+    @Test
+    void lambdaTypeInObjectCreationExpr_builtinConstructor() {
+        String source = "class Test {\n"
+                + "    void example() {\n"
+                + "        new Thread(() -> System.out.println(\"hello\"));\n"
+                + "    }\n"
+                + "}";
+
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        CompilationUnit cu = StaticJavaParser.parse(source);
+        LambdaExpr lambda = cu.findFirst(LambdaExpr.class).get();
+
+        // The lambda is the Runnable argument of Thread(Runnable), so its resolved type
+        // must be Runnable — NOT Thread (the bug would return Thread).
+        assertEquals("java.lang.Runnable", lambda.calculateResolvedType().describe());
+    }
+
+    /**
+     * A lambda passed to a user-defined constructor that accepts a custom
+     * {@code @FunctionalInterface} must resolve to that functional-interface type, not to the
+     * enclosing class.
+     *
+     * @see <a href="https://github.com/javaparser/javaparser/issues/3626">issue #3626</a>
+     */
+    @Test
+    void lambdaTypeInObjectCreationExpr_customFunctionalInterface() {
+        String source = "class MyTask {\n"
+                + "    interface Task { int compute(); }\n"
+                + "    MyTask(Task t) {}\n"
+                + "    static void test() {\n"
+                + "        new MyTask(() -> 42);\n"
+                + "    }\n"
+                + "}";
+
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        CompilationUnit cu = StaticJavaParser.parse(source);
+        LambdaExpr lambda = cu.findFirst(LambdaExpr.class).get();
+
+        // The lambda is the Task argument of MyTask(Task), so its resolved type must be
+        // MyTask.Task — NOT MyTask (the bug would return MyTask).
+        assertEquals("MyTask.Task", lambda.calculateResolvedType().describe());
+    }
 }


### PR DESCRIPTION

Fixes #3626 .

When a LambdaExpr is passed as an argument to a constructor
(e.g. `new Thread(() -> ...)`), TypeExtractor.visit(LambdaExpr)
was calling `expr.getType().resolve()` on the ObjectCreationExpr,
which returned the type of the constructed object (e.g. Thread)
instead of the functional-interface type expected at that
constructor parameter position (e.g. Runnable).
Because Thread is not itself a functional interface, resolveLambda()
could not find a functional method on it, producing a wrong result.
The fix mirrors the existing MethodCallExpr handling: look up the
argument position of the lambda, resolve the constructor via
facade.solve(expr), then call
MethodResolutionLogic.getMethodsExplicitAndVariadicParameterType()
on the ResolvedConstructorDeclaration (which extends
ResolvedMethodLikeDeclaration) to obtain the correct parameter type.
Two regression tests are added to LambdaResolutionTest:
- lambdaTypeInObjectCreationExpr_builtinConstructor
  new Thread(() -> ...) → java.lang.Runnable
- lambdaTypeInObjectCreationExpr_customFunctionalInterface
  new MyTask(() -> 42) → MyTask.Task