### PR TITLE
Add regression test for nested inner class creation resolution (#4673)

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4673Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4673Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import org.junit.jupiter.api.Test;
+
+public class Issue4673Test extends AbstractResolutionTest {
+
+    @Test
+    void nestedInnerClassCreationWithRecursiveFieldShouldNotStackOverflow() {
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+
+        CompilationUnit cu = parser.parse("package p;\n"
+                + "\n"
+                + "class A {\n"
+                + "    A a;\n"
+                + "    class Inner {\n"
+                + "    }\n"
+                + "    void f(A a) {\n"
+                + "        a.a.a.new Inner();\n"
+                + "    }\n"
+                + "}\n");
+
+        ObjectCreationExpr objectCreationExpr = cu.findFirst(ObjectCreationExpr.class)
+                .orElseThrow(() -> new AssertionError("expected an ObjectCreationExpr"));
+
+        // Resolving the qualified inner-class instantiation "a.a.a.new Inner()" used to
+        // recurse without bound and throw a StackOverflowError.
+        ResolvedConstructorDeclaration resolved = assertDoesNotThrow(objectCreationExpr::resolve);
+        assertEquals("p.A.Inner.Inner", resolved.getQualifiedName());
+    }
+}


### PR DESCRIPTION
The `StackOverflowError` reported in #4673 (`a.a.a.new Inner()`) no longer occurs. I bisected the reporter's minimal example against Maven Central: it throws on 3.26.4 and resolves correctly from **3.27.0** onward, but the issue is still open with no test guarding the behavior.

This adds a regression test that resolves the qualified inner-class instantiation and asserts it resolves to `p.A.Inner`'s constructor instead of overflowing the stack. It uses the same `ReflectionTypeSolver` setup as the report; I confirmed it fails with a `StackOverflowError` on 3.26.4 and passes on current `master`.

Closes #4673.

_Written with AI assistance (Claude), reviewed and verified by me._
