### PR TITLE
fix(#4439): convert TreeVisitorValidator to be iterative

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/TreeVisitorValidatorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/validator/TreeVisitorValidatorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.ast.validator;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class TreeVisitorValidatorTest {
+
+    /**
+     * A deeply nested expression (such as a long string concatenation) used to make {@link TreeVisitorValidator}
+     * recurse once per tree level, overflowing the call stack and causing a {@link StackOverflowError}. See <a
+     * href="https://github.com/javaparser/javaparser/issues/4439">issue 4439</a>.
+     */
+    @Test
+    void deeplyNestedTreeIsVisitedWithoutStackOverflow() {
+        int depth = 100_000;
+
+        // Build "a" + "a" + "a" + ... which nests BinaryExpr nodes `depth` levels deep.
+        Expression expression = new StringLiteralExpr("a");
+        for (int i = 0; i < depth; i++) {
+            expression = new BinaryExpr(expression, new StringLiteralExpr("a"), BinaryExpr.Operator.PLUS);
+        }
+
+        AtomicInteger visited = new AtomicInteger();
+        TreeVisitorValidator validator = new TreeVisitorValidator((node, reporter) -> visited.incrementAndGet());
+
+        Expression deepExpression = expression;
+        assertDoesNotThrow(() -> validator.accept(deepExpression, new ProblemReporter(problem -> {})));
+        assertEquals(2 * depth + 1, visited.get());
+    }
+
+    /**
+     * Tests that the TreeVisitorValidator visits nodes pre-order traversal: the default order of any visitor.
+     */
+    @Test
+    void visitorFollowsPreOrderTraversal() {
+        // Create a small tree: (("a" + "b") + "c")
+        // Structure:
+        //      +
+        //     / \
+        //    +   "c"
+        //   / \
+        // "a" "b"
+        StringLiteralExpr a = new StringLiteralExpr("a");
+        StringLiteralExpr b = new StringLiteralExpr("b");
+        BinaryExpr ab = new BinaryExpr(a, b, BinaryExpr.Operator.PLUS);
+        StringLiteralExpr c = new StringLiteralExpr("c");
+        BinaryExpr abc = new BinaryExpr(ab, c, BinaryExpr.Operator.PLUS);
+
+        List<Node> visitedNodes = new ArrayList<>();
+        TreeVisitorValidator validator = new TreeVisitorValidator((node, reporter) -> visitedNodes.add(node));
+        validator.accept(abc, new ProblemReporter(problem -> {}));
+
+        // Pre-order expectation: parent, left child, right child.
+        assertEquals(Arrays.asList(abc, ab, a, b, c), visitedNodes);
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/TreeVisitorValidator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/TreeVisitorValidator.java
@@ -35,9 +35,6 @@ public class TreeVisitorValidator implements Validator {
 
     @Override
     public final void accept(Node node, ProblemReporter reporter) {
-        validator.accept(node, reporter);
-        for (Node child : node.getChildNodes()) {
-            accept(child, reporter);
-        }
+        node.walk(n -> validator.accept(n, reporter));
     }
 }


### PR DESCRIPTION
This addresses #4439

The original issue in #4439 involves `TreeVisitorValidator`, which was recursive. I have converted it to be iterative by using `Node::walk(Consumer)`. This should be equivalent in functionality while avoiding large calls stacks.

#4439 also notes duplicate issues linked regarding `VoidVisitorAdapter`. I am not sure there is a better solution than just increasing the amount of memory. 

- One idea would be to use a "trampoline" strategy by returning the next nodes to visit rather than using recursive calls. We could do this by creating a `GenericVisitorWithDefaults` that, by default, returns the child nodes and then wrapping this with a `Deque` that keeps track of the node to visit. The problem with this approach is when a user overrides any of these methods by calling `super.visit`.  The execution order would change when compared with the recursive implementation. 
- We could create a new seperate implementation or even a new interface, but I believe this would be confusing 
- We could use reflection or bytecode injection, but I believe this overcomplicates things for a fundamental class
