### PR TITLE
fix: describe lambda parameter types without a spurious '? super' prefix

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedLambdaConstraintType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedLambdaConstraintType.java
@@ -28,9 +28,15 @@ public class ResolvedLambdaConstraintType implements ResolvedType {
         this.bound = bound;
     }
 
+    /**
+     * The bound is the type the lambda parameter was inferred to, so that is what callers are
+     * shown. Rendering it as {@code "? super " + bound} used to suggest a lower-bounded wildcard,
+     * but no wildcard is involved: when the functional interface method parameter is one,
+     * {@code LambdaExprContext} already stores its bounded type here.
+     */
     @Override
     public String describe() {
-        return "? super " + bound.describe();
+        return bound.describe();
     }
 
     public ResolvedType getBound() {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3859Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3859Test.java
@@ -62,12 +62,10 @@ public class Issue3859Test extends AbstractResolutionTest {
 
         List<NameExpr> exprs = cu.findAll(NameExpr.class);
         assertEquals(2, exprs.size());
-        assertEquals(
-                "? super java.lang.String", exprs.get(0).calculateResolvedType().describe());
+        assertEquals("java.lang.String", exprs.get(0).calculateResolvedType().describe());
         // Before the fix the following statement failed with an
         // `UnsupportedOperationException` because an extra `(...)` around
         // an argument wasn't handled.
-        assertEquals(
-                "? super java.lang.String", exprs.get(1).calculateResolvedType().describe());
+        assertEquals("java.lang.String", exprs.get(1).calculateResolvedType().describe());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/ContextTest.java
@@ -320,7 +320,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         JavaParserFacade javaParserFacade = JavaParserFacade.get(typeSolver);
         ResolvedType ref = javaParserFacade.getType(refToT);
 
-        assertEquals("? super java.lang.String", ref.describe());
+        assertEquals("java.lang.String", ref.describe());
     }
 
     @Test
@@ -564,7 +564,7 @@ class ContextTest extends AbstractSymbolResolutionTest {
         TypeSolver typeSolver = new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(pathToJar));
         ResolvedType typeOfT = JavaParserFacade.get(typeSolver).getType(referenceToT);
 
-        assertEquals("? super com.github.javaparser.ast.body.TypeDeclaration", typeOfT.describe());
+        assertEquals("com.github.javaparser.ast.body.TypeDeclaration", typeOfT.describe());
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
@@ -30,6 +30,8 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -430,7 +432,7 @@ class LambdaResolutionTest extends AbstractResolutionTest {
         Expression s1Expr = compareToCall.getScope().get();
 
         ResolvedType s1Type = JavaParserFacade.get(typeSolver).getType(s1Expr);
-        assertEquals("? super java.lang.String", s1Type.describe());
+        assertEquals("java.lang.String", s1Type.describe());
     }
 
     // --- Tests for issue #3626 ---
@@ -554,5 +556,36 @@ class LambdaResolutionTest extends AbstractResolutionTest {
         assertEquals(
                 "java.lang.String.toLowerCase()",
                 assertDoesNotThrow(toLowerCaseCall::resolve).getQualifiedSignature());
+    }
+
+    @Test
+    void lambdaParameterOfWildcardBoundedFunctionalInterfaceIsDescribedWithoutTheWildcard() {
+        String source = "import java.util.Map;\n"
+                + "import java.util.HashMap;\n"
+                + "class Value<T> { public Value(T val) {} }\n"
+                + "class Test {\n"
+                + "    public void example(Map<String, String> request) {\n"
+                + "        Map<String, Value<String>> result = new HashMap<>();\n"
+                + "        request.forEach((key, v) -> {\n"
+                + "            result.put(key, new Value<String>(v));\n"
+                + "        });\n"
+                + "    }\n"
+                + "}";
+
+        ReflectionTypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(source);
+
+        LambdaExpr lambda = cu.findFirst(LambdaExpr.class).get();
+        assertEquals("java.lang.String", lambda.getParameter(0).resolve().describeType());
+        assertEquals("java.lang.String", lambda.getParameter(1).resolve().describeType());
+
+        MethodCallExpr putCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("put"))
+                .findFirst()
+                .get();
+        NameExpr vExpr = (NameExpr) ((ObjectCreationExpr) putCall.getArgument(1)).getArgument(0);
+
+        assertEquals("java.lang.String", vExpr.calculateResolvedType().describe());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/LambdaResolutionTest.java
@@ -588,4 +588,32 @@ class LambdaResolutionTest extends AbstractResolutionTest {
 
         assertEquals("java.lang.String", vExpr.calculateResolvedType().describe());
     }
+
+    @Test
+    void lambdaParameterOfWildcardBoundedFunctionalInterfaceKeepsANonFinalBound() {
+        String source = "import java.util.function.Consumer;\n"
+                + "class Test {\n"
+                + "    public void example(Consumer<? super Number> consumer) {\n"
+                + "        consumer.accept(1);\n"
+                + "    }\n"
+                + "    public void call() {\n"
+                + "        example(n -> n.intValue());\n"
+                + "    }\n"
+                + "}";
+
+        ReflectionTypeSolver typeSolver = new ReflectionTypeSolver();
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(typeSolver));
+        CompilationUnit cu = StaticJavaParser.parse(source);
+
+        LambdaExpr lambda = cu.findFirst(LambdaExpr.class).get();
+        assertEquals("java.lang.Number", lambda.getParameter(0).resolve().describeType());
+
+        MethodCallExpr intValueCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("intValue"))
+                .findFirst()
+                .get();
+        Expression nExpr = intValueCall.getScope().get();
+
+        assertEquals("java.lang.Number", nExpr.calculateResolvedType().describe());
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/LambdaExprContextResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/javaparser/contexts/LambdaExprContextResolutionTest.java
@@ -76,7 +76,7 @@ class LambdaExprContextResolutionTest extends AbstractResolutionTest {
 
         Optional<Value> ref = context.solveSymbolAsValue("p");
         assertTrue(ref.isPresent());
-        assertEquals("? super java.lang.String", ref.get().getType().describe());
+        assertEquals("java.lang.String", ref.get().getType().describe());
     }
 
     @Test
