### PR TITLE
Enable sortPom in Spotless for POM formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,7 @@
 # Applied automatic formatting to the entire project
 # See https://github.com/javaparser/javaparser/issues/4408 for details
 5106428130cd3ff052a57d37a3d192f040da5edf
+
+# Applied sortPom formatting to all POM files
+# See https://github.com/javaparser/javaparser/issues/5070 for details
+d379a0c00a9e94eb4e9d0ecba5568e58852b411a

--- a/javaparser-core-generators/pom.xml
+++ b/javaparser-core-generators/pom.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
         <version>3.29.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>javaparser-core-generators</artifactId>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>A code generator framework, and the generators for javaparser-core</description>
+    <url>https://github.com/javaparser</url>
 
     <properties>
         <jpms.moduleName>com.github.javaparser.core.generators</jpms.moduleName>
@@ -56,15 +56,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>generate-javaparser-core</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>java</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <classpathScope>test</classpathScope>
                             <mainClass>com.github.javaparser.generator.core.CoreGenerator</mainClass>
@@ -72,6 +63,15 @@
                                 <argument>${project.basedir}</argument>
                             </arguments>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>generate-javaparser-core</id>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/javaparser-core-generators/pom.xml
+++ b/javaparser-core-generators/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-core-metamodel-generator/pom.xml
+++ b/javaparser-core-metamodel-generator/pom.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
         <version>3.29.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>javaparser-core-metamodel-generator</artifactId>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>The tool that generates the code in the javaparser-metamodel module</description>
+    <url>https://github.com/javaparser</url>
 
     <dependencies>
         <dependency>
@@ -28,15 +28,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>generate-javaparser-metamodel</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>java</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <classpathScope>test</classpathScope>
                             <mainClass>com.github.javaparser.generator.metamodel.MetaModelGenerator</mainClass>
@@ -44,6 +35,15 @@
                                 <argument>${project.basedir}</argument>
                             </arguments>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>generate-javaparser-metamodel</id>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/javaparser-core-metamodel-generator/pom.xml
+++ b/javaparser-core-metamodel-generator/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -1,76 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>javaparser-parent</artifactId>
-		<groupId>com.github.javaparser</groupId>
-		<version>3.29.0-SNAPSHOT</version>
-	</parent>
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
+        <version>3.29.0-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>javaparser-core-serialization</artifactId>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
-	<description>Serializers for the JavaParser AST.</description>
+    <artifactId>javaparser-core-serialization</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Serializers for the JavaParser AST.</description>
+    <url>https://github.com/javaparser</url>
 
-	<licenses>
-		<license>
-			<name>GNU Lesser General Public License</name>
-			<url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
-			<distribution>repo</distribution>
-		</license>
-		<license>
-			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-			<comments>A business-friendly OSS license</comments>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
 
-	<properties>
-		<java.version>1.8</java.version>
-		<jpms.moduleName>com.github.javaparser.core.serialization</jpms.moduleName>
-	</properties>
+    <properties>
+        <java.version>1.8</java.version>
+        <jpms.moduleName>com.github.javaparser.core.serialization</jpms.moduleName>
+    </properties>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>biz.aQute.bnd</groupId>
-				<artifactId>bnd-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<!-- Pick up the manifest produced by bnd-maven-plugin's bnd-process goal (MJAR-193). -->
-						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-					</archive>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <!-- The jakarta.json variant of Glassfish is now available under a new name, Eclipse Parsson -->
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>1.1.9</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.github.javaparser</groupId>
-			<artifactId>javaparser-core</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.json</groupId>
-			<artifactId>jakarta.json-api</artifactId>
-			<version>2.1.3</version>
-		</dependency>
-		<!-- The jakarta.json variant of Glassfish is now available under a new name, Eclipse Parsson -->
-		<dependency>
-			<groupId>org.eclipse.parsson</groupId>
-			<artifactId>parsson</artifactId>
-			<version>1.1.9</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <!-- Pick up the manifest produced by bnd-maven-plugin's bnd-process goal (MJAR-193). -->
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -1,15 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
         <version>3.29.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>javaparser-core-testing-bdd</artifactId>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>The BDD test suite for javaparser-core</description>
