### PR TITLE
Fix StackOverflowError on type resolution with self-referential generics (#3940)

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -413,15 +413,21 @@ public abstract class ResolvedReferenceType
      * that have been overwritten.
      */
     public List<ResolvedMethodDeclaration> getAllMethods() {
+        return getAllMethods(new HashSet<>());
+    }
+
+    // Guard against infinite recursion caused by self-referential generic types (e.g. Builder<B extends Builder<B>>)
+    private List<ResolvedMethodDeclaration> getAllMethods(Set<String> visitedTypeIds) {
         if (!this.getTypeDeclaration().isPresent()) {
-            // empty list -- consider IllegalStateException or similar
             return new ArrayList<>();
         }
-        // Get the methods declared directly on this.
+        // If this type has already been visited, stop recursion to avoid StackOverflowError
+        if (!visitedTypeIds.add(this.getId())) {
+            return new ArrayList<>();
+        }
         List<ResolvedMethodDeclaration> allMethods =
                 new LinkedList<>(this.getTypeDeclaration().get().getDeclaredMethods());
-        // Also get methods inherited from ancestors.
-        getDirectAncestors().forEach(a -> allMethods.addAll(a.getAllMethods()));
+        getDirectAncestors().forEach(a -> allMethods.addAll(a.getAllMethods(visitedTypeIds)));
         return allMethods;
     }
 
@@ -430,10 +436,19 @@ public abstract class ResolvedReferenceType
      * type plus all declared fields which are not private.
      */
     public List<ResolvedFieldDeclaration> getAllFieldsVisibleToInheritors() {
+        return getAllFieldsVisibleToInheritors(new HashSet<>());
+    }
+
+    // Guard against infinite recursion caused by self-referential generic types (e.g. Builder<B extends Builder<B>>)
+    private List<ResolvedFieldDeclaration> getAllFieldsVisibleToInheritors(Set<String> visitedTypeIds) {
+        // If this type has already been visited, stop recursion to avoid StackOverflowError
+        if (!visitedTypeIds.add(this.getId())) {
+            return new ArrayList<>();
+        }
         List<ResolvedFieldDeclaration> res = new LinkedList<>(this.getDeclaredFields().stream()
                 .filter(f -> f.accessSpecifier() != AccessSpecifier.PRIVATE)
                 .collect(Collectors.toList()));
-        getDirectAncestors().forEach(a -> res.addAll(a.getAllFieldsVisibleToInheritors()));
+        getDirectAncestors().forEach(a -> res.addAll(a.getAllFieldsVisibleToInheritors(visitedTypeIds)));
         return res;
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3940Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3940Test.java
@@ -34,19 +34,18 @@ public class Issue3940Test extends AbstractResolutionTest {
     void selfReferentialGenericTypeShouldNotCauseStackOverflow() {
         JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
 
-        CompilationUnit cu = parser.parse(
-                "package org.apache.logging.log4j.core.async;\n"
-                        + "\n"
-                        + "public class AsyncLoggerConfig {\n"
-                        + "    public static class RootLogger {\n"
-                        + "        public static class Builder<B extends Builder<B>> extends RootLogger.Builder<B> {\n"
-                        + "            @Override\n"
-                        + "            public AsyncLoggerConfig build() {\n"
-                        + "                return new AsyncLoggerConfig();\n"
-                        + "            }\n"
-                        + "        }\n"
-                        + "    }\n"
-                        + "}");
+        CompilationUnit cu = parser.parse("package org.apache.logging.log4j.core.async;\n"
+                + "\n"
+                + "public class AsyncLoggerConfig {\n"
+                + "    public static class RootLogger {\n"
+                + "        public static class Builder<B extends Builder<B>> extends RootLogger.Builder<B> {\n"
+                + "            @Override\n"
+                + "            public AsyncLoggerConfig build() {\n"
+                + "                return new AsyncLoggerConfig();\n"
+                + "            }\n"
+                + "        }\n"
+                + "    }\n"
+                + "}");
 
         for (MethodCallExpr methodCallExpr : cu.findAll(MethodCallExpr.class)) {
             assertDoesNotThrow(() -> methodCallExpr.resolve());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3940Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3940Test.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import org.junit.jupiter.api.Test;
+
+public class Issue3940Test extends AbstractResolutionTest {
+
+    @Test
+    void selfReferentialGenericTypeShouldNotCauseStackOverflow() {
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+
+        CompilationUnit cu = parser.parse(
+                "package org.apache.logging.log4j.core.async;\n"
+                        + "\n"
+                        + "public class AsyncLoggerConfig {\n"
+                        + "    public static class RootLogger {\n"
+                        + "        public static class Builder<B extends Builder<B>> extends RootLogger.Builder<B> {\n"
+                        + "            @Override\n"
+                        + "            public AsyncLoggerConfig build() {\n"
+                        + "                return new AsyncLoggerConfig();\n"
+                        + "            }\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}");
+
+        for (MethodCallExpr methodCallExpr : cu.findAll(MethodCallExpr.class)) {
+            assertDoesNotThrow(() -> methodCallExpr.resolve());
+        }
+    }
+}


### PR DESCRIPTION

Fixes #3940 .

Add cycle detection to getAllMethods() and getAllFieldsVisibleToInheritors()
in ResolvedReferenceType. These methods recursively traversed ancestors
without tracking visited types, causing infinite recursion with
self-referential generic type parameters (e.g. Builder<B extends Builder<B>>).
The fix uses a Set of visited type IDs to break the cycle.