@@ -156,7 +156,7 @@ class LambdaExprContextResolutionTest extends AbstractResolutionTest {
         // expects Comparator<? super String>, so the inference engine matches
         // comparing's return type Comparator<T> against Comparator<? super String>
         // and concludes T = ? super String.  The lambda parameter therefore has
-        // type "? super java.lang.String".
+        // type "java.lang.String".
         String source = "import java.util.Arrays;\n"
                 + "import java.util.Comparator;\n"
                 + "import java.util.List;\n"
@@ -176,7 +176,7 @@ class LambdaExprContextResolutionTest extends AbstractResolutionTest {
         Context context = new LambdaExprContext(lambdaExpr, typeSolver);
         Optional<Value> ref = context.solveSymbolAsValue("s");
         assertTrue(ref.isPresent());
-        assertEquals("? super java.lang.String", ref.get().getType().describe());
+        assertEquals("java.lang.String", ref.get().getType().describe());
     }
 
     @Test


### PR DESCRIPTION
### Summary

Fixes #5040

`ResolvedLambdaConstraintType.describe()` hard-coded a `"? super "` prefix:

```java
public String describe() {
    return "? super " + bound.describe();
}
```

So a lambda parameter inferred as `String` was reported as `"? super java.lang.String"`. **No wildcard is involved.** When the functional interface method parameter is a wildcard, `LambdaExprContext` already unwraps it and stores the *bounded type* as the constraint's bound:

```java
if (argType.isWildcard()) {
    conType = ResolvedLambdaConstraintType.bound(argType.asWildcard().getBoundedType());
}
```

For the issue's example, `v` already resolves to a constraint whose bound is `java.lang.String` — the prefix described a wildcard that had already been stripped. This reports the bound itself.

This matches @johannescoetzee's conclusion in [the issue](https://github.com/javaparser/javaparser/issues/5040#issuecomment-3011452403) that `? super java.lang.String` is not correct and the answer should be exactly `java.lang.String`.

**Correction (per @jlerbsc, 2026-07-25):** the *reason* is not that `String` is final. Finality collapses `? extends String`, since no proper subtype exists — it does nothing to `? super String`, which still admits `CharSequence`, `Serializable` and `Object`. The parameter type is `String` because of JLS §15.27.1 / §9.9 / §9.8: an implicitly typed lambda parameter takes its type from the function type of the target type's **non-wildcard parameterization**, in which a lower-bounded argument `? super L` maps directly to `L`. The inferred type is therefore never a wildcard, and `? extends …` would be equally wrong. The behaviour holds for non-final bounds too — see the new test below.

### On the earlier revision of this PR

The first version of this PR was wrong and I've replaced it entirely. For the record, it:

- unwrapped constraint types in `JavaParserParameterDeclaration.getType()` and `JavaSymbolSolver`, which regressed `Issue2065Test` (`Math.max` inside `Stream.reduce` became unresolvable);
- relaxed `ReferenceTypeImpl.isAssignableBy` to treat `? super T` like `? extends T`, which is unsound — `Foo.isAssignableBy(? super Foo)` must be `false` because `? super Foo` may be `Object`. That broke `ReferenceTypeTest.testIsAssignableByGenerics` and `WildcardUsageTest.testIsAssignableBySimple`, which encode correct Java semantics;
- carried a test that asserted `"? super java.lang.String"` — the value the issue calls incorrect — and therefore **passed on an unmodified `master`** without testing anything.

None of those changes are in this revision; inference behaviour is untouched.

### Assertions updated

Seven assertions pinned the old rendering and now expect the bound. All are lambda parameters resolved through `ResolvedLambdaConstraintType`; no assertion on a real `ResolvedWildcard` changed (e.g. `WildcardUsageTest` lines 189/192 still expect `? super …`).

- `Issue3859Test` ×2
- `ContextTest.resolveReferenceToLambdaParamBase`, `ContextTest.resolveReferenceToLambdaParam`
- `LambdaResolutionTest.lambdaParameterTypeIsResolvedToStringNotTypeVariable`
- `LambdaExprContextResolutionTest.solveParameterOfLambdaInMethodCallExpr`, `…InStaticGenericMethodWithOuterContextInference`

### Test Plan

`lambdaParameterOfWildcardBoundedFunctionalInterfaceIsDescribedWithoutTheWildcard` uses the issue's snippet and asserts on both the parameter declarations (`resolve().describeType()`, the API the issue quotes) and the use site (`calculateResolvedType().describe()`). Verified it **fails on `master`** (`expected: <java.lang.String> but was: <? super java.lang.String>`) and passes with the fix.

`lambdaParameterOfWildcardBoundedFunctionalInterfaceKeepsANonFinalBound` (added at @jlerbsc's suggestion) pins the behaviour to the §9.8 rule rather than to finality, using `Consumer<? super Number>` — `Number` is not final, and the parameter still resolves to exactly `java.lang.Number`. Also verified to fail without the `describe()` change:

```
AssertionFailedError: expected: <java.lang.Number> but was: <? super java.lang.Number>
```

`LambdaResolutionTest` — 29 tests, 0 failures, 0 errors (1 pre-existing skip).

Full suites green on JDK 17:

- `javaparser-core-testing` — 2832 tests, 0 failures, 0 errors
- `javaparser-symbol-solver-testing` — 2078 tests, 0 failures, 0 errors
- `spotless:check` clean

### Note

@johannescoetzee, you mentioned you'd take a look at this one — happy to close this if you have a fix in progress, or to adjust the approach. `describe()` is the narrowest place to correct the rendering, but if you'd rather the constraint were unwrapped at the resolution boundary instead, that path needs the `Issue2065Test` interaction sorted out first.

