### PR TITLE
fix: handle wildcard actualType in matchTypeParameters (issue #3751)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -422,6 +422,32 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
         return LeastUpperBoundLogic.of().lub(resolvedTypes);
     }
 
+    /**
+     * Attempts to match the formal type parameter {@code expectedType} against the actual argument
+     * type {@code actualType}, recording any resolved type-variable bindings in
+     * {@code matchedTypeParameters}.
+     *
+     * <p>Supported cases for {@code expectedType}:
+     * <ul>
+     *   <li><b>Type variable</b> – binds the actual type to the variable after boxing primitives and
+     *       replacing {@code null} with {@code Object}.
+     *       When {@code actualType} is a wildcard (e.g. the intermediate accumulation type {@code ?}
+     *       in {@code Collector<T, ?, R>}), capture-conversion rules apply: a bounded wildcard
+     *       ({@code ? extends Foo} or {@code ? super Foo}) contributes its declared bound as the
+     *       inferred type; an unbounded wildcard {@code ?} carries no type information and is
+     *       skipped.</li>
+     *   <li><b>Array</b> – recurses on the component type (null actual types pass through as-is,
+     *       see issue #2258).</li>
+     *   <li><b>Reference type</b> – recurses on each type argument when the actual type also
+     *       carries type arguments.</li>
+     *   <li><b>Primitive or wildcard</b> – no binding needed; returns immediately.</li>
+     * </ul>
+     *
+     * @param expectedType          formal parameter type, possibly containing type variables
+     * @param actualType            actual argument type at the call site
+     * @param matchedTypeParameters accumulator map from type-variable declarations to inferred types
+     * @throws UnsupportedOperationException if an unrecognised type combination is encountered
+     */
     private void matchTypeParameters(
             ResolvedType expectedType,
             ResolvedType actualType,
@@ -441,6 +467,16 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
             if (type.isNull()) {
                 ResolvedReferenceTypeDeclaration resolvedTypedeclaration = typeSolver.getSolvedJavaLangObject();
                 type = new ReferenceTypeImpl(resolvedTypedeclaration);
+            }
+            // When the actual type is a wildcard (e.g. '?' in Collector<T, ?, R>), apply capture
+            // conversion: use the declared bound for bounded wildcards, and skip unbounded ones
+            // since no concrete type can be inferred from '?' alone (issue #3751).
+            if (type.isWildcard()) {
+                ResolvedWildcard wildcard = type.asWildcard();
+                if (wildcard.isBounded()) {
+                    matchedTypeParameters.put(expectedType.asTypeParameter(), wildcard.getBoundedType());
+                }
+                return;
             }
             if (!type.isTypeVariable() && !type.isReferenceType() && !type.isArray()) {
                 throw new UnsupportedOperationException(type.getClass().getCanonicalName());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
@@ -203,6 +203,66 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
         assertEquals("java.lang.String", resolvedType.describe());
     }
 
+    // Related to issue #3751
+    /**
+     * Verifies that {@code calculateResolvedType()} resolves the return type of
+     * {@code stream.collect(Collectors.toList())} without throwing an exception (issue #3751).
+     *
+     * <p>{@code Collectors.toList()} returns {@code Collector<T, ?, List<T>>}: the intermediate
+     * accumulation type is the unbounded wildcard {@code ?}.  {@code Stream.collect} is declared as
+     * {@code <R, A> R collect(Collector<? super T, A, R>)}, so resolving the return type requires
+     * matching the formal type variable {@code A} against the wildcard {@code ?}.
+     *
+     * <p>Before the fix, {@code matchTypeParameters} threw {@code UnsupportedOperationException}
+     * in this situation because it only accepted type variables, reference types, and arrays as
+     * candidates for type-variable bindings — wildcards were not handled.  The fix applies
+     * capture-conversion rules: bounded wildcards contribute their declared bound, and unbounded
+     * wildcards are skipped (no type information can be inferred from {@code ?} alone).  This
+     * leaves {@code A} unresolved while still allowing {@code R = List<String>} to be inferred
+     * correctly from the remaining type arguments.
+     */
+    @Test
+    void resolveStreamCollectWithWildcardAccumulatorType() {
+        ParserConfiguration config =
+                new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+        CompilationUnit cu = parseSample("Issue3751");
+        List<MethodCallExpr> expressions = cu.getChildNodesByType(MethodCallExpr.class);
+
+        MethodCallExpr collectCall = expressions.stream()
+                .filter(e -> e.getNameAsString().equals("collect"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No 'collect' call found in Issue3751 sample"));
+
+        // Must not throw UnsupportedOperationException (issue #3751)
+        ResolvedType resolvedType = collectCall.calculateResolvedType();
+        assertEquals("java.util.List<java.lang.String>", resolvedType.describe());
+    }
+
+    /**
+     * Verifies that the wildcard fix does not regress the common case where all type arguments are
+     * concrete (no wildcards involved).  {@code Stream.collect(Collectors.toList())} returns
+     * {@code List<String>} which must still resolve correctly.
+     */
+    @Test
+    void resolveStreamCollectWithConcreteCollector() {
+        ParserConfiguration config =
+                new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+
+        String code = "import java.util.*; import java.util.stream.*;"
+                + "class T { List<String> f(Stream<String> s) { return s.collect(Collectors.toList()); } }";
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodCallExpr collectCall = cu.getChildNodesByType(MethodCallExpr.class).stream()
+                .filter(e -> e.getNameAsString().equals("collect"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No 'collect' call found"));
+
+        ResolvedType resolvedType = collectCall.calculateResolvedType();
+        assertEquals("java.util.List<java.lang.String>", resolvedType.describe());
+    }
+
     // Related to issue #3195
     @Test
     void solveVariadicStaticGenericMethodCallCanInferFromArguments2() {

--- a/javaparser-symbol-solver-testing/src/test/resources/Issue3751.java.txt
+++ b/javaparser-symbol-solver-testing/src/test/resources/Issue3751.java.txt
@@ -1,0 +1,15 @@
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Issue3751 {
+
+    // Reproduces issue #3751: calculateResolvedType() on stream.collect() threw
+    // UnsupportedOperationException when the Collector argument contained a wildcard
+    // intermediate-accumulation type (the '?' in Collector<T, ?, R>).
+    // Collectors.toList() returns Collector<T, ?, List<T>>, where the accumulator '?'
+    // must be matched against the type variable 'A' in Stream.collect(Collector<? super T, A, R>).
+    List<String> toList(Stream<String> stream) {
+        return stream.collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Fixes #3751 .

When Stream.collect() is called with a Collector whose intermediate
accumulation type is a wildcard (e.g. Collectors.toList() returns
Collector<T, ?, List<T>>), matchTypeParameters threw
UnsupportedOperationException trying to bind the formal type variable
'A' against the wildcard '?'.
Apply capture-conversion rules: a bounded wildcard (? extends / ? super)
contributes its declared bound as the inferred type; an unbounded wildcard
'?' carries no type information and is skipped. This leaves 'A' unresolved
while still allowing the return type 'R' to be correctly inferred from the
remaining type arguments.
Add Javadoc to matchTypeParameters documenting all handled cases.
Add two regression tests in MethodCallExprContextResolutionTest:
- resolveStreamCollectWithWildcardAccumulatorType (issue #3751)
- resolveStreamCollectWithConcreteCollector (non-wildcard regression guard)
