### PR TITLE
Fixes NoCommentEqualsVisitorGenerator uses a fragile blacklist, causing regression with MarkdownComment

### DIFF
--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentEqualsVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentEqualsVisitorGenerator.java
@@ -46,9 +46,7 @@ public class NoCommentEqualsVisitorGenerator extends VisitorGenerator {
         BlockStmt body = visitMethod.getBody().get();
         body.getStatements().clear();
 
-        if (!(node.equals(JavaParserMetaModel.lineCommentMetaModel)
-                || node.equals(JavaParserMetaModel.blockCommentMetaModel)
-                || node.equals(JavaParserMetaModel.traditionalJavadocCommentMetaModel))) {
+        if (!node.isInstanceOfMetaModel(JavaParserMetaModel.commentMetaModel)) {
 
             body.addStatement(f("final %s n2 = (%s) arg;", node.getTypeName(), node.getTypeName()));
 

--- a/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
+++ b/javaparser-core-generators/src/main/java/com/github/javaparser/generator/core/visitor/NoCommentHashCodeVisitorGenerator.java
@@ -50,10 +50,7 @@ public class NoCommentHashCodeVisitorGenerator extends VisitorGenerator {
 
         final SeparatedItemStringBuilder builder = new SeparatedItemStringBuilder("return ", "* 31 +", ";");
         final List<PropertyMetaModel> propertyMetaModels = node.getAllPropertyMetaModels();
-        if (node.equals(JavaParserMetaModel.lineCommentMetaModel)
-                || node.equals(JavaParserMetaModel.blockCommentMetaModel)
-                || node.equals(JavaParserMetaModel.traditionalJavadocCommentMetaModel)
-                || propertyMetaModels.isEmpty()) {
+        if (node.isInstanceOfMetaModel(JavaParserMetaModel.commentMetaModel) || propertyMetaModels.isEmpty()) {
             builder.append("0");
         } else {
             for (PropertyMetaModel field : propertyMetaModels) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitorTest.java
@@ -24,10 +24,19 @@ package com.github.javaparser.ast.visitor;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParser;
 import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.comments.Comment;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class NoCommentEqualsVisitorTest {
 
@@ -52,5 +61,50 @@ class NoCommentEqualsVisitorTest {
         CompilationUnit p1 = parser.parse("class X { }");
         CompilationUnit p2 = parser.parse("class Y { }");
         assertFalse(NoCommentEqualsVisitor.equals(p1, p2));
+    }
+
+    static Stream<BaseNodeMetaModel> provideConcreteCommentMetamodels() {
+        return JavaParserMetaModel.getNodeMetaModels().stream()
+                .filter(meta -> Comment.class.isAssignableFrom(meta.getType()))
+                .filter(meta -> !meta.isAbstract());
+    }
+
+    @ParameterizedTest(name = "Ignore comment for node type: {0}")
+    @MethodSource("provideConcreteCommentMetamodels")
+    @DisplayName("No-Comment equals visitor must unconditionally ignore content of any type of comments")
+    void noCommentVisitors_MustUnconditionallyIgnoreAnyMetamodelCommentSubtypes(BaseNodeMetaModel meta) {
+        Class<? extends Comment> commentClass = (Class<? extends Comment>) meta.getType();
+
+        Comment commentLeft = createCommentInstance(commentClass, "Content Alpha");
+        Comment commentRight = createCommentInstance(commentClass, "Content Omega");
+
+        boolean equalsResult = NoCommentEqualsVisitor.equals(commentLeft, commentRight);
+
+        String commentTypeName = commentClass.getSimpleName();
+        assertTrue(
+                equalsResult,
+                String.format(
+                        "NoCommentEqualsVisitor failed for %s. It evaluated the content instead of skipping the node.",
+                        commentTypeName));
+    }
+
+    private Comment createCommentInstance(Class<? extends Comment> type, String content) {
+        try {
+            return type.getConstructor(String.class).newInstance(content);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to dynamically instantiate comment type: " + type.getName(), e);
+        }
+    }
+
+    @Test
+    @DisplayName("Regression: parsed /// markdown comments must be ignored by NoCommentEqualsVisitor")
+    void markdownCommentContentIsIgnoredWhenParsing() {
+        JavaParserAdapter parser = JavaParserAdapter.of(
+                new JavaParser(new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_23)));
+        CompilationUnit p1 = parser.parse("/// Alpha\nclass X { }");
+        CompilationUnit p2 = parser.parse("/// Omega\nclass X { }");
+        assertTrue(
+                NoCommentEqualsVisitor.equals(p1, p2),
+                "Two compilation units differing only in /// markdown comment content should be equal");
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
@@ -31,13 +31,20 @@ import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
+import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.modules.*;
 import com.github.javaparser.ast.stmt.*;
 import com.github.javaparser.ast.type.*;
+import com.github.javaparser.metamodel.BaseNodeMetaModel;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class NoCommentHashCodeVisitorTest {
 
@@ -1075,5 +1082,38 @@ class NoCommentHashCodeVisitorTest {
         verify(node, times(1)).getType();
         verify(node, times(1)).getPatternList();
         verify(node, never()).getComment();
+    }
+
+    static Stream<BaseNodeMetaModel> provideConcreteCommentMetamodels() {
+        return JavaParserMetaModel.getNodeMetaModels().stream()
+                .filter(meta -> Comment.class.isAssignableFrom(meta.getType()))
+                .filter(meta -> !meta.isAbstract());
+    }
+
+    @ParameterizedTest(name = "Ignore comment for node type: {0}")
+    @MethodSource("provideConcreteCommentMetamodels")
+    @DisplayName("No-Comment hashCode visitor must unconditionally ignore content of any type of comments")
+    void noCommentHashCodeVisitor_MustUnconditionallyIgnoreAnyMetamodelCommentSubtypes(BaseNodeMetaModel meta) {
+        Class<? extends Comment> commentClass = (Class<? extends Comment>) meta.getType();
+
+        Comment commentLeft = createCommentInstance(commentClass, "Content Alpha");
+        Comment commentRight = createCommentInstance(commentClass, "Content Omega");
+
+        int leftHashCode = NoCommentHashCodeVisitor.hashCode(commentLeft);
+        int rightHashCode = NoCommentHashCodeVisitor.hashCode(commentRight);
+
+        assertEquals(
+                leftHashCode,
+                rightHashCode,
+                "NoCommentHashCodeVisitor should return identical hash codes for comments with different content of type: "
+                        + commentClass.getSimpleName());
+    }
+
+    private Comment createCommentInstance(Class<? extends Comment> type, String content) {
+        try {
+            return type.getConstructor(String.class).newInstance(content);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to dynamically instantiate comment type: " + type.getName(), e);
+        }
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitor.java
@@ -943,8 +943,6 @@ public class NoCommentEqualsVisitor implements GenericVisitor<Boolean, Visitable
 
     @Override
     public Boolean visit(final MarkdownComment n, final Visitable arg) {
-        final MarkdownComment n2 = (MarkdownComment) arg;
-        if (!objEquals(n.getContent(), n2.getContent())) return false;
         return true;
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitor.java
@@ -614,6 +614,6 @@ public class NoCommentHashCodeVisitor implements GenericVisitor<Integer, Void> {
 
     @Override
     public Integer visit(final MarkdownComment n, final Void arg) {
-        return (n.getContent().hashCode());
+        return 0;
     }
 }


### PR DESCRIPTION
## Root Cause

`NoCommentEqualsVisitorGenerator` and `NoCommentHashCodeVisitorGenerator` used a hardcoded blacklist of comment class names to skip during comparison. When `MarkdownComment` was added, it was not included in this list, causing equality/hashCode checks to incorrectly consider comment content.

## Fix

Replace the fragile blacklist with a metamodel-based type check using `node.isInstanceOfMetaModel(commentMetaModel)`. This automatically covers all current and future Comment subtypes without manual maintenance.

The generated visitor files (`NoCommentEqualsVisitor.java`, `NoCommentHashCodeVisitor.java`) were regenerated by running the generators — not hand-edited.

## Tests

Added parameterized tests that verify all concrete Comment subtypes (LineComment, BlockComment, JavadocComment, MarkdownComment) are unconditionally ignored by both visitors.

Fixes #5056