+    <url>https://github.com/javaparser</url>
 
     <licenses>
         <license>
@@ -24,24 +25,6 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reportFormat>plain</reportFormat>
-                    <failIfNoTests>true</failIfNoTests>
-                    <argLine>@{jacoco.javaagent}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <dependencies>
         <dependency>
             <groupId>com.github.javaparser</groupId>
@@ -68,5 +51,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reportFormat>plain</reportFormat>
+                    <failIfNoTests>true</failIfNoTests>
+                    <argLine>@{jacoco.javaagent}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -1,15 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
         <version>3.29.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>javaparser-core-testing</artifactId>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>The test suite for javaparser-core</description>
+    <url>https://github.com/javaparser</url>
 
     <licenses>
         <license>
@@ -24,23 +25,6 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reportFormat>plain</reportFormat>
-                    <failIfNoTests>true</failIfNoTests>
-                    <argLine>@{jacoco.javaagent}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <dependencies>
         <dependency>
             <groupId>com.github.javaparser</groupId>
@@ -79,5 +63,22 @@
             <artifactId>mockito-inline</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reportFormat>plain</reportFormat>
+                    <failIfNoTests>true</failIfNoTests>
+                    <argLine>@{jacoco.javaagent}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -1,16 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
         <version>3.29.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>javaparser-core</artifactId>
     <packaging>jar</packaging>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>The core parser functionality. This may be all you need.</description>
+    <url>https://github.com/javaparser</url>
 
     <licenses>
         <license>
@@ -79,10 +80,10 @@
                 <executions>
                     <execution>
                         <id>add-source</id>
-                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <sources>
                                 <source>src/main/javacc-support</source>

--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-      <artifactId>javaparser-parent</artifactId>
-      <groupId>com.github.javaparser</groupId>
-      <version>3.29.0-SNAPSHOT</version>
-  </parent>    
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
+        <version>3.29.0-SNAPSHOT</version>
+    </parent>
 
     <artifactId>javaparser-symbol-solver-core</artifactId>
     <packaging>jar</packaging>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>A Symbol Solver for Java, built on top of JavaParser (core)</description>
+    <url>https://github.com/javaparser</url>
 
     <licenses>
         <license>
@@ -46,10 +46,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-		<dependency>
-			<groupId>org.checkerframework</groupId>
-			<artifactId>checker-qual</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.github.javaparser</groupId>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>javaparser-parent</artifactId>
         <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-parent</artifactId>
         <version>3.29.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>javaparser-symbol-solver-testing</artifactId>
-	<name>${project.groupId}:${project.artifactId}</name>
-	<url>https://github.com/javaparser</url>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>A Symbol Solver for Java, built on top of JavaParser (tests)</description>
+    <url>https://github.com/javaparser</url>
 
     <licenses>
         <license>
@@ -25,6 +25,38 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
+    <dependencies>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-symbol-solver-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>
@@ -69,38 +101,5 @@
             </build>
         </profile>
     </profiles>
-
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-    <dependencies>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-symbol-solver-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.javaparser</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <modules>
-        <module>javaparser-core</module>
-        <module>javaparser-core-testing</module>
-        <module>javaparser-core-testing-bdd</module>
-        <module>javaparser-core-generators</module>
-        <module>javaparser-core-metamodel-generator</module>
-        <module>javaparser-core-serialization</module>
-        <module>javaparser-symbol-solver-core</module>
-        <module>javaparser-symbol-solver-testing</module>
-    </modules>
 
     <groupId>com.github.javaparser</groupId>
     <artifactId>javaparser-parent</artifactId>
-    <packaging>pom</packaging>
     <version>3.29.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
     <name>javaparser-parent</name>
+    <description>Java Parser and Abstract Syntax Tree for Java</description>
     <url>https://github.com/javaparser</url>
     <inceptionYear>2007</inceptionYear>
-    <description>Java Parser and Abstract Syntax Tree for Java</description>
 
     <licenses>
         <license>
@@ -37,64 +28,64 @@
 
     <developers>
         <developer>
