### PR TITLE
Remove redundant Spotless configuration (trimTrailingWhitespace, endWithNewline)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,8 +449,6 @@
                             <!-- google-java-format, but better: see https://github.com/palantir/palantir-java-format -->
                             <palantirJavaFormat/>
                         </java>
-                        <trimTrailingWhitespace/>
-      					<endWithNewline/>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## Summary

Remove `trimTrailingWhitespace` and `endWithNewline` from the Spotless Maven plugin configuration.

## Rationale

`palantirJavaFormat` already handles both trailing whitespace trimming and final newline insertion. These two explicit steps are no-ops and can be safely removed.

## Verification

Tested by adding a probe file with trailing whitespace and no final newline, then running `spotless:apply` with only `palantirJavaFormat` — both issues are corrected by the formatter alone.

## Changes

- Removed `<trimTrailingWhitespace/>` from Spotless configuration
- Removed `<endWithNewline/>` from Spotless configuration

Net diff: 2 lines deleted.