### PR TITLE
fix: implement phase-2 poly-expression inference for method/construct or references (JLS §15.12.2.7)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -447,7 +447,7 @@ public class JavaParserFacade {
         });
     }
 
-    protected MethodUsage toMethodUsage(MethodReferenceExpr methodReferenceExpr, List<ResolvedType> paramTypes) {
+    public MethodUsage toMethodUsage(MethodReferenceExpr methodReferenceExpr, List<ResolvedType> paramTypes) {
         // JLS §15.13.1: "A method reference expression consists of a ReferenceType or Primary,
         // followed by :: and a method name."
         // We need to evaluate the scope to determine what we're referencing.

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -21,15 +21,20 @@
 
 package com.github.javaparser.symbolsolver.javaparsermodel.contexts;
 
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.*;
+import com.github.javaparser.resolution.logic.FunctionalInterfaceLogic;
 import com.github.javaparser.resolution.logic.MethodResolutionLogic;
+import com.github.javaparser.resolution.model.LambdaArgumentTypePlaceholder;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.typesystem.LazyType;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
@@ -92,6 +97,9 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
                         MethodUsage methodUsage = new MethodUsage(m.getCorrespondingDeclaration());
                         methodUsage = resolveMethodTypeParametersFromExplicitList(typeSolver, methodUsage);
                         methodUsage = resolveMethodTypeParameters(methodUsage, argumentsTypes);
+                        // Phase 2 (JLS §15.12.2.7): infer remaining type variables from poly
+                        // expression arguments (method/constructor references).
+                        methodUsage = inferTypeVariablesFromPolyExpressionArguments(methodUsage, argumentsTypes);
                         return Optional.of(methodUsage);
                     }
                     throw new UnsolvedSymbolException(
@@ -228,6 +236,16 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
                 methodUsage = methodUsage.replaceTypeParameter(entry.getKey(), entry.getValue());
             }
 
+            // Phase 2 (JLS §15.12.2.7): infer remaining type variables from poly-expression
+            // arguments (method/constructor references).  After Phase 1 some type variables may
+            // still be unresolved (e.g. K in groupingBy(Function<? super T, ? extends K>, ...)).
+            // For each argument that was a method/constructor reference, we derive the actual
+            // return type of the referenced callable and match it against the SAM's formal return
+            // type to produce additional bindings.  Lambdas are skipped — their return type is
+            // itself context-dependent and cannot be resolved here without full poly-expression
+            // inference.
+            methodUsage = inferTypeVariablesFromPolyExpressionArguments(methodUsage, argumentsTypes);
+
             ResolvedType returnType = refType.useThisTypeParametersOnTheGivenType(methodUsage.returnType());
             // we don't want to replace the return type in case of UNBOUNDED type (<?>)
             if (returnType != methodUsage.returnType() && !(returnType == ResolvedWildcard.UNBOUNDED)) {
@@ -241,6 +259,146 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
             return Optional.of(methodUsage);
         }
         return ref;
+    }
+
+    /**
+     * Phase 2 of JLS §15.12.2.7 poly-expression type inference.
+     *
+     * <p>After Phase 1 has inferred type variables from concrete (non-poly) arguments, some
+     * variables may still be unresolved — for example {@code K} in
+     * {@code groupingBy(Function<? super T, ? extends K> classifier, ...)} when {@code classifier}
+     * is a constructor or method reference.  This method performs a supplementary inference pass
+     * over every argument position that was a method or constructor reference:
+     *
+     * <ol>
+     *   <li>Determine the formal parameter type at that position in {@code methodUsage} (which
+     *       already reflects Phase-1 substitutions, e.g. {@code Function<? super String, ? extends K>}).
+     *   <li>Obtain the SAM of that functional interface type via
+     *       {@link FunctionalInterfaceLogic#getFunctionalMethod}.</li>
+     *   <li>Compute the <em>actual</em> return type of the referenced callable:
+     *       <ul>
+     *         <li>Constructor reference ({@code X::new}): the constructed type {@code X}.</li>
+     *         <li>Method reference ({@code Foo::bar}): the declared return type of the matched
+     *             method obtained via {@link JavaParserFacade#toMethodUsage}.</li>
+     *       </ul>
+     *   </li>
+     *   <li>Match the SAM's formal return type (stripping any {@code ? extends} / {@code ? super}
+     *       wrapper) against the actual return type to derive additional type-variable bindings.</li>
+     * </ol>
+     *
+     * <p>Lambdas are <strong>not</strong> handled: their return type is itself context-dependent
+     * and cannot be inferred without full poly-expression inference.
+     *
+     * @param methodUsage   the partially-resolved method usage (after Phase 1)
+     * @param argumentsTypes the argument types as seen during method resolution; poly arguments
+     *                       are represented by {@link LambdaArgumentTypePlaceholder}
+     * @return a (possibly further refined) {@link MethodUsage} with additional type variables
+     *         replaced by their inferred types
+     */
+    private MethodUsage inferTypeVariablesFromPolyExpressionArguments(
+            MethodUsage methodUsage, List<ResolvedType> argumentsTypes) {
+        NodeList<Expression> callArgs = wrappedNode.getArguments();
+        if (callArgs == null || callArgs.isEmpty()) {
+            return methodUsage;
+        }
+
+        // Determine how many positional (non-vararg) parameters to iterate over
+        int paramCount = methodUsage.getDeclaration().hasVariadicParameter()
+                ? methodUsage.getDeclaration().getNumberOfParams() - 1
+                : methodUsage.getDeclaration().getNumberOfParams();
+
+        Map<ResolvedTypeParameterDeclaration, ResolvedType> polyDerivedValues = new HashMap<>();
+
+        for (int i = 0; i < Math.min(paramCount, Math.min(argumentsTypes.size(), callArgs.size())); i++) {
+            // Identify poly-expression arguments directly from the AST: in solveMethodAsUsage,
+            // method/constructor references are already resolved to their formal parameter type
+            // (via getType(param, false)), so they do NOT appear as LambdaArgumentTypePlaceholder.
+            // We therefore check the original AST node instead.
+            Expression rawArg = callArgs.get(i);
+            while (rawArg instanceof EnclosedExpr) {
+                rawArg = ((EnclosedExpr) rawArg).getInner();
+            }
+            if (!rawArg.isMethodReferenceExpr()) {
+                continue;
+            }
+
+            // Obtain the formal functional interface type with Phase-1 substitutions applied
+            ResolvedType formalParamType = methodUsage.getParamType(i);
+            Optional<MethodUsage> samOpt = FunctionalInterfaceLogic.getFunctionalMethod(formalParamType);
+            if (!samOpt.isPresent()) {
+                continue;
+            }
+
+            // getFunctionalMethod returns the SAM of the raw type declaration; substitute the
+            // type arguments from formalParamType so that the SAM's return type reflects the
+            // actual type arguments (e.g. "? extends K", not the raw "R").
+            MethodUsage sam = samOpt.get();
+            if (formalParamType.isReferenceType()) {
+                for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> typeParamEntry :
+                        formalParamType.asReferenceType().getTypeParametersMap()) {
+                    sam = sam.replaceTypeParameter(typeParamEntry.a, typeParamEntry.b);
+                }
+            }
+
+            ResolvedType samReturnType = sam.returnType();
+            if (samReturnType.isVoid()) {
+                continue;
+            }
+
+            // Unwrap a bounded wildcard on the SAM return type so that matchTypeParameters can
+            // bind the inner type variable.  E.g. "? extends K" → "K", "? super K" → "K".
+            ResolvedType samReturnEffective = samReturnType;
+            if (samReturnType.isWildcard() && samReturnType.asWildcard().isBounded()) {
+                samReturnEffective = samReturnType.asWildcard().getBoundedType();
+            }
+
+            MethodReferenceExpr ref = rawArg.asMethodReferenceExpr();
+            ResolvedType actualReturnType = null;
+
+            if ("new".equals(ref.getIdentifier())) {
+                // Constructor reference X::new always returns the constructed type X
+                try {
+                    actualReturnType = ref.getScope().calculateResolvedType();
+                } catch (Exception e) {
+                    // Unable to resolve the constructed type — skip this argument
+                }
+            } else {
+                // Method reference: resolve the actual method and use its declared return type.
+                // Replace wildcard param types with their bounds before calling toMethodUsage so
+                // that the method lookup can match the correct overload.
+                try {
+                    List<ResolvedType> samParamTypes = new ArrayList<>();
+                    for (int j = 0; j < sam.getNoParams(); j++) {
+                        ResolvedType pt = sam.getParamType(j);
+                        if (pt.isWildcard() && pt.asWildcard().isBounded()) {
+                            pt = pt.asWildcard().getBoundedType();
+                        }
+                        samParamTypes.add(pt);
+                    }
+                    actualReturnType = JavaParserFacade.get(typeSolver)
+                            .toMethodUsage(ref, samParamTypes)
+                            .returnType();
+                } catch (Exception e) {
+                    // Unable to resolve — skip this argument
+                }
+            }
+
+            if (actualReturnType == null) {
+                continue;
+            }
+
+            // Match the effective SAM return type against the actual return type to derive bindings
+            try {
+                matchTypeParameters(samReturnEffective, actualReturnType, polyDerivedValues);
+            } catch (Exception e) {
+                // Mismatch or unsupported combination — skip this argument
+            }
+        }
+
+        for (Map.Entry<ResolvedTypeParameterDeclaration, ResolvedType> entry : polyDerivedValues.entrySet()) {
+            methodUsage = methodUsage.replaceTypeParameter(entry.getKey(), entry.getValue());
+        }
+        return methodUsage;
     }
 
     private MethodUsage resolveMethodTypeParameters(MethodUsage methodUsage, List<ResolvedType> actualParamTypes) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/MethodCallExprContextResolutionTest.java
