### PR TITLE
Fix: UnsupportedOperationException when resolving method calls inside lambdas in Comparator.comparing (#2716)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -241,12 +241,72 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                 return result;
             }
             if (typeOfScope.isConstraint()) {
+                // A ResolvedLambdaConstraintType wraps the inferred bound of an implicit lambda
+                // parameter, e.g. when resolving `a` in `Comparator.comparing(a -> a.getName())`.
+                // We need the type declaration of the bound so that method lookups (like getName())
+                // can proceed.
                 // TODO: Figure out if it is appropriate to remove the orElseThrow() -- if so, how...
                 ResolvedType type = typeOfScope.asConstraintType().getBound();
                 if (type.isReferenceType()) {
+                    // Common case: the bound is a fully-resolved reference type, e.g. `A`.
                     return singletonList(type.asReferenceType()
                             .getTypeDeclaration()
                             .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty.")));
+                }
+                if (type.isTypeVariable()) {
+                    // The bound is still an unresolved type variable (e.g. `T` in
+                    // `Comparator.comparing` when no outer context inference was possible).
+                    // The best we can do is use the type variable's explicit upper bounds;
+                    // if the variable is unconstrained (declared as plain `T`), we fall back
+                    // to Object, which is Java's implicit upper bound for all type parameters.
+                    Collection<ResolvedReferenceTypeDeclaration> result = new ArrayList<>();
+                    for (ResolvedTypeParameterDeclaration.Bound bound : type.asTypeParameter().getBounds()) {
+                        result.add(bound.getType()
+                                .asReferenceType()
+                                .getTypeDeclaration()
+                                .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty.")));
+                    }
+                    if (result.isEmpty()) {
+                        result.add(typeSolver.getSolvedJavaLangObject());
+                    }
+                    return result;
+                }
+                if (type.isWildcard() && type.asWildcard().isSuper()) {
+                    // The bound is a `? super X` wildcard. This shape arises when
+                    // LambdaExprContext infers the type of a lambda parameter by matching
+                    // the outer call's expected parameter type against the inner static
+                    // method's return type. For example:
+                    //   stream.sorted(Comparator.comparing(a -> a.getName()))
+                    // The inference learns that comparing's Comparator<T> must be a
+                    // Comparator<? super A> (sorted's formal type), so T is registered as
+                    // `? super A`. The constraint bound here is therefore `? super A`, and
+                    // we need A's type declaration to look up `getName()`.
+                    ResolvedType bounded = type.asWildcard().getBoundedType();
+                    if (bounded.isReferenceType()) {
+                        // Normal case: `? super A` where A is a concrete reference type.
+                        return singletonList(bounded.asReferenceType()
+                                .getTypeDeclaration()
+                                .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty.")));
+                    }
+                    if (bounded.isTypeVariable()) {
+                        // Edge case: `? super T` where T is itself still an unresolved type
+                        // variable (outer context inference did not fully concretize T).
+                        // Apply the same upper-bound / Object fallback as the plain
+                        // type-variable case above.
+                        Collection<ResolvedReferenceTypeDeclaration> result = new ArrayList<>();
+                        for (ResolvedTypeParameterDeclaration.Bound bound :
+                                bounded.asTypeParameter().getBounds()) {
+                            result.add(bound.getType()
+                                    .asReferenceType()
+                                    .getTypeDeclaration()
+                                    .orElseThrow(
+                                            () -> new RuntimeException("TypeDeclaration unexpectedly empty.")));
+                        }
+                        if (result.isEmpty()) {
+                            result.add(typeSolver.getSolvedJavaLangObject());
+                        }
+                        return result;
+                    }
                 }
                 throw new UnsupportedOperationException(
                         "The type declaration cannot be found on constraint " + type.describe());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -260,7 +260,8 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                     // if the variable is unconstrained (declared as plain `T`), we fall back
                     // to Object, which is Java's implicit upper bound for all type parameters.
                     Collection<ResolvedReferenceTypeDeclaration> result = new ArrayList<>();
-                    for (ResolvedTypeParameterDeclaration.Bound bound : type.asTypeParameter().getBounds()) {
+                    for (ResolvedTypeParameterDeclaration.Bound bound :
+                            type.asTypeParameter().getBounds()) {
                         result.add(bound.getType()
                                 .asReferenceType()
                                 .getTypeDeclaration()
@@ -299,8 +300,7 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
                             result.add(bound.getType()
                                     .asReferenceType()
                                     .getTypeDeclaration()
-                                    .orElseThrow(
-                                            () -> new RuntimeException("TypeDeclaration unexpectedly empty.")));
+                                    .orElseThrow(() -> new RuntimeException("TypeDeclaration unexpectedly empty.")));
                         }
                         if (result.isEmpty()) {
                             result.add(typeSolver.getSolvedJavaLangObject());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -154,7 +154,8 @@ public class LambdaExprContext extends ExpressionContext<LambdaExpr> {
                                                 .getType(outerCall.getScope().get());
                                         if (outerScopeType.isReferenceType()) {
                                             String outerMethodName = outerCall.getNameAsString();
-                                            int outerArgCount = outerCall.getArguments().size();
+                                            int outerArgCount =
+                                                    outerCall.getArguments().size();
                                             final int fOuterArgPos = outerArgPos;
                                             final ResolvedType fOuterScopeType = outerScopeType;
                                             // getTypeDeclaration().getAllMethods() returns MethodUsage objects
@@ -163,7 +164,8 @@ public class LambdaExprContext extends ExpressionContext<LambdaExpr> {
                                             // with the concrete arguments (e.g. Stream<A>). We apply
                                             // useThisTypeParametersOnTheGivenType() below to perform that
                                             // substitution using the outer scope's concrete type arguments.
-                                            outerScopeType.asReferenceType()
+                                            outerScopeType
+                                                    .asReferenceType()
                                                     .getTypeDeclaration()
                                                     .ifPresent(outerDecl -> {
                                                         for (MethodUsage mu : outerDecl.getAllMethods()) {
@@ -178,18 +180,16 @@ public class LambdaExprContext extends ExpressionContext<LambdaExpr> {
                                                                 // Substitute the outer scope's concrete type
                                                                 // arguments (e.g. T_stream → A for Stream<A>),
                                                                 // yielding the expected type `Comparator<? super A>`.
-                                                                ResolvedType expectedType =
-                                                                        fOuterScopeType.asReferenceType()
-                                                                                .useThisTypeParametersOnTheGivenType(
-                                                                                        rawType);
+                                                                ResolvedType expectedType = fOuterScopeType
+                                                                        .asReferenceType()
+                                                                        .useThisTypeParametersOnTheGivenType(rawType);
                                                                 // Register the pair in the inference context:
                                                                 //   comparing's return type `Comparator<T>`
                                                                 //   ↔ expected type `Comparator<? super A>`
                                                                 // This lets the engine resolve T → `? super A`,
                                                                 // whose bound (A) is the concrete element type.
                                                                 inferenceContext.addPair(
-                                                                        methodUsage.returnType(),
-                                                                        expectedType);
+                                                                        methodUsage.returnType(), expectedType);
                                                                 break;
                                                             }
                                                         }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -100,6 +100,106 @@ public class LambdaExprContext extends ExpressionContext<LambdaExpr> {
                                 inferenceContext.addPair(lambdaType, new ReferenceTypeImpl(typeDeclaration));
                             });
 
+                            // --- Outer-context type parameter inference for static generic methods ---
+                            //
+                            // For instance method calls (e.g. stream.map(lambda)), JavaParser can
+                            // substitute the scope's concrete type arguments (e.g. A from Stream<A>)
+                            // into the functional interface type, giving the lambda parameter a
+                            // concrete type directly.
+                            //
+                            // For static generic method calls (e.g. Comparator.comparing(lambda)),
+                            // there is no receiver instance, so the method's own type parameters
+                            // (e.g. T in `comparing`) are left as unresolved type variables.
+                            // The only way to determine T is from the context in which the result
+                            // is consumed — i.e., the outer call that receives the static method's
+                            // return value.
+                            //
+                            // Example:
+                            //   stream.sorted(Comparator.comparing(a -> a.getName()))
+                            //
+                            // Here `methodCallExpr` is `Comparator.comparing(lambda)` and
+                            // `outerCall` is `stream.sorted(...)`. The outer method `sorted`
+                            // declares its parameter as `Comparator<? super T_stream>`, where
+                            // T_stream is the stream element type. After substituting the scope
+                            // type (Stream<A>), the expected parameter type becomes
+                            // `Comparator<? super A>`. Registering the pair
+                            //   (comparing's return type `Comparator<T>`) ↔ (`Comparator<? super A>`)
+                            // into the inference context lets the engine infer T → `? super A`,
+                            // which is sufficient to look up methods on A (getName(), getId(), …).
+                            //
+                            // We wrap this in try/catch so that any failure here (e.g. the outer
+                            // call cannot be resolved, or there are multiple overloads) is silently
+                            // ignored — the existing inference based on the functional interface
+                            // alone will still run, and will produce T → Object (usable as a
+                            // fallback) instead of crashing.
+                            try {
+                                Node outerNode = demandParentNode(methodCallExpr, IS_NOT_ENCLOSED_EXPR);
+                                if (outerNode instanceof MethodCallExpr) {
+                                    MethodCallExpr outerCall = (MethodCallExpr) outerNode;
+                                    // Find the position of methodCallExpr in the outer call's arguments
+                                    // so we can retrieve the corresponding formal parameter type.
+                                    int outerArgPos = -1;
+                                    for (int k = 0; k < outerCall.getArguments().size(); k++) {
+                                        if (outerCall.getArguments().get(k) == methodCallExpr) {
+                                            outerArgPos = k;
+                                            break;
+                                        }
+                                    }
+                                    // We only attempt inference when the outer call has an explicit
+                                    // receiver scope (e.g. `stream.sorted(...)`). Without a scope we
+                                    // cannot obtain the concrete type arguments that would let us
+                                    // substitute the outer method's type parameters.
+                                    if (outerArgPos >= 0 && outerCall.hasScope()) {
+                                        ResolvedType outerScopeType = JavaParserFacade.get(typeSolver)
+                                                .getType(outerCall.getScope().get());
+                                        if (outerScopeType.isReferenceType()) {
+                                            String outerMethodName = outerCall.getNameAsString();
+                                            int outerArgCount = outerCall.getArguments().size();
+                                            final int fOuterArgPos = outerArgPos;
+                                            final ResolvedType fOuterScopeType = outerScopeType;
+                                            // getTypeDeclaration().getAllMethods() returns MethodUsage objects
+                                            // whose parameter types still carry the type declaration's own
+                                            // type parameters (e.g. Stream<T_stream>), not yet substituted
+                                            // with the concrete arguments (e.g. Stream<A>). We apply
+                                            // useThisTypeParametersOnTheGivenType() below to perform that
+                                            // substitution using the outer scope's concrete type arguments.
+                                            outerScopeType.asReferenceType()
+                                                    .getTypeDeclaration()
+                                                    .ifPresent(outerDecl -> {
+                                                        for (MethodUsage mu : outerDecl.getAllMethods()) {
+                                                            if (mu.getName().equals(outerMethodName)
+                                                                    && mu.getNoParams() == outerArgCount) {
+                                                                // Raw parameter type from the type declaration,
+                                                                // e.g. `Comparator<? super T_stream>` for sorted.
+                                                                ResolvedType rawType =
+                                                                        MethodResolutionLogic
+                                                                                .getMethodUsageExplicitAndVariadicParameterType(
+                                                                                        mu, fOuterArgPos);
+                                                                // Substitute the outer scope's concrete type
+                                                                // arguments (e.g. T_stream → A for Stream<A>),
+                                                                // yielding the expected type `Comparator<? super A>`.
+                                                                ResolvedType expectedType =
+                                                                        fOuterScopeType.asReferenceType()
+                                                                                .useThisTypeParametersOnTheGivenType(
+                                                                                        rawType);
+                                                                // Register the pair in the inference context:
+                                                                //   comparing's return type `Comparator<T>`
+                                                                //   ↔ expected type `Comparator<? super A>`
+                                                                // This lets the engine resolve T → `? super A`,
+                                                                // whose bound (A) is the concrete element type.
+                                                                inferenceContext.addPair(
+                                                                        methodUsage.returnType(),
+                                                                        expectedType);
+                                                                break;
+                                                            }
+                                                        }
+                                                    });
+                                        }
+                                    }
+                                }
+                            } catch (Exception ignored) {
+                            }
+
                             // Find the position of this lambda argument
                             boolean found = false;
                             int lambdaParamIndex;

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
@@ -490,4 +490,70 @@ class LambdaResolutionTest extends AbstractResolutionTest {
         // MyTask.Task — NOT MyTask (the bug would return MyTask).
         assertEquals("MyTask.Task", lambda.calculateResolvedType().describe());
     }
+
+    @Test
+    // see https://github.com/javaparser/javaparser/issues/2716
+    void issue2716_resolveMethodCallsInStreamWithComparatorComparingOnUserDefinedClass() {
+        // Regression test: resolving method calls inside lambdas used with
+        // Comparator.comparing() on a Stream whose element type is user-defined
+        // previously threw UnsupportedOperationException.
+        //
+        // Root cause: Comparator.comparing is a static generic method, so the
+        // scope-based substitution path (which works for instance methods like map())
+        // is never taken, leaving its type parameter T unresolved.  Without the outer-
+        // context inference fix the symbol solver could not determine the type of the
+        // lambda parameter and crashed when trying to look up a.getName() / a.getId().
+        String source = "import java.util.Comparator;\n"
+                + "import java.util.List;\n"
+                + "import java.util.stream.Collectors;\n"
+                + "public class Test {\n"
+                + "    static class Item {\n"
+                + "        public int getId() { return 0; }\n"
+                + "        public String getName() { return \"\"; }\n"
+                + "    }\n"
+                + "    void test(List<Item> items) {\n"
+                + "        items.stream()\n"
+                + "             .sorted(Comparator.comparing(a -> a.getName()))\n"
+                + "             .map(a -> a.getId())\n"
+                + "             .collect(Collectors.toList());\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(
+                new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        final CompilationUnit cu = StaticJavaParser.parse(source);
+        // All method calls in the chain — including a.getName() and a.getId() inside
+        // the lambdas — must resolve without throwing.
+        assertDoesNotThrow(() -> cu.findAll(MethodCallExpr.class).forEach(MethodCallExpr::resolve));
+    }
+
+    @Test
+    // see https://github.com/javaparser/javaparser/issues/2716
+    void issue2716_resolveMethodCallInsideLambdaInComparatorComparingWithJdkTypes() {
+        // When the stream element type is a JDK type (String), a method call inside
+        // Comparator.comparing(s -> s.toLowerCase()) must resolve to the correct
+        // overload.  This exercises the same outer-context inference path as the
+        // user-defined-class variant above, but with types fully visible to the
+        // ReflectionTypeSolver, allowing a precise signature assertion.
+        String source = "import java.util.Arrays;\n"
+                + "import java.util.Comparator;\n"
+                + "import java.util.List;\n"
+                + "public class Test {\n"
+                + "    void test() {\n"
+                + "        List<String> list = Arrays.asList(\"b\", \"a\");\n"
+                + "        list.stream().sorted(Comparator.comparing(s -> s.toLowerCase()));\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(
+                new JavaSymbolSolver(new ReflectionTypeSolver()));
+        final CompilationUnit cu = StaticJavaParser.parse(source);
+        MethodCallExpr toLowerCaseCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(mce -> mce.getNameAsString().equals("toLowerCase"))
+                .findFirst()
+                .get();
+        // s is inferred as String (from ? super String), so toLowerCase() must
+        // resolve to the no-argument overload on java.lang.String.
+        assertEquals(
+                "java.lang.String.toLowerCase()",
+                assertDoesNotThrow(toLowerCaseCall::resolve).getQualifiedSignature());
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
@@ -518,8 +518,8 @@ class LambdaResolutionTest extends AbstractResolutionTest {
                 + "             .collect(Collectors.toList());\n"
                 + "    }\n"
                 + "}";
-        StaticJavaParser.getParserConfiguration().setSymbolResolver(
-                new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.getParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
         final CompilationUnit cu = StaticJavaParser.parse(source);
         // All method calls in the chain — including a.getName() and a.getId() inside
         // the lambdas — must resolve without throwing.
@@ -543,8 +543,7 @@ class LambdaResolutionTest extends AbstractResolutionTest {
                 + "        list.stream().sorted(Comparator.comparing(s -> s.toLowerCase()));\n"
                 + "    }\n"
                 + "}";
-        StaticJavaParser.getParserConfiguration().setSymbolResolver(
-                new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
         final CompilationUnit cu = StaticJavaParser.parse(source);
         MethodCallExpr toLowerCaseCall = cu.findAll(MethodCallExpr.class).stream()
                 .filter(mce -> mce.getNameAsString().equals("toLowerCase"))

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/LambdaExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/LambdaExprContextResolutionTest.java
@@ -24,6 +24,7 @@ package com.github.javaparser.symbolsolver.resolution.javaparser.contexts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -141,6 +142,41 @@ class LambdaExprContextResolutionTest extends AbstractResolutionTest {
         Optional<Value> ref = context.solveSymbolAsValue("p");
         assertTrue(ref.isPresent());
         assertEquals("java.lang.String", ref.get().getType().describe());
+    }
+
+    @Test
+    // see https://github.com/javaparser/javaparser/issues/2716
+    void solveParameterOfLambdaInStaticGenericMethodWithOuterContextInference() {
+        // When Comparator.comparing(lambda) is passed to stream.sorted(), the lambda
+        // parameter type cannot be inferred from comparing's scope alone: comparing is
+        // a static method, so there is no receiver instance whose type arguments could
+        // substitute its type parameter T.
+        //
+        // The outer call provides the missing context: sorted() on Stream<String>
+        // expects Comparator<? super String>, so the inference engine matches
+        // comparing's return type Comparator<T> against Comparator<? super String>
+        // and concludes T = ? super String.  The lambda parameter therefore has
+        // type "? super java.lang.String".
+        String source = "import java.util.Arrays;\n"
+                + "import java.util.Comparator;\n"
+                + "import java.util.List;\n"
+                + "public class Test {\n"
+                + "    void test() {\n"
+                + "        List<String> list = Arrays.asList(\"b\", \"a\");\n"
+                + "        list.stream().sorted(Comparator.comparing(s -> s.toLowerCase()));\n"
+                + "    }\n"
+                + "}";
+        CompilationUnit cu = StaticJavaParser.parse(source);
+        MethodCallExpr comparingCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(mce -> mce.getNameAsString().equals("comparing"))
+                .findFirst()
+                .get();
+        LambdaExpr lambdaExpr = (LambdaExpr) comparingCall.getArguments().get(0);
+
+        Context context = new LambdaExprContext(lambdaExpr, typeSolver);
+        Optional<Value> ref = context.solveSymbolAsValue("s");
+        assertTrue(ref.isPresent());
+        assertEquals("? super java.lang.String", ref.get().getType().describe());
     }
 
     @Test


### PR DESCRIPTION

Fixes #2716 .

Resolving method calls on implicit lambda parameters (e.g. `a.getName()` in
`Comparator.comparing(a -> a.getName())`) crashed with an
UnsupportedOperationException when the lambda was used inside a stream chain
on a user-defined element type.

Root cause
----------
`Comparator.comparing` is a static generic method, so the scope-based type
parameter substitution that works for instance calls (e.g. `stream.map(...)`)
is never taken. Its type parameter T therefore remained as an unresolved
TypeVariable, which caused two cascading failures:
1. `LambdaExprContext.solveSymbolAsValue` returned a constraint type whose
   bound was an unresolved TypeVariable T, and
2. `AbstractJavaParserContext.findTypeDeclarations` had no handler for that
   shape, throwing UnsupportedOperationException.
Fix
---
LambdaExprContext.java — outer-context type parameter inference:
  When the enclosing method call (e.g. `comparing(...)`) is itself an
  argument of another method call with a known receiver type (e.g.
  `stream.sorted(...)`), infer the static method's type parameters from the
  outer call's expected parameter type. Concretely, the pair
  (comparing's return type `Comparator<T>`) ↔ (sorted's expected type
  `Comparator<? super A>`) is registered in the InferenceContext, letting
  the engine resolve T → `? super A` and thus determine the lambda
  parameter type.
AbstractJavaParserContext.java — extended constraint-type handling in
findTypeDeclarations:
  Added two new sub-cases inside the isConstraint() branch:
  - isTypeVariable(): the bound is still an unresolved type variable
    (fallback when outer-context inference is unavailable); use the
    variable's explicit upper bounds, defaulting to Object.
  - isWildcard() && isSuper(): the bound is `? super X` produced by the
    outer-context inference; use X's type declaration (with the same
    TypeVariable fallback for X if needed).
Tests
-----
- LambdaExprContextResolutionTest: unit test verifying that
  solveSymbolAsValue("s") on the lambda in
  `stream.sorted(Comparator.comparing(s -> s.toLowerCase()))` returns
  `? super java.lang.String`.
- LambdaResolutionTest: two integration tests — one asserting that all
  method calls in a stream chain with a user-defined element type resolve
  without throwing (direct regression for #2716), and one asserting the
  precise qualified signature of `toLowerCase()` when the element type is
  String.