### PR TITLE
test: add regression tests and document reentrancy invariant for issue #4781

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -36,6 +36,7 @@ import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
+import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.UnionType;
 import com.github.javaparser.ast.type.VoidType;
@@ -1884,5 +1885,40 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         String code = "class A {void foo(int p1, float p2) { }}";
         CompilationUnit cu = StaticJavaParser.parse(code);
         assertNotEquals(code, cu.toString());
+    }
+
+    // issue 4781: PrimitiveType keyword omitted when adding a field programmatically with LPP active.
+    // Before the fix, addField(PrimitiveType.intType(), "foo") produced "foo;" instead of "int foo;":
+    // prettyPrintingTextNode() called node.toString() which re-entered LPP and returned the
+    // still-empty pre-stored NodeText, making toString() return "" (empty string) as token content.
+    @Test
+    void issue4781_addIntFieldPreservesTypeKeyword() {
+        considerCode("class Foo {}");
+        cu.getClassByName("Foo").get().addField(PrimitiveType.intType(), "foo");
+        String printed = LexicalPreservingPrinter.print(cu);
+        assertTrue(printed.contains("int foo"), "Type keyword 'int' missing — got: " + printed);
+    }
+
+    @Test
+    void issue4781_addFieldPreservesKeywordForAllPrimitiveTypes() {
+        for (PrimitiveType.Primitive primitive : PrimitiveType.Primitive.values()) {
+            considerCode("class Foo {}");
+            cu.getClassByName("Foo").get().addField(new PrimitiveType(primitive), "field");
+            String printed = LexicalPreservingPrinter.print(cu);
+            assertTrue(
+                    printed.contains(primitive.asString() + " field"),
+                    "Type keyword '" + primitive.asString() + "' missing — got: " + printed);
+        }
+    }
+
+    // Variant: LPP configured as default printer via ParserConfiguration (the path from issue #1821
+    // that, combined with issue #4781, caused toString() to re-enter LPP during PrimitiveType init)
+    @Test
+    void issue4781_addIntFieldWithLPPAsDefaultPrinterPreservesTypeKeyword() {
+        StaticJavaParser.getParserConfiguration().setLexicalPreservationEnabled(true);
+        CompilationUnit cu = StaticJavaParser.parse("class Foo {}");
+        cu.getClassByName("Foo").get().addField(PrimitiveType.intType(), "foo");
+        String printed = LexicalPreservingPrinter.print(cu);
+        assertTrue(printed.contains("int foo"), "Type keyword 'int' missing — got: " + printed);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -721,8 +721,15 @@ public class LexicalPreservingPrinter {
     //
     // Methods to handle transformations
     //
+    // INVARIANT: this method must never call node.toString() on any node that may be LPP-registered.
+    // getOrCreateNodeText() pre-stores an empty NodeText before invoking this method. If toString()
+    // on an LPP-registered node is called here, LPP re-enters getOrCreateNodeText(), receives the
+    // empty NodeText, prints nothing, and the empty string ends up as the token content (issue #4781).
+    // Use node.get<Property>().asString() or ConcreteSyntaxModel.forClass() + interpret() instead.
     private static void prettyPrintingTextNode(Node node, NodeText nodeText) {
         if (node instanceof PrimitiveType) {
+            // Uses interpret() → ConcreteSyntaxModel → CsmAttribute → Primitive.asString()
+            // to avoid calling PrimitiveType.toString() (see invariant above and issue #4781).
             interpret(node, ConcreteSyntaxModel.forClass(node.getClass()), nodeText);
             return;
         }
@@ -827,6 +834,18 @@ public class LexicalPreservingPrinter {
     // Visible for testing
     static NodeText getOrCreateNodeText(Node node) {
         if (!node.containsData(NODE_TEXT_DATA)) {
+            // Pre-store an empty NodeText BEFORE calling prettyPrintingTextNode.
+            // This is intentional: tokensPreceeding() → partialReverseIterator() may call
+            // getOrCreateNodeText() again for the same node (to find preceding indentation
+            // tokens). Returning the empty NodeText in that case is safe — the iterator
+            // simply finds nothing and the indentation calculation continues without looping.
+            //
+            // IMPORTANT INVARIANT: prettyPrintingTextNode() MUST NOT call node.toString() on
+            // any LPP-registered node. When LPP is configured as the default printer
+            // (issue #1821), toString() re-invokes LexicalPreservingPrinter.print(), which calls
+            // getOrCreateNodeText() again. At that point the pre-stored NodeText is still empty,
+            // so toString() returns "", producing incorrect output (issue #4781).
+            // Always use node.get<Property>().asString() or ConcreteSyntaxModel-based generation.
             NodeText nodeText = new NodeText();
             node.setData(NODE_TEXT_DATA, nodeText);
             prettyPrintingTextNode(node, nodeText);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -834,11 +834,15 @@ public class LexicalPreservingPrinter {
     // Visible for testing
     static NodeText getOrCreateNodeText(Node node) {
         if (!node.containsData(NODE_TEXT_DATA)) {
-            // Pre-store an empty NodeText BEFORE calling prettyPrintingTextNode.
-            // This is intentional: tokensPreceeding() → partialReverseIterator() may call
-            // getOrCreateNodeText() again for the same node (to find preceding indentation
-            // tokens). Returning the empty NodeText in that case is safe — the iterator
-            // simply finds nothing and the indentation calculation continues without looping.
+            // The NodeText is created empty and stored BEFORE prettyPrintingTextNode() fills it.
+            // Reason: interpret() calls findIndentation() → tokensPreceeding() →
+            // partialReverseIterator(), which traverses the parent's NodeText backwards and may
+            // encounter a ChildTextElement pointing to this very node. At that point,
+            // getOrCreateNodeText() is called again for the same node. Because the empty NodeText
+            // is already registered, containsData(NODE_TEXT_DATA) is true and this second call
+            // returns immediately, breaking the recursion. The empty NodeText acts as a sentinel:
+            // the reverse iterator produces no tokens for this node, which is the correct
+            // answer ("no preceding content yet") and lets the indentation calculation proceed.
             //
             // IMPORTANT INVARIANT: prettyPrintingTextNode() MUST NOT call node.toString() on
             // any LPP-registered node. When LPP is configured as the default printer


### PR DESCRIPTION

Fixes #4781 .

Add three regression tests covering the bug where LexicalPreservingPrinter
omitted the PrimitiveType keyword (e.g. "int foo;" was printed as "foo;")
when a field was added programmatically while LPP was active.

Also document in getOrCreateNodeText() and prettyPrintingTextNode() why the
NodeText is intentionally pre-stored empty before initialization, and why
prettyPrintingTextNode() must never call node.toString() on an LPP-registered
node. The pre-stored empty NodeText is the recursion break used by
tokensPreceeding() → partialReverseIterator() during indentation calculation;
if toString() is called inside prettyPrintingTextNode(), LPP re-enters
getOrCreateNodeText(), receives that still-empty NodeText, and returns ""
as the token content, silently producing incorrect output.