@@ -266,9 +266,9 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
     /**
      * Verifies the original case from issue #3751: resolving
      * {@code stream.collect(Collectors.groupingBy(String::new, Collectors.counting()))} must not
-     * throw and must produce a {@code Map<?, Long>} return type.
+     * throw and must produce a fully resolved {@code Map<String, Long>} return type.
      *
-     * <p>Two fixes cooperate here:
+     * <p>Three fixes cooperate here:
      * <ol>
      *   <li>The wildcard fix in {@code matchTypeParameters} – prevents
      *       {@code UnsupportedOperationException} when matching the formal type variable {@code A}
@@ -277,14 +277,11 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
      *       resolves to the functional interface type expected at its call-site position
      *       ({@code Function<? super T, ? extends K>}) so that the correct {@code groupingBy}
      *       overload can be found instead of throwing {@code UnsolvedSymbolException}.</li>
+     *   <li>Phase-2 poly-expression inference in {@code MethodCallExprContext} – after the initial
+     *       type-variable inference pass, the return type of {@code String::new} ({@code String})
+     *       is matched against the SAM's formal return type ({@code ? extends K}) to derive
+     *       {@code K = String}, fully resolving the map key type (JLS §15.12.2.7).</li>
      * </ol>
-     *
-     * <p><b>Note on partial resolution:</b> the key type variable {@code K} (the grouping key)
-     * resolves to {@code String} in a real Java compiler through two-phase poly-expression
-     * inference (JLS §15.12.2.7).  JavaParser's symbol solver does not yet implement that
-     * multi-pass inference, so {@code K} may appear as an unresolved inference variable in the
-     * output.  The assertions below therefore check the outer container type ({@code Map}) and
-     * the value type ({@code Long}) without pinning the exact key type.
      */
     @Test
     void resolveStreamCollectGroupingByWithConstructorReference() {
@@ -303,14 +300,10 @@ class MethodCallExprContextResolutionTest extends AbstractResolutionTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("No 'collect' call found in groupAndCount()"));
 