+            <id>matozoid</id>
             <name>Danny van Bruggen</name>
             <email>hexagonaal@gmail.com</email>
             <url>https://github.com/matozoid</url>
-            <id>matozoid</id>
         </developer>
         <developer>
+            <id>jgesser@gmail.com</id>
             <name>Júlio Vilmar Gesser</name>
             <email>jgesser@gmail.com</email>
-            <id>jgesser@gmail.com</id>
         </developer>
         <developer>
+            <id>sebastiankirsch</id>
             <name>Sebastian Kirsch</name>
             <email>sebastian.kirsch@immobilienscout24.de</email>
             <url>https://github.com/sebastiankirsch</url>
-            <id>sebastiankirsch</id>
         </developer>
         <developer>
+            <id>before</id>
             <name>André Rouél</name>
             <url>https://github.com/before</url>
-            <id>before</id>
         </developer>
         <developer>
+            <id>SmiddyPence</id>
             <name>Nicholas Smith</name>
             <email>smiddypence@gmail.com</email>
             <url>https://github.com/SmiddyPence</url>
-            <id>SmiddyPence</id>
         </developer>
         <developer>
+            <id>ftomassetti</id>
             <name>Federico Tomassetti</name>
             <email>federico@tomassetti.me</email>
             <url>https://github.com/ftomassetti</url>
-            <id>ftomassetti</id>
         </developer>
         <developer>
+            <id>ptitjes</id>
             <name>Didier Villevalois</name>
             <email>ptitjes@free.fr</email>
             <url>https://github.com/ptitjes</url>
-            <id>ptitjes</id>
         </developer>
         <developer>
+            <id>MysterAitch</id>
             <name>Roger Howell</name>
             <url>https://github.com/MysterAitch</url>
-            <id>MysterAitch</id>
         </developer>
         <developer>
+            <id>MysterAitch</id>
             <name>Roger Howell</name>
             <url>https://github.com/MysterAitch</url>
-            <id>MysterAitch</id>
         </developer>
         <developer>
+            <id>jlerbsc</id>
             <name>Jean Pierre Lerbscher</name>
             <url>https://github.com/jlerbsc</url>
-            <id>jlerbsc</id>
         </developer>
         <developer>
+            <id>maartenc</id>
             <name>Maarten Coene</name>
             <url>https://github.com/maartenc</url>
-            <id>maartenc</id>
         </developer>
     </developers>
     <contributors>
@@ -143,6 +134,32 @@
             <url>https://github.com/DeepSnowNeeL</url>
         </contributor>
     </contributors>
+    <modules>
+        <module>javaparser-core</module>
+        <module>javaparser-core-testing</module>
+        <module>javaparser-core-testing-bdd</module>
+        <module>javaparser-core-generators</module>
+        <module>javaparser-core-metamodel-generator</module>
+        <module>javaparser-core-serialization</module>
+        <module>javaparser-symbol-solver-core</module>
+        <module>javaparser-symbol-solver-testing</module>
+    </modules>
+
+    <scm>
+        <connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
+        <developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/javaparser/javaparser.git</url>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub Issue Tracker</system>
+        <url>https://github.com/javaparser/javaparser/issues</url>
+    </issueManagement>
+
+    <distributionManagement>
+        <!-- According to the documentation https://central.sonatype.org/publish/publish-portal-maven/, it is no longer necessary to configure a repository -->
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -161,46 +178,56 @@
         <osgi.export>${project.groupId}.*</osgi.export>
     </properties>
 
