### PR TITLE
fix: resolve NameExpr to field when local variable with same name is declared later

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
@@ -30,14 +30,10 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
-import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserSymbolDeclaration;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 
 public class BlockStmtContext extends StatementContext<BlockStmt> {
 
@@ -97,51 +93,5 @@ public class BlockStmtContext extends StatementContext<BlockStmt> {
         return patternExprs;
     }
 
-    @Override
-    public SymbolReference<? extends ResolvedValueDeclaration> solveSymbol(String name) {
-        Optional<Context> optionalParent = getParent();
-        if (!optionalParent.isPresent()) {
-            return SymbolReference.unsolved();
-        }
 
-        if (wrappedNode.getStatements().size() > 0) {
-            // tries to resolve a declaration from local variables defined in child statements
-            // or from parent node context
-            // for example resolve declaration for the MethodCallExpr a.method() in
-            // A a = this;
-            // {
-            //   a.method();
-            // }
-
-            List<VariableDeclarator> variableDeclarators = new LinkedList<>();
-            // find all variable declarators exposed to child
-            // given that we don't know the statement we are trying to resolve, we look for all variable declarations
-            // defined in the context of the wrapped node whether it is located before or after the statement that
-            // interests us
-            // because a variable cannot be (re)defined after having been used
-            wrappedNode
-                    .getStatements()
-                    .getLast()
-                    .ifPresent(stmt -> variableDeclarators.addAll(localVariablesExposedToChild(stmt)));
-            if (!variableDeclarators.isEmpty()) {
-                // FIXME: Work backwards from the current statement, to only consider declarations prior to this
-                // statement.
-                for (VariableDeclarator vd : variableDeclarators) {
-                    if (vd.getNameAsString().equals(name)) {
-                        return SymbolReference.solved(JavaParserSymbolDeclaration.localVar(vd, typeSolver));
-                    }
-                }
-            }
-
-            SymbolReference<? extends ResolvedValueDeclaration> resolvedFromPattern =
-                    findExposedPatternInParentContext(optionalParent.get().getWrappedNode(), name);
-
-            if (resolvedFromPattern.isSolved()) {
-                return resolvedFromPattern;
-            }
-        }
-
-        // Otherwise continue as normal...
-        return solveSymbolInParentContext(name);
-    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/BlockStmtContext.java
@@ -92,6 +92,4 @@ public class BlockStmtContext extends StatementContext<BlockStmt> {
         }
         return patternExprs;
     }
-
-
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/BlockStmtContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/BlockStmtContextResolutionTest.java
@@ -81,7 +81,8 @@ class BlockStmtContextResolutionTest extends AbstractResolutionTest {
         StaticJavaParser.setConfiguration(configuration);
         CompilationUnit cu = StaticJavaParser.parse(src);
 
-        // 'int value = attribute' — the NameExpr 'attribute' must resolve to the field (int), not the local var (double)
+        // 'int value = attribute' — the NameExpr 'attribute' must resolve to the field (int), not the local var
+        // (double)
         VariableDeclarationExpr valueDecl = cu.findAll(VariableDeclarationExpr.class).stream()
                 .filter(v -> v.getVariable(0).getNameAsString().equals("value"))
                 .findFirst()

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/BlockStmtContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/BlockStmtContextResolutionTest.java
@@ -27,6 +27,8 @@ import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
@@ -61,6 +63,39 @@ class BlockStmtContextResolutionTest extends AbstractResolutionTest {
         AssignExpr expr = cu.findFirst(AssignExpr.class).get();
         ResolvedType rt = expr.calculateResolvedType();
         assertEquals("int", rt.describe());
+    }
+
+    // issue #3674
+    @Test
+    void field_reference_before_local_variable_with_same_name_must_resolve_to_field() {
+        String src = "class Class {\n"
+                + "    int attribute;\n"
+                + "    private int method() {\n"
+                + "        int value = attribute;\n"
+                + "        double attribute = 0.0;\n"
+                + "        return (int) (attribute + 1);\n"
+                + "    }\n"
+                + "}";
+        ParserConfiguration configuration = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(new ReflectionTypeSolver())));
+        StaticJavaParser.setConfiguration(configuration);
+        CompilationUnit cu = StaticJavaParser.parse(src);
+
+        // 'int value = attribute' — the NameExpr 'attribute' must resolve to the field (int), not the local var (double)
+        VariableDeclarationExpr valueDecl = cu.findAll(VariableDeclarationExpr.class).stream()
+                .filter(v -> v.getVariable(0).getNameAsString().equals("value"))
+                .findFirst()
+                .get();
+        NameExpr attributeInInitializer = valueDecl.findFirst(NameExpr.class).get();
+        ResolvedType resolvedType = attributeInInitializer.calculateResolvedType();
+        assertEquals("int", resolvedType.describe());
+
+        // 'double attribute = 0.0' — the local variable 'attribute' must resolve to double
+        VariableDeclarationExpr localAttributeDecl = cu.findAll(VariableDeclarationExpr.class).stream()
+                .filter(v -> v.getVariable(0).getNameAsString().equals("attribute"))
+                .findFirst()
+                .get();
+        assertEquals("double", localAttributeDecl.calculateResolvedType().describe());
     }
 
     @Test


### PR DESCRIPTION

Fixes #3674 .

BlockStmtContext.solveSymbol() was using the last statement of the block
as the reference point for localVariablesExposedToChild(), which exposed
all local variables declared anywhere in the block — including ones
declared after the expression being resolved. This caused a NameExpr
referring to a class field to be incorrectly resolved to a local variable
with the same name declared later in the same method.
The fix removes the solveSymbol() override entirely. StatementContext
(the parent class) already handles both cases correctly: direct child
statements walk backwards through the block and delegate to the method
context, while nested blocks use the NodeWithStatements branch to walk
backwards from their own position in the outer block.