-        // Must not throw UnsupportedOperationException or UnsolvedSymbolException (issue #3751).
+        // Must resolve to Map<String, Long> — K is now fully inferred via Phase-2
+        // poly-expression inference (JLS §15.12.2.7).
         ResolvedType resolvedType = collectCall.calculateResolvedType();
-        assertTrue(resolvedType.isReferenceType(), "Expected a reference type (Map)");
-        // The outer container is Map and the value type is Long; the key type variable K may
-        // remain partially unresolved until poly-expression inference is fully implemented.
-        String described = resolvedType.describe();
-        assertTrue(described.startsWith("java.util.Map<"), "Expected Map return type, was: " + described);
-        assertTrue(described.endsWith(", java.lang.Long>"), "Expected Long value type, was: " + described);
+        assertEquals("java.util.Map<java.lang.String, java.lang.Long>", resolvedType.describe());
     }
 
     /**


### PR DESCRIPTION
After the initial type-variable inference pass (Phase 1), remaining type variables whose only source of information is a poly-expression argument (lambda or method/constructor reference) were left unresolved — for example K in groupingBy(String::new, counting()) stayed as InferenceVariable instead of resolving to String.

Add inferTypeVariablesFromPolyExpressionArguments in MethodCallExprContext: for each argument position whose AST node is a method or constructor reference, retrieve the SAM of the formal functional interface type (with Phase-1 substitutions applied), unwrap any ? extends/? super wildcard on its return type, compute the actual return type of the referenced callable (X for X::new, declared return type for Foo::bar), and match the two to derive additional type-variable bindings. Call this Phase-2 pass in both the instance-method branch and the static (NameExpr) branch of solveMethodAsUsage. Promote JavaParserFacade.toMethodUsage from protected to public to allow access from MethodCallExprContext.

Update the resolveStreamCollectGroupingByWithConstructorReference test to assert the fully resolved type Map<String, Long> instead of the previous relaxed structural checks.


