### PR TITLE
Fix resolution of relative nested type names inherited from ancestors (#3550)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/CompilationUnitContext.java
@@ -253,17 +253,23 @@ public class CompilationUnitContext extends AbstractJavaParserContext<Compilatio
      */
     private SymbolReference<ResolvedTypeDeclaration> solveTypeFromOuterMostRef(String name) {
         SymbolReference<ResolvedTypeDeclaration> ref = null;
+        String remaining = name.substring(name.indexOf(".") + 1);
         SymbolReference<ResolvedTypeDeclaration> outerMostRef = solveType(name.substring(0, name.indexOf(".")));
+        // Use context-based resolution (.getContext().solveType) instead of declaration-based
+        // resolution (.solveType) so that inherited nested types are found via ancestor checking.
+        // This is consistent with how solveExternalTypeFromOuterMostRef already works.
         if (outerMostRef != null
                 && outerMostRef.isSolved()
                 && outerMostRef.getCorrespondingDeclaration() instanceof JavaParserClassDeclaration) {
             ref = ((JavaParserClassDeclaration) outerMostRef.getCorrespondingDeclaration())
-                    .solveType(name.substring(name.indexOf(".") + 1));
+                    .getContext()
+                    .solveType(remaining);
         } else if (outerMostRef != null
                 && outerMostRef.isSolved()
                 && outerMostRef.getCorrespondingDeclaration() instanceof JavaParserInterfaceDeclaration) {
             ref = ((JavaParserInterfaceDeclaration) outerMostRef.getCorrespondingDeclaration())
-                    .solveType(name.substring(name.indexOf(".") + 1));
+                    .getContext()
+                    .solveType(remaining);
         }
         return ref;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -44,6 +44,8 @@ import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserInterfaceDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserTypeParameter;
 import java.util.List;
 import java.util.Optional;
@@ -160,11 +162,28 @@ public class JavaParserTypeDeclarationAdapter {
             }
         }
 
-        // Looking at extended classes and implemented interfaces
-        String typeName = isCompositeName(name) ? innerMostPartOfName(name) : name;
-        ResolvedTypeDeclaration type = checkAncestorsForType(typeName, this.typeDeclaration);
-        if (type != null) {
-            return SymbolReference.solved(type);
+        // Looking at extended classes and implemented interfaces.
+        // For a composite name like "Sub.Test" where "Sub" is itself an inherited nested type,
+        // resolve iteratively: find "Sub" in ancestors, then resolve "Test" within it (#3550).
+        if (isCompositeName(name)) {
+            int firstDot = name.indexOf('.');
+            String outerName = name.substring(0, firstDot);
+            String remainingName = name.substring(firstDot + 1);
+            ResolvedTypeDeclaration outerType = checkAncestorsForType(outerName, this.typeDeclaration);
+            if (outerType instanceof JavaParserClassDeclaration) {
+                SymbolReference<ResolvedTypeDeclaration> innerRef =
+                        ((JavaParserClassDeclaration) outerType).solveType(remainingName);
+                if (innerRef.isSolved()) return innerRef;
+            } else if (outerType instanceof JavaParserInterfaceDeclaration) {
+                SymbolReference<ResolvedTypeDeclaration> innerRef =
+                        ((JavaParserInterfaceDeclaration) outerType).solveType(remainingName);
+                if (innerRef.isSolved()) return innerRef;
+            }
+        } else {
+            ResolvedTypeDeclaration type = checkAncestorsForType(name, this.typeDeclaration);
+            if (type != null) {
+                return SymbolReference.solved(type);
+            }
         }
 
         return SymbolReference.unsolved();

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
@@ -71,6 +72,35 @@ class JavaParserTypeDeclarationAdapterTest extends AbstractResolutionTest {
         MethodCallExpr mce = cu.findAll(MethodCallExpr.class).get(0);
 
         assertEquals("Bar.show()", mce.resolve().getQualifiedSignature());
+    }
+
+    @Test
+    void issue3550() {
+        // A class implementing an interface should be able to reference that interface's nested
+        // types by relative name (e.g. "Sub.Test" instead of the fully-qualified "Base.Sub.Test").
+        // Previously, the symbol solver only searched for the innermost part of the name ("Test")
+        // in ancestors, ignoring intermediate segments, which caused an UnsolvedSymbolException.
+        String code = "interface Base {\n"
+                + "    interface Sub {\n"
+                + "        class Test {}\n"
+                + "    }\n"
+                + "}\n"
+                + "class Default implements Base {\n"
+                + "    Base.Sub.Test x1;\n" // fully-qualified path — always worked
+                + "    Sub.Test x2;\n" // relative path — was throwing UnsolvedSymbolException
+                + "}";
+
+        final JavaSymbolSolver solver = new JavaSymbolSolver(new ReflectionTypeSolver(false));
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(solver);
+        final CompilationUnit compilationUnit = StaticJavaParser.parse(code);
+
+        // Both fields must resolve to the same qualified type name.
+        final List<String> fieldTypes = compilationUnit.findAll(FieldDeclaration.class).stream()
+                .map(fd -> fd.getVariable(0).getType().resolve().describe())
+                .collect(Collectors.toList());
+
+        assertEquals(2, fieldTypes.size());
+        fieldTypes.forEach(type -> assertEquals("Base.Sub.Test", type));
     }
 
     @Test


### PR DESCRIPTION

Fixes #3550 .

When a class implements an interface, nested types from that interface
should be accessible by relative name (e.g. "Sub.Test" instead of
"Base.Sub.Test"). The symbol solver failed with UnsolvedSymbolException
because it only searched for the innermost segment ("Test") directly
in ancestor internal types, ignoring intermediate segments.
Two issues are fixed:
1. JavaParserTypeDeclarationAdapter: for composite names like "Sub.Test",
   resolve iteratively by finding "Sub" in ancestors first, then "Test"
   within the found type, instead of discarding outer segments.
2. CompilationUnitContext.solveTypeFromOuterMostRef: use context-based
   resolution (.getContext().solveType()) instead of declaration-based
   resolution (.solveType()), so that inherited nested types are found
   via ancestor checking. This aligns with how solveExternalTypeFromOuterMostRef
   already works and fixes resolution of "RichPresence.Timestamps" where
   "Timestamps" is inherited through an ancestor interface.
