### PR TITLE
Fix method reference resolution after Class::cast in stream pipelines (#4989)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -635,11 +635,9 @@ public class JavaParserFacade {
      * return type of {@code cast} is still the type variable {@code T}; this method replaces it
      * with {@code Sub}.
      */
-    private static MethodUsage applyTypeParametersFromScope(
-            MethodUsage methodUsage, ResolvedReferenceType scopeType) {
+    private static MethodUsage applyTypeParametersFromScope(MethodUsage methodUsage, ResolvedReferenceType scopeType) {
         MethodUsage result = methodUsage;
-        for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> typeParamEntry :
-                scopeType.getTypeParametersMap()) {
+        for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> typeParamEntry : scopeType.getTypeParametersMap()) {
             result = result.replaceTypeParameter(typeParamEntry.a, typeParamEntry.b);
         }
         return result;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -51,6 +51,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.github.javaparser.utils.Log;
+import com.github.javaparser.utils.Pair;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -481,6 +482,15 @@ public class JavaParserFacade {
             throw new UnsolvedSymbolException("Cannot find method '" + methodName + "' in type " + typeOfScope);
         }
 
+        // Substitute type arguments from the scope type (e.g. Class<Sub>) into candidate methods
+        // so that Class.cast returns Sub rather than the raw type variable T. getAllMethods()
+        // returns methods as declared on the raw type declaration; without this substitution,
+        // poly inference for stream pipelines like list.stream().map(Sub.class::cast) cannot
+        // refine Stream<Base> to Stream<Sub> (see issue #4989).
+        candidateMethods = candidateMethods.stream()
+                .map(m -> applyTypeParametersFromScope(m, typeOfScope.asReferenceType()))
+                .collect(Collectors.toList());
+
         // JLS §15.13.1: Method references have different forms based on their scope:
         //
         // Form 1: ReferenceType :: [TypeArguments] Identifier
@@ -615,6 +625,24 @@ public class JavaParserFacade {
                         + paramTypes + ". Candidates found: "
                         + candidateMethods.size() + " method(s) named '"
                         + methodName + "' in type " + typeOfScope);
+    }
+
+    /**
+     * Substitutes type arguments from {@code scopeType} into {@code methodUsage}.
+     *
+     * <p>Methods obtained via {@link ResolvedReferenceTypeDeclaration#getAllMethods()} are typed
+     * against the raw type declaration. For a parameterized scope such as {@code Class<Sub>}, the
+     * return type of {@code cast} is still the type variable {@code T}; this method replaces it
+     * with {@code Sub}.
+     */
+    private static MethodUsage applyTypeParametersFromScope(
+            MethodUsage methodUsage, ResolvedReferenceType scopeType) {
+        MethodUsage result = methodUsage;
+        for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> typeParamEntry :
+                scopeType.getTypeParametersMap()) {
+            result = result.replaceTypeParameter(typeParamEntry.a, typeParamEntry.b);
+        }
+        return result;
     }
 
     protected ResolvedType getBinaryTypeConcrete(

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
@@ -85,8 +85,8 @@ public class Issue4989Test extends AbstractResolutionTest {
 
     @BeforeEach
     void setup() {
-        ParserConfiguration config = new ParserConfiguration()
-                .setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        ParserConfiguration config =
+                new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
         StaticJavaParser.setConfiguration(config);
     }
 
@@ -150,10 +150,8 @@ public class Issue4989Test extends AbstractResolutionTest {
         CompilationUnit cu = StaticJavaParser.parse(CODE);
 
         for (MethodCallExpr mce : cu.findAll(MethodCallExpr.class)) {
-            ResolvedMethodDeclaration resolved = assertDoesNotThrow(
-                    mce::resolve, () -> "Failed to resolve: " + mce);
-            assertDoesNotThrow(
-                    resolved::getQualifiedSignature, () -> "Failed getQualifiedSignature for: " + mce);
+            ResolvedMethodDeclaration resolved = assertDoesNotThrow(mce::resolve, () -> "Failed to resolve: " + mce);
+            assertDoesNotThrow(resolved::getQualifiedSignature, () -> "Failed getQualifiedSignature for: " + mce);
         }
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproducer for <a href="https://github.com/javaparser/javaparser/issues/4989">#4989</a>.
+ *
+ * <p>Resolving {@code methodCallExpr.resolve().getQualifiedSignature()} on a stream pipeline that
+ * uses {@code X.class::isInstance} / {@code X.class::cast} followed by an instance method reference
+ * ({@code this::convert}) fails, because {@code Class::cast} does not refine the stream element
+ * type from the source type to the cast target type.
+ *
+ * <pre>{@code
+ * contentBlocks.stream()
+ *     .filter(ToolUseBlock.class::isInstance)
+ *     .map(ToolUseBlock.class::cast)
+ *     .map(this::convertToolUseBlockToToolCall)
+ *     .collect(Collectors.toList());
+ * }</pre>
+ */
+public class Issue4989Test extends AbstractResolutionTest {
+
+    private static final String CODE = ""
+            + "import java.util.List;\n"
+            + "import java.util.stream.Collectors;\n"
+            + "\n"
+            + "public class ChatCompletionsResponseBuilder {\n"
+            + "\n"
+            + "    interface ContentBlock {}\n"
+            + "\n"
+            + "    static class ToolUseBlock implements ContentBlock {\n"
+            + "        String id;\n"
+            + "        String name;\n"
+            + "        String input;\n"
+            + "    }\n"
+            + "\n"
+            + "    static class ToolCall {\n"
+            + "        ToolCall(String id, String name, String input) {}\n"
+            + "    }\n"
+            + "\n"
+            + "    public List<ToolCall> extractToolCalls(List<ContentBlock> contentBlocks) {\n"
+            + "        return contentBlocks.stream()\n"
+            + "                .filter(ToolUseBlock.class::isInstance)\n"
+            + "                .map(ToolUseBlock.class::cast)\n"
+            + "                .map(this::convertToolUseBlockToToolCall)\n"
+            + "                .collect(Collectors.toList());\n"
+            + "    }\n"
+            + "\n"
+            + "    private ToolCall convertToolUseBlockToToolCall(ToolUseBlock toolUse) {\n"
+            + "        return new ToolCall(toolUse.id, toolUse.name, toolUse.input);\n"
+            + "    }\n"
+            + "}\n";
+
+    @BeforeEach
+    void setup() {
+        ParserConfiguration config = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+    }
+
+    /**
+     * {@code X.class::cast} used as a stream mapper should yield {@code Stream<X>}, not the
+     * pre-cast element type.
+     */
+    @Test
+    void mapClassCastShouldRefineStreamElementType() {
+        String code = ""
+                + "import java.util.List;\n"
+                + "import java.util.stream.Stream;\n"
+                + "public class A {\n"
+                + "  interface Base {}\n"
+                + "  static class Sub implements Base {}\n"
+                + "  public Stream<Sub> f(List<Base> list) {\n"
+                + "    return list.stream().map(Sub.class::cast);\n"
+                + "  }\n"
+                + "}\n";
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        MethodCallExpr mapCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("map"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        assertEquals(
+                "java.util.stream.Stream<A.Sub>",
+                mapCall.calculateResolvedType().describe());
+    }
+
+    /**
+     * Direct resolution of the instance method reference after {@code class::cast}.
+     * This is the failure reported in the issue:
+     * {@code Unable to resolve method reference this::convertToolUseBlockToToolCall ...}
+     */
+    @Test
+    void resolveInstanceMethodReferenceAfterClassCast() {
+        CompilationUnit cu = StaticJavaParser.parse(CODE);
+
+        MethodReferenceExpr thisConvert = cu.findAll(MethodReferenceExpr.class).stream()
+                .filter(m -> m.toString().equals("this::convertToolUseBlockToToolCall"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        ResolvedMethodDeclaration resolved =
+                assertDoesNotThrow(thisConvert::resolve, "Failed to resolve this::convertToolUseBlockToToolCall");
+        assertEquals(
+                "ChatCompletionsResponseBuilder.convertToolUseBlockToToolCall("
+                        + "ChatCompletionsResponseBuilder.ToolUseBlock)",
+                resolved.getQualifiedSignature());
+    }
+
+    /**
+     * Exactly the API used by the reporter:
+     * {@code methodCallExpr.resolve().getQualifiedSignature()} on every call in the pipeline,
+     * including {@code collect(...)} whose scope contains the failing method reference.
+     */
+    @Test
+    void resolveAllMethodCallsInStreamPipeline() {
+        CompilationUnit cu = StaticJavaParser.parse(CODE);
+
+        for (MethodCallExpr mce : cu.findAll(MethodCallExpr.class)) {
+            ResolvedMethodDeclaration resolved = assertDoesNotThrow(
+                    mce::resolve, () -> "Failed to resolve: " + mce);
+            assertDoesNotThrow(
+                    resolved::getQualifiedSignature, () -> "Failed getQualifiedSignature for: " + mce);
+        }
+    }
+
+    /**
+     * Control case: the same instance method reference works when the stream element type is
+     * already the expected parameter type (no {@code class::cast} involved).
+     */
+    @Test
+    void baselineInstanceMethodReferenceWithoutCastWorks() {
+        String code = ""
+                + "import java.util.List;\n"
+                + "import java.util.stream.Collectors;\n"
+                + "public class A {\n"
+                + "  static class Sub { String v; }\n"
+                + "  static class Out { Out(String v) {} }\n"
+                + "  public List<Out> f(List<Sub> list) {\n"
+                + "    return list.stream().map(this::convert).collect(Collectors.toList());\n"
+                + "  }\n"
+                + "  private Out convert(Sub s) { return new Out(s.v); }\n"
+                + "}\n";
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodReferenceExpr mre = cu.findFirst(MethodReferenceExpr.class).orElseThrow(AssertionError::new);
+        assertEquals("A.convert(A.Sub)", mre.resolve().getQualifiedSignature());
+
+        MethodCallExpr collect = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("collect"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+        assertEquals(
+                "java.util.stream.Stream.collect(java.util.stream.Collector<? super T, A, R>)",
+                collect.resolve().getQualifiedSignature());
+        assertEquals("java.util.List<A.Out>", collect.calculateResolvedType().describe());
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes symbol solver failure when resolving stream pipelines that use `X.class::cast` followed by instance method references such as `this::convert` (issue #4989).
- Root cause: `toMethodUsage` resolved methods from the raw type declaration, so `Class.cast` returned type variable `T` instead of the concrete type argument (e.g. `Sub` from `Class<Sub>`). Poly inference therefore left `map(Sub.class::cast)` typed as `Stream<Base>` instead of `Stream<Sub>`.
- Fix: substitute type arguments from the method-reference scope into candidate methods before overload resolution / return-type inference.

## Test plan

- [x] Added `Issue4989Test` covering:
  - `map(Sub.class::cast)` refines stream element type to `Stream<Sub>`
  - `this::convert` resolves after `class::isInstance` / `class::cast`
  - `methodCallExpr.resolve().getQualifiedSignature()` on the full pipeline from the issue
  - baseline `this::method` without cast still works
- [x] `./mvnw -pl javaparser-symbol-solver-testing -Dtest=Issue4989Test,MethodReferenceResolutionTest test`
- [x] Manual variants (lambda after cast, cast without filter, unbound `Sub::getText`) resolve correctly

Fixes #4989