-    <scm>
-        <connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
-        <developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
-        <url>https://github.com/javaparser/javaparser.git</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <issueManagement>
-        <system>GitHub Issue Tracker</system>
-        <url>https://github.com/javaparser/javaparser/issues</url>
-    </issueManagement>
-
-    <distributionManagement>
-	<!-- According to the documentation https://central.sonatype.org/publish/publish-portal-maven/, it is no longer necessary to configure a repository -->
-    </distributionManagement>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.32.0-GA</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.6.0-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.55.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>3.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.14.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>4.11.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
-			<plugin>
-					<groupId>org.sonatype.central</groupId>
-					<artifactId>central-publishing-maven-plugin</artifactId>
-					<configuration>
-						<excludeArtifacts>
-							<excludeArtifact>com.github.javaparser:javaparser-core-testing</excludeArtifact>
-							<excludeArtifact>com.github.javaparser:javaparser-core-testing-bdd</excludeArtifact>
-							<excludeArtifact>com.github.javaparser:javaparser-symbol-solver-testing</excludeArtifact>
-							<excludeArtifact>com.github.javaparser:javaparser-core-metamodel-generator</excludeArtifact>
-						</excludeArtifacts>
-					</configuration>
-			</plugin>
-        </plugins>
         <pluginManagement>
             <plugins>
                 <!--
@@ -212,13 +239,6 @@
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-maven-plugin</artifactId>
                     <version>6.4.0</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>bnd-process</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <!--
                             Bundle-SymbolicName is derived from groupId + artifactId. OSGi permits
@@ -237,6 +257,13 @@
                             Bundle-DocURL: https://javaparser.org
                         ]]></bnd>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>bnd-process</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.helger.maven</groupId>
@@ -282,45 +309,45 @@
                         <releaseProfiles>run-release</releaseProfiles>
                         <!-- Disable pushing of changes (i.e. false, for local testing) -->
                         <pushChanges>false</pushChanges>
-						<!-- NEW: Disable deployment during release:perform -->
-						<goals>deploy</goals>
+                        <!-- NEW: Disable deployment during release:perform -->
+                        <goals>deploy</goals>
                     </configuration>
                 </plugin>
-				<!-- NEW: Disable the old maven-deploy-plugin -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>3.1.4</version>
-					<executions>
-						<execution>
-							<id>default-deploy</id>
-							<phase>deploy</phase>
-							<goals>
-								<goal>deploy</goal>
-							</goals>
-							<configuration>
-								<skip>true</skip>
-							</configuration>
-						</execution>
-					</executions>
-					<configuration>
-						<skip>true</skip>
-					</configuration>
-				</plugin>
-				<!-- NEW: Plugin for publishing to Maven Central -->
-				<plugin>
-					<groupId>org.sonatype.central</groupId>
-					<artifactId>central-publishing-maven-plugin</artifactId>
-					<version>0.11.0</version>
-					<extensions>true</extensions>
-					<configuration>
-						<publishingServerId>central</publishingServerId>
-						<!-- Automatic publication after validation -->
-						<autoPublish>true</autoPublish>
-						<!-- Readable name to identify the deployment -->
-						<deploymentName>${project.artifactId}-${project.version}</deploymentName>
-					</configuration>
-				</plugin>
+                <!-- NEW: Disable the old maven-deploy-plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.4</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>default-deploy</id>
+                            <goals>
+                                <goal>deploy</goal>
+                            </goals>
+                            <phase>deploy</phase>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!-- NEW: Plugin for publishing to Maven Central -->
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.11.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>central</publishingServerId>
+                        <!-- Automatic publication after validation -->
+                        <autoPublish>true</autoPublish>
+                        <!-- Readable name to identify the deployment -->
+                        <deploymentName>${project.artifactId}-${project.version}</deploymentName>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
@@ -342,9 +369,7 @@
                     <version>0.8.15</version>
                     <configuration>
                         <includes>
