### PR TITLE
fix: bind inherited functional-method type variables in method references (fixes #4936)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -53,6 +53,7 @@ import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.resolution.promotion.ConditionalExprHandler;
 import com.github.javaparser.resolution.types.ResolvedArrayType;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.resolution.types.ResolvedVoidType;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
@@ -60,7 +61,6 @@ import com.github.javaparser.symbolsolver.resolution.promotion.ConditionalExprRe
 import com.github.javaparser.symbolsolver.resolution.typeinference.LeastUpperBoundLogic;
 import com.github.javaparser.symbolsolver.resolution.typeinference.TypeHelper;
 import com.github.javaparser.utils.Log;
-import com.github.javaparser.utils.Pair;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
@@ -843,10 +843,23 @@ public class TypeExtractor extends DefaultVisitorAdapter {
                 if (functionalMethodOpt.isPresent()) {
                     MethodUsage functionalMethod = functionalMethodOpt.get();
 
-                    for (Pair<ResolvedTypeParameterDeclaration, ResolvedType> typeParamDecl :
-                            result.asReferenceType().getTypeParametersMap()) {
-                        functionalMethod = functionalMethod.replaceTypeParameter(typeParamDecl.a, typeParamDecl.b);
+                    // Bind the type variables that appear in the functional method's signature using
+                    // the type arguments of the functional interface. The functional method is often
+                    // inherited (e.g. BinaryOperator<T> inherits apply from BiFunction<T, T, T>), so its
+                    // formal types are expressed with the *ancestor's* type variables. Resolving them via
+                    // useThisTypeParametersOnTheGivenType() walks the type hierarchy, so ancestor type
+                    // variables such as BiFunction's U are bound instead of leaking out unresolved (which
+                    // previously happened because a direct, name-based substitution only matched the
+                    // interface's own type parameters). See issue #4936.
+                    ResolvedReferenceType functionalInterfaceType = result.asReferenceType();
+                    for (int i = 0; i < functionalMethod.getNoParams(); i++) {
+                        functionalMethod = functionalMethod.replaceParamType(
+                                i,
+                                functionalInterfaceType.useThisTypeParametersOnTheGivenType(
+                                        functionalMethod.getParamType(i)));
                     }
+                    functionalMethod = functionalMethod.replaceReturnType(
+                            functionalInterfaceType.useThisTypeParametersOnTheGivenType(functionalMethod.returnType()));
 
                     // replace wildcards
                     for (int i = 0; i < functionalMethod.getNoParams(); i++) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
@@ -573,6 +573,169 @@ class MethodReferenceResolutionTest extends AbstractResolutionTest {
         assertEquals(0, errorCount, "Expected zero UnsolvedSymbolException s");
     }
 
+    /**
+     * BinaryOperator inherits its functional method apply(T, U) from BiFunction, so resolving
+     * BigDecimal::add must bind the ancestor's type parameters instead of leaking them unresolved.
+     * See <a href="https://github.com/javaparser/javaparser/issues/4936">issue #4936</a>.
+     */
+    @Test
+    public void issue4936_inheritedFunctionalMethodTypeParametersDoNotLeak() {
+        String code = "import java.math.BigDecimal;\n" + "import java.util.stream.Stream;\n"
+                + "public class Test{\n"
+                + "    public void test(){\n"
+                + "        Stream.of(new BigDecimal(0L)).reduce(BigDecimal::add).orElse(null);\n"
+                + "    }\n"
+                + "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        assertEquals(
+                "java.util.stream.Stream.of(T)",
+                Navigator.findMethodCall(cu, "of").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.util.stream.Stream.reduce(java.util.function.BinaryOperator<T>)",
+                Navigator.findMethodCall(cu, "reduce").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.util.Optional.orElse(T)",
+                Navigator.findMethodCall(cu, "orElse").get().resolve().getQualifiedSignature());
+    }
+
+    /**
+     * Inherited functional method type parameters must not leak even when the interface declares
+     * no type parameters of its own, leaving name-based matching nothing to bind.
+     * See <a href="https://github.com/javaparser/javaparser/issues/4936">issue #4936</a>.
+     */
+    @Test
+    public void issue4936_inheritedFunctionalMethodTypeParametersDoNotLeak_noOwnTypeParameters() {
+        String code = "import java.math.BigDecimal;\n"
+                + "public class Test {\n"
+                + "    interface DecimalOp extends java.util.function.BinaryOperator<BigDecimal> {}\n"
+                + "    static BigDecimal use(DecimalOp op) { return null; }\n"
+                + "    public void test() {\n"
+                + "        use(BigDecimal::add).negate();\n"
+                + "    }\n"
+                + "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        assertEquals(
+                "Test.use(Test.DecimalOp)",
+                Navigator.findMethodCall(cu, "use").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.math.BigDecimal.negate()",
+                Navigator.findMethodCall(cu, "negate").get().resolve().getQualifiedSignature());
+    }
+
+    /**
+     * Inherited functional method type parameters must not leak across a multi-level inheritance
+     * chain whose own type-parameter names differ from the ancestor's.
+     * See <a href="https://github.com/javaparser/javaparser/issues/4936">issue #4936</a>.
+     */
+    @Test
+    public void issue4936_inheritedFunctionalMethodTypeParametersDoNotLeak_transitiveInheritance() {
+        String code = "import java.math.BigDecimal;\n"
+                + "public class Test {\n"
+                + "    interface Step1<Z> extends java.util.function.BiFunction<Z, Z, Z> {}\n"
+                + "    interface Step2<A> extends Step1<A> {}\n"
+                + "    static BigDecimal use(Step2<BigDecimal> op) { return null; }\n"
+                + "    public void test() {\n"
+                + "        use(BigDecimal::add).negate();\n"
+                + "    }\n"
+                + "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        assertEquals(
+                "Test.use(Test.Step2<java.math.BigDecimal>)",
+                Navigator.findMethodCall(cu, "use").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.math.BigDecimal.negate()",
+                Navigator.findMethodCall(cu, "negate").get().resolve().getQualifiedSignature());
+    }
+
+    /**
+     * Inherited functional method type parameters must not leak when resolving a static method
+     * reference (JLS §15.13.1 form 1a), not just an unbound instance one.
+     * See <a href="https://github.com/javaparser/javaparser/issues/4936">issue #4936</a>.
+     */
+    @Test
+    public void issue4936_inheritedFunctionalMethodTypeParametersDoNotLeak_staticMethodReference() {
+        String code = "import java.util.stream.Stream;\n"
+                + "public class Test {\n"
+                + "    public void test() {\n"
+                + "        Stream.of(1).reduce(Integer::sum).orElse(null);\n"
+                + "    }\n"
+                + "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        assertEquals(
+                "java.util.stream.Stream.of(T)",
+                Navigator.findMethodCall(cu, "of").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.util.stream.Stream.reduce(java.util.function.BinaryOperator<T>)",
+                Navigator.findMethodCall(cu, "reduce").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.util.Optional.orElse(T)",
+                Navigator.findMethodCall(cu, "orElse").get().resolve().getQualifiedSignature());
+    }
+
+    /**
+     * Inherited functional method type parameters bound to a wildcard type argument must be
+     * substituted (and then unwrapped) instead of leaking.
+     * See <a href="https://github.com/javaparser/javaparser/issues/4936">issue #4936</a>.
+     */
+    @Test
+    public void issue4936_inheritedFunctionalMethodTypeParametersDoNotLeak_wildcardTypeArgument() {
+        String code = "import java.math.BigDecimal;\n"
+                + "public class Test {\n"
+                + "    interface Op<A> extends java.util.function.BiFunction<A, A, A> {}\n"
+                + "    static BigDecimal use(Op<? super BigDecimal> op) { return null; }\n"
+                + "    public void test() {\n"
+                + "        use(BigDecimal::add).negate();\n"
+                + "    }\n"
+                + "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        assertEquals(
+                "Test.use(Test.Op<? super java.math.BigDecimal>)",
+                Navigator.findMethodCall(cu, "use").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.math.BigDecimal.negate()",
+                Navigator.findMethodCall(cu, "negate").get().resolve().getQualifiedSignature());
+    }
+
+    /**
+     * Without a chained call, resolving reduce() does not force full type resolution of the
+     * method reference argument; this is the case that already worked before issue #4936.
+     * See <a href="https://github.com/javaparser/javaparser/issues/4936">issue #4936</a>.
+     */
+    @Test
+    public void issue4936_inheritedFunctionalMethodTypeParametersDoNotLeak_withoutChainedCall() {
+        String code = "import java.math.BigDecimal;\n" + "import java.util.stream.Stream;\n"
+                + "public class Test{\n"
+                + "    public void test(){\n"
+                + "        Stream.of(new BigDecimal(0L)).reduce(BigDecimal::add);\n"
+                + "    }\n"
+                + "}";
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        assertEquals(
+                "java.util.stream.Stream.of(T)",
+                Navigator.findMethodCall(cu, "of").get().resolve().getQualifiedSignature());
+        assertEquals(
+                "java.util.stream.Stream.reduce(java.util.function.BinaryOperator<T>)",
+                Navigator.findMethodCall(cu, "reduce").get().resolve().getQualifiedSignature());
+    }
+
     @Test
     public void testIssue3289() {
         String code = "import java.util.ArrayList;\n" + "import java.util.List;\n"


### PR DESCRIPTION
Fixes #4936

### Issue

Resolving `Stream.of(new BigDecimal(0L)).reduce(BigDecimal::add).orElse(null)` threw
`UnsolvedSymbolException`. `BinaryOperator<T>` inherits its functional method `apply(T, U)` from
`BiFunction<T, U, R>`, so the method's formal types are expressed with the *ancestor's* type
parameters. The substitution in `TypeExtractor.visit(MethodReferenceExpr)` used the interface's
direct type-parameter map with name-based matching: `BiFunction.T` was bound only through its
accidental name collision with `BinaryOperator.T`, and `BiFunction.U` leak
`BigDecimal::add` was then looked up with parameter types `[BigDecimal, U]` and failed.

### Fix

Replace the name-based `replaceTypeParameter` loop with the ancestor-aware
`useThisTypeParametersOnTheGivenType()`, which resolves each type variable
hierarchy. Ancestor variables such as `BiFunction.U` are bound by the interface's parametrization
instead of by name coincidence.

### Tests

Each test was verified to fail before the fix, covers a distinct scenario,
resolved method signatures (e.g. that `reduce` resolves to the single-argument
`Stream.reduce(BinaryOperator<T>)` overload) rather than just that resolut

- `issue4979_inheritedFunctionalMethodTypeParametersDoNotLeak` — the repor
  instance reference against `BinaryOperator<BigDecimal>` (leaked `[BigDecimal, U]` pre-fix)
- `…_noOwnTypeParameters` — `interface DecimalOp extends BinaryOperator<Bi
  type parameters of its own, so name matching had nothing to bind (leaked `[T, U]`)
- `…_transitiveInheritance` — two-level generic chain with non-colliding p
  transitive ancestor substitution (leaked `[T, U]`)
- `…_staticMethodReference` — static reference `Integer::sum`, pinning the
  branch (leaked `[Integer, U]`)
- `…_wildcardTypeArgument` — `Op<? super BigDecimal>` target, pinning subs
  unwrapping (leaked `[T, U]`)
