### PR TITLE
fix(#2684): widen NameExpr.resolve() to return ResolvedDeclaration, add type-name fallback

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/NameExpr.java
@@ -36,6 +36,8 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.NameExprMetaModel;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -46,7 +48,31 @@ import java.util.function.Consumer;
  *
  * @author Julio Vilmar Gesser
  */
-public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>, Resolvable<ResolvedValueDeclaration> {
+/**
+ * BREAKING CHANGE (introduced to fix issue #2684):
+ * This class previously implemented {@code Resolvable<ResolvedValueDeclaration>}, implying that
+ * every {@code NameExpr} denotes a value. That assumption is incorrect per JLS §6.5: a simple
+ * name is contextually ambiguous and may denote either a <em>value</em> (variable, field,
+ * parameter) or a <em>type</em> (class, interface, enum), depending on where it appears in the
+ * source code.
+ *
+ * <p>The type parameter has been widened to {@code ResolvedDeclaration}, the common supertype
+ * of both {@link ResolvedValueDeclaration} and {@link ResolvedTypeDeclaration}, so that
+ * {@link #resolve()} can return the correct kind of declaration without throwing for type-denoting
+ * names such as {@code System} in {@code System.out.println()}.
+ *
+ * <p><b>Migration guide for existing callers of {@code resolve()}:</b>
+ * <ul>
+ *   <li>If you know the name is a value (variable, field, parameter), cast the result:
+ *       {@code (ResolvedValueDeclaration) nameExpr.resolve()} — or check first with
+ *       {@code !decl.isType()}.</li>
+ *   <li>If you know the name is a type, cast to {@link ResolvedTypeDeclaration} and verify
+ *       with {@code decl.isType()}.</li>
+ *   <li>If the kind is unknown (e.g., when iterating all {@code NameExpr} nodes), branch on
+ *       {@code decl.isType()} before casting.</li>
+ * </ul>
+ */
+public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>, Resolvable<ResolvedDeclaration> {
 
     private SimpleName name;
 
@@ -148,20 +174,48 @@ public class NameExpr extends Expression implements NodeWithSimpleName<NameExpr>
     }
 
     /**
-     * Attempts to resolve the declaration corresponding to the accessed name. If successful, a
-     * {@link ResolvedValueDeclaration} representing the declaration of the value accessed by this {@code NameExpr} is
-     * returned. Otherwise, an {@link UnsolvedSymbolException} is thrown.
+     * Resolves the declaration corresponding to this name expression.
      *
-     * @return a {@link ResolvedValueDeclaration} representing the declaration of the accessed value.
-     * @throws UnsolvedSymbolException if the declaration corresponding to the name expression could not be resolved.
+     * <p>A {@code NameExpr} is contextually ambiguous per JLS §6.5: the same syntactic construct
+     * may denote either a <em>value</em> (variable, field, parameter, enum constant) or a
+     * <em>type</em> (class, interface, enum), depending on where it appears in the source code.
+     * Examples:
+     * <ul>
+     *   <li>{@code count} in {@code count + 1} is a value name — resolves to a
+     *       {@link ResolvedValueDeclaration}.</li>
+     *   <li>{@code System} in {@code System.out.println()} is a type name — resolves to a
+     *       {@link ResolvedTypeDeclaration}.</li>
+     * </ul>
+     *
+     * <p>The return type is {@link ResolvedDeclaration}, the common supertype of both
+     * {@link ResolvedValueDeclaration} and {@link ResolvedTypeDeclaration}. Use
+     * {@link ResolvedDeclaration#isType()} on the result to determine the actual kind, then
+     * cast accordingly:
+     * <pre>{@code
+     * ResolvedDeclaration decl = nameExpr.resolve();
+     * if (decl.isType()) {
+     *     ResolvedTypeDeclaration typeDecl = (ResolvedTypeDeclaration) decl;
+     * } else {
+     *     ResolvedValueDeclaration valueDecl = (ResolvedValueDeclaration) decl;
+     * }
+     * }</pre>
+     *
+     * <p><b>Note for existing callers (breaking change from prior versions):</b> this method
+     * previously returned {@link ResolvedValueDeclaration}. Code that assigns the result to a
+     * {@code ResolvedValueDeclaration} variable must either widen the variable type to
+     * {@link ResolvedDeclaration} or add a cast for the value case.
+     *
+     * @return a {@link ResolvedDeclaration} — either a {@link ResolvedValueDeclaration} for
+     *         value-denoting names or a {@link ResolvedTypeDeclaration} for type-denoting names.
+     * @throws UnsolvedSymbolException if the name cannot be resolved as a value or as a type.
      * @see FieldAccessExpr#resolve()
      * @see MethodCallExpr#resolve()
      * @see ObjectCreationExpr#resolve()
      * @see ExplicitConstructorInvocationStmt#resolve()
      */
     @Override
-    public ResolvedValueDeclaration resolve() {
-        return getSymbolResolver().resolveDeclaration(this, ResolvedValueDeclaration.class);
+    public ResolvedDeclaration resolve() {
+        return getSymbolResolver().resolveDeclaration(this, ResolvedDeclaration.class);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -228,10 +228,10 @@ public class JavaSymbolSolver implements SymbolResolver {
                 // solveSymbol only searches value declarations (variables, fields, parameters)
                 // and never checks implicitly imported packages such as java.lang.
                 // We therefore attempt a fallback resolution as a type declaration before giving up.
-                // This fallback is intentionally reachable only when the caller asks for
-                // ResolvedDeclaration or ResolvedTypeDeclaration — callers expecting a
-                // ResolvedValueDeclaration (i.e. via NameExpr#resolve()) receive a clear exception
-                // pointing them to the purpose-built NameExpr#resolveToDeclaration() instead.
+                // This fallback is reached when the caller requests ResolvedDeclaration (the normal
+                // path via NameExpr#resolve()) or ResolvedTypeDeclaration (direct API call).
+                // Callers that still pass a narrower resultClass such as ResolvedValueDeclaration
+                // will hit the exception below with a clear migration message.
                 SymbolReference<ResolvedTypeDeclaration> typeResult =
                         JavaParserFactory.getContext(node, typeSolver).solveType(nameExpr.getNameAsString());
                 if (typeResult.isSolved()) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -215,13 +215,41 @@ public class JavaSymbolSolver implements SymbolResolver {
             }
         }
         if (node instanceof NameExpr) {
+            NameExpr nameExpr = (NameExpr) node;
             SymbolReference<? extends ResolvedValueDeclaration> result =
-                    JavaParserFacade.get(typeSolver).solve((NameExpr) node);
+                    JavaParserFacade.get(typeSolver).solve(nameExpr);
             if (result.isSolved()) {
                 if (resultClass.isInstance(result.getCorrespondingDeclaration())) {
                     return resultClass.cast(result.getCorrespondingDeclaration());
                 }
             } else {
+                // Per JLS §6.5, a simple name is contextually ambiguous: it may denote a type
+                // rather than a value (e.g., "System" in "System.out.println()").
+                // solveSymbol only searches value declarations (variables, fields, parameters)
+                // and never checks implicitly imported packages such as java.lang.
+                // We therefore attempt a fallback resolution as a type declaration before giving up.
+                // This fallback is intentionally reachable only when the caller asks for
+                // ResolvedDeclaration or ResolvedTypeDeclaration — callers expecting a
+                // ResolvedValueDeclaration (i.e. via NameExpr#resolve()) receive a clear exception
+                // pointing them to the purpose-built NameExpr#resolveToDeclaration() instead.
+                SymbolReference<ResolvedTypeDeclaration> typeResult =
+                        JavaParserFactory.getContext(node, typeSolver).solveType(nameExpr.getNameAsString());
+                if (typeResult.isSolved()) {
+                    ResolvedTypeDeclaration typeDeclaration = typeResult.getCorrespondingDeclaration();
+                    if (resultClass.isInstance(typeDeclaration)) {
+                        // The caller requested ResolvedTypeDeclaration or ResolvedDeclaration,
+                        // which this type satisfies directly — return it without any wrapping.
+                        return resultClass.cast(typeDeclaration);
+                    }
+                    // The name resolves to a type, but the caller explicitly requested a
+                    // ResolvedValueDeclaration (or a subtype of it). Since NameExpr#resolve()
+                    // now passes ResolvedDeclaration.class, this branch is only reachable when
+                    // resolveDeclaration() is called directly with a narrower resultClass.
+                    throw new UnsolvedSymbolException(
+                            "\"" + nameExpr.getNameAsString() + "\" is a type name, not a value. "
+                                    + "Use resolveDeclaration(node, ResolvedDeclaration.class) or "
+                                    + "NameExpr#resolve() to handle both value and type names.");
+                }
                 throw new UnsolvedSymbolException(
                         "We are unable to find the value declaration corresponding to " + node);
             }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2367Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2367Test.java
@@ -60,7 +60,9 @@ class Issue2367Test extends AbstractSymbolResolutionTest {
         NameExpr nameExpr = unit.findFirst(
                         NameExpr.class, m -> m.getName().getIdentifier().equals("privateField"))
                 .get();
-        ResolvedValueDeclaration resolvedValueDeclaration = nameExpr.resolve();
+        // resolve() now returns ResolvedDeclaration (breaking change: was ResolvedValueDeclaration).
+        // "privateField" is a value name, so the result is a ResolvedValueDeclaration at runtime.
+        ResolvedValueDeclaration resolvedValueDeclaration = (ResolvedValueDeclaration) nameExpr.resolve();
         assertEquals("double", resolvedValueDeclaration.getType().describe());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2684Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2684Test.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for GitHub issue #2684.
+ *
+ * <p>When iterating all {@link NameExpr} nodes in a compilation unit and calling
+ * {@link NameExpr#resolve()}, the symbol solver was throwing a cryptic
+ * {@link UnsolvedSymbolException} for names that denote types rather than values
+ * (e.g., {@code System} in {@code System.out.println()}).
+ *
+ * <p>Root cause: per JLS §6.5, a simple name is contextually ambiguous — it may denote
+ * either a <em>value</em> (variable, field, parameter) or a <em>type</em> (class,
+ * interface, enum). The symbol solver's {@code solveSymbol} only searches value
+ * declarations and never checked the implicit {@code java.lang} package.
+ *
+ * <p>Fix: {@link NameExpr} now implements {@code Resolvable<ResolvedDeclaration>} instead
+ * of {@code Resolvable<ResolvedValueDeclaration>}. The {@link NameExpr#resolve()} method
+ * returns the common supertype {@link ResolvedDeclaration} and a fallback to
+ * {@code solveType} was added in {@link JavaSymbolSolver#resolveDeclaration} so that
+ * type-denoting names are resolved to a {@link ResolvedTypeDeclaration} rather than
+ * throwing. Callers use {@link ResolvedDeclaration#isType()} to branch on the result kind.
+ */
+class Issue2684Test {
+
+    @BeforeEach
+    void setUp() {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Reset to a clean configuration so this test does not affect other test classes.
+        StaticJavaParser.setConfiguration(new ParserConfiguration());
+    }
+
+    // -------------------------------------------------------------------------
+    // Core regression: resolve() on a type-qualifier NameExpr must succeed
+    // -------------------------------------------------------------------------
+
+    /**
+     * {@code System} in {@code System.out.println()} is a type name (java.lang.System).
+     * Before the fix, {@code resolve()} threw a cryptic exception. After the fix it must
+     * succeed and return a {@link ResolvedTypeDeclaration} flagged with {@code isType()}.
+     */
+    @Test
+    void resolve_onJavaLangTypeQualifier_returnsTypeDeclaration() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Test { void m() { System.out.println(\"hello\"); } }");
+
+        NameExpr systemExpr = findNameExpr(cu, "System");
+
+        // Before the fix this threw — it must now succeed.
+        ResolvedDeclaration decl = assertDoesNotThrow(systemExpr::resolve);
+
+        // The result must be flagged as a type so callers can distinguish it from a value.
+        assertTrue(decl.isType(),
+                "Expected isType() == true for a type-qualifier NameExpr, but got: " + decl);
+        assertEquals("java.lang.System", decl.asType().getQualifiedName());
+    }
+
+    /**
+     * {@code String} is another implicitly imported java.lang type commonly seen as a
+     * static-method qualifier.
+     *
+     * <p>Note: a cast expression like {@code (String) x} uses a {@code ClassOrInterfaceType}
+     * node, not a {@code NameExpr}. {@code String.valueOf(42)} produces the required
+     * {@code NameExpr}.
+     */
+    @Test
+    void resolve_onJavaLangStringQualifier_returnsTypeDeclaration() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Test { void m() { String.valueOf(42); } }");
+
+        NameExpr stringExpr = findNameExpr(cu, "String");
+        ResolvedDeclaration decl = assertDoesNotThrow(stringExpr::resolve);
+
+        assertTrue(decl.isType());
+        assertEquals("java.lang.String", decl.asType().getQualifiedName());
+    }
+
+    /**
+     * A user-defined class used as a qualifier must also be resolvable — not only
+     * java.lang classes benefit from the type-fallback path.
+     */
+    @Test
+    void resolve_onUserDefinedClassQualifier_returnsTypeDeclaration() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Foo { static int VALUE = 42; }"
+                        + "class Test { void m() { int x = Foo.VALUE; } }");
+
+        NameExpr fooExpr = findNameExpr(cu, "Foo");
+        ResolvedDeclaration decl = assertDoesNotThrow(fooExpr::resolve);
+
+        assertTrue(decl.isType());
+        assertEquals("Foo", decl.asType().getName());
+    }
+
+    // -------------------------------------------------------------------------
+    // Value-denoting names: resolve() must still return ResolvedValueDeclaration
+    // -------------------------------------------------------------------------
+
+    /**
+     * {@code resolve()} on a local variable must still return a {@link ResolvedValueDeclaration}
+     * at runtime, with {@code isType() == false}. The breaking change must not regress
+     * ordinary value resolution.
+     */
+    @Test
+    void resolve_onLocalVariable_returnsValueDeclaration() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Test { void m() { int count = 0; int x = count + 1; } }");
+
+        NameExpr countExpr = findNameExpr(cu, "count");
+        ResolvedDeclaration decl = assertDoesNotThrow(countExpr::resolve);
+
+        assertFalse(decl.isType(),
+                "Expected isType() == false for a value-denoting NameExpr");
+        assertInstanceOf(ResolvedValueDeclaration.class, decl);
+        assertEquals("int", ((ResolvedValueDeclaration) decl).getType().describe());
+    }
+
+    /**
+     * {@code resolve()} on a method parameter must return a {@link ResolvedValueDeclaration}.
+     */
+    @Test
+    void resolve_onMethodParameter_returnsValueDeclaration() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Test { void m(String name) { System.out.println(name); } }");
+
+        NameExpr nameExpr = findNameExpr(cu, "name");
+        ResolvedDeclaration decl = assertDoesNotThrow(nameExpr::resolve);
+
+        assertFalse(decl.isType());
+        assertInstanceOf(ResolvedValueDeclaration.class, decl);
+        assertEquals(
+                "java.lang.String",
+                ((ResolvedValueDeclaration) decl).getType().asReferenceType().getQualifiedName());
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveDeclaration with an explicit target class
+    // -------------------------------------------------------------------------
+
+    /**
+     * Callers that invoke {@link JavaSymbolSolver#resolveDeclaration} directly with
+     * {@link ResolvedTypeDeclaration} as the target class must also benefit from the
+     * type-fallback path introduced by the fix.
+     */
+    @Test
+    void resolveDeclaration_asTypeDeclaration_resolvesJavaLangSystem() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Test { void m() { System.out.println(\"hello\"); } }");
+
+        NameExpr systemExpr = findNameExpr(cu, "System");
+        JavaSymbolSolver solver =
+                (JavaSymbolSolver) cu.getData(com.github.javaparser.ast.Node.SYMBOL_RESOLVER_KEY);
+
+        ResolvedTypeDeclaration typeDecl =
+                solver.resolveDeclaration(systemExpr, ResolvedTypeDeclaration.class);
+
+        assertEquals("java.lang.System", typeDecl.getQualifiedName());
+    }
+
+    // -------------------------------------------------------------------------
+    // Failure case: truly unknown symbols must still throw
+    // -------------------------------------------------------------------------
+
+    /**
+     * A name that cannot be resolved as either a value or a type must still throw
+     * {@link UnsolvedSymbolException}. The fallback must not suppress genuine failures.
+     */
+    @Test
+    void resolve_onUnknownSymbol_throwsUnsolvedSymbolException() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Test { void m() { unknownSymbol; } }");
+
+        NameExpr unknown = findNameExpr(cu, "unknownSymbol");
+
+        assertThrows(UnsolvedSymbolException.class, unknown::resolve);
+    }
+
+    // -------------------------------------------------------------------------
+    // calculateResolvedType() consistency
+    // -------------------------------------------------------------------------
+
+    /**
+     * {@code calculateResolvedType()} must agree with {@code resolve().asType().getQualifiedName()}
+     * for type-denoting names.
+     */
+    @Test
+    void calculateResolvedType_andResolve_agreeOnTypeName() {
+        CompilationUnit cu = StaticJavaParser.parse(
+                "class Test { void m() { System.out.println(\"hello\"); } }");
+
+        NameExpr systemExpr = findNameExpr(cu, "System");
+
+        String viaCalculate = systemExpr.calculateResolvedType().describe();
+        String viaResolve   = systemExpr.resolve().asType().getQualifiedName();
+
+        assertEquals(viaCalculate, viaResolve,
+                "calculateResolvedType() and resolve().asType() must agree on the type name");
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration: the exact scenario from issue #2684
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reproduces the exact usage pattern from issue #2684: iterate all {@link NameExpr}
+     * nodes in a compilation unit and call {@code resolve()} on each. No unexpected
+     * exception (anything other than {@link UnsolvedSymbolException}) must be thrown.
+     */
+    @Test
+    void resolve_onAllNameExprs_neverThrowsUnexpectedException() {
+        CompilationUnit cu = StaticJavaParser.parse("package test;\n"
+                + "class HelloWorld {\n"
+                + "    private void greet() throws java.io.IOException {\n"
+                + "        System.out.println(\"Hello World\");\n"
+                + "    }\n"
+                + "}");
+
+        List<NameExpr> exprs = cu.findAll(NameExpr.class);
+        assertFalse(exprs.isEmpty(), "Expected at least one NameExpr in the test class");
+
+        for (NameExpr expr : exprs) {
+            try {
+                expr.resolve();
+            } catch (UnsolvedSymbolException e) {
+                // Acceptable: some names may be genuinely unresolvable (e.g., external
+                // references not on the classpath). Any other exception type is a bug.
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Finds the last {@link NameExpr} in the compilation unit whose identifier matches
+     * {@code name}. Using the last occurrence targets the <em>use site</em> rather than
+     * a declaration site (e.g., the class name in its own declaration header).
+     */
+    private NameExpr findNameExpr(CompilationUnit cu, String name) {
+        return cu.findAll(NameExpr.class).stream()
+                .filter(e -> e.getNameAsString().equals(name))
+                .reduce((first, second) -> second) // last = use site
+                .orElseThrow(() -> new AssertionError("No NameExpr named '" + name + "' found"));
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2684Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2684Test.java
@@ -82,8 +82,7 @@ class Issue2684Test {
      */
     @Test
     void resolve_onJavaLangTypeQualifier_returnsTypeDeclaration() {
-        CompilationUnit cu = StaticJavaParser.parse(
-                "class Test { void m() { System.out.println(\"hello\"); } }");
+        CompilationUnit cu = StaticJavaParser.parse("class Test { void m() { System.out.println(\"hello\"); } }");
 
         NameExpr systemExpr = findNameExpr(cu, "System");
 
@@ -91,8 +90,7 @@ class Issue2684Test {
         ResolvedDeclaration decl = assertDoesNotThrow(systemExpr::resolve);
 
         // The result must be flagged as a type so callers can distinguish it from a value.
-        assertTrue(decl.isType(),
-                "Expected isType() == true for a type-qualifier NameExpr, but got: " + decl);
+        assertTrue(decl.isType(), "Expected isType() == true for a type-qualifier NameExpr, but got: " + decl);
         assertEquals("java.lang.System", decl.asType().getQualifiedName());
     }
 
@@ -106,8 +104,7 @@ class Issue2684Test {
      */
     @Test
     void resolve_onJavaLangStringQualifier_returnsTypeDeclaration() {
-        CompilationUnit cu = StaticJavaParser.parse(
-                "class Test { void m() { String.valueOf(42); } }");
+        CompilationUnit cu = StaticJavaParser.parse("class Test { void m() { String.valueOf(42); } }");
 
         NameExpr stringExpr = findNameExpr(cu, "String");
         ResolvedDeclaration decl = assertDoesNotThrow(stringExpr::resolve);
@@ -123,8 +120,7 @@ class Issue2684Test {
     @Test
     void resolve_onUserDefinedClassQualifier_returnsTypeDeclaration() {
         CompilationUnit cu = StaticJavaParser.parse(
-                "class Foo { static int VALUE = 42; }"
-                        + "class Test { void m() { int x = Foo.VALUE; } }");
+                "class Foo { static int VALUE = 42; }" + "class Test { void m() { int x = Foo.VALUE; } }");
 
         NameExpr fooExpr = findNameExpr(cu, "Foo");
         ResolvedDeclaration decl = assertDoesNotThrow(fooExpr::resolve);
@@ -144,14 +140,12 @@ class Issue2684Test {
      */
     @Test
     void resolve_onLocalVariable_returnsValueDeclaration() {
-        CompilationUnit cu = StaticJavaParser.parse(
-                "class Test { void m() { int count = 0; int x = count + 1; } }");
+        CompilationUnit cu = StaticJavaParser.parse("class Test { void m() { int count = 0; int x = count + 1; } }");
 
         NameExpr countExpr = findNameExpr(cu, "count");
         ResolvedDeclaration decl = assertDoesNotThrow(countExpr::resolve);
 
-        assertFalse(decl.isType(),
-                "Expected isType() == false for a value-denoting NameExpr");
+        assertFalse(decl.isType(), "Expected isType() == false for a value-denoting NameExpr");
         assertInstanceOf(ResolvedValueDeclaration.class, decl);
         assertEquals("int", ((ResolvedValueDeclaration) decl).getType().describe());
     }
@@ -161,8 +155,7 @@ class Issue2684Test {
      */
     @Test
     void resolve_onMethodParameter_returnsValueDeclaration() {
-        CompilationUnit cu = StaticJavaParser.parse(
-                "class Test { void m(String name) { System.out.println(name); } }");
+        CompilationUnit cu = StaticJavaParser.parse("class Test { void m(String name) { System.out.println(name); } }");
 
         NameExpr nameExpr = findNameExpr(cu, "name");
         ResolvedDeclaration decl = assertDoesNotThrow(nameExpr::resolve);
@@ -185,15 +178,12 @@ class Issue2684Test {
      */
     @Test
     void resolveDeclaration_asTypeDeclaration_resolvesJavaLangSystem() {
-        CompilationUnit cu = StaticJavaParser.parse(
-                "class Test { void m() { System.out.println(\"hello\"); } }");
+        CompilationUnit cu = StaticJavaParser.parse("class Test { void m() { System.out.println(\"hello\"); } }");
 
         NameExpr systemExpr = findNameExpr(cu, "System");
-        JavaSymbolSolver solver =
-                (JavaSymbolSolver) cu.getData(com.github.javaparser.ast.Node.SYMBOL_RESOLVER_KEY);
+        JavaSymbolSolver solver = (JavaSymbolSolver) cu.getData(com.github.javaparser.ast.Node.SYMBOL_RESOLVER_KEY);
 
-        ResolvedTypeDeclaration typeDecl =
-                solver.resolveDeclaration(systemExpr, ResolvedTypeDeclaration.class);
+        ResolvedTypeDeclaration typeDecl = solver.resolveDeclaration(systemExpr, ResolvedTypeDeclaration.class);
 
         assertEquals("java.lang.System", typeDecl.getQualifiedName());
     }
@@ -208,8 +198,7 @@ class Issue2684Test {
      */
     @Test
     void resolve_onUnknownSymbol_throwsUnsolvedSymbolException() {
-        CompilationUnit cu = StaticJavaParser.parse(
-                "class Test { void m() { unknownSymbol; } }");
+        CompilationUnit cu = StaticJavaParser.parse("class Test { void m() { unknownSymbol; } }");
 
         NameExpr unknown = findNameExpr(cu, "unknownSymbol");
 
@@ -226,16 +215,15 @@ class Issue2684Test {
      */
     @Test
     void calculateResolvedType_andResolve_agreeOnTypeName() {
-        CompilationUnit cu = StaticJavaParser.parse(
-                "class Test { void m() { System.out.println(\"hello\"); } }");
+        CompilationUnit cu = StaticJavaParser.parse("class Test { void m() { System.out.println(\"hello\"); } }");
 
         NameExpr systemExpr = findNameExpr(cu, "System");
 
         String viaCalculate = systemExpr.calculateResolvedType().describe();
-        String viaResolve   = systemExpr.resolve().asType().getQualifiedName();
+        String viaResolve = systemExpr.resolve().asType().getQualifiedName();
 
-        assertEquals(viaCalculate, viaResolve,
-                "calculateResolvedType() and resolve().asType() must agree on the type name");
+        assertEquals(
+                viaCalculate, viaResolve, "calculateResolvedType() and resolve().asType() must agree on the type name");
     }
 
     // -------------------------------------------------------------------------

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2764Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2764Test.java
@@ -54,7 +54,8 @@ public class Issue2764Test {
 
         CompilationUnit cu = parseResult.getResult().get();
         NameExpr name = (NameExpr) cu.findFirst(UnaryExpr.class).get().getExpression();
-        ResolvedValueDeclaration resolve = name.resolve();
+        // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+        ResolvedValueDeclaration resolve = (ResolvedValueDeclaration) name.resolve();
 
         assertTrue("int".contentEquals(resolve.getType().describe()));
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3159Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3159Test.java
@@ -46,7 +46,8 @@ public class Issue3159Test extends AbstractResolutionTest {
         CompilationUnit cu = StaticJavaParser.parse(code);
         NameExpr mce = cu.findFirst(NameExpr.class).get();
 
-        ResolvedValueDeclaration v = mce.resolve();
+        // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+        ResolvedValueDeclaration v = (ResolvedValueDeclaration) mce.resolve();
         // verify that the symbol declaration represents a variable
         assertTrue(v.isVariable());
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4568Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4568Test.java
@@ -72,7 +72,8 @@ public class Issue4568Test extends AbstractResolutionTest {
         for (Expression e : oce.getArguments()) {
             if (e.isNameExpr()) {
                 NameExpr ne = e.asNameExpr();
-                final ResolvedValueDeclaration rvd = ne.resolve();
+                // resolve() now returns ResolvedDeclaration; cast since the argument is a value.
+                final ResolvedValueDeclaration rvd = (ResolvedValueDeclaration) ne.resolve();
                 assertEquals("int", rvd.getType().describe());
             }
         }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserVariableDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserVariableDeclarationTest.java
@@ -93,7 +93,8 @@ class JavaParserVariableDeclarationTest extends AbstractResolutionTest implement
                 .parse(code);
 
         List<NameExpr> names = cu.findAll(NameExpr.class);
-        ResolvedValueDeclaration rvd = names.get(3).resolve();
+        // resolve() now returns ResolvedDeclaration; the name at index 3 is a field (a value).
+        ResolvedValueDeclaration rvd = (ResolvedValueDeclaration) names.get(3).resolve();
 
         String decl = rvd.asField().toAst().get().toString();
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/CompilationUnitContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/CompilationUnitContextResolutionTest.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.resolution.Navigator;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
@@ -107,7 +108,8 @@ class CompilationUnitContextResolutionTest extends AbstractResolutionTest {
         CompilationUnit cu = StaticJavaParser.parse(
                 adaptPath("src/test/resources/CompilationUnitContextResolutionTest/03_symbol/main/Main.java"));
         NameExpr ne = Navigator.findNameExpression(cu, "A").get();
-        String actual = ne.resolve().getType().describe();
+        // resolve() now returns ResolvedDeclaration; "A" is an enum constant (a value).
+        String actual = ((ResolvedValueDeclaration) ne.resolve()).getType().describe();
         assertEquals("main.Clazz.MyEnum", actual);
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/FieldsResolutionTest.java
@@ -192,7 +192,8 @@ class FieldsResolutionTest extends AbstractResolutionTest {
         NameExpr expression = returnStmt.getExpression().get().asNameExpr();
 
         // resolve field access expression
-        ResolvedValueDeclaration resolvedValueDeclaration = expression.resolve();
+        // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+        ResolvedValueDeclaration resolvedValueDeclaration = (ResolvedValueDeclaration) expression.resolve();
 
         // get expected field declaration
         VariableDeclarator variableDeclarator = Navigator.demandField(clazz, "foo");

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InstanceOfTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InstanceOfTest.java
@@ -530,7 +530,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -546,7 +548,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -576,7 +580,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -593,7 +599,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -612,7 +620,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -647,7 +657,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -665,7 +677,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -685,7 +699,9 @@ public class InstanceOfTest {
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
             // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InstanceOfTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/InstanceOfTest.java
@@ -364,7 +364,8 @@ public class InstanceOfTest {
                 assertEquals(1, nameExprs.size());
 
                 NameExpr nameExpr = nameExprs.get(0);
-                ResolvedValueDeclaration resolvedNameExpr = nameExpr.resolve();
+                // resolve() now returns ResolvedDeclaration; cast since the name is a value.
+                ResolvedValueDeclaration resolvedNameExpr = (ResolvedValueDeclaration) nameExpr.resolve();
             }
 
             /**
@@ -528,7 +529,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -543,7 +545,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -572,7 +575,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -588,7 +592,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -606,7 +611,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -640,7 +646,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -657,7 +664,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -676,7 +684,8 @@ public class InstanceOfTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "s").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -711,7 +720,8 @@ public class InstanceOfTest {
             assertEquals(2, nameExprs.size());
 
             NameExpr nameExpr = nameExprs.get(0);
-            ResolvedValueDeclaration resolvedNameExpr = nameExpr.resolve();
+            // resolve() now returns ResolvedDeclaration; cast since the name is a value.
+            ResolvedValueDeclaration resolvedNameExpr = (ResolvedValueDeclaration) nameExpr.resolve();
             ResolvedType resolvedNameExprType = nameExpr.calculateResolvedType();
         }
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.SwitchStmt;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -75,7 +76,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -101,7 +102,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -115,7 +116,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -129,9 +130,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name1 = Navigator.findNameExpression(cu, "value1").get();
-            assertEquals("java.lang.String", name1.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name1.resolve()).getType().describe());
             NameExpr name2 = Navigator.findNameExpression(cu, "value2").get();
-            assertEquals("java.lang.Integer", name2.resolve().getType().describe());
+            assertEquals("java.lang.Integer", ((ResolvedValueDeclaration) name2.resolve()).getType().describe());
         }
 
         @Test
@@ -188,7 +189,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -201,7 +202,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.Boolean", name.resolve().getType().describe());
+            assertEquals("java.lang.Boolean", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -226,7 +227,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -252,7 +253,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -266,7 +267,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -307,7 +308,7 @@ public class PatternVariableIntroductionTest {
                     + "}\n");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -346,7 +347,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -370,7 +371,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -394,7 +395,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -431,7 +432,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -464,7 +465,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -496,7 +497,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -529,7 +530,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -560,7 +561,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -606,11 +607,11 @@ public class PatternVariableIntroductionTest {
             NameExpr firstValue = Navigator.findNameExpression(
                             switchStmt.getEntries().get(0), "value")
                     .get();
-            assertEquals("java.lang.Integer", firstValue.resolve().getType().describe());
+            assertEquals("java.lang.Integer", ((ResolvedValueDeclaration) firstValue.resolve()).getType().describe());
             NameExpr secondValue = Navigator.findNameExpression(
                             switchStmt.getEntries().get(1), "value")
                     .get();
-            assertEquals("java.lang.String", secondValue.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) secondValue.resolve()).getType().describe());
         }
 
         @Test
@@ -653,7 +654,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -683,7 +684,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -733,7 +734,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -776,7 +777,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -820,7 +821,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -835,7 +836,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -865,7 +866,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -896,7 +897,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -926,7 +927,7 @@ public class PatternVariableIntroductionTest {
                     + "    }\n"
                     + "}");
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -969,7 +970,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1011,7 +1012,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1044,7 +1045,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1073,7 +1074,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -1099,7 +1100,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1144,7 +1145,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1170,7 +1171,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1198,7 +1199,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1225,7 +1226,7 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", name.resolve().getType().describe());
+            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/PatternVariableIntroductionTest.java
@@ -30,8 +30,8 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.SwitchStmt;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.junit.jupiter.api.Disabled;
@@ -76,7 +76,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -102,7 +104,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -116,7 +120,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -130,9 +136,13 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name1 = Navigator.findNameExpression(cu, "value1").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name1.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name1.resolve()).getType().describe());
             NameExpr name2 = Navigator.findNameExpression(cu, "value2").get();
-            assertEquals("java.lang.Integer", ((ResolvedValueDeclaration) name2.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.Integer",
+                    ((ResolvedValueDeclaration) name2.resolve()).getType().describe());
         }
 
         @Test
@@ -189,7 +199,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -202,7 +214,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.Boolean", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.Boolean",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -227,7 +241,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -253,7 +269,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -267,7 +285,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -308,7 +328,9 @@ public class PatternVariableIntroductionTest {
                     + "}\n");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -347,7 +369,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -371,7 +395,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -395,7 +421,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -432,7 +460,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -465,7 +495,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -497,7 +529,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -530,7 +564,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -561,7 +597,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -607,11 +645,15 @@ public class PatternVariableIntroductionTest {
             NameExpr firstValue = Navigator.findNameExpression(
                             switchStmt.getEntries().get(0), "value")
                     .get();
-            assertEquals("java.lang.Integer", ((ResolvedValueDeclaration) firstValue.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.Integer",
+                    ((ResolvedValueDeclaration) firstValue.resolve()).getType().describe());
             NameExpr secondValue = Navigator.findNameExpression(
                             switchStmt.getEntries().get(1), "value")
                     .get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) secondValue.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) secondValue.resolve()).getType().describe());
         }
 
         @Test
@@ -654,7 +696,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -684,7 +728,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -734,7 +780,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -777,7 +825,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -821,7 +871,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -836,7 +888,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -866,7 +920,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -897,7 +953,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -927,7 +985,9 @@ public class PatternVariableIntroductionTest {
                     + "    }\n"
                     + "}");
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -970,7 +1030,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1012,7 +1074,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1045,7 +1109,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1074,7 +1140,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
     }
 
@@ -1100,7 +1168,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1145,7 +1215,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1171,7 +1243,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1199,7 +1273,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test
@@ -1226,7 +1302,9 @@ public class PatternVariableIntroductionTest {
                     + "}");
 
             NameExpr name = Navigator.findNameExpression(cu, "value").get();
-            assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+            assertEquals(
+                    "java.lang.String",
+                    ((ResolvedValueDeclaration) name.resolve()).getType().describe());
         }
 
         @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SwitchExprTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SwitchExprTest.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
@@ -58,7 +59,8 @@ public class SwitchExprTest {
                 + "}");
 
         NameExpr name = Navigator.findNameExpression(cu, "s").get();
-        assertEquals("java.lang.String", name.resolve().getType().describe());
+        // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+        assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
     }
 
     @Test
@@ -74,8 +76,10 @@ public class SwitchExprTest {
         cu.findAll(NameExpr.class).stream()
                 .filter(nameExpr -> nameExpr.getNameAsString().equals("s"))
                 .forEach(nameExpr -> {
+                    // resolve() now returns ResolvedDeclaration; "s" is a value (parameter).
                     assertEquals(
-                            "java.lang.String", nameExpr.resolve().getType().describe());
+                            "java.lang.String",
+                            ((ResolvedValueDeclaration) nameExpr.resolve()).getType().describe());
                 });
     }
 
@@ -121,7 +125,8 @@ public class SwitchExprTest {
                 + "}");
 
         NameExpr name = Navigator.findNameExpression(cu, "s").get();
-        assertEquals("java.lang.String", name.resolve().getType().describe());
+        // resolve() now returns ResolvedDeclaration; cast since this name is a value.
+        assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
     }
 
     /**

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SwitchExprTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/SwitchExprTest.java
@@ -31,8 +31,8 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -60,7 +60,9 @@ public class SwitchExprTest {
 
         NameExpr name = Navigator.findNameExpression(cu, "s").get();
         // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-        assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+        assertEquals(
+                "java.lang.String",
+                ((ResolvedValueDeclaration) name.resolve()).getType().describe());
     }
 
     @Test
@@ -79,7 +81,9 @@ public class SwitchExprTest {
                     // resolve() now returns ResolvedDeclaration; "s" is a value (parameter).
                     assertEquals(
                             "java.lang.String",
-                            ((ResolvedValueDeclaration) nameExpr.resolve()).getType().describe());
+                            ((ResolvedValueDeclaration) nameExpr.resolve())
+                                    .getType()
+                                    .describe());
                 });
     }
 
@@ -126,7 +130,9 @@ public class SwitchExprTest {
 
         NameExpr name = Navigator.findNameExpression(cu, "s").get();
         // resolve() now returns ResolvedDeclaration; cast since this name is a value.
-        assertEquals("java.lang.String", ((ResolvedValueDeclaration) name.resolve()).getType().describe());
+        assertEquals(
+                "java.lang.String",
+                ((ResolvedValueDeclaration) name.resolve()).getType().describe());
     }
 
     /**


### PR DESCRIPTION
Fixes #2684 .

NameExpr was typed as Resolvable<ResolvedValueDeclaration>, which is incorrect per JLS §6.5 — a simple name can denote either a value or a type. As a result, calling resolve() on a type-qualifier name like System in System.out.println() threw a cryptic UnsolvedSymbolException instead of returning the corresponding type declaration.

Fix: the return type of NameExpr.resolve() is widened from ResolvedValueDeclaration to ResolvedDeclaration (their common supertype), and a solveType fallback is added in JavaSymbolSolver.resolveDeclaration() so that type-denoting names resolve correctly. Use decl.isType() on the result to distinguish a ResolvedTypeDeclaration from a ResolvedValueDeclaration.

Note: this is a source-level breaking change — existing code that assigns nameExpr.resolve() directly to a ResolvedValueDeclaration variable must add an explicit cast or widen the variable type.