### PR TITLE
Remove stale Spotless Java 8 comment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,6 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <!-- This is the last version with Java 8 support -->
                     <version>2.46.1</version>
                     <configuration>
 						<lineEndings>UNIX</lineEndings>


### PR DESCRIPTION
## Summary

Remove the inaccurate comment `<!-- This is the last version with Java 8 support -->` from the Spotless plugin version declaration.

## Rationale

- Spotless 2.46.1 does **not** support Java 8 — the minimum JRE was bumped to 11 around plugin 2.31.x (early 2023)
- The plugin sits in `<pluginManagement>` and only runs on JDK 11 in CI, so the constraint never applies
- The comment actively discourages version upgrades for a reason that doesn't exist

## Change

Single line deletion. No version change, no behavior change.

Fixes #5071