### PR TITLE
Fix parsing of annotation member declarations with array dimensions after parentheses (issue #3649)

### DIFF
--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -5865,18 +5865,20 @@ AnnotationMemberDeclaration AnnotationTypeMemberDeclaration(ModifierHolder modif
 {
     Type type;
     SimpleName name;
+    ArrayBracketPair arrayBracketPair;
+    List<ArrayBracketPair> arrayBracketPairs = new ArrayList<ArrayBracketPair>(0);
     Expression defaultVal = null;
 }
 {
-    // TODO/FIXME: Consider missing `[Dims] (present in the JLS, but not the JavaParser grammar)
-    // TODO/FIXME: {AnnotationTypeElementModifier} UnannType Identifier ( ) [Dims] [DefaultValue] ;
     type = Type(emptyNodeList())
     name = SimpleName()
     "(" ")"
+    ( arrayBracketPair = ArrayBracketPair(Origin.NAME) { arrayBracketPairs=add(arrayBracketPairs, arrayBracketPair); } )*
     [ defaultVal = DefaultValue() ]
     ";"
 
     {
+        type = juggleArrayType(type, arrayBracketPairs);
         JavaToken begin = orIfInvalid(modifier.begin, type);
         return new AnnotationMemberDeclaration(range(begin, token()), modifier.modifiers, modifier.annotations, type, name, defaultVal);
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4832Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4832Test.java
@@ -53,4 +53,18 @@ public class Issue4832Test extends AbstractResolutionTest {
             assertEquals("java.util.stream.Stream<java.lang.String>", resolvedType.describe());
         });
     }
+
+    @Test
+    void test2() {
+        String code = "public @interface Foo {\n"
+                + "    int value()[];\n"
+                + "}";
+
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        StaticJavaParser.setConfiguration(config);
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        System.out.println(cu);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4832Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4832Test.java
@@ -56,9 +56,7 @@ public class Issue4832Test extends AbstractResolutionTest {
 
     @Test
     void test2() {
-        String code = "public @interface Foo {\n"
-                + "    int value()[];\n"
-                + "}";
+        String code = "public @interface Foo {\n" + "    int value()[];\n" + "}";
 
         ParserConfiguration config = new ParserConfiguration();
         config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));


### PR DESCRIPTION

Fixes #3649 .

The JLS §9.6.1 grammar allows `[Dims]` after the parentheses in annotation type element declarations (e.g., `int value()[]`), but JavaParser's grammar was missing this support. Add `ArrayBracketPair` parsing to `AnnotationTypeMemberDeclaration` in the JavaCC grammar, matching the existing pattern used by `MethodDeclaration`.
