### PR TITLE
(fix: #5065) Fix method resolution when a parameter is a primitive array

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
@@ -248,7 +248,7 @@ public class TokenTypes {
             case RSIGNEDSHIFT:
             case GT:
                 return JavaToken.Category.OPERATOR;
-                // The following are tokens that are only used internally by the lexer
+            // The following are tokens that are only used internally by the lexer
             case ENTER_JAVADOC_COMMENT:
             case ENTER_MULTILINE_COMMENT:
             case COMMENT_CONTENT:

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -49,8 +49,7 @@ public class MethodResolutionLogic {
             // TODO if there are no variadic values we should default to the bound of the formal type
             res.add(variadicType);
         } else {
-            ResolvedType componentType = findCommonType(variadicValues);
-            res.add(convertToVariadicParameter(componentType));
+            res.add(convertToVariadicParameter(variadicType));
         }
         return res;
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -657,11 +657,11 @@ public class MethodResolutionLogic {
                 return false;
             }
         }
-        // Unboxing (primitive expected, reference type provided)
+        // Both are primitive types
         if (expectedType.isPrimitive() && actualType.isPrimitive()) {
             ResolvedPrimitiveType expectedPrimitive = expectedType.asPrimitive();
             ResolvedPrimitiveType actualPrimitive = actualType.asPrimitive();
-            return expectedPrimitive.isAssignableBy(actualPrimitive);
+            return expectedPrimitive.equals(actualPrimitive);
         }
         // Both are reference types but one might be a constrained/wildcard type
         // This can happen after type variable substitution

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -151,7 +151,7 @@ public class MethodResolutionLogic {
                 // array.
                 // Confirm all of these grouped "trailing" arguments have the required type -- if not, this is not a
                 // valid type. (Maybe this is also done later..?)
-                for (int variadicArgumentIndex = countOfMethodParametersDeclared;
+                for (int variadicArgumentIndex = getLastParameterIndex(countOfMethodParametersDeclared);
                         variadicArgumentIndex < countOfNeedleArgumentsPassed;
                         variadicArgumentIndex++) {
                     ResolvedType currentArgumentType = needleArgumentTypes.get(variadicArgumentIndex);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionLogicTest.java
@@ -360,7 +360,7 @@ class MethodsResolutionLogicTest extends AbstractResolutionTest {
                 + "     public static int[] copyOf(int[] original, int newLength) { return original; }"
                 + "     public static float[] copyOf(float[] original, int newLength) { return original; }"
                 + "     public static void test() {"
-                + "       copyOf(new int[]{1});"
+                + "       copyOf(new int[]{1}, 1);"
                 + "     }"
                 + "   }";
         StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
@@ -371,8 +371,9 @@ class MethodsResolutionLogicTest extends AbstractResolutionTest {
                 .get();
         String signature = expr.resolve().getQualifiedSignature();
 
-        assertTrue(
-                "Arrays.print(int[])".equals(signature),
+        assertEquals(
+                "Arrays.copyOf(int[], int)",
+                signature,
                 "arrays of primitive types should only match on exact component types");
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionLogicTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodsResolutionLogicTest.java
@@ -354,6 +354,28 @@ class MethodsResolutionLogicTest extends AbstractResolutionTest {
         assertEquals(true, MethodResolutionLogic.isApplicable(mu, "forEach", ImmutableList.of(typeParam), typeSolver));
     }
 
+    @Test
+    void testIssue5065() {
+        String code = "public class Arrays {"
+                + "     public static int[] copyOf(int[] original, int newLength) { return original; }"
+                + "     public static float[] copyOf(float[] original, int newLength) { return original; }"
+                + "     public static void test() {"
+                + "       copyOf(new int[]{1});"
+                + "     }"
+                + "   }";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        MethodCallExpr expr = cu.findAll(MethodCallExpr.class).stream()
+                .filter(mce -> mce.getNameAsString().equals("copyOf"))
+                .findFirst()
+                .get();
+        String signature = expr.resolve().getQualifiedSignature();
+
+        assertTrue(
+                "Arrays.print(int[])".equals(signature),
+                "arrays of primitive types should only match on exact component types");
+    }
+
     /**
      * Test variadic method with primitive varargs and primitive arguments
      * Example: print(int... values) called with print(1, 2, 3)


### PR DESCRIPTION
Fixes #5065.

The comment in `isBoxingCompatibleWithTypeSolver` was incorrect, as was the logic: When we compare `float[]` and `int[]` and then consider their component types, we should use `equals` as in `ResolvedArrayType#isAssignableBy`.