-                            <include>
-                                com/github/javaparser/**
-                            </include>
+                            <include>com/github/javaparser/**</include>
                         </includes>
                     </configuration>
                     <executions>
@@ -359,10 +384,10 @@
                         </execution>
                         <execution>
                             <id>jacoco-report</id>
-                            <phase>test</phase>
                             <goals>
                                 <goal>report-aggregate</goal>
                             </goals>
+                            <phase>test</phase>
                             <configuration>
                                 <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
                             </configuration>
@@ -443,67 +468,46 @@
                     <artifactId>spotless-maven-plugin</artifactId>
                     <version>2.46.1</version>
                     <configuration>
-						<lineEndings>UNIX</lineEndings>
+                        <lineEndings>UNIX</lineEndings>
                         <java>
                             <!-- google-java-format, but better: see https://github.com/palantir/palantir-java-format -->
                             <palantirJavaFormat/>
                         </java>
+                        <pom>
+                            <sortPom>
+                                <nrOfIndentSpace>4</nrOfIndentSpace>
+                                <expandEmptyElements>false</expandEmptyElements>
+                                <spaceBeforeCloseEmptyElement>false</spaceBeforeCloseEmptyElement>
+                                <keepBlankLines>true</keepBlankLines>
+                            </sortPom>
+                        </pom>
                     </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>
+                        <excludeArtifact>com.github.javaparser:javaparser-core-testing</excludeArtifact>
+                        <excludeArtifact>com.github.javaparser:javaparser-core-testing-bdd</excludeArtifact>
+                        <excludeArtifact>com.github.javaparser:javaparser-symbol-solver-testing</excludeArtifact>
+                        <excludeArtifact>com.github.javaparser:javaparser-core-metamodel-generator</excludeArtifact>
+                    </excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
-
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.javassist</groupId>
-                <artifactId>javassist</artifactId>
-                <version>3.32.0-GA</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
-            </dependency>
-			<dependency>
-				<groupId>org.checkerframework</groupId>
-				<artifactId>checker-qual</artifactId>
-				<version>3.55.1</version>
-			</dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>3.0</version>
-                <scope>test</scope>
-            </dependency>
-			<dependency>
-				<groupId>org.junit</groupId>
-				<artifactId>junit-bom</artifactId>
-				<version>5.14.4</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>4.11.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${byte-buddy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>${byte-buddy.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
 
     <profiles>
         <profile>
@@ -527,10 +531,10 @@
                         <executions>
                             <execution>
                                 <id>copy-readme</id>
-                                <phase>compile</phase>
                                 <goals>
                                     <goal>copy-resources</goal>
                                 </goals>
+                                <phase>compile</phase>
                                 <configuration>
                                     <outputDirectory>${project.basedir}</outputDirectory>
                                     <resources>
@@ -596,10 +600,10 @@
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <phase>verify</phase>
                                 <configuration>
                                     <!-- Prevent `gpg` from using pinentry programs -->
                                     <gpgArguments>


### PR DESCRIPTION
## Summary

Enable `sortPom()` in the existing Spotless configuration to normalize POM formatting across all 9 modules.

## Commits

| Commit | Purpose | In .git-blame-ignore-revs? |
|--------|---------|---------------------------|
| A: Enable sortPom + reformat | Formatting only (tabs→spaces, element reordering) | ✅ Yes |
| B: Schema URL http→https and  Update .git-blame-ignore-revs | Non-cosmetic URL fix (9 files) and Add commit A's SHA | ❌ No |

## sortPom Configuration

```xml
<pom>
    <sortPom>
        <nrOfIndentSpace>4</nrOfIndentSpace>
        <expandEmptyElements>false</expandEmptyElements>
        <spaceBeforeCloseEmptyElement>false</spaceBeforeCloseEmptyElement>
        <keepBlankLines>true</keepBlankLines>
    </sortPom>
</pom>
```

## Verification

- ✅ `dependency:tree` output is byte-identical before/after reformat [dep-tree-before.txt](https://github.com/user-attachments/files/30273997/dep-tree-before.txt)
[dep-tree-after.txt](https://github.com/user-attachments/files/30273998/dep-tree-after.txt)
- ✅ Clean build passes (`mvn clean install -DskipTests`)
- ✅ No CI changes needed — existing `spotless:check` + `git diff --exit-code` enforces POM formatting automatically

## Stats (Commit A)

| Module | Changes |
|--------|---------|
| pom.xml (root) | ±1,242 |
| javaparser-core | ±219 |
| javaparser-symbol-solver-testing | ±211 |
| javaparser-core-testing | ±167 |
| javaparser-core-generators | ±160 |
| javaparser-core-serialization | ±153 |
| javaparser-symbol-solver-core | ±146 |
| javaparser-core-testing-bdd | ±145 |
| javaparser-core-metamodel-generator | ±104 |

Total: 9 files, +1,277 / -1,270 (net +7 lines, pure reformat)

Fixes #5070