### PR TITLE
Isolate test parsers from the shared StaticJavaParser configuration

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/GeneratedJavaParserTokenManagerTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/GeneratedJavaParserTokenManagerTest.java
@@ -21,18 +21,18 @@
 
 package com.github.javaparser;
 
-import static com.github.javaparser.StaticJavaParser.parseResource;
-
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 class GeneratedJavaParserTokenManagerTest {
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     private String makeFilename(String sampleName) {
         return "com/github/javaparser/issue_samples/" + sampleName + ".java.txt";
     }
 
     @Test
     void issue1003() throws IOException {
-        parseResource(makeFilename("issue1003"));
+        parser.parseResource(makeFilename("issue1003"));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue1017Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue1017Test.java
@@ -26,12 +26,14 @@ import org.junit.jupiter.api.Test;
 
 public class Issue1017Test {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test()
     void test() {
         String code = "class X{int x(){ a(1+1 -> 10);}}";
 
         Assertions.assertThrows(ParseProblemException.class, () -> {
-            CompilationUnit cu = StaticJavaParser.parse(code);
+            CompilationUnit cu = parser.parse(code);
         });
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue2482Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue2482Test.java
@@ -31,9 +31,12 @@ import org.junit.jupiter.api.Test;
  * Tests related to https://github.com/javaparser/javaparser/issues/2482.
  */
 public class Issue2482Test {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     public void commentBeforeLambda() {
-        LambdaExpr le = StaticJavaParser.parseExpression(
+        LambdaExpr le = parser.parseExpression(
                 "// a comment before parent" + System.lineSeparator() + "()->{return 1;}");
 
         assertTrue(le.getComment().isPresent());
@@ -43,7 +46,7 @@ public class Issue2482Test {
 
     @Test
     public void commentBeforeBlock() {
-        Statement st = StaticJavaParser.parseBlock(
+        Statement st = parser.parseBlock(
                 "// a comment before parent" + System.lineSeparator() + "{ if (file != null) {} }");
         assertTrue(st.getComment().isPresent());
         assertTrue(st.getOrphanComments().isEmpty());
@@ -52,7 +55,7 @@ public class Issue2482Test {
 
     @Test
     public void commentBeforeIfStatement() {
-        Statement st = StaticJavaParser.parseStatement(
+        Statement st = parser.parseStatement(
                 "// a comment before parent" + System.lineSeparator() + "if (file != null) {}");
         assertTrue(st.getComment().isPresent());
         assertTrue(st.getOrphanComments().isEmpty());
@@ -61,7 +64,7 @@ public class Issue2482Test {
 
     @Test
     public void commentBeforeAssignment() {
-        Statement st = StaticJavaParser.parseStatement("// a comment" + System.lineSeparator() + "int x = 3;");
+        Statement st = parser.parseStatement("// a comment" + System.lineSeparator() + "int x = 3;");
 
         assertTrue(st.getComment().isPresent());
         assertTrue(st.getOrphanComments().isEmpty());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue2482Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue2482Test.java
@@ -36,8 +36,8 @@ public class Issue2482Test {
 
     @Test
     public void commentBeforeLambda() {
-        LambdaExpr le = parser.parseExpression(
-                "// a comment before parent" + System.lineSeparator() + "()->{return 1;}");
+        LambdaExpr le =
+                parser.parseExpression("// a comment before parent" + System.lineSeparator() + "()->{return 1;}");
 
         assertTrue(le.getComment().isPresent());
         assertTrue(le.getOrphanComments().isEmpty());
@@ -46,8 +46,8 @@ public class Issue2482Test {
 
     @Test
     public void commentBeforeBlock() {
-        Statement st = parser.parseBlock(
-                "// a comment before parent" + System.lineSeparator() + "{ if (file != null) {} }");
+        Statement st =
+                parser.parseBlock("// a comment before parent" + System.lineSeparator() + "{ if (file != null) {} }");
         assertTrue(st.getComment().isPresent());
         assertTrue(st.getOrphanComments().isEmpty());
         assertEquals(0, st.getAllContainedComments().size());
@@ -55,8 +55,8 @@ public class Issue2482Test {
 
     @Test
     public void commentBeforeIfStatement() {
-        Statement st = parser.parseStatement(
-                "// a comment before parent" + System.lineSeparator() + "if (file != null) {}");
+        Statement st =
+                parser.parseStatement("// a comment before parent" + System.lineSeparator() + "if (file != null) {}");
         assertTrue(st.getComment().isPresent());
         assertTrue(st.getOrphanComments().isEmpty());
         assertEquals(0, st.getAllContainedComments().size());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3064Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3064Test.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 public class Issue3064Test {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     public void test0() {
         String str = "import java.util.function.Supplier;\n" + "\n"
@@ -38,10 +40,7 @@ public class Issue3064Test {
                 + "    }\n"
                 + "}\n";
 
-        JavaParser parser = new JavaParser();
-        ParseResult<CompilationUnit> unitOpt = parser.parse(new StringReader(str));
-        unitOpt.getProblems().stream().forEach(p -> System.err.println(p.toString()));
-        CompilationUnit unit = unitOpt.getResult().orElseThrow(() -> new IllegalStateException("Could not parse file"));
+        CompilationUnit unit = parser.parse(new StringReader(str));
 
         assertEquals(str, unit.toString());
     }
@@ -52,7 +51,7 @@ public class Issue3064Test {
                 + "        Supplier<String> aStringSupplier = false ? () -> \"F\" : true ? () -> \"T\" : () -> \"path\";\n"
                 + "    }\n"
                 + "}";
-        CompilationUnit unit = StaticJavaParser.newParserAdapter().parse(str);
+        CompilationUnit unit = parser.parse(str);
         assertEquals(str.replace("\n", ""), unit.toString().replace("\n", ""));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3064Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3064Test.java
@@ -52,7 +52,7 @@ public class Issue3064Test {
                 + "        Supplier<String> aStringSupplier = false ? () -> \"F\" : true ? () -> \"T\" : () -> \"path\";\n"
                 + "    }\n"
                 + "}";
-        CompilationUnit unit = StaticJavaParser.parse(str);
+        CompilationUnit unit = StaticJavaParser.newParserAdapter().parse(str);
         assertEquals(str.replace("\n", ""), unit.toString().replace("\n", ""));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3577Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue3577Test.java
@@ -36,9 +36,9 @@ public class Issue3577Test {
                 + "}";
 
         ParserConfiguration config = new ParserConfiguration().setLanguageLevel(LanguageLevel.JAVA_15);
-        StaticJavaParser.setConfiguration(config);
+        JavaParserAdapter parser = StaticJavaParser.newParserAdapter(config);
 
-        assertDoesNotThrow(() -> StaticJavaParser.parse(str));
+        assertDoesNotThrow(() -> parser.parse(str));
         //        unitOpt.getProblems().stream().forEach(p -> System.err.println(p.toString()));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/Issue5012Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/Issue5012Test.java
@@ -19,8 +19,6 @@
  */
 package com.github.javaparser;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static com.github.javaparser.StaticJavaParser.parseSimpleName;
 import static com.github.javaparser.utils.TestUtils.assertNoProblems;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,27 +37,29 @@ import org.junit.jupiter.api.Test;
  */
 public class Issue5012Test {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void parseStringWithMultipleUUnicodeEscape() {
-        StringLiteralExpr expr = parseExpression("\"t\\uuuu1234\"");
+        StringLiteralExpr expr = parser.parseExpression("\"t\\uuuu1234\"");
         assertEquals("t\\uuuu1234", expr.getValue());
     }
 
     @Test
     void parseStringWithSingleUUnicodeEscape() {
-        StringLiteralExpr expr = parseExpression("\"t\\u1234\"");
+        StringLiteralExpr expr = parser.parseExpression("\"t\\u1234\"");
         assertEquals("t\\u1234", expr.getValue());
     }
 
     @Test
     void parseCharWithMultipleUUnicodeEscape() {
-        CharLiteralExpr expr = parseExpression("'\\uuuu1234'");
+        CharLiteralExpr expr = parser.parseExpression("'\\uuuu1234'");
         assertEquals("\\uuuu1234", expr.getValue());
     }
 
     @Test
     void parseIdentifierWithMultipleUUnicodeEscape() {
-        SimpleName name = parseSimpleName("xxx\\uuu2122xxx");
+        SimpleName name = parser.parseSimpleName("xxx\\uuu2122xxx");
         assertEquals("xxx\\uuu2122xxx", name.asString());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -26,7 +26,6 @@ import static com.github.javaparser.ParserConfiguration.LanguageLevel.BLEEDING_E
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.CURRENT;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.Range.range;
-import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.TestUtils.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,26 +45,17 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.printer.YamlPrinter;
 import com.github.javaparser.utils.LineSeparator;
 import java.util.Optional;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class JavaParserTest {
 
-    @BeforeEach
-    void setToLatestJava() {
-        StaticJavaParser.getConfiguration().setLanguageLevel(BLEEDING_EDGE);
-    }
-
-    @AfterEach
-    void resetJavaLevel() {
-        StaticJavaParser.getConfiguration().setLanguageLevel(CURRENT);
-    }
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+            new ParserConfiguration().setLanguageLevel(BLEEDING_EDGE));
 
     @Test
     void rangeOfAnnotationMemberDeclarationIsCorrect() {
         String code = "@interface AD { String foo(); }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         AnnotationMemberDeclaration memberDeclaration =
                 cu.getAnnotationDeclarationByName("AD").get().getMember(0).asAnnotationMemberDeclaration();
         assertTrue(memberDeclaration.hasRange());
@@ -108,7 +98,7 @@ class JavaParserTest {
     @Test
     void rangeOfAnnotationMemberDeclarationWithArrayTypeIsCorrect() {
         String code = "@interface AD { String[] foo(); }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         AnnotationMemberDeclaration memberDeclaration =
                 cu.getAnnotationDeclarationByName("AD").get().getMember(0).asAnnotationMemberDeclaration();
         assertTrue(memberDeclaration.hasRange());
@@ -121,7 +111,7 @@ class JavaParserTest {
     void annotationMemberDeclarationWithArrayDimsAfterParentheses() {
         // https://github.com/javaparser/javaparser/issues/3649
         String code = "public @interface Foo { int value()[]; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         AnnotationMemberDeclaration memberDeclaration =
                 cu.getAnnotationDeclarationByName("Foo").get().getMember(0).asAnnotationMemberDeclaration();
         assertTrue(memberDeclaration.getType().isArrayType());
@@ -133,7 +123,7 @@ class JavaParserTest {
     @Test
     void rangeOfArrayCreationLevelWithExpressionIsCorrect() {
         String code = "new int[123][456]";
-        ArrayCreationExpr expression = parseExpression(code);
+        ArrayCreationExpr expression = parser.parseExpression(code);
         Optional<Range> range;
 
         range = expression.getLevels().get(0).getRange();
@@ -148,7 +138,7 @@ class JavaParserTest {
     @Test
     void rangeOfArrayCreationLevelWithoutExpressionIsCorrect() {
         String code = "new int[][]";
-        ArrayCreationExpr expression = parseExpression(code);
+        ArrayCreationExpr expression = parser.parseExpression(code);
         Optional<Range> range;
 
         range = expression.getLevels().get(0).getRange();
@@ -175,7 +165,7 @@ class JavaParserTest {
     @Test
     void parseIntersectionType() {
         String code = "(Runnable & Serializable) (() -> {})";
-        Expression expression = parseExpression(code);
+        Expression expression = parser.parseExpression(code);
         Type type = expression.asCastExpr().getType();
 
         assertTrue(type instanceof IntersectionType);
@@ -194,7 +184,7 @@ class JavaParserTest {
     @Test
     void parseArrayInitialization() {
         String code = "{1,2,3}";
-        ArrayInitializerExpr expression = parseArrayInitializerExpr(code);
+        ArrayInitializerExpr expression = parser.parseArrayInitializerExpr(code);
 
         assertEquals(3, expression.getValues().size());
     }
@@ -206,7 +196,7 @@ class JavaParserTest {
                 + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
                 + LineSeparator.SYSTEM
                 + "}}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration methodDeclaration =
                 cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
         ReturnStmt returnStmt =
@@ -223,7 +213,7 @@ class JavaParserTest {
                 + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
                 + LineSeparator.SYSTEM
                 + "}}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration methodDeclaration =
                 cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
         ReturnStmt returnStmt =
@@ -239,7 +229,7 @@ class JavaParserTest {
                 + "    return (Comparator<Map.Entry<K, V>>               )(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
                 + LineSeparator.SYSTEM
                 + "}}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration methodDeclaration =
                 cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
         ReturnStmt returnStmt =
@@ -255,7 +245,7 @@ class JavaParserTest {
                 + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
                 + LineSeparator.SYSTEM
                 + "}}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration methodDeclaration =
                 cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
         ReturnStmt returnStmt =
@@ -278,7 +268,7 @@ class JavaParserTest {
                 + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
                 + LineSeparator.SYSTEM
                 + "}}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration methodDeclaration =
                 cu.getClassByName("A").get().getMember(0).asMethodDeclaration();
         ReturnStmt returnStmt =
@@ -298,18 +288,18 @@ class JavaParserTest {
 
     @Test
     void trailingCodeIsAnError() {
-        assertThrows(ParseProblemException.class, () -> parseBlock("{} efijqoifjqefj"));
+        assertThrows(ParseProblemException.class, () -> parser.parseBlock("{} efijqoifjqefj"));
     }
 
     @Test
     void trailingWhitespaceIsIgnored() {
-        BlockStmt blockStmt = parseBlock("{} // hello");
+        BlockStmt blockStmt = parser.parseBlock("{} // hello");
         assertEquals("{}", blockStmt.getTokenRange().get().toString());
     }
 
     @Test
     void parsingInitializedAndUnitializedVarsInForStmt() {
-        ForStmt forStmt = parseStatement("for(int a,b=0;;){}").asForStmt();
+        ForStmt forStmt = parser.parseStatement("for(int a,b=0;;){}").asForStmt();
         assertEquals(1, forStmt.getInitialization().size());
         assertTrue(forStmt.getInitialization().get(0).isVariableDeclarationExpr());
         assertEquals(
@@ -355,7 +345,7 @@ class JavaParserTest {
     void parsingInitializedAndUnitializedVarsInForStmtComplexCase() {
         // See issue 1281
         ForStmt forStmt =
-                parseStatement("for(int i, j = array2.length - 1;;){}").asForStmt();
+                parser.parseStatement("for(int i, j = array2.length - 1;;){}").asForStmt();
         assertEquals(1, forStmt.getInitialization().size());
         assertTrue(forStmt.getInitialization().get(0).isVariableDeclarationExpr());
         assertEquals(
@@ -400,40 +390,40 @@ class JavaParserTest {
     @Test
     void creatingNewObjectCreationExprShouldDefaultToParsing() {
         String className = String.class.getCanonicalName();
-        ClassOrInterfaceType type = parseClassOrInterfaceType(className);
-        ObjectCreationExpr expected = parseExpression("new " + className + "()");
+        ClassOrInterfaceType type = parser.parseClassOrInterfaceType(className);
+        ObjectCreationExpr expected = parser.parseExpression("new " + className + "()");
         ObjectCreationExpr actual = new ObjectCreationExpr(null, type, NodeList.nodeList());
         assertEquals(expected, actual);
     }
 
     @Test
     void parseModuleDeclaration() {
-        StaticJavaParser.parseModuleDeclaration("module X {}");
+        parser.parseModuleDeclaration("module X {}");
     }
 
     @Test
     void parseModuleDirective() {
-        StaticJavaParser.parseModuleDirective("opens C;");
+        parser.parseModuleDirective("opens C;");
     }
 
     @Test
     void parseTypeParameter() {
-        StaticJavaParser.parseTypeParameter("T extends Serializable & AttachableListener");
+        parser.parseTypeParameter("T extends Serializable & AttachableListener");
     }
 
     @Test
     void parseTypeDeclaration() {
-        StaticJavaParser.parseTypeDeclaration("enum Z {A, B}");
+        parser.parseTypeDeclaration("enum Z {A, B}");
     }
 
     @Test
     void xxx() {
-        YamlPrinter.print(StaticJavaParser.parse("class X{}"));
+        YamlPrinter.print(parser.parse("class X{}"));
     }
 
     @Test
     void issue2879() {
-        StaticJavaParser.parse("public class Test {" + "    public void method(int @MyAnno ... param) {}"
+        parser.parse("public class Test {" + "    public void method(int @MyAnno ... param) {}"
                 + "}"
                 + "@Target(java.lang.annotation.ElementType.TYPE_USE) @interface MyAnno {}");
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -23,7 +23,6 @@ package com.github.javaparser;
 
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.BLEEDING_EDGE;
-import static com.github.javaparser.ParserConfiguration.LanguageLevel.CURRENT;
 import static com.github.javaparser.Providers.provider;
 import static com.github.javaparser.Range.range;
 import static com.github.javaparser.utils.TestUtils.assertInstanceOf;
@@ -49,8 +48,8 @@ import org.junit.jupiter.api.Test;
 
 class JavaParserTest {
 
-    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
-            new ParserConfiguration().setLanguageLevel(BLEEDING_EDGE));
+    private final JavaParserAdapter parser =
+            StaticJavaParser.newParserAdapter(new ParserConfiguration().setLanguageLevel(BLEEDING_EDGE));
 
     @Test
     void rangeOfAnnotationMemberDeclarationIsCorrect() {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/TokenRangeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/TokenRangeTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -30,9 +29,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class TokenRangeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void toStringWorks() {
-        CompilationUnit cu = parse("class X {\n\tX(){\n// hello\n}\n}");
+        CompilationUnit cu = parser.parse("class X {\n\tX(){\n// hello\n}\n}");
         assertEquals(
                 "X(){\n// hello\n}",
                 cu.getClassByName("X")
@@ -46,7 +48,7 @@ class TokenRangeTest {
 
     @Test
     void renumberRangesWorks() {
-        CompilationUnit cu = parse("class X {\n\tX(){\n// hello\n}\n}");
+        CompilationUnit cu = parser.parse("class X {\n\tX(){\n// hello\n}\n}");
 
         assertEquals(
                 "1,1-5/6,1-1/7,1-1/8,1-1/9,1-1/10,1-1/1,2-1/2,2-1/3,2-1/4,2-1/5,2-1/6,2-1/1,3-8/9,3-1/1,4-1/2,4-1/1,5-1/1,5-1/",

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/TokenTypesTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/TokenTypesTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.CodeGenerationUtils.mavenModuleRoot;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,12 +33,14 @@ import org.junit.jupiter.api.Test;
 
 public class TokenTypesTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void everyTokenHasACategory() throws IOException {
         final int tokenCount = GeneratedJavaParserConstants.tokenImage.length;
         Path tokenTypesPath = mavenModuleRoot(JavaParserTest.class)
                 .resolve("../javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java");
-        CompilationUnit tokenTypesCu = parse(tokenTypesPath);
+        CompilationUnit tokenTypesCu = parser.parse(tokenTypesPath);
 
         // -1 to take off the default: case.
         int switchEntries = tokenTypesCu.findAll(SwitchEntry.class).size() - 1;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/CompilationUnitTest.java
@@ -21,20 +21,24 @@
 
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.CodeGenerationUtils.mavenModuleRoot;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 class CompilationUnitTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void issue578TheFirstCommentIsWithinTheCompilationUnit() {
         CompilationUnit compilationUnit =
-                parse("// This is my class, with my comment\n" + "class A {\n" + "    static int a;\n" + "}");
+                parser.parse("// This is my class, with my comment\n" + "class A {\n" + "    static int a;\n" + "}");
 
         assertEquals(1, compilationUnit.getAllContainedComments().size());
     }
@@ -46,7 +50,7 @@ class CompilationUnitTest {
                 .normalize();
         Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "Z.java"));
 
-        CompilationUnit cu = parse(testFile);
+        CompilationUnit cu = parser.parse(testFile);
         Path sourceRoot1 = cu.getStorage().get().getSourceRoot();
         assertEquals(sourceRoot, sourceRoot1);
     }
@@ -58,7 +62,7 @@ class CompilationUnitTest {
                     .resolve(Paths.get("src", "test", "resources"))
                     .normalize();
             Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "A.java"));
-            CompilationUnit cu = parse(testFile);
+            CompilationUnit cu = parser.parse(testFile);
             cu.getStorage().get().getSourceRoot();
         });
     }
@@ -70,7 +74,7 @@ class CompilationUnitTest {
                 .normalize();
         Path testFile = sourceRoot.resolve(Paths.get("B.java"));
 
-        CompilationUnit cu = parse(testFile);
+        CompilationUnit cu = parser.parse(testFile);
         Path sourceRoot1 = cu.getStorage().get().getSourceRoot();
         assertEquals(sourceRoot, sourceRoot1);
     }
@@ -81,14 +85,14 @@ class CompilationUnitTest {
                 .resolve(Paths.get("src", "test", "resources"))
                 .normalize();
         Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType.java"));
-        CompilationUnit cu = parse(testFile);
+        CompilationUnit cu = parser.parse(testFile);
 
         assertEquals("PrimaryType", cu.getPrimaryTypeName().get());
     }
 
     @Test
     void testNoPrimaryTypeName() {
-        CompilationUnit cu = parse("class PrimaryType{}");
+        CompilationUnit cu = parser.parse("class PrimaryType{}");
 
         assertFalse(cu.getPrimaryTypeName().isPresent());
     }
@@ -99,7 +103,7 @@ class CompilationUnitTest {
                 .resolve(Paths.get("src", "test", "resources"))
                 .normalize();
         Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType.java"));
-        CompilationUnit cu = parse(testFile);
+        CompilationUnit cu = parser.parse(testFile);
 
         assertEquals("PrimaryType", cu.getPrimaryType().get().getNameAsString());
     }
@@ -110,7 +114,7 @@ class CompilationUnitTest {
                 .resolve(Paths.get("src", "test", "resources"))
                 .normalize();
         Path testFile = sourceRoot.resolve(Paths.get("com", "github", "javaparser", "storage", "PrimaryType2.java"));
-        CompilationUnit cu = parse(testFile);
+        CompilationUnit cu = parser.parse(testFile);
 
         assertFalse(cu.getPrimaryType().isPresent());
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/FindNodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/FindNodeTest.java
@@ -21,9 +21,10 @@
 
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
@@ -34,9 +35,12 @@ import org.junit.jupiter.api.Test;
  * Some tests for finding descendant and ancestor nodes.
  */
 class FindNodeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void testFindFirst() {
-        CompilationUnit cu = parse("class Foo {\n" + "    void foo() {\n"
+        CompilationUnit cu = parser.parse("class Foo {\n" + "    void foo() {\n"
                 + "        try {\n"
                 + "        } catch (Exception e) {\n"
                 + "        } finally {\n"
@@ -77,7 +81,7 @@ class FindNodeTest {
 
     @Test
     void testFindAncestralFinallyBlock() {
-        CompilationUnit cu = parse("class Foo {\n" + "    void foo() {\n"
+        CompilationUnit cu = parser.parse("class Foo {\n" + "    void foo() {\n"
                 + "        try {\n"
                 + "        } catch (Exception e) {\n"
                 + "        } finally {\n"

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ListObservationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ListObservationTest.java
@@ -41,7 +41,6 @@ public class ListObservationTest {
 
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
-
     private FieldDeclaration createIntField(String name) {
         return new FieldDeclaration(new NodeList<>(), PrimitiveType.intType(), name);
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ListObservationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ListObservationTest.java
@@ -20,11 +20,12 @@
 
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.expr.SimpleName;
@@ -37,6 +38,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class ListObservationTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
 
     private FieldDeclaration createIntField(String name) {
         return new FieldDeclaration(new NodeList<>(), PrimitiveType.intType(), name);
@@ -74,7 +78,7 @@ public class ListObservationTest {
     void addAllWithoutIndex() {
         List<String> changes = new LinkedList<>();
         String code = "class A { void foo(int p) { }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -91,7 +95,7 @@ public class ListObservationTest {
     void addAllWithIndex() {
         List<String> changes = new LinkedList<>();
         String code = "class A { void foo(int p) { }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -108,7 +112,7 @@ public class ListObservationTest {
     void clear() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -125,7 +129,7 @@ public class ListObservationTest {
     void set() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -137,7 +141,7 @@ public class ListObservationTest {
     void removeNode() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; int d; int e; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -149,7 +153,7 @@ public class ListObservationTest {
     void removeFirstNode() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; int d; int e; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -169,7 +173,7 @@ public class ListObservationTest {
     void removeLastNode() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; int d; int e; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -189,7 +193,7 @@ public class ListObservationTest {
     void removeObject() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; int d; int e; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -201,7 +205,7 @@ public class ListObservationTest {
     void removeAll() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; int d; int e; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -217,7 +221,7 @@ public class ListObservationTest {
     void retainAll() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; int d; int e; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -237,7 +241,7 @@ public class ListObservationTest {
     void replaceAll() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int b; int c; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 
@@ -258,7 +262,7 @@ public class ListObservationTest {
     void removeIf() {
         List<String> changes = new LinkedList<>();
         String code = "class A { int a; int longName; int c; }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         ClassOrInterfaceDeclaration cd = cu.getClassByName("A").get();
         cd.getMembers().register(createObserver(changes));
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -133,7 +133,8 @@ class NodeTest {
 
     @Test
     void findCompilationUnitOfOrphanCommentNode() {
-        CompilationUnit cu = parser.parse("class X {\n" + "  void x() {\n" + "    // this is a comment\n" + "  }\n" + "}\n");
+        CompilationUnit cu =
+                parser.parse("class X {\n" + "  void x() {\n" + "    // this is a comment\n" + "  }\n" + "}\n");
 
         Comment comment = cu.getType(0)
                 .getMember(0)

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeTest.java
@@ -21,14 +21,15 @@
 
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.Position;
 import com.github.javaparser.Range;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -50,6 +51,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class NodeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void removeOrphanCommentPositiveCase() {
         ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration(new NodeList<>(), false, "A");
@@ -112,7 +116,7 @@ class NodeTest {
 
     @Test
     void findCompilationUnitOfCommentNode() {
-        CompilationUnit cu = parse(
+        CompilationUnit cu = parser.parse(
                 "class X {\n" + "  void x() {\n" + "    // this is a comment\n" + "    foo();\n" + "  }\n" + "}\n");
 
         Comment comment = cu.getType(0)
@@ -129,7 +133,7 @@ class NodeTest {
 
     @Test
     void findCompilationUnitOfOrphanCommentNode() {
-        CompilationUnit cu = parse("class X {\n" + "  void x() {\n" + "    // this is a comment\n" + "  }\n" + "}\n");
+        CompilationUnit cu = parser.parse("class X {\n" + "  void x() {\n" + "    // this is a comment\n" + "  }\n" + "}\n");
 
         Comment comment = cu.getType(0)
                 .getMember(0)
@@ -144,7 +148,7 @@ class NodeTest {
 
     @Test
     void removeAllOnRequiredProperty() {
-        CompilationUnit cu = parse("class X{ void x(){}}");
+        CompilationUnit cu = parser.parse("class X{ void x(){}}");
         MethodDeclaration methodDeclaration = cu.getType(0).getMethods().get(0);
         methodDeclaration.getName().removeForced();
         // Name is required, so to remove it the whole method is removed.
@@ -153,7 +157,7 @@ class NodeTest {
 
     @Test
     void removingTheSecondOfAListOfIdenticalStatementsDoesNotMessUpTheParents() {
-        CompilationUnit unit = parse(String.format(
+        CompilationUnit unit = parser.parse(String.format(
                 "public class Example {%1$s" + "  public static void example() {%1$s"
                         + "    boolean swapped;%1$s"
                         + "    swapped=false;%1$s"
@@ -170,7 +174,7 @@ class NodeTest {
 
     @Test
     void findNodeByRange() {
-        CompilationUnit cu = parse("class X {\n" + "  void x() {\n" + "  }\n" + "}\n");
+        CompilationUnit cu = parser.parse("class X {\n" + "  void x() {\n" + "  }\n" + "}\n");
         ClassOrInterfaceDeclaration coid =
                 cu.findFirst(ClassOrInterfaceDeclaration.class).get();
         MethodDeclaration md = cu.findFirst(MethodDeclaration.class).get();
@@ -222,7 +226,7 @@ class NodeTest {
 
         @Test
         void astHasMultipleLeafs() {
-            Node root = parse("package com;" + "import com.*;" + "import org.*;" + "abstract class Foo {}");
+            Node root = parser.parse("package com;" + "import com.*;" + "import org.*;" + "abstract class Foo {}");
             List<Node> nodes = root.findAll(Node.class, Node.TreeTraversal.PREORDER);
             assertEquals(
                     Arrays.asList(
@@ -262,7 +266,7 @@ class NodeTest {
 
         @Test
         void astHasMultipleLeafs() {
-            Node root = parse("package com;" + "import com.*;" + "import org.*;" + "abstract class Foo {}");
+            Node root = parser.parse("package com;" + "import com.*;" + "import org.*;" + "abstract class Foo {}");
             List<Node> nodes = root.findAll(Node.class, Node.TreeTraversal.POSTORDER);
             assertEquals(
                     Arrays.asList(

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ObservationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ObservationTest.java
@@ -38,7 +38,6 @@ public class ObservationTest {
 
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
-
     @Test
     void registerSubTree() {
         String code = "class A { int f; void foo(int p) { return 'z'; }}";

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ObservationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ObservationTest.java
@@ -20,11 +20,12 @@
 
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.observer.AstObserver;
 import com.github.javaparser.ast.observer.AstObserverAdapter;
 import com.github.javaparser.ast.observer.ObservableProperty;
@@ -35,10 +36,13 @@ import org.junit.jupiter.api.Test;
 
 public class ObservationTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
+
     @Test
     void registerSubTree() {
         String code = "class A { int f; void foo(int p) { return 'z'; }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new AstObserverAdapter() {
             @Override
@@ -86,7 +90,7 @@ public class ObservationTest {
     @Test
     void registerWithJustNodeMode() {
         String code = "class A { int f; void foo(int p) { return 'z'; }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new AstObserverAdapter() {
             @Override
@@ -133,7 +137,7 @@ public class ObservationTest {
     @Test
     void registerWithNodeAndExistingDescendantsMode() {
         String code = "class A { int f; void foo(int p) { return 'z'; }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new AstObserverAdapter() {
             @Override
@@ -196,7 +200,7 @@ public class ObservationTest {
     @Test
     void registerWithSelfPropagatingMode() {
         String code = "class A { int f; void foo(int p) { return 'z'; }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new AstObserverAdapter() {
             @Override
@@ -258,7 +262,7 @@ public class ObservationTest {
     @Test
     void deleteAParameterTriggerNotifications() {
         String code = "class A { void foo(int p) { }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new AstObserverAdapter() {
 
@@ -281,7 +285,7 @@ public class ObservationTest {
     @Test
     void deleteClassNameDoesNotTriggerNotifications() {
         String code = "class A { void foo(int p) { }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new AstObserverAdapter() {
 
@@ -300,7 +304,7 @@ public class ObservationTest {
     @Test
     void deleteMethodBodyDoesTriggerNotifications() {
         String code = "class A { void foo(int p) { }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new AstObserverAdapter() {
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ReplaceNodeTest.java
@@ -21,18 +21,21 @@
 
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parsePackageDeclaration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.utils.LineSeparator;
 import org.junit.jupiter.api.Test;
 
 class ReplaceNodeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void testSimplePropertyWithGenericReplace() {
-        CompilationUnit cu = parse("package x; class Y {}");
-        cu.replace(cu.getPackageDeclaration().get(), parsePackageDeclaration("package z;"));
+        CompilationUnit cu = parser.parse("package x; class Y {}");
+        cu.replace(cu.getPackageDeclaration().get(), parser.parsePackageDeclaration("package z;"));
         assertEquals(
                 String.format("package z;%1$s" + "%1$s" + "class Y {%1$s" + "}%1$s", LineSeparator.SYSTEM),
                 cu.toString());
@@ -40,10 +43,10 @@ class ReplaceNodeTest {
 
     @Test
     void testListProperty() {
-        CompilationUnit cu = parse("package x; class Y {}");
+        CompilationUnit cu = parser.parse("package x; class Y {}");
         cu.replace(
                 cu.getClassByName("Y").get(),
-                parse("class B{int y;}").getClassByName("B").get());
+                parser.parse("class B{int y;}").getClassByName("B").get());
         assertEquals(
                 String.format(
                         "package x;%1$s" + "%1$s" + "class B {%1$s" + "%1$s" + "    int y;%1$s" + "}%1$s",

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/WalkFindTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/WalkFindTest.java
@@ -20,11 +20,11 @@
 
 package com.github.javaparser.ast;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -37,9 +37,12 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class WalkFindTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void findCompilationUnit() {
-        CompilationUnit cu = parse("class X{int x;}");
+        CompilationUnit cu = parser.parse("class X{int x;}");
         VariableDeclarator x = cu.getClassByName("X")
                 .get()
                 .getMember(0)
@@ -51,7 +54,7 @@ public class WalkFindTest {
 
     @Test
     void findParent() {
-        CompilationUnit cu = parse("class X{int x;}");
+        CompilationUnit cu = parser.parse("class X{int x;}");
         SimpleName x = cu.getClassByName("X")
                 .get()
                 .getMember(0)
@@ -64,7 +67,7 @@ public class WalkFindTest {
 
     @Test
     void findParentFromTypes() {
-        CompilationUnit cu = parse("class X{Integer x;}");
+        CompilationUnit cu = parser.parse("class X{Integer x;}");
         VariableDeclarator vd = cu.getClassByName("X")
                 .get()
                 .getMember(0)
@@ -95,7 +98,7 @@ public class WalkFindTest {
 
     @Test
     void genericWalk() {
-        Expression e = parseExpression("1+1");
+        Expression e = parser.parseExpression("1+1");
         StringBuilder b = new StringBuilder();
         e.walk(n -> b.append(n.toString()));
         assertEquals("1 + 111", b.toString());
@@ -103,7 +106,7 @@ public class WalkFindTest {
 
     @Test
     void classSpecificWalk() {
-        Expression e = parseExpression("1+1");
+        Expression e = parser.parseExpression("1+1");
         StringBuilder b = new StringBuilder();
         e.walk(IntegerLiteralExpr.class, n -> b.append(n.toString()));
         assertEquals("11", b.toString());
@@ -111,42 +114,42 @@ public class WalkFindTest {
 
     @Test
     void conditionalFindAll() {
-        Expression e = parseExpression("1+2+3");
+        Expression e = parser.parseExpression("1+2+3");
         List<IntegerLiteralExpr> ints = e.findAll(IntegerLiteralExpr.class, n -> n.asInt() > 1);
         assertEquals("[2, 3]", ints.toString());
     }
 
     @Test
     void typeOnlyFindAll() {
-        Expression e = parseExpression("1+2+3");
+        Expression e = parser.parseExpression("1+2+3");
         List<IntegerLiteralExpr> ints = e.findAll(IntegerLiteralExpr.class);
         assertEquals("[1, 2, 3]", ints.toString());
     }
 
     @Test
     void typeOnlyFindAllMatchesSubclasses() {
-        Expression e = parseExpression("1+2+3");
+        Expression e = parser.parseExpression("1+2+3");
         List<Node> ints = e.findAll(Node.class);
         assertEquals("[1 + 2 + 3, 1 + 2, 1, 2, 3]", ints.toString());
     }
 
     @Test
     void conditionalTypedFindFirst() {
-        Expression e = parseExpression("1+2+3");
+        Expression e = parser.parseExpression("1+2+3");
         Optional<IntegerLiteralExpr> ints = e.findFirst(IntegerLiteralExpr.class, n -> n.asInt() > 1);
         assertEquals("Optional[2]", ints.toString());
     }
 
     @Test
     void typeOnlyFindFirst() {
-        Expression e = parseExpression("1+2+3");
+        Expression e = parser.parseExpression("1+2+3");
         Optional<IntegerLiteralExpr> ints = e.findFirst(IntegerLiteralExpr.class);
         assertEquals("Optional[1]", ints.toString());
     }
 
     @Test
     void stream() {
-        Expression e = parseExpression("1+2+3");
+        Expression e = parser.parseExpression("1+2+3");
         List<IntegerLiteralExpr> ints = e.stream()
                 .filter(n -> n instanceof IntegerLiteralExpr)
                 .map(IntegerLiteralExpr.class::cast)

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
@@ -21,11 +21,11 @@
 
 package com.github.javaparser.ast.body;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.utils.TestParser;
@@ -35,9 +35,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.opentest4j.AssertionFailedError;
 
 class ClassOrInterfaceDeclarationTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void staticNestedClass() {
-        CompilationUnit cu = parse("class X{static class Y{}}");
+        CompilationUnit cu = parser.parse("class X{static class Y{}}");
         ClassOrInterfaceDeclaration y =
                 cu.getClassByName("X").get().getMembers().get(0).asClassOrInterfaceDeclaration();
 
@@ -48,7 +51,7 @@ class ClassOrInterfaceDeclarationTest {
 
     @Test
     void nestedInterface() {
-        CompilationUnit cu = parse("class X{interface Y{}}");
+        CompilationUnit cu = parser.parse("class X{interface Y{}}");
         ClassOrInterfaceDeclaration y =
                 cu.getClassByName("X").get().getMembers().get(0).asClassOrInterfaceDeclaration();
 
@@ -59,7 +62,7 @@ class ClassOrInterfaceDeclarationTest {
 
     @Test
     void nonStaticNestedClass() {
-        CompilationUnit cu = parse("class X{class Y{}}");
+        CompilationUnit cu = parser.parse("class X{class Y{}}");
         ClassOrInterfaceDeclaration y =
                 cu.getClassByName("X").get().getMembers().get(0).asClassOrInterfaceDeclaration();
 
@@ -70,7 +73,7 @@ class ClassOrInterfaceDeclarationTest {
 
     @Test
     void topClass() {
-        CompilationUnit cu = parse("class X{}");
+        CompilationUnit cu = parser.parse("class X{}");
         ClassOrInterfaceDeclaration y = cu.getClassByName("X").get();
 
         assertFalse(y.isInnerClass());
@@ -80,7 +83,7 @@ class ClassOrInterfaceDeclarationTest {
 
     @Test
     void localClass() {
-        MethodDeclaration method = parseBodyDeclaration("void x(){class X{};}").asMethodDeclaration();
+        MethodDeclaration method = parser.parseBodyDeclaration("void x(){class X{};}").asMethodDeclaration();
         ClassOrInterfaceDeclaration x =
                 method.findFirst(ClassOrInterfaceDeclaration.class).get();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/ClassOrInterfaceDeclarationTest.java
@@ -83,7 +83,8 @@ class ClassOrInterfaceDeclarationTest {
 
     @Test
     void localClass() {
-        MethodDeclaration method = parser.parseBodyDeclaration("void x(){class X{};}").asMethodDeclaration();
+        MethodDeclaration method =
+                parser.parseBodyDeclaration("void x(){class X{};}").asMethodDeclaration();
         ClassOrInterfaceDeclaration x =
                 method.findFirst(ClassOrInterfaceDeclaration.class).get();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
@@ -21,10 +21,9 @@
 
 package com.github.javaparser.ast.body;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
@@ -34,9 +33,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class FieldDeclarationTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void wofjweoifj() {
-        CompilationUnit compilationUnit = parse("" + "class A {\n" + "    int a, b;\n" + "}");
+        CompilationUnit compilationUnit = parser.parse("" + "class A {\n" + "    int a, b;\n" + "}");
 
         BodyDeclaration<?> declaration = compilationUnit.getType(0).getMembers().get(0);
         FieldDeclaration fieldDeclaration = declaration.asFieldDeclaration();
@@ -49,14 +51,14 @@ class FieldDeclarationTest {
     @Test
     void setModifiersPrimitiveType() {
         FieldDeclaration field =
-                parseBodyDeclaration("public static final int var = 1;").asFieldDeclaration();
+                parser.parseBodyDeclaration("public static final int var = 1;").asFieldDeclaration();
         testChangingModifiers(field);
     }
 
     @Test
     void setModifiersNonPrimitiveType() {
         FieldDeclaration field =
-                parseBodyDeclaration("public static final String var = \"a\";").asFieldDeclaration();
+                parser.parseBodyDeclaration("public static final String var = \"a\";").asFieldDeclaration();
         testChangingModifiers(field);
     }
 
@@ -80,7 +82,7 @@ class FieldDeclarationTest {
 
     @Test
     void interfaceFieldTest() {
-        CompilationUnit compilationUnit = parse("" + "interface A {\n"
+        CompilationUnit compilationUnit = parser.parse("" + "interface A {\n"
                 + "    int a = 1;\n"
                 + "    static int a_s = 1;\n"
                 + "    final int a_f = 1;\n"
@@ -116,7 +118,7 @@ class FieldDeclarationTest {
                 + "    private int i;\n"
                 + "  }\n"
                 + "}";
-        CompilationUnit cu = StaticJavaParser.parse(source);
+        CompilationUnit cu = parser.parse(source);
         FieldDeclaration i = cu.getTypes()
                 .get(0)
                 .asClassOrInterfaceDeclaration()

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/FieldDeclarationTest.java
@@ -57,8 +57,8 @@ class FieldDeclarationTest {
 
     @Test
     void setModifiersNonPrimitiveType() {
-        FieldDeclaration field =
-                parser.parseBodyDeclaration("public static final String var = \"a\";").asFieldDeclaration();
+        FieldDeclaration field = parser.parseBodyDeclaration("public static final String var = \"a\";")
+                .asFieldDeclaration();
         testChangingModifiers(field);
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
@@ -21,30 +21,33 @@
 
 package com.github.javaparser.ast.body;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
 class MethodDeclarationTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void annotationsAllowedAfterGenericsAndBeforeReturnType() {
-        parseBodyDeclaration("public <T> @Abc String method() {return null;}");
+        parser.parseBodyDeclaration("public <T> @Abc String method() {return null;}");
     }
 
     @Test
     void annotationsAllowedBeforeGenerics() {
-        parseBodyDeclaration("public @Abc <T> String method() {return null;}");
+        parser.parseBodyDeclaration("public @Abc <T> String method() {return null;}");
     }
 
     @Test
     void explicitReceiverParameters1() {
-        MethodDeclaration method = parseBodyDeclaration(
+        MethodDeclaration method = parser.parseBodyDeclaration(
                         "void InnerInner(@mypackage.Anno Source.@mypackage.Anno Inner Source.Inner.this) { }")
                 .asMethodDeclaration();
         assertEquals("Source.Inner.this", method.getReceiverParameter().get().getNameAsString());
@@ -52,83 +55,83 @@ class MethodDeclarationTest {
 
     @Test
     void explicitReceiverParameters2() {
-        MethodDeclaration method = parseBodyDeclaration("void x(A this) { }").asMethodDeclaration();
+        MethodDeclaration method = parser.parseBodyDeclaration("void x(A this) { }").asMethodDeclaration();
         assertEquals("this", method.getReceiverParameter().get().getNameAsString());
     }
 
     @Test
     void explicitReceiverParameters3() {
-        MethodDeclaration method = parseBodyDeclaration("void x(A that) { }").asMethodDeclaration();
+        MethodDeclaration method = parser.parseBodyDeclaration("void x(A that) { }").asMethodDeclaration();
         assertFalse(method.getReceiverParameter().isPresent());
     }
 
     @Test
     void signaturesEqual() {
-        MethodDeclaration method1 = parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
-        MethodDeclaration method2 = parseBodyDeclaration("int x(String z);").asMethodDeclaration();
+        MethodDeclaration method1 = parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
+        MethodDeclaration method2 = parser.parseBodyDeclaration("int x(String z);").asMethodDeclaration();
         assertEquals(method1.getSignature(), method2.getSignature());
     }
 
     @Test
     void signaturesEqualWhenGenericsDiffer() {
         MethodDeclaration method1 =
-                parseBodyDeclaration("void x(List<Long> a) { }").asMethodDeclaration();
+                parser.parseBodyDeclaration("void x(List<Long> a) { }").asMethodDeclaration();
         MethodDeclaration method2 =
-                parseBodyDeclaration("void x(List<Integer> a) { }").asMethodDeclaration();
+                parser.parseBodyDeclaration("void x(List<Integer> a) { }").asMethodDeclaration();
         assertEquals(method1.getSignature(), method2.getSignature());
     }
 
     @Test
     void signaturesEqualWhenAnnotationsDiffer() {
         MethodDeclaration method1 =
-                parseBodyDeclaration("void x(@A @B List a) { }").asMethodDeclaration();
+                parser.parseBodyDeclaration("void x(@A @B List a) { }").asMethodDeclaration();
         MethodDeclaration method2 =
-                parseBodyDeclaration("void x(@C List a) { }").asMethodDeclaration();
+                parser.parseBodyDeclaration("void x(@C List a) { }").asMethodDeclaration();
         assertEquals(method1.getSignature(), method2.getSignature());
     }
 
     @Test
     void signaturesDifferentName() {
-        MethodDeclaration method1 = parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
-        MethodDeclaration method2 = parseBodyDeclaration("int y(String z);").asMethodDeclaration();
+        MethodDeclaration method1 = parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
+        MethodDeclaration method2 = parser.parseBodyDeclaration("int y(String z);").asMethodDeclaration();
         assertNotEquals(method1.getSignature(), method2.getSignature());
     }
 
     @Test
     void signaturesDifferentTypes() {
-        MethodDeclaration method1 = parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
-        MethodDeclaration method2 = parseBodyDeclaration("int x(int z);").asMethodDeclaration();
+        MethodDeclaration method1 = parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
+        MethodDeclaration method2 = parser.parseBodyDeclaration("int x(int z);").asMethodDeclaration();
         assertNotEquals(method1.getSignature(), method2.getSignature());
     }
 
     @Test
     void signaturesDifferentVarargs() {
-        MethodDeclaration method1 = parseBodyDeclaration("int x(int z);").asMethodDeclaration();
-        MethodDeclaration method2 = parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
+        MethodDeclaration method1 = parser.parseBodyDeclaration("int x(int z);").asMethodDeclaration();
+        MethodDeclaration method2 = parser.parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
         assertNotEquals(method1.getSignature(), method2.getSignature());
     }
 
     @Test
     void signatureToString() {
         MethodDeclaration method1 =
-                parseBodyDeclaration("int x(int z, String q);").asMethodDeclaration();
+                parser.parseBodyDeclaration("int x(int z, String q);").asMethodDeclaration();
         assertEquals("x(int, String)", method1.getSignature().toString());
     }
 
     @Test
     void isVariableArityMethod() {
-        MethodDeclaration method1 = parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
+        MethodDeclaration method1 = parser.parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
         assertTrue(method1.isVariableArityMethod());
         MethodDeclaration method2 =
-                parseBodyDeclaration("int x(int i, int... z);").asMethodDeclaration();
+                parser.parseBodyDeclaration("int x(int i, int... z);").asMethodDeclaration();
         assertTrue(method2.isVariableArityMethod());
     }
 
     @Test
     void isFixedArityMethod() {
-        MethodDeclaration method1 = parseBodyDeclaration("int x(int z);").asMethodDeclaration();
+        MethodDeclaration method1 = parser.parseBodyDeclaration("int x(int z);").asMethodDeclaration();
         assertTrue(method1.isFixedArityMethod());
-        MethodDeclaration method2 = parseBodyDeclaration("int x();").asMethodDeclaration();
+        MethodDeclaration method2 = parser.parseBodyDeclaration("int x();").asMethodDeclaration();
         assertTrue(method2.isFixedArityMethod());
     }
 
@@ -139,13 +142,13 @@ class MethodDeclarationTest {
      */
     @Test
     void isMethodInterfaceImplictlyPublic() {
-        CompilationUnit cu = parse("interface Foo { void m(); }");
+        CompilationUnit cu = parser.parse("interface Foo { void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isPublic());
-        cu = parse("interface Foo { public void m(); }");
+        cu = parser.parse("interface Foo { public void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isPublic());
-        cu = parse("interface Foo { abstract void m(); }");
+        cu = parser.parse("interface Foo { abstract void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isPublic());
-        cu = parse("interface Foo { private void m(); }");
+        cu = parser.parse("interface Foo { private void m(); }");
         assertFalse(cu.findFirst(MethodDeclaration.class).get().isPublic());
     }
 
@@ -155,15 +158,15 @@ class MethodDeclarationTest {
      */
     @Test
     void isMethodInterfaceImplictlyAbstract() {
-        CompilationUnit cu = parse("interface Foo { void m(); }");
+        CompilationUnit cu = parser.parse("interface Foo { void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isAbstract());
-        cu = parse("interface Foo { abstract void m(); }");
+        cu = parser.parse("interface Foo { abstract void m(); }");
         assertTrue(cu.findFirst(MethodDeclaration.class).get().isAbstract());
-        cu = parse("interface Foo { private void m(); }");
+        cu = parser.parse("interface Foo { private void m(); }");
         assertFalse(cu.findFirst(MethodDeclaration.class).get().isAbstract());
-        cu = parse("interface Foo { static void m(); }");
+        cu = parser.parse("interface Foo { static void m(); }");
         assertFalse(cu.findFirst(MethodDeclaration.class).get().isAbstract());
-        cu = parse("interface Foo { default void m(){} }");
+        cu = parser.parse("interface Foo { default void m(){} }");
         assertFalse(cu.findFirst(MethodDeclaration.class).get().isAbstract());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/body/MethodDeclarationTest.java
@@ -55,20 +55,24 @@ class MethodDeclarationTest {
 
     @Test
     void explicitReceiverParameters2() {
-        MethodDeclaration method = parser.parseBodyDeclaration("void x(A this) { }").asMethodDeclaration();
+        MethodDeclaration method =
+                parser.parseBodyDeclaration("void x(A this) { }").asMethodDeclaration();
         assertEquals("this", method.getReceiverParameter().get().getNameAsString());
     }
 
     @Test
     void explicitReceiverParameters3() {
-        MethodDeclaration method = parser.parseBodyDeclaration("void x(A that) { }").asMethodDeclaration();
+        MethodDeclaration method =
+                parser.parseBodyDeclaration("void x(A that) { }").asMethodDeclaration();
         assertFalse(method.getReceiverParameter().isPresent());
     }
 
     @Test
     void signaturesEqual() {
-        MethodDeclaration method1 = parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
-        MethodDeclaration method2 = parser.parseBodyDeclaration("int x(String z);").asMethodDeclaration();
+        MethodDeclaration method1 =
+                parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
+        MethodDeclaration method2 =
+                parser.parseBodyDeclaration("int x(String z);").asMethodDeclaration();
         assertEquals(method1.getSignature(), method2.getSignature());
     }
 
@@ -92,14 +96,17 @@ class MethodDeclarationTest {
 
     @Test
     void signaturesDifferentName() {
-        MethodDeclaration method1 = parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
-        MethodDeclaration method2 = parser.parseBodyDeclaration("int y(String z);").asMethodDeclaration();
+        MethodDeclaration method1 =
+                parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
+        MethodDeclaration method2 =
+                parser.parseBodyDeclaration("int y(String z);").asMethodDeclaration();
         assertNotEquals(method1.getSignature(), method2.getSignature());
     }
 
     @Test
     void signaturesDifferentTypes() {
-        MethodDeclaration method1 = parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
+        MethodDeclaration method1 =
+                parser.parseBodyDeclaration("void x(String a) { }").asMethodDeclaration();
         MethodDeclaration method2 = parser.parseBodyDeclaration("int x(int z);").asMethodDeclaration();
         assertNotEquals(method1.getSignature(), method2.getSignature());
     }
@@ -107,7 +114,8 @@ class MethodDeclarationTest {
     @Test
     void signaturesDifferentVarargs() {
         MethodDeclaration method1 = parser.parseBodyDeclaration("int x(int z);").asMethodDeclaration();
-        MethodDeclaration method2 = parser.parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
+        MethodDeclaration method2 =
+                parser.parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
         assertNotEquals(method1.getSignature(), method2.getSignature());
     }
 
@@ -120,7 +128,8 @@ class MethodDeclarationTest {
 
     @Test
     void isVariableArityMethod() {
-        MethodDeclaration method1 = parser.parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
+        MethodDeclaration method1 =
+                parser.parseBodyDeclaration("int x(int... z);").asMethodDeclaration();
         assertTrue(method1.isVariableArityMethod());
         MethodDeclaration method2 =
                 parser.parseBodyDeclaration("int x(int i, int... z);").asMethodDeclaration();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
@@ -21,12 +21,13 @@
 
 package com.github.javaparser.ast.comments;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -50,6 +51,8 @@ class CommentTest {
 
     private static final PrinterConfiguration PRETTY_PRINTER_CONFIG_TWO_INDENT = new DefaultPrinterConfiguration()
             .addOption(new DefaultConfigurationOption(ConfigOption.INDENTATION, new Indentation(IndentType.SPACES, 2)));
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     @Test
     void removeOrphanComment() {
@@ -79,7 +82,7 @@ class CommentTest {
 
     @Test
     void unicodeEscapesArePreservedInComments() {
-        CompilationUnit cu = parse("// xxx\\u2122xxx");
+        CompilationUnit cu = parser.parse("// xxx\\u2122xxx");
         Comment comment = cu.getAllContainedComments().get(0);
         assertEquals(" xxx\\u2122xxx", comment.getContent());
     }
@@ -87,7 +90,7 @@ class CommentTest {
     @Test
     void testReplaceDuplicateJavaDocComment() {
         // Arrange
-        CompilationUnit cu = parse("public class MyClass {" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
+        CompilationUnit cu = parser.parse("public class MyClass {" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
                 + "  /**"
                 + LineSeparator.SYSTEM + "   * Comment A"
                 + LineSeparator.SYSTEM + "   */"
@@ -130,7 +133,7 @@ class CommentTest {
     @Test
     void testRemoveDuplicateComment() {
         // Arrange
-        CompilationUnit cu = parse("public class MyClass {" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
+        CompilationUnit cu = parser.parse("public class MyClass {" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
                 + "  /**"
                 + LineSeparator.SYSTEM + "   * Comment A"
                 + LineSeparator.SYSTEM + "   */"
@@ -169,7 +172,7 @@ class CommentTest {
     @Test
     void testRemoveDuplicateJavaDocComment() {
         // Arrange
-        CompilationUnit cu = parse("public class MyClass {" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
+        CompilationUnit cu = parser.parse("public class MyClass {" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
                 + "  /**"
                 + LineSeparator.SYSTEM + "   * Comment A"
                 + LineSeparator.SYSTEM + "   */"
@@ -228,7 +231,7 @@ class CommentTest {
 
     @Test
     void testSingleLineCommentContent() {
-        CompilationUnit cu = parse("class Test {\n" + "  // this is a single line comment\n"
+        CompilationUnit cu = parser.parse("class Test {\n" + "  // this is a single line comment\n"
                 + "  // and so is this\n"
                 + "  void test() {}\n"
                 + "}");
@@ -248,7 +251,7 @@ class CommentTest {
     @Test
     void testJavadocCommentContent() {
         String commentCode = "\n   * This is a regular {@code JavaDoc comment}\n   * @see some reference\n    ";
-        CompilationUnit cu = parse("class Test {\n" + "  /**" + commentCode + "*/\n" + "  void test() {}\n" + "}");
+        CompilationUnit cu = parser.parse("class Test {\n" + "  /**" + commentCode + "*/\n" + "  void test() {}\n" + "}");
 
         MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
 
@@ -268,7 +271,7 @@ class CommentTest {
                 + "  ///\n"
                 + "  ///  and empty lines preceded by ///\n"
                 + "  ///  without issues\n";
-        CompilationUnit cu = parse("class Test {\n" + commentCode + "  void test() {}\n" + "}");
+        CompilationUnit cu = parser.parse("class Test {\n" + commentCode + "  void test() {}\n" + "}");
 
         MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
 
@@ -294,7 +297,7 @@ class CommentTest {
                 + "  ///  */\n"
                 + "  /// // and single line comments\n";
         String comment2Code = "  ///\n" + "  /// and empty lines preceded by ///\n" + "  /// without issues\n";
-        CompilationUnit cu = parse("class Test {\n" + comment1Code + "\n" + comment2Code + "  void test() {}\n" + "}");
+        CompilationUnit cu = parser.parse("class Test {\n" + comment1Code + "\n" + comment2Code + "  void test() {}\n" + "}");
 
         MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
 
@@ -320,7 +323,7 @@ class CommentTest {
 
     @Test
     void markdownCommentShouldNotHaveSingleLineContent() {
-        CompilationUnit cu = parse(
+        CompilationUnit cu = parser.parse(
                 "class Test {\n" + "  /// this is a single-line markdown comment test\n" + "  void test() {}\n" + "}");
 
         MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
@@ -344,7 +347,7 @@ class CommentTest {
                 + "  ///\n"
                 + "  ///  and empty lines preceded by ///\n"
                 + "  ///  without issues\n";
-        CompilationUnit cu = parse("class Test {\n" + commentCode + "  void test() {}\n" + "}");
+        CompilationUnit cu = parser.parse("class Test {\n" + commentCode + "  void test() {}\n" + "}");
 
         MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
 
@@ -378,7 +381,7 @@ class CommentTest {
 
     @Test
     void testTraditionalJavadocComment() {
-        CompilationUnit cu = parse("class Test {\n" + "  /**\n"
+        CompilationUnit cu = parser.parse("class Test {\n" + "  /**\n"
                 + "   * This is a traditional javadoc comment\n"
                 + "   */\n"
                 + "  void test() {}\n"

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/comments/CommentTest.java
@@ -251,7 +251,8 @@ class CommentTest {
     @Test
     void testJavadocCommentContent() {
         String commentCode = "\n   * This is a regular {@code JavaDoc comment}\n   * @see some reference\n    ";
-        CompilationUnit cu = parser.parse("class Test {\n" + "  /**" + commentCode + "*/\n" + "  void test() {}\n" + "}");
+        CompilationUnit cu =
+                parser.parse("class Test {\n" + "  /**" + commentCode + "*/\n" + "  void test() {}\n" + "}");
 
         MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
 
@@ -297,7 +298,8 @@ class CommentTest {
                 + "  ///  */\n"
                 + "  /// // and single line comments\n";
         String comment2Code = "  ///\n" + "  /// and empty lines preceded by ///\n" + "  /// without issues\n";
-        CompilationUnit cu = parser.parse("class Test {\n" + comment1Code + "\n" + comment2Code + "  void test() {}\n" + "}");
+        CompilationUnit cu =
+                parser.parse("class Test {\n" + comment1Code + "\n" + comment2Code + "  void test() {}\n" + "}");
 
         MethodDeclaration testMethod = cu.findFirst(MethodDeclaration.class).get();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/BinaryExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/BinaryExprTest.java
@@ -114,8 +114,7 @@ class BinaryExprTest {
 
         @Test
         public void example() {
-            Expression expression =
-                    parser.parseExpression("year % 4 == 0 && year % 100 != 0 || year % 400 == 0");
+            Expression expression = parser.parseExpression("year % 4 == 0 && year % 100 != 0 || year % 400 == 0");
             Expression bracketedExpression = applyBrackets(expression);
 
             String expected = "((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)";

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/BinaryExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/BinaryExprTest.java
@@ -21,22 +21,18 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class BinaryExprTest {
 
-    @BeforeEach
-    void initParser() {
-        StaticJavaParser.setConfiguration(new ParserConfiguration());
-    }
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     @Test
     void convertOperator() {
@@ -63,7 +59,7 @@ class BinaryExprTest {
 
         @Test
         public void logicalAndOr() {
-            Expression expression = StaticJavaParser.parseExpression("true || false && false || false");
+            Expression expression = parser.parseExpression("true || false && false || false");
             Expression bracketedExpression = applyBrackets(expression);
 
             String expected = "(true || (false && false)) || false";
@@ -74,7 +70,7 @@ class BinaryExprTest {
 
         @Test
         public void logicalOrEvaluationLeftToRight() {
-            Expression expression = StaticJavaParser.parseExpression("false || true || false || true || false || true");
+            Expression expression = parser.parseExpression("false || true || false || true || false || true");
             Expression bracketedExpression = applyBrackets(expression);
 
             String expected = "((((false || true) || false) || true) || false) || true";
@@ -85,7 +81,7 @@ class BinaryExprTest {
 
         @Test
         public void logicalAndEvaluationLeftToRight() {
-            Expression expression = StaticJavaParser.parseExpression("false && true && false && true && false && true");
+            Expression expression = parser.parseExpression("false && true && false && true && false && true");
             Expression bracketedExpression = applyBrackets(expression);
 
             String expected = "((((false && true) && false) && true) && false) && true";
@@ -96,7 +92,7 @@ class BinaryExprTest {
 
         @Test
         public void andTakesPrecedenceOverOr() {
-            Expression expression = StaticJavaParser.parseExpression("true || false && false");
+            Expression expression = parser.parseExpression("true || false && false");
             Expression bracketedExpression = applyBrackets(expression);
 
             String expected = "true || (false && false)";
@@ -107,7 +103,7 @@ class BinaryExprTest {
 
         @Test
         public void andTakesPrecedenceOverOrThenLeftToRight() {
-            Expression expression = StaticJavaParser.parseExpression("true || false && false || true");
+            Expression expression = parser.parseExpression("true || false && false || true");
             Expression bracketedExpression = applyBrackets(expression);
 
             String expected = "(true || (false && false)) || true";
@@ -119,7 +115,7 @@ class BinaryExprTest {
         @Test
         public void example() {
             Expression expression =
-                    StaticJavaParser.parseExpression("year % 4 == 0 && year % 100 != 0 || year % 400 == 0");
+                    parser.parseExpression("year % 4 == 0 && year % 100 != 0 || year % 400 == 0");
             Expression bracketedExpression = applyBrackets(expression);
 
             String expected = "((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)";
@@ -150,9 +146,10 @@ class BinaryExprTest {
         // Note: "assert" as an identifier is only valid in Java < 1.4
         // In modern Java, "assert" is a keyword. However, "assert" as an identifier is still supported
         // for backward compatibility.
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0);
+        JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+                new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0));
 
-        Expression e = parseExpression("assert + 42");
+        Expression e = parser.parseExpression("assert + 42");
         assertInstanceOf(BinaryExpr.class, e);
         BinaryExpr binary = e.asBinaryExpr();
         assertEquals(BinaryExpr.Operator.PLUS, binary.getOperator());
@@ -170,9 +167,10 @@ class BinaryExprTest {
         // Note: "assert" as an identifier is only valid in Java < 1.4
         // In modern Java, "assert" is a keyword. However, "assert" as an identifier is still supported
         // for backward compatibility.
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0);
+        JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+                new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0));
 
-        Expression e = parseExpression("x + assert");
+        Expression e = parser.parseExpression("x + assert");
         assertInstanceOf(BinaryExpr.class, e);
         BinaryExpr binary = e.asBinaryExpr();
         assertEquals(BinaryExpr.Operator.PLUS, binary.getOperator());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/CharLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/CharLiteralExprTest.java
@@ -22,42 +22,46 @@
 package com.github.javaparser.ast.expr;
 
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParseStart;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import org.junit.jupiter.api.Test;
 
 class CharLiteralExprTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void parseSimpleChar() {
-        CharLiteralExpr c = parseExpression("'a'");
+        CharLiteralExpr c = parser.parseExpression("'a'");
         assertEquals("a", c.getValue());
     }
 
     @Test
     void parseSimpleEscape() {
-        CharLiteralExpr c = parseExpression("'\\t'");
+        CharLiteralExpr c = parser.parseExpression("'\\t'");
         assertEquals("\\t", c.getValue());
     }
 
     @Test
     void parseUnicode() {
-        CharLiteralExpr c = parseExpression("'Ω'");
+        CharLiteralExpr c = parser.parseExpression("'Ω'");
         assertEquals("Ω", c.getValue());
     }
 
     @Test
     void parseNumericEscape() {
-        CharLiteralExpr c = parseExpression("'\\177'");
+        CharLiteralExpr c = parser.parseExpression("'\\177'");
         assertEquals("\\177", c.getValue());
     }
 
     @Test
     void parseUnicodeEscape() {
-        CharLiteralExpr c = parseExpression("'\\u03a9'");
+        CharLiteralExpr c = parser.parseExpression("'\\u03a9'");
         assertEquals("\\u03a9", c.getValue());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/DoubleLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/DoubleLiteralExprTest.java
@@ -21,44 +21,47 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class DoubleLiteralExprTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void test1() {
         float x = 0x0.00_00_02p-126f;
-        DoubleLiteralExpr e = parseExpression("0x0.00_00_02p-126f");
+        DoubleLiteralExpr e = parser.parseExpression("0x0.00_00_02p-126f");
         Assertions.assertEquals(x, e.asDouble());
     }
 
     @Test
     void test2() {
         double x = 0x0.000_000_000_000_1p-1_022;
-        DoubleLiteralExpr e = parseExpression("0x0.000_000_000_000_1p-1_022");
+        DoubleLiteralExpr e = parser.parseExpression("0x0.000_000_000_000_1p-1_022");
         Assertions.assertEquals(x, e.asDouble());
     }
 
     @Test
     void test3() {
         double a = 0x1.p+1;
-        DoubleLiteralExpr e = parseExpression("0x1.p+1");
+        DoubleLiteralExpr e = parser.parseExpression("0x1.p+1");
         Assertions.assertEquals(a, e.asDouble());
     }
 
     @Test
     void test4() {
         double a = 0x.0p0;
-        DoubleLiteralExpr e = parseExpression("0x.0p0");
+        DoubleLiteralExpr e = parser.parseExpression("0x.0p0");
         Assertions.assertEquals(a, e.asDouble());
     }
 
     @Test
     void test5() {
         double x = 0x0_0.0_0p-1_0;
-        DoubleLiteralExpr e = parseExpression("0x0_0.0_0p-1_0");
+        DoubleLiteralExpr e = parser.parseExpression("0x0_0.0_0p-1_0");
         Assertions.assertEquals(x, e.asDouble());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LambdaExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LambdaExprTest.java
@@ -21,11 +21,11 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseBlock;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
@@ -34,15 +34,18 @@ import com.github.javaparser.ast.type.UnknownType;
 import org.junit.jupiter.api.Test;
 
 class LambdaExprTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void lambdaRange1() {
-        Expression expression = parseExpression("x -> y");
+        Expression expression = parser.parseExpression("x -> y");
         assertRange("x", "y", expression);
     }
 
     @Test
     void lambdaRange2() {
-        Expression expression = parseExpression("(x) -> y");
+        Expression expression = parser.parseExpression("(x) -> y");
         assertRange("(", "y", expression);
     }
 
@@ -54,25 +57,25 @@ class LambdaExprTest {
 
     @Test
     void getExpressionBody() {
-        LambdaExpr lambdaExpr = parseExpression("x -> y").asLambdaExpr();
+        LambdaExpr lambdaExpr = parser.parseExpression("x -> y").asLambdaExpr();
         assertEquals("Optional[y]", lambdaExpr.getExpressionBody().toString());
     }
 
     @Test
     void getNoExpressionBody() {
-        LambdaExpr lambdaExpr = parseExpression("x -> {y;}").asLambdaExpr();
+        LambdaExpr lambdaExpr = parser.parseExpression("x -> {y;}").asLambdaExpr();
         assertEquals("Optional.empty", lambdaExpr.getExpressionBody().toString());
     }
 
     @Test
     void oneParameterAndExpressionUtilityConstructor() {
-        LambdaExpr expr = new LambdaExpr(new Parameter(new UnknownType(), "a"), parseExpression("5"));
+        LambdaExpr expr = new LambdaExpr(new Parameter(new UnknownType(), "a"), parser.parseExpression("5"));
         assertEquals("a -> 5", expr.toString());
     }
 
     @Test
     void oneParameterAndStatementUtilityConstructor() {
-        LambdaExpr expr = new LambdaExpr(new Parameter(new UnknownType(), "a"), parseBlock("{return 5;}"));
+        LambdaExpr expr = new LambdaExpr(new Parameter(new UnknownType(), "a"), parser.parseBlock("{return 5;}"));
         assertEqualsStringIgnoringEol("a -> {\n    return 5;\n}", expr.toString());
     }
 
@@ -80,7 +83,7 @@ class LambdaExprTest {
     void multipleParametersAndExpressionUtilityConstructor() {
         LambdaExpr expr = new LambdaExpr(
                 new NodeList<>(new Parameter(new UnknownType(), "a"), new Parameter(new UnknownType(), "b")),
-                parseExpression("5"));
+                parser.parseExpression("5"));
         assertEquals("(a, b) -> 5", expr.toString());
     }
 
@@ -88,13 +91,13 @@ class LambdaExprTest {
     void multipleParametersAndStatementUtilityConstructor() {
         LambdaExpr expr = new LambdaExpr(
                 new NodeList<>(new Parameter(new UnknownType(), "a"), new Parameter(new UnknownType(), "b")),
-                parseBlock("{return 5;}"));
+                parser.parseBlock("{return 5;}"));
         assertEqualsStringIgnoringEol("(a, b) -> {\n    return 5;\n}", expr.toString());
     }
 
     @Test
     void zeroParametersAndStatementUtilityConstructor() {
-        LambdaExpr expr = new LambdaExpr(new NodeList<>(), parseBlock("{return 5;}"));
+        LambdaExpr expr = new LambdaExpr(new NodeList<>(), parser.parseBlock("{return 5;}"));
         assertEqualsStringIgnoringEol("() -> {\n    return 5;\n}", expr.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
@@ -20,12 +20,13 @@
  */
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.observer.AstObserver;
 import java.math.BigInteger;
 import org.assertj.core.data.Percentage;
@@ -33,6 +34,8 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OctalInteger")
 class LiteralStringValueExprTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     @Test
     void trivialLiteralsAreConverted() {
@@ -78,13 +81,13 @@ class LiteralStringValueExprTest {
 
     @Test
     void lowerAndUpperBoundIntegersAreConverted() {
-        IntegerLiteralExpr dec = parseExpression("2147483647");
-        IntegerLiteralExpr posOct = parseExpression("0177_7777_7777");
-        IntegerLiteralExpr negOct = parseExpression("0377_7777_7777");
-        IntegerLiteralExpr posHex = parseExpression("0x7fff_ffff");
-        IntegerLiteralExpr negHex = parseExpression("0xffff_ffff");
-        IntegerLiteralExpr posBin = parseExpression("0b0111_1111_1111_1111_1111_1111_1111_1111");
-        IntegerLiteralExpr negBin = parseExpression("0b1000_0000_0000_0000_0000_0000_0000_0000");
+        IntegerLiteralExpr dec = parser.parseExpression("2147483647");
+        IntegerLiteralExpr posOct = parser.parseExpression("0177_7777_7777");
+        IntegerLiteralExpr negOct = parser.parseExpression("0377_7777_7777");
+        IntegerLiteralExpr posHex = parser.parseExpression("0x7fff_ffff");
+        IntegerLiteralExpr negHex = parser.parseExpression("0xffff_ffff");
+        IntegerLiteralExpr posBin = parser.parseExpression("0b0111_1111_1111_1111_1111_1111_1111_1111");
+        IntegerLiteralExpr negBin = parser.parseExpression("0b1000_0000_0000_0000_0000_0000_0000_0000");
 
         assertThat(dec.asInt()).isEqualTo(2147483647);
         assertThat(posOct.asInt()).isEqualTo(2147483647); // 0177_7777_7777
@@ -97,13 +100,13 @@ class LiteralStringValueExprTest {
 
     @Test
     void negativeLiteralValues() {
-        UnaryExpr unaryIntExpr = parseExpression("-2147483648"); // valid, Integer.MIN_VALUE
+        UnaryExpr unaryIntExpr = parser.parseExpression("-2147483648"); // valid, Integer.MIN_VALUE
         IntegerLiteralExpr literalIntExpr = (IntegerLiteralExpr) unaryIntExpr.getExpression();
-        IntegerLiteralExpr notValidIntExpr = parseExpression("2147483648"); // not valid
+        IntegerLiteralExpr notValidIntExpr = parser.parseExpression("2147483648"); // not valid
 
-        UnaryExpr unaryLongExpr = parseExpression("-9223372036854775808L"); // valid, Long.MIN_VALUE
+        UnaryExpr unaryLongExpr = parser.parseExpression("-9223372036854775808L"); // valid, Long.MIN_VALUE
         LongLiteralExpr literalLongExpr = (LongLiteralExpr) unaryLongExpr.getExpression();
-        LongLiteralExpr notValidLongExpr = parseExpression("9223372036854775808L"); // not valid
+        LongLiteralExpr notValidLongExpr = parser.parseExpression("9223372036854775808L"); // not valid
 
         assertThat(literalIntExpr.asNumber()).isEqualTo(2147483648L);
         assertThat(literalLongExpr.asNumber()).isEqualTo(new BigInteger("9223372036854775808"));
@@ -114,15 +117,15 @@ class LiteralStringValueExprTest {
 
     @Test
     void lowerAndUpperBoundLongsAreConverted() {
-        LongLiteralExpr dec = parseExpression("9223372036854775807L");
-        LongLiteralExpr posOct = parseExpression("07_7777_7777_7777_7777_7777L");
-        LongLiteralExpr negOct = parseExpression("010_0000_0000_0000_0000_0000L");
-        LongLiteralExpr posHex = parseExpression("0x7fff_ffff_ffff_ffffL");
-        LongLiteralExpr negHex = parseExpression("0xffff_ffff_ffff_ffffL");
+        LongLiteralExpr dec = parser.parseExpression("9223372036854775807L");
+        LongLiteralExpr posOct = parser.parseExpression("07_7777_7777_7777_7777_7777L");
+        LongLiteralExpr negOct = parser.parseExpression("010_0000_0000_0000_0000_0000L");
+        LongLiteralExpr posHex = parser.parseExpression("0x7fff_ffff_ffff_ffffL");
+        LongLiteralExpr negHex = parser.parseExpression("0xffff_ffff_ffff_ffffL");
         LongLiteralExpr posBin =
-                parseExpression("0b0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L");
+                parser.parseExpression("0b0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L");
         LongLiteralExpr negBin =
-                parseExpression("0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L");
+                parser.parseExpression("0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L");
 
         assertThat(dec.asLong()).isEqualTo(9223372036854775807L);
         assertThat(posOct.asLong()).isEqualTo(9223372036854775807L); // 07_7777_7777_7777_7777_7777L
@@ -137,16 +140,16 @@ class LiteralStringValueExprTest {
 
     @Test
     void charLiteralsAreConverted() {
-        CharLiteralExpr a = parseExpression("'a'");
-        CharLiteralExpr percent = parseExpression("'%'");
-        CharLiteralExpr tab = parseExpression("'\\t'");
-        CharLiteralExpr newLine = parseExpression("'\\n'");
-        CharLiteralExpr slash = parseExpression("'\\\\'");
-        CharLiteralExpr quote = parseExpression("'\\''");
-        CharLiteralExpr omega = parseExpression("'\\u03a9'");
-        CharLiteralExpr unicode = parseExpression("'\\uFFFF'");
-        CharLiteralExpr ascii = parseExpression("'\\177'");
-        CharLiteralExpr trademark = parseExpression("'™'");
+        CharLiteralExpr a = parser.parseExpression("'a'");
+        CharLiteralExpr percent = parser.parseExpression("'%'");
+        CharLiteralExpr tab = parser.parseExpression("'\\t'");
+        CharLiteralExpr newLine = parser.parseExpression("'\\n'");
+        CharLiteralExpr slash = parser.parseExpression("'\\\\'");
+        CharLiteralExpr quote = parser.parseExpression("'\\''");
+        CharLiteralExpr omega = parser.parseExpression("'\\u03a9'");
+        CharLiteralExpr unicode = parser.parseExpression("'\\uFFFF'");
+        CharLiteralExpr ascii = parser.parseExpression("'\\177'");
+        CharLiteralExpr trademark = parser.parseExpression("'™'");
 
         assertThat(a.asChar()).isEqualTo('a');
         assertThat(percent.asChar()).isEqualTo('%');
@@ -162,12 +165,12 @@ class LiteralStringValueExprTest {
 
     @Test
     void lowerAndUpperBoundDoublesAreConverted() {
-        DoubleLiteralExpr posFloat = parseExpression("3.4028235e38f");
-        DoubleLiteralExpr negFloat = parseExpression("1.40e-45f");
-        DoubleLiteralExpr posDouble = parseExpression("1.7976931348623157e308");
-        DoubleLiteralExpr negDouble = parseExpression("4.9e-324");
-        DoubleLiteralExpr posHexFloat = parseExpression("0x1.fffffffffffffp1023");
-        DoubleLiteralExpr negHexFloat = parseExpression("0x0.0000000000001P-1022");
+        DoubleLiteralExpr posFloat = parser.parseExpression("3.4028235e38f");
+        DoubleLiteralExpr negFloat = parser.parseExpression("1.40e-45f");
+        DoubleLiteralExpr posDouble = parser.parseExpression("1.7976931348623157e308");
+        DoubleLiteralExpr negDouble = parser.parseExpression("4.9e-324");
+        DoubleLiteralExpr posHexFloat = parser.parseExpression("0x1.fffffffffffffp1023");
+        DoubleLiteralExpr negHexFloat = parser.parseExpression("0x0.0000000000001P-1022");
 
         assertThat(posFloat.asDouble()).isCloseTo(3.4028235e38f, Percentage.withPercentage(1));
         assertThat(negFloat.asDouble()).isCloseTo(1.40e-45f, Percentage.withPercentage(1));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/LiteralStringValueExprTest.java
@@ -122,10 +122,10 @@ class LiteralStringValueExprTest {
         LongLiteralExpr negOct = parser.parseExpression("010_0000_0000_0000_0000_0000L");
         LongLiteralExpr posHex = parser.parseExpression("0x7fff_ffff_ffff_ffffL");
         LongLiteralExpr negHex = parser.parseExpression("0xffff_ffff_ffff_ffffL");
-        LongLiteralExpr posBin =
-                parser.parseExpression("0b0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L");
-        LongLiteralExpr negBin =
-                parser.parseExpression("0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L");
+        LongLiteralExpr posBin = parser.parseExpression(
+                "0b0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111L");
+        LongLiteralExpr negBin = parser.parseExpression(
+                "0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L");
 
         assertThat(dec.asLong()).isEqualTo(9223372036854775807L);
         assertThat(posOct.asLong()).isEqualTo(9223372036854775807L); // 07_7777_7777_7777_7777_7777L

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/MethodCallExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/MethodCallExprTest.java
@@ -34,8 +34,8 @@ class MethodCallExprTest {
 
     @Test
     void replaceLambdaIssue1290() {
-        MethodCallExpr methodCallExpr =
-                parser.parseExpression("callSomeFun(r -> r instanceof SomeType)").asMethodCallExpr();
+        MethodCallExpr methodCallExpr = parser.parseExpression("callSomeFun(r -> r instanceof SomeType)")
+                .asMethodCallExpr();
         LambdaExpr lambdaExpr = methodCallExpr.getArgument(0).asLambdaExpr();
         MethodCallExpr lambdaWrapper = new MethodCallExpr("lambdaWrapper");
         lambdaExpr.replace(lambdaWrapper);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/MethodCallExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/MethodCallExprTest.java
@@ -21,18 +21,21 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static java.util.Optional.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import org.junit.jupiter.api.Test;
 
 class MethodCallExprTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void replaceLambdaIssue1290() {
         MethodCallExpr methodCallExpr =
-                parseExpression("callSomeFun(r -> r instanceof SomeType)").asMethodCallExpr();
+                parser.parseExpression("callSomeFun(r -> r instanceof SomeType)").asMethodCallExpr();
         LambdaExpr lambdaExpr = methodCallExpr.getArgument(0).asLambdaExpr();
         MethodCallExpr lambdaWrapper = new MethodCallExpr("lambdaWrapper");
         lambdaExpr.replace(lambdaWrapper);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/NameTest.java
@@ -21,12 +21,13 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.observer.AstObserver;
@@ -36,26 +37,28 @@ import org.junit.jupiter.api.Test;
 
 class NameTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void outerNameExprIsTheRightMostIdentifier() {
-        Name name = parseName("a.b.c");
+        Name name = parser.parseName("a.b.c");
         assertEquals("c", name.getIdentifier());
     }
 
     @Test
     void parsingAndUnparsingWorks() {
-        Name name = parseName("a.b.c");
+        Name name = parser.parseName("a.b.c");
         assertEquals("a.b.c", name.asString());
     }
 
     @Test
     void parsingEmptyNameThrowsException() {
-        assertThrows(ParseProblemException.class, () -> parseName(""));
+        assertThrows(ParseProblemException.class, () -> parser.parseName(""));
     }
 
     @Test
     void importName() {
-        ImportDeclaration importDeclaration = parseImport("import java.util.List;");
+        ImportDeclaration importDeclaration = parser.parseImport("import java.util.List;");
 
         assertEquals("import java.util.List;" + LineSeparator.SYSTEM, importDeclaration.toString());
         assertEquals("import java.util.List;", ConcreteSyntaxModel.genericPrettyPrint(importDeclaration));
@@ -63,7 +66,7 @@ class NameTest {
 
     @Test
     void packageName() {
-        CompilationUnit cu = parse("package p1.p2;");
+        CompilationUnit cu = parser.parse("package p1.p2;");
 
         assertEquals("package p1.p2;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM, cu.toString());
         assertEquals(
@@ -73,27 +76,27 @@ class NameTest {
 
     @Test
     void isInternalNegative() {
-        Name name = parseName("a.b.c");
+        Name name = parser.parseName("a.b.c");
         assertFalse(name.isInternal());
     }
 
     @Test
     void isInternalPositive() {
-        Name name = parseName("a.b.c");
+        Name name = parser.parseName("a.b.c");
         assertTrue(name.getQualifier().get().isInternal());
         assertTrue(name.getQualifier().get().getQualifier().get().isInternal());
     }
 
     @Test
     void isTopLevelNegative() {
-        Name name = parseName("a.b.c");
+        Name name = parser.parseName("a.b.c");
         assertFalse(name.getQualifier().get().isTopLevel());
         assertFalse(name.getQualifier().get().getQualifier().get().isTopLevel());
     }
 
     @Test
     void isTopLevelPositive() {
-        Name name = parseName("a.b.c");
+        Name name = parser.parseName("a.b.c");
         assertTrue(name.isTopLevel());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/PatternExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/PatternExprTest.java
@@ -20,16 +20,14 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,18 +37,8 @@ import org.junit.jupiter.api.Test;
  */
 public class PatternExprTest {
 
-    private static final ParserConfiguration.LanguageLevel storedLanguageLevel =
-            StaticJavaParser.getParserConfiguration().getLanguageLevel();
-
-    @BeforeAll
-    public static void setLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-    }
-
-    @AfterAll
-    public static void resetLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(storedLanguageLevel);
-    }
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+            new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE));
 
     class TestConsumer<T> implements Consumer<T> {
         public boolean isConsumed = false;
@@ -63,7 +51,7 @@ public class PatternExprTest {
 
     @Test
     public void patternGeneratedMethodsShouldWork() {
-        Expression expr = parseExpression("x instanceof Foo f");
+        Expression expr = parser.parseExpression("x instanceof Foo f");
 
         assertTrue(expr.isInstanceOfExpr());
 
@@ -103,7 +91,7 @@ public class PatternExprTest {
 
     @Test
     public void recordPatternGeneratedMethodsShouldWork() {
-        Expression expr = parseExpression("x instanceof Foo(Bar b)");
+        Expression expr = parser.parseExpression("x instanceof Foo(Bar b)");
 
         assertTrue(expr.isInstanceOfExpr());
 
@@ -144,7 +132,7 @@ public class PatternExprTest {
 
     @Test
     public void aSingleMatchAllPatternInRecordListShouldWork() {
-        Expression expr = parseExpression("x instanceof Foo(_)");
+        Expression expr = parser.parseExpression("x instanceof Foo(_)");
 
         assertTrue(expr.isInstanceOfExpr());
 
@@ -166,7 +154,7 @@ public class PatternExprTest {
 
     @Test
     public void multipleMatchAllPatternsInRecordListShouldWork() {
-        Expression expr = parseExpression("x instanceof Foo(_, Bar b, _)");
+        Expression expr = parser.parseExpression("x instanceof Foo(_, Bar b, _)");
 
         assertTrue(expr.isInstanceOfExpr());
 
@@ -196,7 +184,7 @@ public class PatternExprTest {
     public void emptyRecordPatternListShouldWork() {
         // JLS 14.30: RecordPattern = ReferenceType ( [ComponentPatternList] )
         // The component list is optional — "Point()" is valid.
-        Expression expr = parseExpression("x instanceof Point()");
+        Expression expr = parser.parseExpression("x instanceof Point()");
 
         assertTrue(expr.isInstanceOfExpr());
         InstanceOfExpr instanceOfExpr = expr.asInstanceOfExpr();
@@ -212,7 +200,7 @@ public class PatternExprTest {
 
     @Test
     public void anUnnamedTypePatternShouldWork() {
-        Expression expr = parseExpression("x instanceof Foo _");
+        Expression expr = parser.parseExpression("x instanceof Foo _");
 
         assertTrue(expr.isInstanceOfExpr());
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SimpleNameTest.java
@@ -21,16 +21,19 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseSimpleName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.observer.AstObserver;
 import org.junit.jupiter.api.Test;
 
 class SimpleNameTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     @Test
     void defaultConstructorSetsIdentifierToEmpty() {
@@ -49,7 +52,7 @@ class SimpleNameTest {
 
     @Test
     void unicodeEscapesArePreservedInIdentifiers() {
-        SimpleName name = parseSimpleName("xxx\\u2122xxx");
+        SimpleName name = parser.parseSimpleName("xxx\\u2122xxx");
         assertEquals("xxx\\u2122xxx", name.asString());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/StringLiteralExprTest.java
@@ -21,15 +21,19 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import org.junit.jupiter.api.Test;
 
 class StringLiteralExprTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void unicodeEscapesArePreservedInStrings() {
-        StringLiteralExpr omega = parseExpression("\"xxx\\u03a9xxx\"");
+        StringLiteralExpr omega = parser.parseExpression("\"xxx\\u03a9xxx\"");
         assertEquals("xxx\\u03a9xxx", omega.getValue());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SuperExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/SuperExprTest.java
@@ -21,22 +21,26 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.StaticJavaParser;
 import org.junit.jupiter.api.Test;
 
 class SuperExprTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void justSuper() {
-        assertThrows(ParseProblemException.class, () -> parseExpression("super"));
+        assertThrows(ParseProblemException.class, () -> parser.parseExpression("super"));
     }
 
     @Test
     void singleScopeSuper() {
-        Expression expr = parseExpression("A.super");
+        Expression expr = parser.parseExpression("A.super");
 
         Name className = expr.asSuperExpr().getTypeName().get();
 
@@ -45,7 +49,7 @@ class SuperExprTest {
 
     @Test
     void multiScopeSuper() {
-        Expression expr = parseExpression("a.B.super");
+        Expression expr = parser.parseExpression("a.B.super");
 
         Name className = expr.asSuperExpr().getTypeName().get();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/ThisExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/ThisExprTest.java
@@ -21,19 +21,23 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import org.junit.jupiter.api.Test;
 
 class ThisExprTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void justThis() {
-        Expression expr = parseExpression("this");
+        Expression expr = parser.parseExpression("this");
 
         assertTrue(expr.isThisExpr());
     }
@@ -48,7 +52,7 @@ class ThisExprTest {
 
     @Test
     void singleScopeThis() {
-        Expression expr = parseExpression("A.this");
+        Expression expr = parser.parseExpression("A.this");
 
         Name className = expr.asThisExpr().getTypeName().get();
 
@@ -65,7 +69,7 @@ class ThisExprTest {
 
     @Test
     void multiScopeThis() {
-        Expression expr = parseExpression("a.B.this");
+        Expression expr = parser.parseExpression("a.B.this");
 
         Name className = expr.asThisExpr().getTypeName().get();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/UnaryExprTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/expr/UnaryExprTest.java
@@ -21,28 +21,24 @@
 
 package com.github.javaparser.ast.expr;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.stmt.AssertStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UnaryExprTest {
-    @BeforeEach
-    void initParser() {
-        StaticJavaParser.setConfiguration(new ParserConfiguration());
-    }
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     @Test
     void unaryPlusTest() {
-        Expression e = parseExpression("+x");
+        Expression e = parser.parseExpression("+x");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.PLUS, unary.getOperator());
@@ -53,7 +49,7 @@ class UnaryExprTest {
 
     @Test
     void unaryMinusTest() {
-        Expression e = parseExpression("-x");
+        Expression e = parser.parseExpression("-x");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.MINUS, unary.getOperator());
@@ -64,7 +60,7 @@ class UnaryExprTest {
 
     @Test
     void prefixIncrementTest() {
-        Expression e = parseExpression("++x");
+        Expression e = parser.parseExpression("++x");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, unary.getOperator());
@@ -75,7 +71,7 @@ class UnaryExprTest {
 
     @Test
     void prefixDecrementTest() {
-        Expression e = parseExpression("--x");
+        Expression e = parser.parseExpression("--x");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.PREFIX_DECREMENT, unary.getOperator());
@@ -86,7 +82,7 @@ class UnaryExprTest {
 
     @Test
     void logicalComplementTest() {
-        Expression e = parseExpression("!flag");
+        Expression e = parser.parseExpression("!flag");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.LOGICAL_COMPLEMENT, unary.getOperator());
@@ -97,7 +93,7 @@ class UnaryExprTest {
 
     @Test
     void bitwiseComplementTest() {
-        Expression e = parseExpression("~x");
+        Expression e = parser.parseExpression("~x");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.BITWISE_COMPLEMENT, unary.getOperator());
@@ -108,7 +104,7 @@ class UnaryExprTest {
 
     @Test
     void postfixIncrementTest() {
-        Expression e = parseExpression("x++");
+        Expression e = parser.parseExpression("x++");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.POSTFIX_INCREMENT, unary.getOperator());
@@ -119,7 +115,7 @@ class UnaryExprTest {
 
     @Test
     void postfixDecrementTest() {
-        Expression e = parseExpression("x--");
+        Expression e = parser.parseExpression("x--");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.POSTFIX_DECREMENT, unary.getOperator());
@@ -130,7 +126,7 @@ class UnaryExprTest {
 
     @Test
     void nestedUnaryTest() {
-        Expression e = parseExpression("!!flag");
+        Expression e = parser.parseExpression("!!flag");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr outerUnary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.LOGICAL_COMPLEMENT, outerUnary.getOperator());
@@ -145,7 +141,7 @@ class UnaryExprTest {
 
     @Test
     void unaryWithMethodCallTest() {
-        Expression e = parseExpression("!obj.isValid()");
+        Expression e = parser.parseExpression("!obj.isValid()");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.LOGICAL_COMPLEMENT, unary.getOperator());
@@ -160,7 +156,7 @@ class UnaryExprTest {
 
     @Test
     void unaryWithArrayAccessTest() {
-        Expression e = parseExpression("++array[i]");
+        Expression e = parser.parseExpression("++array[i]");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, unary.getOperator());
@@ -177,7 +173,7 @@ class UnaryExprTest {
 
     @Test
     void unaryWithFieldAccessTest() {
-        Expression e = parseExpression("-obj.value");
+        Expression e = parser.parseExpression("-obj.value");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr unary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.MINUS, unary.getOperator());
@@ -192,7 +188,7 @@ class UnaryExprTest {
 
     @Test
     void mixedPrefixAndPostfixTest() {
-        Expression e = parseExpression("++(x--)");
+        Expression e = parser.parseExpression("++(x--)");
         assertInstanceOf(UnaryExpr.class, e);
         UnaryExpr prefixUnary = e.asUnaryExpr();
         assertEquals(UnaryExpr.Operator.PREFIX_INCREMENT, prefixUnary.getOperator());
@@ -210,7 +206,7 @@ class UnaryExprTest {
 
     @Test
     void unaryInBinaryExprTest() {
-        Expression e = parseExpression("-x + y");
+        Expression e = parser.parseExpression("-x + y");
         assertInstanceOf(BinaryExpr.class, e);
         BinaryExpr binary = e.asBinaryExpr();
         assertEquals(BinaryExpr.Operator.PLUS, binary.getOperator());
@@ -226,7 +222,7 @@ class UnaryExprTest {
 
     @Test
     void unaryInAssertStatementTest() {
-        Statement stmt = parseStatement("assert ++counter == 1 : \"Counter should be incremented\";");
+        Statement stmt = parser.parseStatement("assert ++counter == 1 : \"Counter should be incremented\";");
         assertInstanceOf(AssertStmt.class, stmt);
         AssertStmt assertStmt = stmt.asAssertStmt();
 
@@ -255,9 +251,10 @@ class UnaryExprTest {
         // Note: "assert" as an identifier is only valid in Java < 1.4 In modern Java,
         // "assert" is a keyword. However, "assert" as an identifier is still supported
         // for backward compatibility
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0);
+        JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+                new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0));
 
-        Statement stmt = parseStatement("assert++;");
+        Statement stmt = parser.parseStatement("assert++;");
         assertInstanceOf(ExpressionStmt.class, stmt);
         ExpressionStmt exprStmt = stmt.asExpressionStmt();
 
@@ -274,9 +271,10 @@ class UnaryExprTest {
         // Note: "assert" as an identifier is only valid in Java < 1.4 In modern Java,
         // "assert" is a keyword. However, "assert" as an identifier is still supported
         // for backward compatibility
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0);
+        JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+                new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_1_0));
 
-        Statement stmt = parseStatement("++assert;");
+        Statement stmt = parser.parseStatement("++assert;");
         assertInstanceOf(ExpressionStmt.class, stmt);
         ExpressionStmt exprStmt = stmt.asExpressionStmt();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 
 class ImportDeclarationTest {
 
+    // JAVA_25 is required by the module import tests ("import module ...;"), which the parser only accepts from
+    // Java 25 onwards. The remaining (regular/static) import tests are language-level agnostic and pass at any level.
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
             new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25));
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/imports/ImportDeclarationTest.java
@@ -21,65 +21,62 @@
 
 package com.github.javaparser.ast.imports;
 
-import static com.github.javaparser.StaticJavaParser.parseImport;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.ImportDeclaration;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class ImportDeclarationTest {
 
-    @BeforeAll
-    static void initParser() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
-    }
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+            new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25));
 
     @Test
     void singleTypeImportDeclaration() {
-        ImportDeclaration i = parseImport("import a.b.c.X;");
+        ImportDeclaration i = parser.parseImport("import a.b.c.X;");
         assertEquals("a.b.c.X", i.getNameAsString());
     }
 
     @Test
     void typeImportOnDemandDeclaration() {
-        ImportDeclaration i = parseImport("import a.b.c.D.*;");
+        ImportDeclaration i = parser.parseImport("import a.b.c.D.*;");
         assertEquals("a.b.c.D", i.getName().toString());
         assertEquals("D", i.getName().getIdentifier());
     }
 
     @Test
     void singleStaticImportDeclaration() {
-        ImportDeclaration i = parseImport("import static a.b.c.X.def;");
+        ImportDeclaration i = parser.parseImport("import static a.b.c.X.def;");
         assertEquals("a.b.c.X", i.getName().getQualifier().get().asString());
         assertEquals("def", i.getName().getIdentifier());
     }
 
     @Test
     void staticImportOnDemandDeclaration() {
-        ImportDeclaration i = parseImport("import static a.b.c.X.*;");
+        ImportDeclaration i = parser.parseImport("import static a.b.c.X.*;");
         assertEquals("a.b.c.X", i.getNameAsString());
     }
 
     @Test
     void moduleImport() {
-        ImportDeclaration i = parseImport("import module java.base;");
+        ImportDeclaration i = parser.parseImport("import module java.base;");
         assertEquals("java.base", i.getNameAsString());
         assertTrue(i.isModule());
     }
 
     @Test
     void modulePackageImport() {
-        ImportDeclaration i = parseImport("import module.base.Foo;");
+        ImportDeclaration i = parser.parseImport("import module.base.Foo;");
         assertEquals("module.base.Foo", i.getNameAsString());
         assertFalse(i.isModule());
     }
 
     @Test
     void staticModulePackageImport() {
-        ImportDeclaration i = parseImport("import static module.base.Foo;");
+        ImportDeclaration i = parser.parseImport("import static module.base.Foo;");
         assertEquals("module.base.Foo", i.getNameAsString());
         assertFalse(i.isModule());
         assertTrue(i.isStatic());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithTraversableScopeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithTraversableScopeTest.java
@@ -21,18 +21,22 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import org.junit.jupiter.api.Test;
 
 class NodeWithTraversableScopeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void traverse1() {
-        NodeWithTraversableScope expression = parseExpression("getAddress().name.startsWith(\"abc\")");
+        NodeWithTraversableScope expression = parser.parseExpression("getAddress().name.startsWith(\"abc\")");
 
         assertInstanceOf(MethodCallExpr.class, expression);
         expression = (NodeWithTraversableScope) expression.traverseScope().get();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithVariablesTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/nodeTypes/NodeWithVariablesTest.java
@@ -21,10 +21,10 @@
 
 package com.github.javaparser.ast.nodeTypes;
 
-import static com.github.javaparser.StaticJavaParser.parseVariableDeclarationExpr;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.type.PrimitiveType;
@@ -32,27 +32,29 @@ import org.junit.jupiter.api.Test;
 
 class NodeWithVariablesTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void getCommonTypeWorksForNormalVariables() {
-        VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a,b");
+        VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int a,b");
         assertEquals(PrimitiveType.intType(), declaration.getCommonType());
     }
 
     @Test
     void getCommonTypeWorksForArrayTypes() {
-        parseVariableDeclarationExpr("int a[],b[]").getCommonType();
+        parser.parseVariableDeclarationExpr("int a[],b[]").getCommonType();
     }
 
     @Test
     void getCommonTypeFailsOnArrayDifferences() {
-        assertThrows(AssertionError.class, () -> parseVariableDeclarationExpr("int a[],b[][]")
+        assertThrows(AssertionError.class, () -> parser.parseVariableDeclarationExpr("int a[],b[][]")
                 .getCommonType());
     }
 
     @Test
     void getCommonTypeFailsOnDodgySetterUsage() {
         assertThrows(AssertionError.class, () -> {
-            VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a,b");
+            VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int a,b");
             declaration.getVariable(1).setType(String.class);
             declaration.getCommonType();
         });
@@ -61,7 +63,7 @@ class NodeWithVariablesTest {
     @Test
     void getCommonTypeFailsOnInvalidEmptyVariableList() {
         assertThrows(AssertionError.class, () -> {
-            VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a");
+            VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int a");
             declaration.getVariables().clear();
             declaration.getCommonType();
         });
@@ -69,25 +71,25 @@ class NodeWithVariablesTest {
 
     @Test
     void getElementTypeWorksForNormalVariables() {
-        VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a,b");
+        VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int a,b");
         assertEquals(PrimitiveType.intType(), declaration.getElementType());
     }
 
     @Test
     void getElementTypeWorksForArrayTypes() {
-        VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a[],b[]");
+        VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int a[],b[]");
         assertEquals(PrimitiveType.intType(), declaration.getElementType());
     }
 
     @Test
     void getElementTypeIsOkayWithArrayDifferences() {
-        parseVariableDeclarationExpr("int a[],b[][]").getElementType();
+        parser.parseVariableDeclarationExpr("int a[],b[][]").getElementType();
     }
 
     @Test
     void getElementTypeFailsOnDodgySetterUsage() {
         assertThrows(AssertionError.class, () -> {
-            VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a,b");
+            VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int a,b");
             declaration.getVariable(1).setType(String.class);
             declaration.getElementType();
         });
@@ -96,7 +98,7 @@ class NodeWithVariablesTest {
     @Test
     void getElementTypeFailsOnInvalidEmptyVariableList() {
         assertThrows(AssertionError.class, () -> {
-            VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int a");
+            VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int a");
             declaration.getVariables().clear();
             declaration.getElementType();
         });
@@ -104,8 +106,8 @@ class NodeWithVariablesTest {
 
     @Test
     void setAllTypesWorks() {
-        VariableDeclarationExpr declaration = parseVariableDeclarationExpr("int[] a[],b[][]");
-        declaration.setAllTypes(StaticJavaParser.parseType("Dog"));
+        VariableDeclarationExpr declaration = parser.parseVariableDeclarationExpr("int[] a[],b[][]");
+        declaration.setAllTypes(parser.parseType("Dog"));
         assertEquals("Dog a, b", declaration.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
@@ -21,10 +21,11 @@
 
 package com.github.javaparser.ast.observer;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -34,10 +35,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class PropagatingAstObserverTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void verifyPropagation() {
         String code = "class A {  }";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         List<String> changes = new ArrayList<>();
         AstObserver observer = new PropagatingAstObserver() {
             @Override

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/ForEachStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/ForEachStmtTest.java
@@ -43,7 +43,8 @@ class ForEachStmtTest {
 
     @Test
     void finalNonPrimitive() {
-        ForEachStmt statement = parser.parseStatement("for (final Object o : objs) {}").asForEachStmt();
+        ForEachStmt statement =
+                parser.parseStatement("for (final Object o : objs) {}").asForEachStmt();
         assertTrue(statement.hasFinalVariable());
         assertEquals(
                 new ClassOrInterfaceType(null, "Object"),

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/ForEachStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/ForEachStmtTest.java
@@ -21,17 +21,21 @@
 
 package com.github.javaparser.ast.stmt;
 
-import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.PrimitiveType;
 import org.junit.jupiter.api.Test;
 
 class ForEachStmtTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void nonFinalPrimitive() {
-        ForEachStmt statement = parseStatement("for (int i : ints) {}").asForEachStmt();
+        ForEachStmt statement = parser.parseStatement("for (int i : ints) {}").asForEachStmt();
         assertFalse(statement.hasFinalVariable());
         assertEquals(PrimitiveType.intType(), statement.getVariableDeclarator().getType());
         assertEquals("i", statement.getVariableDeclarator().getName().getIdentifier());
@@ -39,7 +43,7 @@ class ForEachStmtTest {
 
     @Test
     void finalNonPrimitive() {
-        ForEachStmt statement = parseStatement("for (final Object o : objs) {}").asForEachStmt();
+        ForEachStmt statement = parser.parseStatement("for (final Object o : objs) {}").asForEachStmt();
         assertTrue(statement.hasFinalVariable());
         assertEquals(
                 new ClassOrInterfaceType(null, "Object"),

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/IfElseStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/IfElseStmtTest.java
@@ -21,17 +21,20 @@
 
 package com.github.javaparser.ast.stmt;
 
-import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import org.junit.jupiter.api.Test;
 
 class IfElseStmtTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void issue1247withElseSingleStmt() {
-        IfStmt ifStmt = parseStatement("if (cond) doSomething(); else doSomethingElse();")
+        IfStmt ifStmt = parser.parseStatement("if (cond) doSomething(); else doSomethingElse();")
                 .asIfStmt();
         assertFalse(ifStmt.hasElseBlock());
         assertTrue(ifStmt.hasElseBranch());
@@ -40,7 +43,7 @@ class IfElseStmtTest {
 
     @Test
     void issue1247withElseBlockStmt() {
-        IfStmt ifStmt = parseStatement("if (cond) doSomething(); else { doSomethingElse(); }")
+        IfStmt ifStmt = parser.parseStatement("if (cond) doSomething(); else { doSomethingElse(); }")
                 .asIfStmt();
         assertTrue(ifStmt.hasElseBlock());
         assertTrue(ifStmt.hasElseBranch());
@@ -49,7 +52,7 @@ class IfElseStmtTest {
 
     @Test
     void issue1247withElseSingleStmtWhichIsAnIf() {
-        IfStmt ifStmt = parseStatement("if (cond1) doSomething(); else if (cond2) doSomethingElse();")
+        IfStmt ifStmt = parser.parseStatement("if (cond1) doSomething(); else if (cond2) doSomethingElse();")
                 .asIfStmt();
         assertFalse(ifStmt.hasElseBlock());
         assertTrue(ifStmt.hasElseBranch());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
@@ -21,39 +21,27 @@
 
 package com.github.javaparser.ast.stmt;
 
-import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.EXPRESSION;
 import static com.github.javaparser.ast.stmt.SwitchEntry.Type.STATEMENT_GROUP;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class SwitchStmtTest {
 
-    private static final ParserConfiguration.LanguageLevel storedLanguageLevel =
-            StaticJavaParser.getParserConfiguration().getLanguageLevel();
-
-    @BeforeAll
-    public static void setLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-    }
-
-    @AfterAll
-    public static void resetLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(storedLanguageLevel);
-    }
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+            new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE));
 
     @Test
     void classicSwitch() {
-        SwitchStmt switchStmt = parseStatement("switch (day) {\n" + "    case TUESDAY: System.out.println(7); break;\n"
+        SwitchStmt switchStmt = parser.parseStatement("switch (day) {\n" + "    case TUESDAY: System.out.println(7); break;\n"
                         + "    case FRIDAY: System.out.println(8); break;\n"
                         + "    default: System.out.println(-1); \n"
                         + "}")
@@ -70,7 +58,7 @@ class SwitchStmtTest {
 
     @Test
     void jep325Example1() {
-        SwitchStmt switchStmt = parseStatement("switch (day) {\n" +
+        SwitchStmt switchStmt = parser.parseStatement("switch (day) {\n" +
                         //                "    case MONDAY, FRIDAY, SUNDAY -> System.out.println(6);\n" +
                         "    case TUESDAY                -> System.out.println(7);\n"
                         +
@@ -84,7 +72,7 @@ class SwitchStmtTest {
 
     @Test
     void jep441Example1() {
-        SwitchStmt switchStmt = parseStatement(
+        SwitchStmt switchStmt = parser.parseStatement(
                         "switch (day) {\n" + "    case null, default -> System.out.println(-1); \n" + "}")
                 .asSwitchStmt();
 
@@ -95,7 +83,7 @@ class SwitchStmtTest {
 
     @Test
     void issue4455Test() {
-        SwitchStmt switchStmt = parseStatement(
+        SwitchStmt switchStmt = parser.parseStatement(
                         "switch (column) {\n" + "  case CustomDeployTableModel.ARTIFACT_NAME:\n" + "}")
                 .asSwitchStmt();
 
@@ -110,7 +98,7 @@ class SwitchStmtTest {
 
     @Test
     void issue4607Test() {
-        SwitchStmt switchStmt = parseStatement("switch (o) { case String s when s.length() == 1 -> 0; }")
+        SwitchStmt switchStmt = parser.parseStatement("switch (o) { case String s when s.length() == 1 -> 0; }")
                 .asSwitchStmt();
         assertEquals(switchStmt.toString(), switchStmt.clone().toString());
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/stmt/SwitchStmtTest.java
@@ -41,10 +41,11 @@ class SwitchStmtTest {
 
     @Test
     void classicSwitch() {
-        SwitchStmt switchStmt = parser.parseStatement("switch (day) {\n" + "    case TUESDAY: System.out.println(7); break;\n"
-                        + "    case FRIDAY: System.out.println(8); break;\n"
-                        + "    default: System.out.println(-1); \n"
-                        + "}")
+        SwitchStmt switchStmt = parser.parseStatement(
+                        "switch (day) {\n" + "    case TUESDAY: System.out.println(7); break;\n"
+                                + "    case FRIDAY: System.out.println(8); break;\n"
+                                + "    default: System.out.println(-1); \n"
+                                + "}")
                 .asSwitchStmt();
 
         assertEquals(STATEMENT_GROUP, switchStmt.getEntry(0).getType());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
@@ -82,7 +82,8 @@ class ArrayTypeTest {
         assertThat(arrayType4.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("B")));
 
         assertThat(elementType.getType()).isEqualTo(PrimitiveType.Primitive.INT);
-        assertThat(variableDeclarationExpr.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("C")));
+        assertThat(variableDeclarationExpr.getAnnotations())
+                .containsExactly(new MarkerAnnotationExpr(parser.parseName("C")));
 
         assertThat(arrayType1.getParentNode().get().getParentNode().get()).isSameAs(variableDeclarationExpr);
     }
@@ -146,7 +147,8 @@ class ArrayTypeTest {
 
     @Test
     void setMethodDeclarationWithArrays() {
-        MethodDeclaration method = parser.parseBodyDeclaration("int[][] a()[][] {}").asMethodDeclaration();
+        MethodDeclaration method =
+                parser.parseBodyDeclaration("int[][] a()[][] {}").asMethodDeclaration();
         method.setType(new ArrayType(new ArrayType(parser.parseClassOrInterfaceType("Blob"))));
 
         assertEquals("Blob[][] a() {" + LineSeparator.SYSTEM + "}", method.toString());
@@ -154,7 +156,8 @@ class ArrayTypeTest {
 
     @Test
     void fieldDeclarationWithArraysHasCorrectOrigins() {
-        FieldDeclaration fieldDeclaration = parser.parseBodyDeclaration("int[] a[];").asFieldDeclaration();
+        FieldDeclaration fieldDeclaration =
+                parser.parseBodyDeclaration("int[] a[];").asFieldDeclaration();
 
         Type outerType = fieldDeclaration.getVariables().get(0).getType();
         assertEquals(ArrayType.Origin.NAME, outerType.asArrayType().getOrigin());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ArrayTypeTest.java
@@ -21,10 +21,11 @@
 
 package com.github.javaparser.ast.type;
 
-import static com.github.javaparser.StaticJavaParser.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
@@ -37,10 +38,13 @@ import com.github.javaparser.utils.LineSeparator;
 import org.junit.jupiter.api.Test;
 
 class ArrayTypeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void getFieldDeclarationWithArrays() {
         FieldDeclaration fieldDeclaration =
-                parseBodyDeclaration("@C int @A[] @B[] a @X[] @Y[];").asFieldDeclaration();
+                parser.parseBodyDeclaration("@C int @A[] @B[] a @X[] @Y[];").asFieldDeclaration();
 
         ArrayType arrayType1 = fieldDeclaration.getVariable(0).getType().asArrayType();
         ArrayType arrayType2 = arrayType1.getComponentType().asArrayType();
@@ -48,13 +52,13 @@ class ArrayTypeTest {
         ArrayType arrayType4 = arrayType3.getComponentType().asArrayType();
         PrimitiveType elementType = arrayType4.getComponentType().asPrimitiveType();
 
-        assertThat(arrayType1.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("X")));
-        assertThat(arrayType2.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("Y")));
-        assertThat(arrayType3.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("A")));
-        assertThat(arrayType4.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("B")));
+        assertThat(arrayType1.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("X")));
+        assertThat(arrayType2.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("Y")));
+        assertThat(arrayType3.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("A")));
+        assertThat(arrayType4.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("B")));
 
         assertThat(elementType.getType()).isEqualTo(PrimitiveType.Primitive.INT);
-        assertThat(fieldDeclaration.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("C")));
+        assertThat(fieldDeclaration.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("C")));
 
         assertThat(arrayType1.getParentNode().get().getParentNode().get()).isSameAs(fieldDeclaration);
     }
@@ -62,7 +66,7 @@ class ArrayTypeTest {
     @Test
     void getVariableDeclarationWithArrays() {
         ExpressionStmt variableDeclarationStatement =
-                parseStatement("@C int @A[] @B[] a @X[] @Y[];").asExpressionStmt();
+                parser.parseStatement("@C int @A[] @B[] a @X[] @Y[];").asExpressionStmt();
         VariableDeclarationExpr variableDeclarationExpr =
                 variableDeclarationStatement.getExpression().asVariableDeclarationExpr();
 
@@ -72,13 +76,13 @@ class ArrayTypeTest {
         ArrayType arrayType4 = arrayType3.getComponentType().asArrayType();
         PrimitiveType elementType = arrayType4.getComponentType().asPrimitiveType();
 
-        assertThat(arrayType1.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("X")));
-        assertThat(arrayType2.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("Y")));
-        assertThat(arrayType3.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("A")));
-        assertThat(arrayType4.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("B")));
+        assertThat(arrayType1.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("X")));
+        assertThat(arrayType2.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("Y")));
+        assertThat(arrayType3.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("A")));
+        assertThat(arrayType4.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("B")));
 
         assertThat(elementType.getType()).isEqualTo(PrimitiveType.Primitive.INT);
-        assertThat(variableDeclarationExpr.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("C")));
+        assertThat(variableDeclarationExpr.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("C")));
 
         assertThat(arrayType1.getParentNode().get().getParentNode().get()).isSameAs(variableDeclarationExpr);
     }
@@ -86,16 +90,16 @@ class ArrayTypeTest {
     @Test
     void getMethodDeclarationWithArrays() {
         MethodDeclaration methodDeclaration =
-                parseBodyDeclaration("@C int @A[] a() @B[] {}").asMethodDeclaration();
+                parser.parseBodyDeclaration("@C int @A[] a() @B[] {}").asMethodDeclaration();
 
         ArrayType arrayType1 = methodDeclaration.getType().asArrayType();
         ArrayType arrayType2 = arrayType1.getComponentType().asArrayType();
         Type elementType = arrayType2.getComponentType();
         assertThat(elementType).isInstanceOf(PrimitiveType.class);
 
-        assertThat(arrayType1.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("B")));
-        assertThat(arrayType2.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("A")));
-        assertThat(methodDeclaration.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("C")));
+        assertThat(arrayType1.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("B")));
+        assertThat(arrayType2.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("A")));
+        assertThat(methodDeclaration.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("C")));
 
         assertThat(methodDeclaration.getType().getParentNode().get()).isSameAs(methodDeclaration);
     }
@@ -103,7 +107,7 @@ class ArrayTypeTest {
     @Test
     void getParameterWithArrays() {
         MethodDeclaration methodDeclaration =
-                parseBodyDeclaration("void a(@C int @A[] a @B[]) {}").asMethodDeclaration();
+                parser.parseBodyDeclaration("void a(@C int @A[] a @B[]) {}").asMethodDeclaration();
 
         Parameter parameter = methodDeclaration.getParameter(0);
 
@@ -113,9 +117,9 @@ class ArrayTypeTest {
         PrimitiveType elementType = innerArrayType.getComponentType().asPrimitiveType();
 
         assertThat(elementType).isInstanceOf(PrimitiveType.class);
-        assertThat(outerArrayType.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("B")));
-        assertThat(innerArrayType.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("A")));
-        assertThat(parameter.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("C")));
+        assertThat(outerArrayType.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("B")));
+        assertThat(innerArrayType.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("A")));
+        assertThat(parameter.getAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("C")));
 
         assertThat(parameter.getType().getParentNode().get()).isSameAs(parameter);
     }
@@ -123,7 +127,7 @@ class ArrayTypeTest {
     @Test
     void setVariableDeclarationWithArrays() {
         ExpressionStmt variableDeclarationStatement =
-                parseStatement("@C int @A[] @B[] a @X[] @Y[];").asExpressionStmt();
+                parser.parseStatement("@C int @A[] @B[] a @X[] @Y[];").asExpressionStmt();
         VariableDeclarationExpr variableDeclarationExpr =
                 variableDeclarationStatement.getExpression().asVariableDeclarationExpr();
 
@@ -134,23 +138,23 @@ class ArrayTypeTest {
     @Test
     void setFieldDeclarationWithArrays() {
         FieldDeclaration fieldDeclaration =
-                parseBodyDeclaration("int[][] a[][];").asFieldDeclaration();
-        fieldDeclaration.getVariable(0).setType(new ArrayType(new ArrayType(parseClassOrInterfaceType("Blob"))));
+                parser.parseBodyDeclaration("int[][] a[][];").asFieldDeclaration();
+        fieldDeclaration.getVariable(0).setType(new ArrayType(new ArrayType(parser.parseClassOrInterfaceType("Blob"))));
 
         assertEquals("Blob[][] a;", fieldDeclaration.toString());
     }
 
     @Test
     void setMethodDeclarationWithArrays() {
-        MethodDeclaration method = parseBodyDeclaration("int[][] a()[][] {}").asMethodDeclaration();
-        method.setType(new ArrayType(new ArrayType(parseClassOrInterfaceType("Blob"))));
+        MethodDeclaration method = parser.parseBodyDeclaration("int[][] a()[][] {}").asMethodDeclaration();
+        method.setType(new ArrayType(new ArrayType(parser.parseClassOrInterfaceType("Blob"))));
 
         assertEquals("Blob[][] a() {" + LineSeparator.SYSTEM + "}", method.toString());
     }
 
     @Test
     void fieldDeclarationWithArraysHasCorrectOrigins() {
-        FieldDeclaration fieldDeclaration = parseBodyDeclaration("int[] a[];").asFieldDeclaration();
+        FieldDeclaration fieldDeclaration = parser.parseBodyDeclaration("int[] a[];").asFieldDeclaration();
 
         Type outerType = fieldDeclaration.getVariables().get(0).getType();
         assertEquals(ArrayType.Origin.NAME, outerType.asArrayType().getOrigin());
@@ -161,7 +165,7 @@ class ArrayTypeTest {
 
     @Test
     void methodDeclarationWithArraysHasCorrectOrigins() {
-        MethodDeclaration method = (MethodDeclaration) parseBodyDeclaration("int[] a()[] {}");
+        MethodDeclaration method = (MethodDeclaration) parser.parseBodyDeclaration("int[] a()[] {}");
 
         Type outerType = method.getType();
         assertEquals(ArrayType.Origin.NAME, outerType.asArrayType().getOrigin());
@@ -173,15 +177,15 @@ class ArrayTypeTest {
     @Test
     void setParameterWithArrays() {
         MethodDeclaration method =
-                parseBodyDeclaration("void a(int[][] a[][]) {}").asMethodDeclaration();
-        method.getParameter(0).setType(new ArrayType(new ArrayType(parseClassOrInterfaceType("Blob"))));
+                parser.parseBodyDeclaration("void a(int[][] a[][]) {}").asMethodDeclaration();
+        method.getParameter(0).setType(new ArrayType(new ArrayType(parser.parseClassOrInterfaceType("Blob"))));
 
         assertEquals("void a(Blob[][] a) {" + LineSeparator.SYSTEM + "}", method.toString());
     }
 
     @Test
     void getArrayCreationType() {
-        ArrayCreationExpr expr = parseExpression("new int[]");
+        ArrayCreationExpr expr = parser.parseExpression("new int[]");
         ArrayType outerType = expr.createdType().asArrayType();
         Type innerType = outerType.getComponentType();
         assertThat(innerType).isEqualTo(expr.getElementType());
@@ -189,24 +193,24 @@ class ArrayTypeTest {
 
     @Test
     void ellipsisCanHaveAnnotationsToo() {
-        Parameter p = parseParameter("int[]@X...a[]");
+        Parameter p = parser.parseParameter("int[]@X...a[]");
 
-        assertThat(p.getVarArgsAnnotations()).containsExactly(new MarkerAnnotationExpr(parseName("X")));
+        assertThat(p.getVarArgsAnnotations()).containsExactly(new MarkerAnnotationExpr(parser.parseName("X")));
         assertEquals("int[][]@X ... a", p.toString());
         assertEquals("int[][]@X... a", ConcreteSyntaxModel.genericPrettyPrint(p));
     }
 
     @Test
     void arrayLevel() {
-        FieldDeclaration fd1 = parseBodyDeclaration("int[] a;").asFieldDeclaration();
+        FieldDeclaration fd1 = parser.parseBodyDeclaration("int[] a;").asFieldDeclaration();
         assertEquals(1, fd1.getVariable(0).getType().getArrayLevel());
-        FieldDeclaration fd2 = parseBodyDeclaration("int[][] a;").asFieldDeclaration();
+        FieldDeclaration fd2 = parser.parseBodyDeclaration("int[][] a;").asFieldDeclaration();
         assertEquals(2, fd2.getVariable(0).getType().getArrayLevel());
     }
 
     @Test
     void range() {
-        Type type = parseType("Long[][]");
+        Type type = parser.parseType("Long[][]");
         assertEquals(8, type.getRange().get().end.column);
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ClassOrInterfaceTypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/ClassOrInterfaceTypeTest.java
@@ -22,6 +22,7 @@ package com.github.javaparser.ast.type;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -33,6 +34,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ClassOrInterfaceTypeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     @Test
     void testSetName() {
@@ -67,7 +70,7 @@ class ClassOrInterfaceTypeTest {
 
     @Test
     void testWithAnnotations() {
-        AnnotationExpr annotationExpr = StaticJavaParser.parseAnnotation("@Override");
+        AnnotationExpr annotationExpr = parser.parseAnnotation("@Override");
         ClassOrInterfaceType classA =
                 new ClassOrInterfaceType(null, new SimpleName("A"), null, new NodeList<>(annotationExpr));
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/TypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/TypeTest.java
@@ -24,19 +24,22 @@ package com.github.javaparser.ast.type;
 import static com.github.javaparser.ParseStart.VARIABLE_DECLARATION_EXPR;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.RAW;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.StaticJavaParser.parseType;
-import static com.github.javaparser.StaticJavaParser.parseVariableDeclarationExpr;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.javaparser.JavaParser;
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.validator.language_level_validations.Java5Validator;
 import org.junit.jupiter.api.Test;
 
 class TypeTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void asString() {
         assertEquals("int", typeAsString("int x"));
@@ -69,12 +72,12 @@ class TypeTest {
     }
 
     private String typeAsString(String s) {
-        return parseVariableDeclarationExpr(s).getVariable(0).getType().asString();
+        return parser.parseVariableDeclarationExpr(s).getVariable(0).getType().asString();
     }
 
     @Test
     void arrayType() {
-        Type type = parseType("int[]");
+        Type type = parser.parseType("int[]");
         assertTrue(type.isArrayType());
         ArrayType arrayType = type.asArrayType();
         final ArrayType[] s = new ArrayType[1];
@@ -84,7 +87,7 @@ class TypeTest {
 
     @Test
     void issue1251() {
-        final Type type = parseType("TypeUtilsTest<String>.Tester");
+        final Type type = parser.parseType("TypeUtilsTest<String>.Tester");
         assertEquals("TypeUtilsTest<String>.Tester", type.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/CloneVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/CloneVisitorTest.java
@@ -21,9 +21,10 @@
 
 package com.github.javaparser.ast.visitor;
 
-import static com.github.javaparser.StaticJavaParser.parseType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.*;
@@ -34,6 +35,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CloneVisitorTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     CompilationUnit cu;
 
     @BeforeEach
@@ -100,7 +104,7 @@ class CloneVisitorTest {
 
     @Test
     void cloneAnnotationOnWildcardTypeArgument() {
-        Type type = parseType("List<@C ? extends Object>").clone();
+        Type type = parser.parseType("List<@C ? extends Object>").clone();
         assertEquals("List<@C ? extends Object>", type.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/HashCodeVisitorTest.java
@@ -21,12 +21,13 @@
 
 package com.github.javaparser.ast.visitor;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.ast.type.PrimitiveType.intType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.*;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
@@ -40,17 +41,19 @@ import org.junit.jupiter.api.Test;
 
 class HashCodeVisitorTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void testEquals() {
-        CompilationUnit p1 = parse("class X { }");
-        CompilationUnit p2 = parse("class X { }");
+        CompilationUnit p1 = parser.parse("class X { }");
+        CompilationUnit p2 = parser.parse("class X { }");
         assertEquals(p1.hashCode(), p2.hashCode());
     }
 
     @Test
     void testNotEquals() {
-        CompilationUnit p1 = parse("class X { }");
-        CompilationUnit p2 = parse("class Y { }");
+        CompilationUnit p1 = parser.parse("class X { }");
+        CompilationUnit p2 = parser.parse("class Y { }");
         assertNotEquals(p1.hashCode(), p2.hashCode());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ModifierVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/ModifierVisitorTest.java
@@ -21,8 +21,6 @@
 
 package com.github.javaparser.ast.visitor;
 
-import static com.github.javaparser.StaticJavaParser.parseBodyDeclaration;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -78,7 +76,7 @@ class ModifierVisitorTest extends AbstractLexicalPreservingTest {
 
     @Test
     void binaryExprReturnsLeftExpressionWhenRightSideIsRemoved() {
-        Expression expression = parseExpression("1+2");
+        Expression expression = parser.parseExpression("1+2");
         Visitable result = expression.accept(
                 new ModifierVisitor<Void>() {
                     public Visitable visit(IntegerLiteralExpr integerLiteralExpr, Void arg) {
@@ -94,7 +92,7 @@ class ModifierVisitorTest extends AbstractLexicalPreservingTest {
 
     @Test
     void binaryExprReturnsRightExpressionWhenLeftSideIsRemoved() {
-        final Expression expression = parseExpression("1+2");
+        final Expression expression = parser.parseExpression("1+2");
         final Visitable result = expression.accept(
                 new ModifierVisitor<Void>() {
                     public Visitable visit(IntegerLiteralExpr integerLiteralExpr, Void arg) {
@@ -110,7 +108,7 @@ class ModifierVisitorTest extends AbstractLexicalPreservingTest {
 
     @Test
     void fieldDeclarationCantSurviveWithoutVariables() {
-        final BodyDeclaration<?> bodyDeclaration = parseBodyDeclaration("int x=1;");
+        final BodyDeclaration<?> bodyDeclaration = parser.parseBodyDeclaration("int x=1;");
 
         final Visitable result = bodyDeclaration.accept(
                 new ModifierVisitor<Void>() {
@@ -125,7 +123,7 @@ class ModifierVisitorTest extends AbstractLexicalPreservingTest {
 
     @Test
     void variableDeclarationCantSurviveWithoutVariables() {
-        final BodyDeclaration<?> bodyDeclaration = parseBodyDeclaration("void x() {int x=1;}");
+        final BodyDeclaration<?> bodyDeclaration = parser.parseBodyDeclaration("void x() {int x=1;}");
 
         final Visitable result = bodyDeclaration.accept(
                 new ModifierVisitor<Void>() {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentEqualsVisitorTest.java
@@ -21,33 +21,36 @@
 
 package com.github.javaparser.ast.visitor;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
 class NoCommentEqualsVisitorTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void testEquals() {
-        CompilationUnit p1 = parse("class X { }");
-        CompilationUnit p2 = parse("class X { }");
+        CompilationUnit p1 = parser.parse("class X { }");
+        CompilationUnit p2 = parser.parse("class X { }");
         assertTrue(NoCommentEqualsVisitor.equals(p1, p2));
     }
 
     @Test
     void testEqualsWithDifferentComments() {
-        CompilationUnit p1 = parse("/* a */ class X { /** b */} //c");
-        CompilationUnit p2 = parse("/* b */ class X { }  //c");
+        CompilationUnit p1 = parser.parse("/* a */ class X { /** b */} //c");
+        CompilationUnit p2 = parser.parse("/* b */ class X { }  //c");
         assertTrue(NoCommentEqualsVisitor.equals(p1, p2));
     }
 
     @Test
     void testNotEquals() {
-        CompilationUnit p1 = parse("class X { }");
-        CompilationUnit p2 = parse("class Y { }");
+        CompilationUnit p1 = parser.parse("class X { }");
+        CompilationUnit p2 = parser.parse("class Y { }");
         assertFalse(NoCommentEqualsVisitor.equals(p1, p2));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NoCommentHashCodeVisitorTest.java
@@ -21,12 +21,13 @@
 
 package com.github.javaparser.ast.visitor;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.ast.type.PrimitiveType.intType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.*;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.BlockComment;
@@ -40,17 +41,19 @@ import org.junit.jupiter.api.Test;
 
 class NoCommentHashCodeVisitorTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void testEquals() {
-        CompilationUnit p1 = parse("class X { }");
-        CompilationUnit p2 = parse("class X { }");
+        CompilationUnit p1 = parser.parse("class X { }");
+        CompilationUnit p2 = parser.parse("class X { }");
         assertEquals(p1.hashCode(), p2.hashCode());
     }
 
     @Test
     void testEqualsWithDifferentComments() {
-        CompilationUnit p1 = parse("/* a */ class X { /** b */} //c");
-        CompilationUnit p2 = parse("/* b */ class X { }  //c");
+        CompilationUnit p1 = parser.parse("/* a */ class X { /** b */} //c");
+        CompilationUnit p2 = parser.parse("/* b */ class X { }  //c");
         assertEquals(p1.hashCode(), p2.hashCode());
         assertEquals(3, p1.getAllComments().size());
         assertEquals(2, p2.getAllComments().size());
@@ -58,8 +61,8 @@ class NoCommentHashCodeVisitorTest {
 
     @Test
     void testNotEquals() {
-        CompilationUnit p1 = parse("class X { }");
-        CompilationUnit p2 = parse("class Y { }");
+        CompilationUnit p1 = parser.parse("class X { }");
+        CompilationUnit p2 = parser.parse("class Y { }");
         assertNotEquals(p1.hashCode(), p2.hashCode());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NodeFinderVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/NodeFinderVisitorTest.java
@@ -20,11 +20,12 @@
 
 package com.github.javaparser.ast.visitor;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.Position;
 import com.github.javaparser.Range;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -32,11 +33,13 @@ import org.junit.jupiter.api.Test;
 
 class NodeFinderVisitorTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     NodeFinderVisitor finder = new NodeFinderVisitor(NodeFinderVisitor.fConveringNode);
 
     @Test
     void testNoCoveringNode() {
-        CompilationUnit cu = parse("class X { }");
+        CompilationUnit cu = parser.parse("class X { }");
         Position position = new Position(0, 0);
         Range range = new Range(position, position);
         cu.accept(finder, range);
@@ -45,7 +48,7 @@ class NodeFinderVisitorTest {
 
     @Test
     void testClassOrInterfaceDeclarationIsCovering() {
-        CompilationUnit cu = parse("class X { }");
+        CompilationUnit cu = parser.parse("class X { }");
         ClassOrInterfaceDeclaration cid =
                 cu.findFirst(ClassOrInterfaceDeclaration.class).get();
         Range range = new Range(Position.HOME, Position.HOME);
@@ -55,7 +58,7 @@ class NodeFinderVisitorTest {
 
     @Test
     void testClassOrInterfaceDeclarationIsCovering2() {
-        CompilationUnit cu = parse("class X { }");
+        CompilationUnit cu = parser.parse("class X { }");
         ClassOrInterfaceDeclaration cid =
                 cu.findFirst(ClassOrInterfaceDeclaration.class).get();
         cu.accept(finder, range(1, 11));
@@ -64,7 +67,7 @@ class NodeFinderVisitorTest {
 
     @Test
     void testClassOrInterfaceDeclarationCovering() {
-        CompilationUnit cu = parse("class X {\n" + "  Boolean f;\n" + "}");
+        CompilationUnit cu = parser.parse("class X {\n" + "  Boolean f;\n" + "}");
 
         ClassOrInterfaceDeclaration cid =
                 cu.findFirst(ClassOrInterfaceDeclaration.class).get();
@@ -74,7 +77,7 @@ class NodeFinderVisitorTest {
 
     @Test
     void testNoCoveringOrCoveredNode2() {
-        CompilationUnit cu = parse("class X {\n" + "  void f() {\n" + "     int i = 0;\n" + "  }\n" + "}");
+        CompilationUnit cu = parser.parse("class X {\n" + "  void f() {\n" + "     int i = 0;\n" + "  }\n" + "}");
         MethodDeclaration md = cu.findFirst(MethodDeclaration.class).get();
         cu.accept(finder, range(3, 11));
         System.out.println(finder.getSelectedNode().toString());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/TreeVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/visitor/TreeVisitorTest.java
@@ -21,12 +21,12 @@
 
 package com.github.javaparser.ast.visitor;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.ArrayInitializerExpr;
@@ -36,9 +36,12 @@ import com.github.javaparser.ast.expr.SimpleName;
 import org.junit.jupiter.api.Test;
 
 class TreeVisitorTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void isValidBreadthFirstTraversal() {
-        Expression expression = parseExpression("(2+3)+(4+5)");
+        Expression expression = parser.parseExpression("(2+3)+(4+5)");
 
         StringBuilder result = new StringBuilder();
 
@@ -55,7 +58,7 @@ class TreeVisitorTest {
 
     @Test
     void issue743ConcurrentModificationProblem() {
-        Expression expression = parseExpression("new int[]{1,2,3,4}");
+        Expression expression = parser.parseExpression("new int[]{1,2,3,4}");
 
         StringBuilder result = new StringBuilder();
         TreeVisitor visitor = new TreeVisitor() {
@@ -81,7 +84,7 @@ class TreeVisitorTest {
             public void process(Node node) {
                 result.append("<").append(node).append("> ");
             }
-        }.visitPreOrder(parseExpression("(2+3)+(4+5)"));
+        }.visitPreOrder(parser.parseExpression("(2+3)+(4+5)"));
         assertEquals("<(2 + 3) + (4 + 5)> <(2 + 3)> <2 + 3> <2> <3> <(4 + 5)> <4 + 5> <4> <5> ", result.toString());
     }
 
@@ -93,7 +96,7 @@ class TreeVisitorTest {
             public void process(Node node) {
                 result.append("<").append(node).append("> ");
             }
-        }.visitPostOrder(parseExpression("(2+3)+(4+5)"));
+        }.visitPostOrder(parser.parseExpression("(2+3)+(4+5)"));
         assertEquals("<2> <3> <2 + 3> <(2 + 3)> <4> <5> <4 + 5> <(4 + 5)> <(2 + 3) + (4 + 5)> ", result.toString());
     }
 
@@ -108,7 +111,7 @@ class TreeVisitorTest {
                                     ((ArrayInitializerExpr) parent).getValues().add(new IntegerLiteralExpr("1")));
                 }
             }
-        }.visitPreOrder(parseExpression("new int[]{1,2,3,4}"));
+        }.visitPreOrder(parser.parseExpression("new int[]{1,2,3,4}"));
     }
 
     @Test
@@ -122,12 +125,12 @@ class TreeVisitorTest {
                                     ((ArrayInitializerExpr) parent).getValues().add(new IntegerLiteralExpr("1")));
                 }
             }
-        }.visitPostOrder(parseExpression("new int[]{1,2,3,4}"));
+        }.visitPostOrder(parser.parseExpression("new int[]{1,2,3,4}"));
     }
 
     @Test
     void parents() {
-        CompilationUnit cu = parse("class X{int x=1;}");
+        CompilationUnit cu = parser.parse("class X{int x=1;}");
         SimpleName x = cu.getClassByName("X")
                 .get()
                 .getMember(0)
@@ -148,7 +151,7 @@ class TreeVisitorTest {
 
     @Test
     void isValidDirectChildrenTraversal() {
-        Expression expression = parseExpression("(2+3)+(4+5)");
+        Expression expression = parser.parseExpression("(2+3)+(4+5)");
 
         StringBuilder result = new StringBuilder();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/CompilationUnitBuildersTest.java
@@ -21,11 +21,12 @@
 
 package com.github.javaparser.builders;
 
-import static com.github.javaparser.StaticJavaParser.parseImport;
 import static com.github.javaparser.ast.Modifier.Keyword.PRIVATE;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Modifier;
@@ -43,6 +44,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class CompilationUnitBuildersTest {
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
     private final CompilationUnit cu = new CompilationUnit();
 
     @Test
@@ -219,7 +221,7 @@ class CompilationUnitBuildersTest {
     @Test
     void doNotAddDuplicateImportsByImportDeclaration() {
         cu.addImport(Map.class);
-        cu.addImport(parseImport("import java.util.Map;"));
+        cu.addImport(parser.parseImport("import java.util.Map;"));
         assertEquals(1, cu.getImports().size());
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithMembersBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithMembersBuildersTest.java
@@ -21,10 +21,11 @@
 
 package com.github.javaparser.builders;
 
-import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.ast.Modifier.Keyword.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -33,6 +34,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class NodeWithMembersBuildersTest {
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
     private final CompilationUnit cu = new CompilationUnit();
     private final ClassOrInterfaceDeclaration classDeclaration = cu.addClass("test");
 
@@ -97,8 +99,8 @@ class NodeWithMembersBuildersTest {
     void testGetMethodsWithParameterTypes() {
         MethodDeclaration mFoo = classDeclaration.addMethod("foo", PUBLIC); // foo()
         MethodDeclaration mFooInt = classDeclaration.addMethod("foo", PUBLIC).addParameter(int.class, "i"); // foo(int)
-        ClassOrInterfaceType type = parseClassOrInterfaceType("List");
-        type.setTypeArguments(parseClassOrInterfaceType("String"));
+        ClassOrInterfaceType type = parser.parseClassOrInterfaceType("List");
+        type.setTypeArguments(parser.parseClassOrInterfaceType("String"));
         MethodDeclaration mFooIntList = classDeclaration
                 .addMethod("foo", PUBLIC)
                 .addParameter(int.class, "i")
@@ -161,8 +163,8 @@ class NodeWithMembersBuildersTest {
     void testGetConstructorsWithParameterTypes() {
         ConstructorDeclaration c = classDeclaration.addConstructor(PUBLIC); // Foo()
         ConstructorDeclaration cInt = classDeclaration.addConstructor(PUBLIC).addParameter(int.class, "i"); // Foo(int)
-        ClassOrInterfaceType type = parseClassOrInterfaceType("List");
-        type.setTypeArguments(parseClassOrInterfaceType("String"));
+        ClassOrInterfaceType type = parser.parseClassOrInterfaceType("List");
+        type.setTypeArguments(parser.parseClassOrInterfaceType("String"));
         ConstructorDeclaration cIntList = classDeclaration
                 .addConstructor(PUBLIC)
                 .addParameter(int.class, "i")
@@ -229,7 +231,7 @@ class NodeWithMembersBuildersTest {
     void testAddPrivateFieldWithType() {
         CompilationUnit compilationUnit = new CompilationUnit();
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = compilationUnit.addClass("Person");
-        classOrInterfaceDeclaration.addPrivateField(parseType("java.lang.String"), "name");
+        classOrInterfaceDeclaration.addPrivateField(parser.parseType("java.lang.String"), "name");
 
         assertNotNull(classOrInterfaceDeclaration.getFields());
         assertEquals(1, classOrInterfaceDeclaration.getFields().size());
@@ -247,7 +249,7 @@ class NodeWithMembersBuildersTest {
     void testAddPublicFieldWithType() {
         CompilationUnit compilationUnit = new CompilationUnit();
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = compilationUnit.addClass("Person");
-        classOrInterfaceDeclaration.addPublicField(parseType("java.lang.String"), "name");
+        classOrInterfaceDeclaration.addPublicField(parser.parseType("java.lang.String"), "name");
 
         assertNotNull(classOrInterfaceDeclaration.getFields());
         assertEquals(1, classOrInterfaceDeclaration.getFields().size());
@@ -265,7 +267,7 @@ class NodeWithMembersBuildersTest {
     void testAddProtectedFieldWithType() {
         CompilationUnit compilationUnit = new CompilationUnit();
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = compilationUnit.addClass("Person");
-        classOrInterfaceDeclaration.addProtectedField(parseType("java.lang.String"), "name");
+        classOrInterfaceDeclaration.addProtectedField(parser.parseType("java.lang.String"), "name");
 
         assertNotNull(classOrInterfaceDeclaration.getFields());
         assertEquals(1, classOrInterfaceDeclaration.getFields().size());
@@ -285,7 +287,7 @@ class NodeWithMembersBuildersTest {
         CompilationUnit compilationUnit = new CompilationUnit();
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = compilationUnit.addClass("Person");
         classOrInterfaceDeclaration.addFieldWithInitializer(
-                "java.lang.String", "name", parseExpression("John"), PUBLIC);
+                "java.lang.String", "name", parser.parseExpression("John"), PUBLIC);
         assertNotNull(classOrInterfaceDeclaration.getFields());
         assertEquals(1, classOrInterfaceDeclaration.getFields().size());
 
@@ -306,7 +308,7 @@ class NodeWithMembersBuildersTest {
         CompilationUnit compilationUnit = new CompilationUnit();
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = compilationUnit.addClass("Person");
         classOrInterfaceDeclaration.addFieldWithInitializer(
-                List.class, "skills", parseExpression("new ArrayList()"), PUBLIC);
+                List.class, "skills", parser.parseExpression("new ArrayList()"), PUBLIC);
         assertNotNull(classOrInterfaceDeclaration.getFields());
         assertEquals(1, classOrInterfaceDeclaration.getFields().size());
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithThrownExceptionsBuildersTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/builders/NodeWithThrownExceptionsBuildersTest.java
@@ -21,16 +21,18 @@
 
 package com.github.javaparser.builders;
 
-import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import org.junit.jupiter.api.Test;
 
 class NodeWithThrownExceptionsBuildersTest {
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
     private final CompilationUnit cu = new CompilationUnit();
 
     @Test
@@ -39,7 +41,7 @@ class NodeWithThrownExceptionsBuildersTest {
         addMethod.addThrownException(IllegalStateException.class);
         assertEquals(1, addMethod.getThrownExceptions().size());
         assertTrue(addMethod.isThrown(IllegalStateException.class));
-        addMethod.addThrownException(parseClassOrInterfaceType("Test"));
+        addMethod.addThrownException(parser.parseClassOrInterfaceType("Test"));
         assertEquals(2, addMethod.getThrownExceptions().size());
         assertEquals("Test", addMethod.getThrownException(1).toString());
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue2627Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue2627Test.java
@@ -22,8 +22,8 @@ package com.github.javaparser.issues;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.github.javaparser.Range;
 import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.Range;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -37,7 +37,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class Issue2627Test {
 
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
-
 
     private static final String RESOURCE_PATH_STRING_CR = "com/github/javaparser/issue_samples/issue_2627/Ops_cr.java";
     private static final String RESOURCE_PATH_STRING_LF = "com/github/javaparser/issue_samples/issue_2627/Ops_lf.java";

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue2627Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue2627Test.java
@@ -23,6 +23,7 @@ package com.github.javaparser.issues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.javaparser.Range;
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -34,6 +35,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class Issue2627Test {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
 
     private static final String RESOURCE_PATH_STRING_CR = "com/github/javaparser/issue_samples/issue_2627/Ops_cr.java";
     private static final String RESOURCE_PATH_STRING_LF = "com/github/javaparser/issue_samples/issue_2627/Ops_lf.java";
@@ -84,7 +88,7 @@ public class Issue2627Test {
 
     //    @Test
     //    public void cuLength_minimal() throws IOException {
-    //        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_STRING_MINIMAL);
+    //        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_STRING_MINIMAL);
     //
     //        final Range cuRange = cu.getRange().get();
     //
@@ -94,7 +98,7 @@ public class Issue2627Test {
 
     //    @Test
     //    public void commentPositions_minimal() throws IOException {
-    //        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_STRING_MINIMAL);
+    //        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_STRING_MINIMAL);
     //
     //        List<Comment> allComments = cu.getAllComments();
     //        for (int i = 0; i < allComments.size(); i++) {
@@ -119,42 +123,42 @@ public class Issue2627Test {
     @ParameterizedTest
     @MethodSource("arguments_minimal")
     public void method_minimal(String name, int expectedStart, int expectedEnd) throws IOException {
-        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_STRING_MINIMAL);
+        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_STRING_MINIMAL);
         assertMethodInExpectedLines(cu, name, expectedStart, expectedEnd);
     }
 
     @ParameterizedTest
     @MethodSource("arguments_original")
     public void method_original(String name, int expectedStart, int expectedEnd) throws IOException {
-        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_STRING_ORIGINAL);
+        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_STRING_ORIGINAL);
         assertMethodInExpectedLines(cu, name, expectedStart, expectedEnd);
     }
 
     @ParameterizedTest
     @MethodSource("arguments_original")
     public void method_original_cr(String name, int expectedStart, int expectedEnd) throws IOException {
-        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_STRING_CR);
+        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_STRING_CR);
         assertMethodInExpectedLines(cu, name, expectedStart, expectedEnd);
     }
 
     @ParameterizedTest
     @MethodSource("arguments_original")
     public void method_original_crlf(String name, int expectedStart, int expectedEnd) throws IOException {
-        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_STRING_CRLF);
+        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_STRING_CRLF);
         assertMethodInExpectedLines(cu, name, expectedStart, expectedEnd);
     }
 
     @ParameterizedTest
     @MethodSource("arguments_original")
     public void method_original_lf(String name, int expectedStart, int expectedEnd) throws IOException {
-        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_STRING_LF);
+        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_STRING_LF);
         assertMethodInExpectedLines(cu, name, expectedStart, expectedEnd);
     }
 
     @ParameterizedTest
     @MethodSource("arguments_groovy_original")
     public void method_groovy_original(String name, int expectedStart, int expectedEnd) throws IOException {
-        CompilationUnit cu = StaticJavaParser.parseResource(RESOURCE_PATH_GROOVY_ORIGINAL);
+        CompilationUnit cu = parser.parseResource(RESOURCE_PATH_GROOVY_ORIGINAL);
         assertMethodInExpectedLines(cu, name, expectedStart, expectedEnd);
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue3113Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/issues/Issue3113Test.java
@@ -22,6 +22,7 @@ package com.github.javaparser.issues;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -33,7 +34,8 @@ import org.junit.jupiter.api.Test;
 public class Issue3113Test extends AbstractLexicalPreservingTest {
     @Test
     public void issue3113() {
-        StaticJavaParser.getConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_12);
+        JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+                new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_12));
 
         String originalSourceCode = "public class HelloWorld {\n" + "  public static void main(String[] args) {\n"
                 + "      final int value = 2;\n"
@@ -47,7 +49,7 @@ public class Issue3113Test extends AbstractLexicalPreservingTest {
                 + "  }\n"
                 + "}\n";
 
-        CompilationUnit cu = StaticJavaParser.parse(originalSourceCode);
+        CompilationUnit cu = parser.parse(originalSourceCode);
         LexicalPreservingPrinter.setup(cu);
         SwitchStmt expr = cu.findFirst(SwitchStmt.class).get();
         String modifiedSourceCode = LexicalPreservingPrinter.print(expr);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
@@ -35,7 +35,6 @@ class JavadocExtractorTest {
 
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
-
     @Test
     void canParseAllJavadocsInJavaParser() throws FileNotFoundException {
         processDir(new File(".."));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocExtractorTest.java
@@ -21,9 +21,9 @@
 
 package com.github.javaparser.javadoc;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
@@ -33,6 +33,9 @@ import org.junit.jupiter.api.Test;
 
 class JavadocExtractorTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
+
     @Test
     void canParseAllJavadocsInJavaParser() throws FileNotFoundException {
         processDir(new File(".."));
@@ -40,7 +43,7 @@ class JavadocExtractorTest {
 
     private void processFile(File file) throws FileNotFoundException {
         try {
-            CompilationUnit cu = parse(file);
+            CompilationUnit cu = parser.parse(file);
             new VoidVisitorAdapter<Object>() {
                 @Override
                 public void visit(TraditionalJavadocComment n, Object arg) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
@@ -21,9 +21,10 @@
 
 package com.github.javaparser.javadoc;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseJavadoc;
 import static com.github.javaparser.javadoc.description.JavadocInlineTag.Type.*;
+
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,6 +41,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class JavadocTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
 
     @Test
     void toTextForEmptyJavadoc() {
@@ -95,7 +99,7 @@ class JavadocTest {
 
     @Test
     void descriptionAndBlockTagsAreRetrievable() {
-        Javadoc javadoc = parseJavadoc(
+        Javadoc javadoc = parser.parseJavadoc(
                 "first line" + LineSeparator.SYSTEM + "second line" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
                         + "@param node a node" + LineSeparator.SYSTEM + "@return result the result",
                 false);
@@ -115,7 +119,7 @@ class JavadocTest {
                 + LineSeparator.SYSTEM
                 + "@throws InvalidIDException if the {@link IPersistence} doesn't recognize the given versionID."
                 + LineSeparator.SYSTEM;
-        Javadoc javadoc = parseJavadoc(docText, false);
+        Javadoc javadoc = parser.parseJavadoc(docText, false);
 
         List<JavadocInlineTag> inlineTags = javadoc.getDescription().getElements().stream()
                 .filter(element -> element instanceof JavadocInlineTag)
@@ -146,7 +150,7 @@ class JavadocTest {
                 + LineSeparator.SYSTEM + " * "
                 + LineSeparator.SYSTEM + " * @param <T>"
                 + LineSeparator.SYSTEM;
-        Javadoc javadoc = parseJavadoc(comment, false);
+        Javadoc javadoc = parser.parseJavadoc(comment, false);
         assertEquals(2, javadoc.getBlockTags().size());
     }
 
@@ -160,7 +164,7 @@ class JavadocTest {
                 + LineSeparator.SYSTEM + "    /// "
                 + LineSeparator.SYSTEM + "    /// @param <T>"
                 + LineSeparator.SYSTEM;
-        Javadoc javadoc = parseJavadoc(comment, true);
+        Javadoc javadoc = parser.parseJavadoc(comment, true);
         assertEqualsStringIgnoringEol(
                 "The type of the Object to be mapped.\n"
                         + "This interface maps the given Objects to existing ones in the database and\n"
@@ -205,7 +209,7 @@ class JavadocTest {
     @Test
     void issue1533() {
         CompilationUnit compilationUnit =
-                parse("/** hallo {@link Foo} welt */ public interface Foo extends Comparable { }");
+                parser.parse("/** hallo {@link Foo} welt */ public interface Foo extends Comparable { }");
         List<JavadocDescriptionElement> elements =
                 compilationUnit.getType(0).getJavadoc().get().getDescription().getElements();
         assertEquals(3, elements.size());

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/javadoc/JavadocTest.java
@@ -22,14 +22,13 @@
 package com.github.javaparser.javadoc;
 
 import static com.github.javaparser.javadoc.description.JavadocInlineTag.Type.*;
-
-import com.github.javaparser.JavaParserAdapter;
-import com.github.javaparser.StaticJavaParser;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.comments.TraditionalJavadocComment;
 import com.github.javaparser.javadoc.description.JavadocDescription;
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.Test;
 class JavadocTest {
 
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
-
 
     @Test
     void toTextForEmptyJavadoc() {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
@@ -41,12 +41,13 @@ import org.junit.jupiter.api.Test;
 
 class ModuleDeclarationTest {
 
-    private final JavaParserAdapter parserAdapter = StaticJavaParser.newParserAdapter();
-
-    public static final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_9));
+    // A single parser (Java 9, for module support) backs both the low-level parse(...) helper below and the
+    // parseName(...) convenience calls, the latter through its JavaParserAdapter wrapper.
+    private final JavaParserAdapter parser =
+            JavaParserAdapter.of(new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_9)));
 
     private CompilationUnit parse(String code) {
-        ParseResult<CompilationUnit> result = javaParser.parse(ParseStart.COMPILATION_UNIT, provider(code));
+        ParseResult<CompilationUnit> result = parser.getParser().parse(ParseStart.COMPILATION_UNIT, provider(code));
         if (!result.isSuccessful()) {
             System.err.println(result);
         }
@@ -111,12 +112,12 @@ class ModuleDeclarationTest {
         ModuleExportsDirective moduleExportsStmt = module.getDirectives().get(5).asModuleExportsStmt();
         assertThat(moduleExportsStmt.getNameAsString()).isEqualTo("R.S");
         assertThat(moduleExportsStmt.getModuleNames())
-                .containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
+                .containsExactly(parser.parseName("T1.U1"), parser.parseName("T2.U2"));
 
         ModuleOpensDirective moduleOpensStmt = module.getDirectives().get(7).asModuleOpensStmt();
         assertThat(moduleOpensStmt.getNameAsString()).isEqualTo("R.S");
         assertThat(moduleOpensStmt.getModuleNames())
-                .containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
+                .containsExactly(parser.parseName("T1.U1"), parser.parseName("T2.U2"));
 
         ModuleUsesDirective moduleUsesStmt = module.getDirectives().get(8).asModuleUsesStmt();
         assertThat(moduleUsesStmt.getNameAsString()).isEqualTo("V.W");
@@ -124,8 +125,7 @@ class ModuleDeclarationTest {
         ModuleProvidesDirective moduleProvidesStmt =
                 module.getDirectives().get(9).asModuleProvidesStmt();
         assertThat(moduleProvidesStmt.getNameAsString()).isEqualTo("X.Y");
-        assertThat(moduleProvidesStmt.getWith())
-                .containsExactly(parserAdapter.parseName("Z1.Z2"), parserAdapter.parseName("Z3.Z4"));
+        assertThat(moduleProvidesStmt.getWith()).containsExactly(parser.parseName("Z1.Z2"), parser.parseName("Z3.Z4"));
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
@@ -24,7 +24,6 @@ package com.github.javaparser.modules;
 import static com.github.javaparser.GeneratedJavaParserConstants.IDENTIFIER;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_9;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.StaticJavaParser.parseName;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,6 +40,9 @@ import com.github.javaparser.utils.LineSeparator;
 import org.junit.jupiter.api.Test;
 
 class ModuleDeclarationTest {
+
+    private final JavaParserAdapter parserAdapter = StaticJavaParser.newParserAdapter();
+
     public static final JavaParser javaParser = new JavaParser(new ParserConfiguration().setLanguageLevel(JAVA_9));
 
     private CompilationUnit parse(String code) {
@@ -108,11 +110,11 @@ class ModuleDeclarationTest {
 
         ModuleExportsDirective moduleExportsStmt = module.getDirectives().get(5).asModuleExportsStmt();
         assertThat(moduleExportsStmt.getNameAsString()).isEqualTo("R.S");
-        assertThat(moduleExportsStmt.getModuleNames()).containsExactly(parseName("T1.U1"), parseName("T2.U2"));
+        assertThat(moduleExportsStmt.getModuleNames()).containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
 
         ModuleOpensDirective moduleOpensStmt = module.getDirectives().get(7).asModuleOpensStmt();
         assertThat(moduleOpensStmt.getNameAsString()).isEqualTo("R.S");
-        assertThat(moduleOpensStmt.getModuleNames()).containsExactly(parseName("T1.U1"), parseName("T2.U2"));
+        assertThat(moduleOpensStmt.getModuleNames()).containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
 
         ModuleUsesDirective moduleUsesStmt = module.getDirectives().get(8).asModuleUsesStmt();
         assertThat(moduleUsesStmt.getNameAsString()).isEqualTo("V.W");
@@ -120,7 +122,7 @@ class ModuleDeclarationTest {
         ModuleProvidesDirective moduleProvidesStmt =
                 module.getDirectives().get(9).asModuleProvidesStmt();
         assertThat(moduleProvidesStmt.getNameAsString()).isEqualTo("X.Y");
-        assertThat(moduleProvidesStmt.getWith()).containsExactly(parseName("Z1.Z2"), parseName("Z3.Z4"));
+        assertThat(moduleProvidesStmt.getWith()).containsExactly(parserAdapter.parseName("Z1.Z2"), parserAdapter.parseName("Z3.Z4"));
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
@@ -48,9 +48,7 @@ class ModuleDeclarationTest {
 
     private CompilationUnit parse(String code) {
         ParseResult<CompilationUnit> result = parser.getParser().parse(ParseStart.COMPILATION_UNIT, provider(code));
-        if (!result.isSuccessful()) {
-            System.err.println(result);
-        }
+        assertTrue(result.isSuccessful(), () -> "Parsing failed with problems: " + result.getProblems());
         return result.getResult().get();
     }
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/modules/ModuleDeclarationTest.java
@@ -110,11 +110,13 @@ class ModuleDeclarationTest {
 
         ModuleExportsDirective moduleExportsStmt = module.getDirectives().get(5).asModuleExportsStmt();
         assertThat(moduleExportsStmt.getNameAsString()).isEqualTo("R.S");
-        assertThat(moduleExportsStmt.getModuleNames()).containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
+        assertThat(moduleExportsStmt.getModuleNames())
+                .containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
 
         ModuleOpensDirective moduleOpensStmt = module.getDirectives().get(7).asModuleOpensStmt();
         assertThat(moduleOpensStmt.getNameAsString()).isEqualTo("R.S");
-        assertThat(moduleOpensStmt.getModuleNames()).containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
+        assertThat(moduleOpensStmt.getModuleNames())
+                .containsExactly(parserAdapter.parseName("T1.U1"), parserAdapter.parseName("T2.U2"));
 
         ModuleUsesDirective moduleUsesStmt = module.getDirectives().get(8).asModuleUsesStmt();
         assertThat(moduleUsesStmt.getNameAsString()).isEqualTo("V.W");
@@ -122,7 +124,8 @@ class ModuleDeclarationTest {
         ModuleProvidesDirective moduleProvidesStmt =
                 module.getDirectives().get(9).asModuleProvidesStmt();
         assertThat(moduleProvidesStmt.getNameAsString()).isEqualTo("X.Y");
-        assertThat(moduleProvidesStmt.getWith()).containsExactly(parserAdapter.parseName("Z1.Z2"), parserAdapter.parseName("Z3.Z4"));
+        assertThat(moduleProvidesStmt.getWith())
+                .containsExactly(parserAdapter.parseName("Z1.Z2"), parserAdapter.parseName("Z3.Z4"));
     }
 
     @Test

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelAcceptanceTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelAcceptanceTest.java
@@ -21,8 +21,8 @@
 
 package com.github.javaparser.printer;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.utils.CodeGenerationUtils;
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 class ConcreteSyntaxModelAcceptanceTest {
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
     private final Path rootDir = CodeGenerationUtils.mavenModuleRoot(ConcreteSyntaxModelAcceptanceTest.class)
             .resolve("src/test/test_sourcecode");
 
@@ -45,18 +46,18 @@ class ConcreteSyntaxModelAcceptanceTest {
 
     @Test
     void printingExamplePrettyPrintVisitor() throws IOException {
-        CompilationUnit cu = parse(rootDir.resolve("com/github/javaparser/printer/PrettyPrintVisitor.java"));
+        CompilationUnit cu = parser.parse(rootDir.resolve("com/github/javaparser/printer/PrettyPrintVisitor.java"));
         TestUtils.assertEqualsStringIgnoringEol(prettyPrintedExpectation("PrettyPrintVisitor"), prettyPrint(cu));
     }
 
     @Test
     void printingExampleJavaConcepts() throws IOException {
-        CompilationUnit base = parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsBase.java"));
-        CompilationUnit enums = parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsEnums.java"));
+        CompilationUnit base = parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsBase.java"));
+        CompilationUnit enums = parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsEnums.java"));
         CompilationUnit innerClass =
-                parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsInnerClasses.java"));
-        CompilationUnit methods = parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsMethods.java"));
-        CompilationUnit ugly = parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsUgly.java"));
+                parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsInnerClasses.java"));
+        CompilationUnit methods = parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsMethods.java"));
+        CompilationUnit ugly = parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsUgly.java"));
         TestUtils.assertEqualsStringIgnoringEol(prettyPrintedExpectation("JavaConceptsBase"), prettyPrint(base));
         TestUtils.assertEqualsStringIgnoringEol(prettyPrintedExpectation("JavaConceptsEnums"), prettyPrint(enums));
         TestUtils.assertEqualsStringIgnoringEol(

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelAcceptanceTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelAcceptanceTest.java
@@ -56,7 +56,8 @@ class ConcreteSyntaxModelAcceptanceTest {
         CompilationUnit enums = parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsEnums.java"));
         CompilationUnit innerClass =
                 parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsInnerClasses.java"));
-        CompilationUnit methods = parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsMethods.java"));
+        CompilationUnit methods =
+                parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsMethods.java"));
         CompilationUnit ugly = parser.parse(rootDir.resolve("com/github/javaparser/printer/JavaConceptsUgly.java"));
         TestUtils.assertEqualsStringIgnoringEol(prettyPrintedExpectation("JavaConceptsBase"), prettyPrint(base));
         TestUtils.assertEqualsStringIgnoringEol(prettyPrintedExpectation("JavaConceptsEnums"), prettyPrint(enums));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
@@ -21,9 +21,10 @@
 
 package com.github.javaparser.printer;
 
-import static com.github.javaparser.StaticJavaParser.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.utils.LineSeparator;
@@ -31,37 +32,39 @@ import org.junit.jupiter.api.Test;
 
 class ConcreteSyntaxModelTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     private String print(Node node) {
         return ConcreteSyntaxModel.genericPrettyPrint(node);
     }
 
     @Test
     void printSimpleClassExpr() {
-        ClassExpr expr = parseExpression("Foo.class");
+        ClassExpr expr = parser.parseExpression("Foo.class");
         assertEquals("Foo.class", print(expr));
     }
 
     @Test
     void printArrayClassExpr() {
-        ClassExpr expr = parseExpression("Foo[].class");
+        ClassExpr expr = parser.parseExpression("Foo[].class");
         assertEquals("Foo[].class", print(expr));
     }
 
     @Test
     void printGenericClassExpr() {
-        ClassExpr expr = parseExpression("Foo<String>.class");
+        ClassExpr expr = parser.parseExpression("Foo<String>.class");
         assertEquals("Foo<String>.class", print(expr));
     }
 
     @Test
     void printSimplestClass() {
-        Node node = parse("class A {}");
+        Node node = parser.parse("class A {}");
         assertEquals("class A {" + LineSeparator.SYSTEM + "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printAClassWithField() {
-        Node node = parse("class A { int a; }");
+        Node node = parser.parse("class A { int a; }");
         assertEquals(
                 "class A {" + LineSeparator.SYSTEM
                         + LineSeparator.SYSTEM + "    int a;"
@@ -72,25 +75,25 @@ class ConcreteSyntaxModelTest {
 
     @Test
     void printParameters() {
-        Node node = parseBodyDeclaration("int x(int y, int z) {}");
+        Node node = parser.parseBodyDeclaration("int x(int y, int z) {}");
         assertEquals("int x(int y, int z) {" + LineSeparator.SYSTEM + "}", print(node));
     }
 
     @Test
     void printReceiverParameter() {
-        Node node = parseBodyDeclaration("int x(X A.B.this, int y, int z) {}");
+        Node node = parser.parseBodyDeclaration("int x(X A.B.this, int y, int z) {}");
         assertEquals("int x(X A.B.this, int y, int z) {" + LineSeparator.SYSTEM + "}", print(node));
     }
 
     @Test
     void printAnEmptyInterface() {
-        Node node = parse("interface A {}");
+        Node node = parser.parse("interface A {}");
         assertEquals("interface A {" + LineSeparator.SYSTEM + "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printAnEmptyInterfaceWithModifier() {
-        Node node = parse("public interface A {}");
+        Node node = parser.parse("public interface A {}");
         assertEquals("public interface A {" + LineSeparator.SYSTEM + "}" + LineSeparator.SYSTEM, print(node));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
@@ -24,7 +24,6 @@ package com.github.javaparser.printer;
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_9;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -66,12 +65,12 @@ class DefaultPrettyPrinterTest {
     }
 
     private String prettyPrintField(String code) {
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parserAdapter.parse(code);
         return getDefaultPrinter().print(cu.findFirst(FieldDeclaration.class).get());
     }
 
     private String prettyPrintVar(String code) {
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parserAdapter.parse(code);
         return getDefaultPrinter()
                 .print(cu.findAll(VariableDeclarationExpr.class).get(0));
     }
@@ -116,7 +115,7 @@ class DefaultPrettyPrinterTest {
 
     @Disabled
     private String prettyPrintConfigurable(String code) {
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parserAdapter.parse(code);
         return getDefaultPrinter()
                 .print(cu.findFirst(ClassOrInterfaceDeclaration.class).get().getName());
     }
@@ -151,7 +150,7 @@ class DefaultPrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        assertEquals(expected, getDefaultPrinter(configuration).print(parse(code)));
+        assertEquals(expected, getDefaultPrinter(configuration).print(parserAdapter.parse(code)));
     }
 
     @Test
@@ -171,7 +170,7 @@ class DefaultPrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        assertEquals(expected, getDefaultPrinter(configuration).print(parse(code)));
+        assertEquals(expected, getDefaultPrinter(configuration).print(parserAdapter.parse(code)));
     }
 
     @Test
@@ -198,7 +197,7 @@ class DefaultPrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        String printed = getDefaultPrinter(configuration).print(parse(code));
+        String printed = getDefaultPrinter(configuration).print(parserAdapter.parse(code));
 
         assertEquals(expected, printed);
     }
@@ -222,25 +221,25 @@ class DefaultPrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        assertEquals(expected, getDefaultPrinter(configuration).print(parse(code)));
+        assertEquals(expected, getDefaultPrinter(configuration).print(parserAdapter.parse(code)));
     }
 
     @Test
     void enumConstantsHorizontally() {
-        CompilationUnit cu = parse("enum X{A, B, C, D, E}");
+        CompilationUnit cu = parserAdapter.parse("enum X{A, B, C, D, E}");
         assertEqualsStringIgnoringEol("enum X {\n\n    A, B, C, D, E\n}\n", new DefaultPrettyPrinter().print(cu));
     }
 
     @Test
     void enumConstantsVertically() {
-        CompilationUnit cu = parse("enum X{A, B, C, D, E, F}");
+        CompilationUnit cu = parserAdapter.parse("enum X{A, B, C, D, E, F}");
         assertEqualsStringIgnoringEol(
                 "enum X {\n\n    A,\n    B,\n    C,\n    D,\n    E,\n    F\n}\n", new DefaultPrettyPrinter().print(cu));
     }
 
     @Test
     void printingInconsistentVariables() {
-        FieldDeclaration fieldDeclaration = parseBodyDeclaration("int a, b;").asFieldDeclaration();
+        FieldDeclaration fieldDeclaration = parserAdapter.parseBodyDeclaration("int a, b;").asFieldDeclaration();
 
         assertEquals("int a, b;", fieldDeclaration.toString());
 
@@ -256,7 +255,7 @@ class DefaultPrettyPrinterTest {
     @Test
     void prettyAlignMethodCallChainsIndentsArgumentsWithBlocksCorrectly() {
 
-        CompilationUnit cu = parse(
+        CompilationUnit cu = parserAdapter.parse(
                 "class Foo { void bar() { a.b.c.d.e; a.b.c().d().e(); a.b.c().d.e(); foo().bar().baz(boo().baa().bee()).bam(); foo().bar().baz(boo().baa().bee()).bam; foo().bar(Long.foo().b.bar(), bam).baz(); foo().bar().baz(foo, () -> { boo().baa().bee(); }).baz(() -> { boo().baa().bee(); }).bam(() -> { boo().baa().bee(); }); } }");
 
         Indentation indentation = new Indentation(IndentType.TABS_WITH_SPACE_ALIGN, 1);
@@ -304,7 +303,7 @@ class DefaultPrettyPrinterTest {
 
     @Test
     void noChainsIndentsInIf() {
-        Statement cu = parseStatement("if (x.y().z()) { boo().baa().bee(); }");
+        Statement cu = parserAdapter.parseStatement("if (x.y().z()) { boo().baa().bee(); }");
 
         PrinterConfiguration configuration = new DefaultPrinterConfiguration()
                 .addOption(new DefaultConfigurationOption(ConfigOption.COLUMN_ALIGN_FIRST_METHOD_CHAIN));
@@ -315,7 +314,7 @@ class DefaultPrettyPrinterTest {
 
     @Test
     void noChainsIndentsInFor() {
-        Statement cu = parseStatement("for(int x=1; x.y().z(); x.z().z()) { boo().baa().bee(); }");
+        Statement cu = parserAdapter.parseStatement("for(int x=1; x.y().z(); x.z().z()) { boo().baa().bee(); }");
 
         PrinterConfiguration configuration = new DefaultPrinterConfiguration()
                 .addOption(new DefaultConfigurationOption(ConfigOption.COLUMN_ALIGN_FIRST_METHOD_CHAIN));
@@ -328,7 +327,7 @@ class DefaultPrettyPrinterTest {
 
     @Test
     void noChainsIndentsInWhile() {
-        Statement cu = parseStatement("while(x.y().z()) { boo().baa().bee(); }");
+        Statement cu = parserAdapter.parseStatement("while(x.y().z()) { boo().baa().bee(); }");
 
         PrinterConfiguration configuration = new DefaultPrinterConfiguration()
                 .addOption(new DefaultConfigurationOption(ConfigOption.COLUMN_ALIGN_FIRST_METHOD_CHAIN));
@@ -342,7 +341,8 @@ class DefaultPrettyPrinterTest {
     void indentWithTabsAsFarAsPossible() {
 
         CompilationUnit cu =
-                parse("class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).bam(); } }");
+                parserAdapter.parse(
+                        "class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).bam(); } }");
 
         Indentation indentation = new Indentation(IndentType.TABS, 1);
         PrinterConfiguration configuration = new DefaultPrinterConfiguration()
@@ -371,7 +371,7 @@ class DefaultPrettyPrinterTest {
     @Test
     void indentWithTabsAlignWithSpaces() {
 
-        CompilationUnit cu = parse(
+        CompilationUnit cu = parserAdapter.parse(
                 "class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).baz(() -> { return boo().baa(); }).bam(); } }");
 
         Indentation indentation = new Indentation(IndentType.TABS_WITH_SPACE_ALIGN, 1);
@@ -530,7 +530,7 @@ class DefaultPrettyPrinterTest {
     @Test
     public void testIssue2578() {
         String code = "class C{\n" + "  //orphan\n" + "  /*orphan*/\n" + "}";
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parserAdapter.parse(code);
         TypeDeclaration td = cu.findFirst(TypeDeclaration.class).get();
         assertEquals(2, td.getAllContainedComments().size());
         td.setPublic(true); // --- simple AST change -----
@@ -548,9 +548,7 @@ class DefaultPrettyPrinterTest {
                 + " }\n"
                 + "}";
 
-        StaticJavaParser.setConfiguration(new ParserConfiguration());
-
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parserAdapter.parse(code);
 
         // default indent is 4 spaces
         assertTrue(cu.toString().contains("        // TODO"));
@@ -608,9 +606,7 @@ class DefaultPrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        StaticJavaParser.setConfiguration(new ParserConfiguration());
-
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parserAdapter.parse(code);
 
         assertEqualsStringIgnoringEol(expected, cu.toString());
     }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
@@ -239,7 +239,8 @@ class DefaultPrettyPrinterTest {
 
     @Test
     void printingInconsistentVariables() {
-        FieldDeclaration fieldDeclaration = parserAdapter.parseBodyDeclaration("int a, b;").asFieldDeclaration();
+        FieldDeclaration fieldDeclaration =
+                parserAdapter.parseBodyDeclaration("int a, b;").asFieldDeclaration();
 
         assertEquals("int a, b;", fieldDeclaration.toString());
 
@@ -340,9 +341,8 @@ class DefaultPrettyPrinterTest {
     @Test
     void indentWithTabsAsFarAsPossible() {
 
-        CompilationUnit cu =
-                parserAdapter.parse(
-                        "class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).bam(); } }");
+        CompilationUnit cu = parserAdapter.parse(
+                "class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).bam(); } }");
 
         Indentation indentation = new Indentation(IndentType.TABS, 1);
         PrinterConfiguration configuration = new DefaultPrinterConfiguration()

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DotPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DotPrinterTest.java
@@ -21,16 +21,19 @@
 
 package com.github.javaparser.printer;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import org.junit.jupiter.api.Test;
 
 class DotPrinterTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void testWithType() {
         String expectedOutput = "digraph {" + System.lineSeparator();
@@ -52,7 +55,7 @@ class DotPrinterTest {
         expectedOutput += "}";
 
         DotPrinter dotPrinter = new DotPrinter(true);
-        Expression expression = parseExpression("x(1,1)");
+        Expression expression = parser.parseExpression("x(1,1)");
         String output = dotPrinter.output(expression);
         assertEquals(expectedOutput, output);
     }
@@ -74,7 +77,7 @@ class DotPrinterTest {
         expectedOutput += "}";
 
         DotPrinter dotPrinter = new DotPrinter(false);
-        Expression expression = parseExpression("1+1");
+        Expression expression = parser.parseExpression("1+1");
         String output = dotPrinter.output(expression);
         assertEquals(expectedOutput, output);
     }
@@ -82,7 +85,7 @@ class DotPrinterTest {
     @Test
     void testIssue1871() {
         DotPrinter printer = new DotPrinter(false);
-        CompilationUnit cu = parse("//q\"q\nclass X{}");
+        CompilationUnit cu = parser.parse("//q\"q\nclass X{}");
         String output = printer.output(cu);
         assertEqualsStringIgnoringEol(
                 "digraph {\n" + "n0 [label=\"root\"];\n"

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -49,6 +49,9 @@ import org.junit.jupiter.api.Test;
 
 class PrettyPrintVisitorTest extends TestParser {
 
+    // This class parses through two mechanisms: the helpers inherited from TestParser (which use BLEEDING_EDGE) and
+    // this field, used by the parse(...) calls. Some of those need recent syntax (e.g. module imports since Java 25),
+    // hence JAVA_25; a few tests additionally request a specific level inline via TestParser.
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
             new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25));
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -21,10 +21,10 @@
 
 package com.github.javaparser.printer;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -45,14 +45,12 @@ import com.github.javaparser.printer.configuration.PrinterConfiguration;
 import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.utils.TestParser;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class PrettyPrintVisitorTest extends TestParser {
-    @BeforeAll
-    static void initParser() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
-    }
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+            new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25));
 
     private Optional<ConfigurationOption> getOption(PrinterConfiguration config, ConfigOption cOption) {
         return config.get(new DefaultConfigurationOption(cOption));
@@ -185,13 +183,13 @@ class PrettyPrintVisitorTest extends TestParser {
 
     @Test
     void printSimplestClass() {
-        Node node = parse("class A {}");
+        Node node = parser.parse("class A {}");
         assertEquals("class A {" + LineSeparator.SYSTEM + "}" + LineSeparator.SYSTEM, print(node));
     }
 
     @Test
     void printAClassWithField() {
-        Node node = parse("class A { int a; }");
+        Node node = parser.parse("class A { int a; }");
         assertEquals(
                 "class A {" + LineSeparator.SYSTEM
                         + LineSeparator.SYSTEM + "    int a;"
@@ -213,7 +211,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + LineSeparator.SYSTEM + "    r = (Runnable & Serializable)() -> {};"
                 + LineSeparator.SYSTEM + "    r = (Runnable & I)() -> {};"
                 + LineSeparator.SYSTEM + "  }}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration methodDeclaration = (MethodDeclaration) cu.getType(0).getMember(0);
 
         assertEquals(
@@ -237,7 +235,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "    return (Comparator<Map.Entry<K, V>> & Serializable)(c1, c2) -> c1.getKey().compareTo(c2.getKey()); "
                 + LineSeparator.SYSTEM
                 + "}}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration methodDeclaration = (MethodDeclaration) cu.getType(0).getMember(0);
 
         assertEquals(
@@ -249,7 +247,7 @@ class PrettyPrintVisitorTest extends TestParser {
     void printClassWithoutJavaDocButWithComment() {
         String code = String.format(
                 "/** javadoc */ public class A { %s// stuff%s}", LineSeparator.SYSTEM, LineSeparator.SYSTEM);
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         PrinterConfiguration ignoreJavaDoc = new DefaultPrinterConfiguration()
                 .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_JAVADOC));
         String content = cu.toString(ignoreJavaDoc);
@@ -263,7 +261,7 @@ class PrettyPrintVisitorTest extends TestParser {
     @Test
     void printImportsDefaultOrder() {
         String code = "import x.y.z;import a.b.c;import static b.c.d;class c {}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         String content = cu.toString();
         assertEqualsStringIgnoringEol(
                 "import x.y.z;\n" + "import a.b.c;\n" + "import static b.c.d;\n" + "\n" + "class c {\n" + "}\n",
@@ -273,7 +271,7 @@ class PrettyPrintVisitorTest extends TestParser {
     @Test
     void printImportsOrdered() {
         String code = "import x.y.z;import a.b.c;import static b.c.d;class c {}";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         PrinterConfiguration orderImports =
                 new DefaultPrinterConfiguration().addOption(new DefaultConfigurationOption(ConfigOption.ORDER_IMPORTS));
         String content = cu.toString(orderImports);
@@ -391,7 +389,7 @@ class PrettyPrintVisitorTest extends TestParser {
 
     @Test
     void blockcommentGetsNoFormatting() {
-        CompilationUnit cu = parse("class A {\n" + "    public void helloWorld(String greeting, String name) {\n"
+        CompilationUnit cu = parser.parse("class A {\n" + "    public void helloWorld(String greeting, String name) {\n"
                 + "        //sdfsdfsdf\n"
                 + "            //sdfds\n"
                 + "        /*\n"
@@ -436,7 +434,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + " */\n"
                 + "public void add(int x, int y){}}";
 
-        CompilationUnit cu_allLeadingSpaces = parse(input_allLeadingSpaces);
+        CompilationUnit cu_allLeadingSpaces = parser.parse(input_allLeadingSpaces);
         assertEqualsStringIgnoringEol(expected, cu_allLeadingSpaces.toString());
     }
 
@@ -451,7 +449,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + " */\n"
                 + "public void add(int x, int y){}}";
 
-        CompilationUnit cu_singleMissingLeadingSpace = parse(input_singleMissingLeadingSpace);
+        CompilationUnit cu_singleMissingLeadingSpace = parser.parse(input_singleMissingLeadingSpace);
         assertEqualsStringIgnoringEol(expected, cu_singleMissingLeadingSpace.toString());
     }
 
@@ -537,7 +535,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -545,7 +543,7 @@ class PrettyPrintVisitorTest extends TestParser {
     public void testModuleImport() {
         String code = "import module java.base;\n\n" + "class Foo {\n" + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -557,28 +555,28 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "        super();\n"
                 + "    }\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
     @Test
     void printMinimalCompactClass() {
         String code = "void main() {\n" + "    System.out.println(\"Hello, World!\");\n" + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
     @Test
     void printCompactClassWithInstanceField() {
         String code = "int count = 0;\n" + "\n" + "void main() {\n" + "    count++;\n" + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
     @Test
     void printCompactClassWithMultipleMethods() {
         String code = "int add(int a, int b) {\n" + "    return a + b;\n" + "}\n" + "\n" + "void main() {\n" + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -594,7 +592,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "\n"
                 + "void main() {\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -611,7 +609,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "    Inner inner = new Inner();\n"
                 + "    inner.greet();\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -619,7 +617,7 @@ class PrettyPrintVisitorTest extends TestParser {
     void printCompactClassWithArrayField() {
         String code =
                 "int[] numbers = { 1, 2, 3, 4, 5 };\n" + "\n" + "void main() {\n" + "    printNumbers();\n" + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -634,7 +632,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "    printValue(42);\n"
                 + "    printValue(3.14);\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -647,7 +645,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "    Person p = new Person(\"Alice\", 30);\n"
                 + "    System.out.println(p.name() + \" is \" + p.age() + \" years old\");\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -663,7 +661,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "        System.out.println(c);\n"
                 + "    }\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -685,7 +683,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "    Printer p = new ConsolePrinter();\n"
                 + "    p.print();\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -702,7 +700,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "void main() {\n"
                 + "    System.out.println(sum(1, 2, 3, 4, 5));\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -719,7 +717,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "        System.out.println(\"Caught: \" + e.getMessage());\n"
                 + "    }\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -733,7 +731,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "void main() {\n"
                 + "    System.out.println(\"Annotation declared\");\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -753,7 +751,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "    oldMethod();\n"
                 + "    System.out.println(toString());\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 
@@ -771,7 +769,7 @@ class PrettyPrintVisitorTest extends TestParser {
                 + "\n"
                 + "void main() {\n"
                 + "}\n";
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -63,6 +63,9 @@ class PrettyPrinterTest {
         return config.get(new DefaultConfigurationOption(cOption));
     }
 
+    // Several tests exercise printing of recent syntax (switch patterns, guards, record and unnamed patterns since
+    // Java 21+, and module imports since Java 25), so the parser is configured class-wide at JAVA_25. The remaining
+    // tests parse basic code and behave identically at this higher level.
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
             new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25));
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -221,7 +221,8 @@ class PrettyPrinterTest {
 
     @Test
     void printingInconsistentVariables() {
-        FieldDeclaration fieldDeclaration = parser.parseBodyDeclaration("int a, b;").asFieldDeclaration();
+        FieldDeclaration fieldDeclaration =
+                parser.parseBodyDeclaration("int a, b;").asFieldDeclaration();
 
         assertEquals("int a, b;", fieldDeclaration.toString());
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -24,7 +24,6 @@ package com.github.javaparser.printer;
 import static com.github.javaparser.ParseStart.COMPILATION_UNIT;
 import static com.github.javaparser.ParserConfiguration.LanguageLevel.JAVA_9;
 import static com.github.javaparser.Providers.provider;
-import static com.github.javaparser.StaticJavaParser.*;
 import static com.github.javaparser.printer.configuration.Indentation.IndentType.TABS;
 import static com.github.javaparser.printer.configuration.Indentation.IndentType.TABS_WITH_SPACE_ALIGN;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
@@ -44,20 +43,18 @@ import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.C
 import com.github.javaparser.printer.configuration.Indentation.IndentType;
 import java.util.Optional;
 import java.util.function.Function;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class PrettyPrinterTest {
 
     private String prettyPrintField(String code) {
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         return new DefaultPrettyPrinter()
                 .print(cu.findFirst(FieldDeclaration.class).get());
     }
 
     private String prettyPrintVar(String code) {
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         return new DefaultPrettyPrinter()
                 .print(cu.findAll(VariableDeclarationExpr.class).get(0));
     }
@@ -66,18 +63,8 @@ class PrettyPrinterTest {
         return config.get(new DefaultConfigurationOption(cOption));
     }
 
-    private static final ParserConfiguration.LanguageLevel storedLanguageLevel =
-            StaticJavaParser.getParserConfiguration().getLanguageLevel();
-
-    @BeforeEach
-    public void setLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
-    }
-
-    @AfterEach
-    public void resetLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(storedLanguageLevel);
-    }
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter(
+            new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25));
 
     @Test
     void printingArrayFields() {
@@ -118,7 +105,7 @@ class PrettyPrinterTest {
     }
 
     private String prettyPrintConfigurable(String code) {
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         PrinterConfiguration configuration = new DefaultPrinterConfiguration();
         Function<PrinterConfiguration, VoidVisitor<Void>> visitorFactory =
                 (config) -> new TestVisitor(config, new SourcePrinter(config));
@@ -152,7 +139,7 @@ class PrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        assertEquals(expected, new DefaultPrettyPrinter(config).print(parse(code)));
+        assertEquals(expected, new DefaultPrettyPrinter(config).print(parser.parse(code)));
     }
 
     @Test
@@ -170,7 +157,7 @@ class PrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        assertEquals(expected, new DefaultPrettyPrinter(config).print(parse(code)));
+        assertEquals(expected, new DefaultPrettyPrinter(config).print(parser.parse(code)));
     }
 
     @Test
@@ -194,7 +181,7 @@ class PrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        assertEquals(expected, new DefaultPrettyPrinter(config).print(parse(code)));
+        assertEquals(expected, new DefaultPrettyPrinter(config).print(parser.parse(code)));
     }
 
     @Test
@@ -214,27 +201,27 @@ class PrettyPrinterTest {
                 + EOL + "}"
                 + EOL + "";
 
-        String printed = new DefaultPrettyPrinter(config).print(parse(code));
+        String printed = new DefaultPrettyPrinter(config).print(parser.parse(code));
 
         assertEquals(expected, printed);
     }
 
     @Test
     void enumConstantsHorizontally() {
-        CompilationUnit cu = parse("enum X{A, B, C, D, E}");
+        CompilationUnit cu = parser.parse("enum X{A, B, C, D, E}");
         assertEqualsStringIgnoringEol("enum X {\n\n    A, B, C, D, E\n}\n", new DefaultPrettyPrinter().print(cu));
     }
 
     @Test
     void enumConstantsVertically() {
-        CompilationUnit cu = parse("enum X{A, B, C, D, E, F}");
+        CompilationUnit cu = parser.parse("enum X{A, B, C, D, E, F}");
         assertEqualsStringIgnoringEol(
                 "enum X {\n\n    A,\n    B,\n    C,\n    D,\n    E,\n    F\n}\n", new DefaultPrettyPrinter().print(cu));
     }
 
     @Test
     void printingInconsistentVariables() {
-        FieldDeclaration fieldDeclaration = parseBodyDeclaration("int a, b;").asFieldDeclaration();
+        FieldDeclaration fieldDeclaration = parser.parseBodyDeclaration("int a, b;").asFieldDeclaration();
 
         assertEquals("int a, b;", fieldDeclaration.toString());
 
@@ -250,7 +237,7 @@ class PrettyPrinterTest {
     @Test
     void prettyAlignMethodCallChainsIndentsArgumentsWithBlocksCorrectly() {
 
-        CompilationUnit cu = parse(
+        CompilationUnit cu = parser.parse(
                 "class Foo { void bar() { a.b.c.d.e; a.b.c().d().e(); a.b.c().d.e(); foo().bar().baz(boo().baa().bee()).bam(); foo().bar().baz(boo().baa().bee()).bam; foo().bar(Long.foo().b.bar(), bam).baz(); foo().bar().baz(foo, () -> { boo().baa().bee(); }).baz(() -> { boo().baa().bee(); }).bam(() -> { boo().baa().bee(); }); } }");
         Indentation indentation = new Indentation(TABS_WITH_SPACE_ALIGN, 1);
 
@@ -299,7 +286,7 @@ class PrettyPrinterTest {
 
     @Test
     void noChainsIndentsInIf() {
-        Statement cu = parseStatement("if (x.y().z()) { boo().baa().bee(); }");
+        Statement cu = parser.parseStatement("if (x.y().z()) { boo().baa().bee(); }");
 
         String printed = new DefaultPrettyPrinter(new DefaultPrinterConfiguration()
                         .addOption(new DefaultConfigurationOption(ConfigOption.COLUMN_ALIGN_FIRST_METHOD_CHAIN)))
@@ -310,7 +297,7 @@ class PrettyPrinterTest {
 
     @Test
     void noChainsIndentsInFor() {
-        Statement cu = parseStatement("for(int x=1; x.y().z(); x.z().z()) { boo().baa().bee(); }");
+        Statement cu = parser.parseStatement("for(int x=1; x.y().z(); x.z().z()) { boo().baa().bee(); }");
 
         String printed = new DefaultPrettyPrinter(new DefaultPrinterConfiguration()
                         .addOption(new DefaultConfigurationOption(ConfigOption.COLUMN_ALIGN_FIRST_METHOD_CHAIN)))
@@ -323,7 +310,7 @@ class PrettyPrinterTest {
 
     @Test
     void noChainsIndentsInWhile() {
-        Statement cu = parseStatement("while(x.y().z()) { boo().baa().bee(); }");
+        Statement cu = parser.parseStatement("while(x.y().z()) { boo().baa().bee(); }");
 
         String printed = new DefaultPrettyPrinter(new DefaultPrinterConfiguration()
                         .addOption(new DefaultConfigurationOption(ConfigOption.COLUMN_ALIGN_FIRST_METHOD_CHAIN)))
@@ -336,8 +323,8 @@ class PrettyPrinterTest {
     @Test
     void indentWithTabsAsFarAsPossible() {
 
-        CompilationUnit cu =
-                parse("class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).bam(); } }");
+        CompilationUnit cu = parser.parse(
+                "class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).bam(); } }");
         Indentation indentation = new Indentation(TABS, 1);
         String printed = new DefaultPrettyPrinter(new DefaultPrinterConfiguration()
                         .addOption(new DefaultConfigurationOption(ConfigOption.COLUMN_ALIGN_FIRST_METHOD_CHAIN))
@@ -363,7 +350,7 @@ class PrettyPrinterTest {
 
     @Test
     void initializeWithSpecificConfiguration() {
-        CompilationUnit cu = parse("class Foo { // this is a comment \n" + "}");
+        CompilationUnit cu = parser.parse("class Foo { // this is a comment \n" + "}");
         PrinterConfiguration config = new DefaultPrinterConfiguration()
                 .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
 
@@ -378,7 +365,7 @@ class PrettyPrinterTest {
     @Test
     void indentWithTabsAlignWithSpaces() {
 
-        CompilationUnit cu = parse(
+        CompilationUnit cu = parser.parse(
                 "class Foo { void bar() { foo().bar().baz(() -> { boo().baa().bee(a, b, c); }).baz(() -> { return boo().baa(); }).bam(); } }");
         Indentation indentation = new Indentation(TABS_WITH_SPACE_ALIGN, 1);
         String printed = new DefaultPrettyPrinter(new DefaultPrinterConfiguration()
@@ -535,7 +522,7 @@ class PrettyPrinterTest {
     @Test
     public void testIssue2578() {
         String code = "class C{\n" + "  //orphan\n" + "  /*orphan*/\n" + "}";
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parser.parse(code);
         TypeDeclaration td = cu.findFirst(TypeDeclaration.class).get();
         assertEquals(2, td.getAllContainedComments().size());
         td.setPublic(true); // --- simple AST change -----
@@ -553,9 +540,9 @@ class PrettyPrinterTest {
                 + " }\n"
                 + "}";
 
-        StaticJavaParser.setConfiguration(new ParserConfiguration());
+        JavaParserAdapter defaultParser = StaticJavaParser.newParserAdapter();
 
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = defaultParser.parse(code);
 
         // default indent is 4 spaces
         assertTrue(cu.toString().contains("        // TODO"));
@@ -603,7 +590,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -618,7 +605,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -633,7 +620,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -648,7 +635,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -663,7 +650,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -678,7 +665,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -693,7 +680,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -706,7 +693,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -718,7 +705,7 @@ class PrettyPrinterTest {
                 + "    }\n"
                 + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 
@@ -726,7 +713,7 @@ class PrettyPrinterTest {
     public void testModuleImport() {
         String code = "import module java.base;\n\n" + "class Foo {\n" + "}\n";
 
-        CompilationUnit cu = parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, new DefaultPrettyPrinter().print(cu));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/XmlPrinterTest.java
@@ -21,10 +21,10 @@
 
 package com.github.javaparser.printer;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static com.github.javaparser.StaticJavaParser.parseType;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.type.Type;
 import java.io.ByteArrayInputStream;
@@ -57,6 +57,8 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 class XmlPrinterTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     // Used for building XML documents
     private static DocumentBuilderFactory documentBuilderFactory;
@@ -157,7 +159,7 @@ class XmlPrinterTest {
 
     @Test
     void testWithType() throws SAXException, IOException {
-        Expression expression = parseExpression("1+1");
+        Expression expression = parser.parseExpression("1+1");
         XmlPrinter xmlOutput = new XmlPrinter(true);
 
         String output = xmlOutput.output(expression);
@@ -174,7 +176,7 @@ class XmlPrinterTest {
 
     @Test
     void testWithTypeXmlKeyCollision() throws SAXException, IOException {
-        Type type = parseType("int");
+        Type type = parser.parseType("int");
         XmlPrinter xmlOutput = new XmlPrinter(true);
 
         String output = xmlOutput.output(type);
@@ -184,7 +186,7 @@ class XmlPrinterTest {
 
     @Test
     void testWithoutType() throws SAXException, IOException {
-        Expression expression = parseExpression("1+1");
+        Expression expression = parser.parseExpression("1+1");
 
         XmlPrinter xmlOutput = new XmlPrinter(false);
 
@@ -195,7 +197,7 @@ class XmlPrinterTest {
 
     @Test
     void testList() throws SAXException, IOException {
-        Expression expression = parseExpression("a(1,2)");
+        Expression expression = parser.parseExpression("a(1,2)");
 
         XmlPrinter xmlOutput = new XmlPrinter(true);
 
@@ -222,7 +224,7 @@ class XmlPrinterTest {
 
         try (FileWriter fileWriter = new FileWriter(tempFile)) {
             XmlPrinter xmlOutput = new XmlPrinter(false);
-            xmlOutput.outputDocument(parseExpression("1+1"), "root", fileWriter);
+            xmlOutput.outputDocument(parser.parseExpression("1+1"), "root", fileWriter);
         }
 
         assertXMLEquals(
@@ -250,8 +252,8 @@ class XmlPrinterTest {
         xmlWriter.writeStartDocument();
         xmlWriter.writeStartElement("custom");
 
-        xmlOutput.outputNode(parseExpression("1+1"), "plusExpr", xmlWriter);
-        xmlOutput.outputNode(parseExpression("a(1,2)"), "callExpr", xmlWriter);
+        xmlOutput.outputNode(parser.parseExpression("1+1"), "plusExpr", xmlWriter);
+        xmlOutput.outputNode(parser.parseExpression("a(1,2)"), "callExpr", xmlWriter);
 
         xmlWriter.writeEndElement();
         xmlWriter.writeEndDocument();
@@ -279,7 +281,7 @@ class XmlPrinterTest {
 
     @Test
     void testAbsentTypeParameterList() throws SAXException, IOException, XMLStreamException {
-        Expression expression = parseExpression("new HashSet()");
+        Expression expression = parser.parseExpression("new HashSet()");
         XmlPrinter xmlOutput = new XmlPrinter(false);
         String output = xmlOutput.output(expression);
         assertXMLEquals(
@@ -296,7 +298,7 @@ class XmlPrinterTest {
 
     @Test
     void testEmptyTypeParameterList() throws SAXException, IOException, XMLStreamException {
-        Expression expression = parseExpression("new HashSet<>()");
+        Expression expression = parser.parseExpression("new HashSet<>()");
         XmlPrinter xmlOutput = new XmlPrinter(false);
         String output = xmlOutput.output(expression);
         assertXMLEquals(
@@ -314,7 +316,7 @@ class XmlPrinterTest {
 
     @Test
     void testNonEmptyTypeParameterList() throws SAXException, IOException, XMLStreamException {
-        Expression expression = parseExpression("new HashSet<Integer,File>()");
+        Expression expression = parser.parseExpression("new HashSet<Integer,File>()");
         XmlPrinter xmlOutput = new XmlPrinter(false);
         String output = xmlOutput.output(expression);
         assertXMLEquals(

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/YamlPrinterTest.java
@@ -21,16 +21,18 @@
 
 package com.github.javaparser.printer;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static com.github.javaparser.utils.TestUtils.readTextResource;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import org.junit.jupiter.api.Test;
 
 class YamlPrinterTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     private String read(String filename) {
         return readTextResource(YamlPrinterTest.class, filename);
@@ -39,7 +41,7 @@ class YamlPrinterTest {
     @Test
     void testWithType() {
         YamlPrinter yamlPrinter = new YamlPrinter(true);
-        Expression expression = parseExpression("x(1,1)");
+        Expression expression = parser.parseExpression("x(1,1)");
         String output = yamlPrinter.output(expression);
         assertEqualsStringIgnoringEol(read("yamlWithType.yaml"), output);
     }
@@ -47,7 +49,7 @@ class YamlPrinterTest {
     @Test
     void testWithoutType() {
         YamlPrinter yamlPrinter = new YamlPrinter(false);
-        Expression expression = parseExpression("1+1");
+        Expression expression = parser.parseExpression("1+1");
         String output = yamlPrinter.output(expression);
         assertEqualsStringIgnoringEol(read("yamlWithoutType.yaml"), output);
     }
@@ -55,7 +57,7 @@ class YamlPrinterTest {
     @Test
     void testWithColonFollowedBySpaceInValue() {
         YamlPrinter yamlPrinter = new YamlPrinter(true);
-        Expression expression = parseExpression("\"a\\\\: b\"");
+        Expression expression = parser.parseExpression("\"a\\\\: b\"");
         String output = yamlPrinter.output(expression);
         assertEqualsStringIgnoringEol(read("yamlWithColonFollowedBySpaceInValue.yaml"), output);
     }
@@ -63,7 +65,7 @@ class YamlPrinterTest {
     @Test
     void testWithColonFollowedByLineSeparatorInValue() {
         YamlPrinter yamlPrinter = new YamlPrinter(true);
-        Expression expression = parseExpression("\"a\\\\:\\\\nb\"");
+        Expression expression = parser.parseExpression("\"a\\\\:\\\\nb\"");
         String output = yamlPrinter.output(expression);
         assertEqualsStringIgnoringEol(read("yamlWithColonFollowedByLineSeparatorInValue.yaml"), output);
     }
@@ -73,7 +75,7 @@ class YamlPrinterTest {
         String code = "/**\n" + " * \" this comment contains a quote and newlines\n" + " */\n" + "public class Dog {}";
 
         YamlPrinter yamlPrinter = new YamlPrinter(true);
-        CompilationUnit computationUnit = parse(code);
+        CompilationUnit computationUnit = parser.parse(code);
         String output = yamlPrinter.output(computationUnit);
         assertEqualsStringIgnoringEol(
                 read("yamlParsingJavadocWithQuoteAndNewline.yaml").trim(), output);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/AbstractLexicalPreservingTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/AbstractLexicalPreservingTest.java
@@ -24,44 +24,40 @@ package com.github.javaparser.printer.lexicalpreservation;
 import static com.github.javaparser.utils.TestUtils.assertEqualsString;
 import static com.github.javaparser.utils.TestUtils.readResource;
 
-import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.Statement;
 import java.io.IOException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 
 public abstract class AbstractLexicalPreservingTest {
+
+    /**
+     * The parser used by the {@code consider...} helpers. Each test class gets its own isolated
+     * instance, so configuring it (for example the language level) never leaks to other tests.
+     */
+    protected final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
     protected CompilationUnit cu;
     protected Expression expression;
     protected Statement statement;
 
-    @AfterAll
-    public static void tearDown() {}
-
-    @AfterEach
-    public void reset() {
-        StaticJavaParser.setConfiguration(new ParserConfiguration());
-    }
-
     protected void considerCode(String code) {
-        cu = LexicalPreservingPrinter.setup(StaticJavaParser.parse(code));
+        cu = LexicalPreservingPrinter.setup(parser.parse(code));
     }
 
     protected void considerExpression(String code) {
-        expression = LexicalPreservingPrinter.setup(StaticJavaParser.parseExpression(code));
+        expression = LexicalPreservingPrinter.setup(parser.parseExpression(code));
     }
 
     protected void considerStatement(String code) {
-        statement = LexicalPreservingPrinter.setup(StaticJavaParser.parseStatement(code));
+        statement = LexicalPreservingPrinter.setup(parser.parseStatement(code));
     }
 
     protected void considerVariableDeclaration(String code) {
-        expression = LexicalPreservingPrinter.setup(StaticJavaParser.parseVariableDeclarationExpr(code));
+        expression = LexicalPreservingPrinter.setup(parser.parseVariableDeclarationExpr(code));
     }
 
     protected String considerExample(String resourceName) throws IOException {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceApplyAddedRulesCompleteTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceApplyAddedRulesCompleteTest.java
@@ -22,7 +22,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -109,7 +108,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add statement (should be positioned correctly relative to comment)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int y = 2;").asExpressionStmt();
         body.getStatements().add(0, newStmt);
 
         String result = print();
@@ -134,7 +133,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add statement after line with trailing comment
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int y = 2;").asExpressionStmt();
         body.getStatements().add(newStmt);
 
         String expected = "class X {\n" + "    void method() {\n"
@@ -158,7 +157,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add statement (should skip newline and add with proper indentation)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int y = 2;").asExpressionStmt();
         body.getStatements().add(newStmt);
 
         String result = print();
@@ -180,7 +179,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add statement at beginning (special case)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int x = 1;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int x = 1;").asExpressionStmt();
         body.getStatements().add(0, newStmt);
 
         String expected = "class X {\n" + "    void method() {\n"
@@ -200,7 +199,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add statement (should handle multiple newlines)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int x = 1;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int x = 1;").asExpressionStmt();
         body.getStatements().add(0, newStmt);
 
         String result = print();
@@ -243,7 +242,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add statement (creates newline)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int y = 2;").asExpressionStmt();
         body.getStatements().add(newStmt);
 
         String result = print();
@@ -266,7 +265,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add statement (should handle closing brace properly)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int y = 2;").asExpressionStmt();
         body.getStatements().add(newStmt);
 
         String result = print();
@@ -289,7 +288,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
 
         // Add nested if statements
         IfStmt ifStmt =
-                StaticJavaParser.parseStatement("if (true) { int x = 1; }").asIfStmt();
+                parser.parseStatement("if (true) { int x = 1; }").asIfStmt();
         body.addStatement(ifStmt);
 
         String result = print();
@@ -313,7 +312,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
 
         // Add nested if inside existing if
         IfStmt nestedIf =
-                StaticJavaParser.parseStatement("if (false) { int x = 1; }").asIfStmt();
+                parser.parseStatement("if (false) { int x = 1; }").asIfStmt();
         thenBlock.addStatement(nestedIf);
 
         String result = print();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceApplyAddedRulesCompleteTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceApplyAddedRulesCompleteTest.java
@@ -287,8 +287,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt body = method.getBody().get();
 
         // Add nested if statements
-        IfStmt ifStmt =
-                parser.parseStatement("if (true) { int x = 1; }").asIfStmt();
+        IfStmt ifStmt = parser.parseStatement("if (true) { int x = 1; }").asIfStmt();
         body.addStatement(ifStmt);
 
         String result = print();
@@ -311,8 +310,7 @@ class DifferenceApplyAddedRulesCompleteTest extends AbstractLexicalPreservingTes
         BlockStmt thenBlock = ifStmt.getThenStmt().asBlockStmt();
 
         // Add nested if inside existing if
-        IfStmt nestedIf =
-                parser.parseStatement("if (false) { int x = 1; }").asIfStmt();
+        IfStmt nestedIf = parser.parseStatement("if (false) { int x = 1; }").asIfStmt();
         thenBlock.addStatement(nestedIf);
 
         String result = print();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceApplyLeftoverRulesTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/DifferenceApplyLeftoverRulesTest.java
@@ -22,7 +22,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -69,7 +68,7 @@ class DifferenceApplyLeftoverRulesTest extends AbstractLexicalPreservingTest {
         BlockStmt body = method.getBody().get();
 
         // Add statement at end (may have leftover indent directive)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int y = 2;").asExpressionStmt();
         body.getStatements().add(newStmt);
 
         String expected = "class X {\n" + "    void method() {\n"
@@ -98,7 +97,7 @@ class DifferenceApplyLeftoverRulesTest extends AbstractLexicalPreservingTest {
         BlockStmt body = method.getBody().get();
 
         // Add statement after if (may have leftover unindent)
-        ExpressionStmt newStmt = StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt();
+        ExpressionStmt newStmt = parser.parseStatement("int y = 2;").asExpressionStmt();
         body.getStatements().add(newStmt);
 
         String expected = "class X {\n" + "    void method() {\n"
@@ -124,8 +123,8 @@ class DifferenceApplyLeftoverRulesTest extends AbstractLexicalPreservingTest {
         BlockStmt body = method.getBody().get();
 
         // Add multiple statements (some may be leftover)
-        body.getStatements().add(StaticJavaParser.parseStatement("int y = 2;").asExpressionStmt());
-        body.getStatements().add(StaticJavaParser.parseStatement("int z = 3;").asExpressionStmt());
+        body.getStatements().add(parser.parseStatement("int y = 2;").asExpressionStmt());
+        body.getStatements().add(parser.parseStatement("int z = 3;").asExpressionStmt());
 
         String expected = "class X {\n" + "    void method() {\n"
                 + "        int x = 1;\n"
@@ -285,7 +284,7 @@ class DifferenceApplyLeftoverRulesTest extends AbstractLexicalPreservingTest {
         BlockStmt body = method.getBody().get();
 
         // Add statement at end
-        body.getStatements().add(StaticJavaParser.parseStatement("int z = 3;").asExpressionStmt());
+        body.getStatements().add(parser.parseStatement("int z = 3;").asExpressionStmt());
 
         String result = print();
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue1793Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue1793Test.java
@@ -23,17 +23,9 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class Issue1793Test extends AbstractLexicalPreservingTest {
-
-    @AfterEach
-    public void reset() {
-        StaticJavaParser.setConfiguration(new ParserConfiguration());
-    }
 
     @Test
     void importIsAddedOnTheSameLine() {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2374Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2374Test.java
@@ -23,7 +23,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.Statement;
 import java.util.Optional;
@@ -49,7 +48,7 @@ public class Issue2374Test extends AbstractLexicalPreservingTest {
                 + "    }\n"
                 + "}";
         // contruct a statement with a comment
-        Statement stmt = StaticJavaParser.parseStatement("System.out.println(\"World!\");");
+        Statement stmt = parser.parseStatement("System.out.println(\"World!\");");
         stmt.setLineComment(lineComment);
         // add the statement to the ast
         Optional<MethodDeclaration> md = cu.findFirst(MethodDeclaration.class);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2393Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2393Test.java
@@ -23,7 +23,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.stmt.IfStmt;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class Issue2393Test extends AbstractLexicalPreservingTest {
     public void test() {
         considerCode("public class Test { public void foo() { int i = 0;\nif(i == 5) { System.out.println(i); } } }");
         IfStmt ifStmt = cu.findFirst(IfStmt.class).orElseThrow(() -> new IllegalStateException("Expected if"));
-        ifStmt.setCondition(StaticJavaParser.parseExpression("i > 0"));
+        ifStmt.setCondition(parser.parseExpression("i > 0"));
         assertEquals("i > 0", ifStmt.getCondition().toString());
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2610Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue2610Test.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.printer.lexicalpreservation;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import java.util.Optional;
@@ -41,7 +40,7 @@ public class Issue2610Test extends AbstractLexicalPreservingTest {
                 + "    }\n"
                 + "}");
         // contruct a statement with a comment
-        Expression expr = StaticJavaParser.parseExpression("System.out.println(\"warning\")");
+        Expression expr = parser.parseExpression("System.out.println(\"warning\")");
         // Replace the method expression
         Optional<MethodCallExpr> mce = cu.findFirst(MethodCallExpr.class);
         mce.get().getParentNode().get().replace(mce.get(), expr);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3818Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue3818Test.java
@@ -23,7 +23,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
@@ -38,7 +37,7 @@ public class Issue3818Test extends AbstractLexicalPreservingTest {
 
         String expected = "public class Foo {\n" + "\n" + "    public Long[][] m(int[] b){}\n" + "}";
 
-        BodyDeclaration<?> cu = StaticJavaParser.parseBodyDeclaration(src);
+        BodyDeclaration<?> cu = parser.parseBodyDeclaration(src);
         MethodDeclaration md = cu.findAll(MethodDeclaration.class).get(0);
         LexicalPreservingPrinter.setup(md);
         Parameter p = md.getParameter(0);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4163Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4163Test.java
@@ -23,7 +23,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
@@ -52,7 +51,7 @@ public class Issue4163Test extends AbstractLexicalPreservingTest {
         PrinterConfiguration config = new DefaultPrinterConfiguration()
                 .addOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS));
         Printer printer = new DefaultPrettyPrinter(config);
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration md = cu.findFirst(MethodDeclaration.class).get();
 
         // expected result is

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4245Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4245Test.java
@@ -22,9 +22,7 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 
-import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import org.junit.jupiter.api.Test;
 
@@ -33,9 +31,7 @@ class Issue4245Test extends AbstractLexicalPreservingTest {
     @Test
     public void test() {
 
-        ParserConfiguration parserConfiguration = new ParserConfiguration();
-        parserConfiguration.setLanguageLevel(LanguageLevel.JAVA_17);
-        StaticJavaParser.setConfiguration(parserConfiguration);
+        parser.getParserConfiguration().setLanguageLevel(LanguageLevel.JAVA_17);
         considerCode("public sealed interface IUpdatePortCommand permits UpdateScheduleCommand, UpdateStateCommand {}");
 
         ClassOrInterfaceDeclaration classOrInterface =

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4488Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4488Test.java
@@ -22,6 +22,7 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -35,10 +36,10 @@ public class Issue4488Test {
     void cannotChangeMethodNameInLambda() {
         ParserConfiguration parserConfiguration = new ParserConfiguration();
         parserConfiguration.setLexicalPreservationEnabled(true);
-        StaticJavaParser.setConfiguration(parserConfiguration);
+        JavaParserAdapter parser = StaticJavaParser.newParserAdapter(parserConfiguration);
 
         CompilationUnit cu =
-                StaticJavaParser.parse("class Test {\n" + "	private Map<String, String> dummyMap = new HashMap<>();\n"
+                parser.parse("class Test {\n" + "	private Map<String, String> dummyMap = new HashMap<>();\n"
                         + "	public String dummyFunction(String name) {\n"
                         + "		return dummyMap.computeIfAbsent(name,\n"
                         + "			(Function<String, String>) s -> SomeFunction.withAMethodHere(\"test\").build());\n"

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4829Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4829Test.java
@@ -22,9 +22,7 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 
-import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import org.junit.jupiter.api.Test;
@@ -34,9 +32,7 @@ class Issue4829Test extends AbstractLexicalPreservingTest {
     @Test
     public void test() {
 
-        ParserConfiguration parserConfiguration = new ParserConfiguration();
-        parserConfiguration.setLanguageLevel(LanguageLevel.JAVA_17);
-        StaticJavaParser.setConfiguration(parserConfiguration);
+        parser.getParserConfiguration().setLanguageLevel(LanguageLevel.JAVA_17);
         considerCode("public sealed interface Foo permits A,B,C,D,E,F,G,H,I {}");
 
         cu.findAll(ClassOrInterfaceDeclaration.class)

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinterTest.java
@@ -21,7 +21,6 @@
 
 package com.github.javaparser.printer.lexicalpreservation;
 
-import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter.NODE_TEXT_DATA;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
@@ -30,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.github.javaparser.GeneratedJavaParserConstants;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.LineComment;
@@ -979,7 +977,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
                 .get()
                 .getStatements()
                 .add(new ExpressionStmt(new VariableDeclarationExpr(new VariableDeclarator(
-                        parseClassOrInterfaceType("String"), "test2", new StringLiteralExpr("")))));
+                        parser.parseClassOrInterfaceType("String"), "test2", new StringLiteralExpr("")))));
         TestUtils.assertEqualsStringIgnoringEol(
                 "public void someMethod() {" + LineSeparator.SYSTEM
                         + "        String test = \"\";" + LineSeparator.SYSTEM
@@ -1338,14 +1336,14 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
         considerExample("IndentOfInsertedCodeBlocks");
 
         IfStmt ifStmt = new IfStmt();
-        ifStmt.setCondition(StaticJavaParser.parseExpression("name.equals(\"foo\")"));
+        ifStmt.setCondition(parser.parseExpression("name.equals(\"foo\")"));
         BlockStmt blockStmt = new BlockStmt();
-        blockStmt.addStatement(StaticJavaParser.parseStatement("int i = 0;"));
-        blockStmt.addStatement(StaticJavaParser.parseStatement("System.out.println(i);"));
+        blockStmt.addStatement(parser.parseStatement("int i = 0;"));
+        blockStmt.addStatement(parser.parseStatement("System.out.println(i);"));
         blockStmt.addStatement(new IfStmt()
-                .setCondition(StaticJavaParser.parseExpression("i < 0"))
-                .setThenStmt(new BlockStmt().addStatement(StaticJavaParser.parseStatement("i = 0;"))));
-        blockStmt.addStatement(StaticJavaParser.parseStatement("new Object(){};"));
+                .setCondition(parser.parseExpression("i < 0"))
+                .setThenStmt(new BlockStmt().addStatement(parser.parseStatement("i = 0;"))));
+        blockStmt.addStatement(parser.parseStatement("new Object(){};"));
         ifStmt.setThenStmt(blockStmt);
         ifStmt.setElseStmt(new BlockStmt());
 
@@ -1826,7 +1824,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     @Test
     void checkLPPIsAvailableOnNode() {
         String code = "class A {void foo(int p1, float p2) { }}";
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parser.parse(code);
         MethodDeclaration md = cu.findFirst(MethodDeclaration.class).get();
         LexicalPreservingPrinter.setup(md);
 
@@ -1866,16 +1864,16 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     @Test
     void checkLPPIsDefaultPrinter() {
         String code = "class A {void foo(int p1, float p2) { }}";
-        StaticJavaParser.getParserConfiguration().setLexicalPreservationEnabled(true);
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        parser.getParserConfiguration().setLexicalPreservationEnabled(true);
+        CompilationUnit cu = parser.parse(code);
         assertEquals(code, cu.toString());
     }
 
     @Test
     void checkLegacyLPPExecution() {
         String code = "class A {void foo(int p1, float p2) { }}";
-        StaticJavaParser.getParserConfiguration().setLexicalPreservationEnabled(true);
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        parser.getParserConfiguration().setLexicalPreservationEnabled(true);
+        CompilationUnit cu = parser.parse(code);
         LexicalPreservingPrinter.setup(cu);
         assertEquals(cu.toString(), LexicalPreservingPrinter.print(cu));
     }
@@ -1883,7 +1881,7 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     @Test
     void checkLPPIsNotDefaultPrinter() {
         String code = "class A {void foo(int p1, float p2) { }}";
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertNotEquals(code, cu.toString());
     }
 
@@ -1915,8 +1913,8 @@ class LexicalPreservingPrinterTest extends AbstractLexicalPreservingTest {
     // that, combined with issue #4781, caused toString() to re-enter LPP during PrimitiveType init)
     @Test
     void issue4781_addIntFieldWithLPPAsDefaultPrinterPreservesTypeKeyword() {
-        StaticJavaParser.getParserConfiguration().setLexicalPreservationEnabled(true);
-        CompilationUnit cu = StaticJavaParser.parse("class Foo {}");
+        parser.getParserConfiguration().setLexicalPreservationEnabled(true);
+        CompilationUnit cu = parser.parse("class Foo {}");
         cu.getClassByName("Foo").get().addField(PrimitiveType.intType(), "foo");
         String printed = LexicalPreservingPrinter.print(cu);
         assertTrue(printed.contains("int foo"), "Type keyword 'int' missing — got: " + printed);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TokenOwnerDetectorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TokenOwnerDetectorTest.java
@@ -2,6 +2,7 @@ package com.github.javaparser.printer.lexicalpreservation;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -17,9 +18,11 @@ import org.junit.jupiter.api.Test;
  */
 class TokenOwnerDetectorTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     // Helper method to parse and find nodes
     private CompilationUnit parse(String code) {
-        return StaticJavaParser.parse(code);
+        return parser.parse(code);
     }
 
     // =========================================================================
@@ -160,8 +163,8 @@ class TokenOwnerDetectorTest {
 
     @Test
     void typeInRecordImplementsClause() {
-        StaticJavaParser.getConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE);
-        CompilationUnit cu = StaticJavaParser.parse("record X() implements List<String> {}");
+        parser.getParserConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE);
+        CompilationUnit cu = parser.parse("record X() implements List<String> {}");
         ClassOrInterfaceType type = cu.findFirst(
                         ClassOrInterfaceType.class, t -> t.getNameAsString().equals("List"))
                 .get();
@@ -213,8 +216,8 @@ class TokenOwnerDetectorTest {
 
     @Test
     void typeInRecordPatternExpression() {
-        StaticJavaParser.getConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE);
-        CompilationUnit cu = StaticJavaParser.parse("class X { void m() { switch (a) { case Box(String s) -> {} } } }");
+        parser.getParserConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE);
+        CompilationUnit cu = parser.parse("class X { void m() { switch (a) { case Box(String s) -> {} } } }");
         ClassOrInterfaceType type = cu.findFirst(
                         ClassOrInterfaceType.class, t -> t.getNameAsString().equals("Box"))
                 .get();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
@@ -178,8 +178,8 @@ class TransformationsTest extends AbstractLexicalPreservingTest {
         considerStatement("    if(value != null) {" + LineSeparator.SYSTEM + "        value.value();"
                 + LineSeparator.SYSTEM + "    }");
 
-        BlockStmt blockStmt = LexicalPreservingPrinter.setup(
-                parser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
+        BlockStmt blockStmt =
+                LexicalPreservingPrinter.setup(parser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
                         + LineSeparator.SYSTEM + "    value2(); // Test"
                         + LineSeparator.SYSTEM + "}"));
 
@@ -199,8 +199,8 @@ class TransformationsTest extends AbstractLexicalPreservingTest {
         considerStatement("    if(value != null) {" + LineSeparator.SYSTEM + "        value.value();"
                 + LineSeparator.SYSTEM + "    }");
 
-        BlockStmt blockStmt = LexicalPreservingPrinter.setup(
-                parser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
+        BlockStmt blockStmt =
+                LexicalPreservingPrinter.setup(parser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
                         + LineSeparator.SYSTEM + "    value2(); /* test */"
                         + LineSeparator.SYSTEM + "}"));
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/TransformationsTest.java
@@ -24,7 +24,6 @@ package com.github.javaparser.printer.lexicalpreservation;
 import static com.github.javaparser.ast.Modifier.Keyword.STATIC;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -180,7 +179,7 @@ class TransformationsTest extends AbstractLexicalPreservingTest {
                 + LineSeparator.SYSTEM + "    }");
 
         BlockStmt blockStmt = LexicalPreservingPrinter.setup(
-                StaticJavaParser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
+                parser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
                         + LineSeparator.SYSTEM + "    value2(); // Test"
                         + LineSeparator.SYSTEM + "}"));
 
@@ -201,7 +200,7 @@ class TransformationsTest extends AbstractLexicalPreservingTest {
                 + LineSeparator.SYSTEM + "    }");
 
         BlockStmt blockStmt = LexicalPreservingPrinter.setup(
-                StaticJavaParser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
+                parser.parseBlock("{" + LineSeparator.SYSTEM + "       value1();"
                         + LineSeparator.SYSTEM + "    value2(); /* test */"
                         + LineSeparator.SYSTEM + "}"));
 
@@ -222,7 +221,7 @@ class TransformationsTest extends AbstractLexicalPreservingTest {
                 + LineSeparator.SYSTEM + "        }");
 
         CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(
-                StaticJavaParser.parse("public class Test {" + LineSeparator.SYSTEM + "    public void method() {"
+                parser.parse("public class Test {" + LineSeparator.SYSTEM + "    public void method() {"
                         + LineSeparator.SYSTEM + "           value1();"
                         + LineSeparator.SYSTEM + "        value2(); // Test"
                         + LineSeparator.SYSTEM + "    }"
@@ -251,7 +250,7 @@ class TransformationsTest extends AbstractLexicalPreservingTest {
                 + LineSeparator.SYSTEM + "        }");
 
         CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(
-                StaticJavaParser.parse("public class Test {" + LineSeparator.SYSTEM + "    public void method() {"
+                parser.parse("public class Test {" + LineSeparator.SYSTEM + "    public void method() {"
                         + LineSeparator.SYSTEM + "           value1();"
                         + LineSeparator.SYSTEM + "        value2();"
                         + LineSeparator.SYSTEM + "    }"
@@ -280,7 +279,7 @@ class TransformationsTest extends AbstractLexicalPreservingTest {
                 + LineSeparator.SYSTEM + "        }");
 
         CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(
-                StaticJavaParser.parse("public class Test {" + LineSeparator.SYSTEM + "    public void method() {"
+                parser.parse("public class Test {" + LineSeparator.SYSTEM + "    public void method() {"
                         + LineSeparator.SYSTEM + "           value1();"
                         + LineSeparator.SYSTEM + "        value2();"
                         + LineSeparator.SYSTEM + LineSeparator.SYSTEM + "    }"

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/CompilationUnitTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/CompilationUnitTransformationsTest.java
@@ -22,7 +22,6 @@
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
@@ -37,7 +36,7 @@ class CompilationUnitTransformationsTest extends AbstractLexicalPreservingTest {
 
     @BeforeEach
     void initParser() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
     }
 
     // packageDeclaration

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/CompilationUnitTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/CompilationUnitTransformationsTest.java
@@ -26,18 +26,12 @@ import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.utils.LineSeparator;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Transforming CompilationUnit and verifying the LexicalPreservation works as expected.
  */
 class CompilationUnitTransformationsTest extends AbstractLexicalPreservingTest {
-
-    @BeforeEach
-    void initParser() {
-        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
-    }
 
     // packageDeclaration
 
@@ -75,6 +69,8 @@ class CompilationUnitTransformationsTest extends AbstractLexicalPreservingTest {
 
     @Test
     void removingModuleImport() {
+        // "import module ..." requires Java 25 (the default level is JAVA_11).
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("import module java.base; class A {}");
         cu.remove(cu.getImport(0));
         assertTransformedToString("class A {}", cu);
@@ -82,6 +78,7 @@ class CompilationUnitTransformationsTest extends AbstractLexicalPreservingTest {
 
     @Test
     void modifyingModuleImport() {
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("import module java.base; class A {}");
         cu.getImport(0).setName("a.b");
         assertTransformedToString("import module a.b; class A {}", cu);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
@@ -35,18 +35,12 @@ import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.utils.LineSeparator;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Transforming AnnotationMemberDeclaration and verifying the LexicalPreservation works as expected.
  */
 class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPreservingTest {
-
-    @BeforeEach
-    public void setLanguageLevel() {
-        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-    }
 
     protected AnnotationMemberDeclaration consider(String code) {
         considerCode("@interface AD { " + code + " }");
@@ -186,6 +180,8 @@ class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void modifyingRecord() {
+        // Records nested in an annotation type require a language level >= Java 16 (the default is JAVA_11).
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
         considerCode("@interface AD { record Bar(String s) {} }");
         RecordDeclaration recordDecl =
                 cu.getAnnotationDeclarationByName("AD").get().getMember(0).asRecordDeclaration();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/AnnotationMemberDeclarationTransformationsTest.java
@@ -27,7 +27,6 @@ import static com.github.javaparser.ast.Modifier.createModifierList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
 import com.github.javaparser.ast.body.RecordDeclaration;
@@ -36,7 +35,6 @@ import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.printer.lexicalpreservation.AbstractLexicalPreservingTest;
 import com.github.javaparser.utils.LineSeparator;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,17 +43,9 @@ import org.junit.jupiter.api.Test;
  */
 class AnnotationMemberDeclarationTransformationsTest extends AbstractLexicalPreservingTest {
 
-    private static final ParserConfiguration.LanguageLevel storedLanguageLevel =
-            StaticJavaParser.getParserConfiguration().getLanguageLevel();
-
     @BeforeEach
     public void setLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-    }
-
-    @AfterEach
-    public void resetLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(storedLanguageLevel);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
     }
 
     protected AnnotationMemberDeclaration consider(String code) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
@@ -21,13 +21,11 @@
 
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
 
-import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -115,7 +113,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
     @Test
     void replacingExtendedTypes() {
         ClassOrInterfaceDeclaration cid = consider("public class A extends Foo {}");
-        cid.getExtendedTypes().set(0, parseClassOrInterfaceType("Bar"));
+        cid.getExtendedTypes().set(0, parser.parseClassOrInterfaceType("Bar"));
         assertTransformedToString("public class A extends Bar {}", cid);
     }
 
@@ -138,7 +136,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
     @Test
     void replacingImplementedTypes() {
         ClassOrInterfaceDeclaration cid = consider("public class A implements Foo {}");
-        cid.getImplementedTypes().set(0, parseClassOrInterfaceType("Bar"));
+        cid.getImplementedTypes().set(0, parser.parseClassOrInterfaceType("Bar"));
         assertTransformedToString("public class A implements Bar {}", cid);
     }
 
@@ -211,7 +209,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void addingFieldToCompactClass() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("void main() { }");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
         cid.addField("int", "count");
@@ -220,7 +218,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void addingMethodToCompactClass() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("void main() { }");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
         cid.addMethod("greet", PUBLIC);
@@ -232,7 +230,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void modifyingFieldInCompactClass() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("int count = 0;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + "void main() { }");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
         cid.getFields().get(0).getVariables().get(0).setType(PrimitiveType.longType());
@@ -242,7 +240,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void modifyingMethodInCompactClass() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("int add(int a, int b) { return a + b; }" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
                 + "void main() { }");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
@@ -255,7 +253,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void removingFieldFromCompactClass() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("int count = 0;" + LineSeparator.SYSTEM + LineSeparator.SYSTEM + "void main() { }");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
         cid.getMembers().remove(0);
@@ -264,7 +262,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void removingMethodFromCompactClass() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("int add(int a, int b) { return a + b; }" + LineSeparator.SYSTEM + LineSeparator.SYSTEM
                 + "void main() { }");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
@@ -274,7 +272,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void makingNonCompactClassCompact() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("class Foo {" + LineSeparator.SYSTEM + "    void main() { }" + LineSeparator.SYSTEM + "}");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
         cid.setCompact(true);
@@ -283,7 +281,7 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
 
     @Test
     void makingCompactClassNonCompact() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         considerCode("void main() { }");
         ClassOrInterfaceDeclaration cid = cu.getType(0).asClassOrInterfaceDeclaration();
         cid.setCompact(false);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ConstructorDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ConstructorDeclarationTransformationsTest.java
@@ -26,7 +26,6 @@ import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.Parameter;
@@ -131,7 +130,7 @@ class ConstructorDeclarationTransformationsTest extends AbstractLexicalPreservin
 
     @Test
     void modifyingConstructorInvocationAsSecondStatement() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         ConstructorDeclaration cd = consider("public A() { int x; super(); }");
         cd.getBody()
                 .getStatements()
@@ -143,7 +142,7 @@ class ConstructorDeclarationTransformationsTest extends AbstractLexicalPreservin
 
     @Test
     void removingConstructorInvocationAsSecondStatement() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
         ConstructorDeclaration cd = consider("public A() { int x; super(); }");
         cd.getBody().getStatements().remove(1);
         assertTransformedToString("public A() { int x; }", cd);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -21,8 +21,6 @@
 
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
 
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.Modifier.createModifierList;
@@ -541,14 +539,14 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
 
     @Test
     public void parseAndPrintAnonymousClassExpression() {
-        Expression expression = parseExpression("new Object() {" + LineSeparator.SYSTEM + "}");
+        Expression expression = parser.parseExpression("new Object() {" + LineSeparator.SYSTEM + "}");
         String expected = "new Object() {" + LineSeparator.SYSTEM + "}";
         assertTransformedToString(expected, expression);
     }
 
     @Test
     public void parseAndPrintAnonymousClassStatement() {
-        Statement statement = parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM + "};");
+        Statement statement = parser.parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM + "};");
         String expected = "Object anonymous = new Object() {" + LineSeparator.SYSTEM + "};";
         assertTransformedToString(expected, statement);
     }
@@ -557,7 +555,7 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     public void replaceBodyShouldNotBreakAnonymousClasses() {
         MethodDeclaration it = consider("public void method() { }");
         it.getBody().ifPresent(body -> {
-            Statement statement = parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM + "};");
+            Statement statement = parser.parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM + "};");
             NodeList<Statement> statements = new NodeList<>();
             statements.add(statement);
             body.setStatements(statements);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/MethodDeclarationTransformationsTest.java
@@ -555,7 +555,8 @@ class MethodDeclarationTransformationsTest extends AbstractLexicalPreservingTest
     public void replaceBodyShouldNotBreakAnonymousClasses() {
         MethodDeclaration it = consider("public void method() { }");
         it.getBody().ifPresent(body -> {
-            Statement statement = parser.parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM + "};");
+            Statement statement =
+                    parser.parseStatement("Object anonymous = new Object() {" + LineSeparator.SYSTEM + "};");
             NodeList<Statement> statements = new NodeList<>();
             statements.add(statement);
             body.setStatements(statements);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
@@ -21,13 +21,11 @@
 
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
 
-import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Range;
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.*;
@@ -44,21 +42,13 @@ import org.junit.jupiter.api.*;
  */
 class StatementTransformationsTest extends AbstractLexicalPreservingTest {
 
-    private static final ParserConfiguration.LanguageLevel storedLanguageLevel =
-            StaticJavaParser.getParserConfiguration().getLanguageLevel();
-
     @BeforeEach
     public void setLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-    }
-
-    @AfterEach
-    public void resetLanguageLevel() {
-        StaticJavaParser.getParserConfiguration().setLanguageLevel(storedLanguageLevel);
+        parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
     }
 
     Statement consider(String code) {
-        Statement statement = parseStatement(code);
+        Statement statement = parser.parseStatement(code);
         LexicalPreservingPrinter.setup(statement);
         return statement;
     }
@@ -159,10 +149,7 @@ class StatementTransformationsTest extends AbstractLexicalPreservingTest {
                 + "				case Box(_) -> new Object();\n"
                 + "				default -> throw new IllegalStateException(\"Cant create for year\");\n"
                 + "			}";
-        ParserConfiguration config = new ParserConfiguration();
-        config.setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-        StaticJavaParser.setConfiguration(config);
-        CompilationUnit cu = LexicalPreservingPrinter.setup(StaticJavaParser.parse(originalCode));
+        CompilationUnit cu = LexicalPreservingPrinter.setup(parser.parse(originalCode));
         SwitchExpr switchExpr = cu.findFirst(SwitchExpr.class).get();
         NodeList<SwitchEntry> entries = switchExpr.getEntries();
 
@@ -189,10 +176,7 @@ class StatementTransformationsTest extends AbstractLexicalPreservingTest {
                 + "				case Box(String _) -> new Object();\n"
                 + "				default -> throw new IllegalStateException(\"Cant create for year\");\n"
                 + "			}";
-        ParserConfiguration config = new ParserConfiguration();
-        config.setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-        StaticJavaParser.setConfiguration(config);
-        CompilationUnit cu = LexicalPreservingPrinter.setup(StaticJavaParser.parse(originalCode));
+        CompilationUnit cu = LexicalPreservingPrinter.setup(parser.parse(originalCode));
         SwitchExpr switchExpr = cu.findFirst(SwitchExpr.class).get();
         NodeList<SwitchEntry> entries = switchExpr.getEntries();
 
@@ -220,10 +204,7 @@ class StatementTransformationsTest extends AbstractLexicalPreservingTest {
                 + "				case 2024 -> new java.lang.Object();\n"
                 + "				default -> throw new IllegalStateException(\"Cant create for year\");\n"
                 + "			}";
-        ParserConfiguration config = new ParserConfiguration();
-        config.setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
-        StaticJavaParser.setConfiguration(config);
-        CompilationUnit cu = LexicalPreservingPrinter.setup(StaticJavaParser.parse(originalCode));
+        CompilationUnit cu = LexicalPreservingPrinter.setup(parser.parse(originalCode));
         SwitchExpr switchExpr = cu.findFirst(SwitchExpr.class).get();
         NodeList<SwitchEntry> entries = switchExpr.getEntries();
         NodeList<Expression> labels = NodeList.nodeList(new IntegerLiteralExpr("2024"));

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/StatementTransformationsTest.java
@@ -42,6 +42,11 @@ import org.junit.jupiter.api.*;
  */
 class StatementTransformationsTest extends AbstractLexicalPreservingTest {
 
+    // Most tests in this class parse recent-language constructs (arrow switches since Java 14, and type/record/unnamed
+    // patterns in switch since Java 21+), which the default level (JAVA_11) cannot parse. Configuring the parser
+    // class-wide via @BeforeEach is therefore the right choice here. Had only a few tests needed it, we would instead
+    // set the level inline in those specific tests (as AnnotationMemberDeclarationTransformationsTest does) rather than
+    // raise the level for the whole class.
     @BeforeEach
     public void setLanguageLevel() {
         parser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/PositionUtilsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/PositionUtilsTest.java
@@ -24,6 +24,7 @@ import static com.github.javaparser.utils.PositionUtils.nodeContains;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -36,9 +37,12 @@ import com.github.javaparser.ast.type.Type;
 import org.junit.jupiter.api.Test;
 
 public class PositionUtilsTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     public void nodeContains_NoAnnotationsAnywhere_IgnoringAnnotations() {
-        CompilationUnit cu = StaticJavaParser.parse("class X { int a; }");
+        CompilationUnit cu = parser.parse("class X { int a; }");
         FieldDeclaration field = cu.findFirst(FieldDeclaration.class).get();
 
         boolean contains = nodeContains(cu, field, true);
@@ -47,7 +51,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeDoesNotContain_NoAnnotationsAnywhere_IgnoringAnnotations() {
-        CompilationUnit cu = StaticJavaParser.parse("class X { int a; }");
+        CompilationUnit cu = parser.parse("class X { int a; }");
         FieldDeclaration field = cu.findFirst(FieldDeclaration.class).get();
 
         Type fieldType = field.getVariable(0).getType();
@@ -59,7 +63,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeContains_NoAnnotationsAnywhere_IncludeAnnotations() {
-        CompilationUnit cu = StaticJavaParser.parse("class X { int a; }");
+        CompilationUnit cu = parser.parse("class X { int a; }");
         FieldDeclaration field = cu.findFirst(FieldDeclaration.class).get();
 
         boolean contains = nodeContains(cu, field, false);
@@ -68,7 +72,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeDoesNotContain_NoAnnotationsAnywhere_IncludeAnnotations() {
-        CompilationUnit cu = StaticJavaParser.parse("class X { int a; }");
+        CompilationUnit cu = parser.parse("class X { int a; }");
         FieldDeclaration field = cu.findFirst(FieldDeclaration.class).get();
 
         Type fieldType = field.getVariable(0).getType();
@@ -80,7 +84,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeContainsAnnotations_IgnoringAnnotations() {
-        CompilationUnit cu = StaticJavaParser.parse("@A class X {} class Y {}");
+        CompilationUnit cu = parser.parse("@A class X {} class Y {}");
         ClassOrInterfaceDeclaration x = cu.getClassByName("X").get();
         ClassOrInterfaceDeclaration y = cu.getClassByName("Y").get();
 
@@ -92,7 +96,7 @@ public class PositionUtilsTest {
     public void nodeContainsAnnotations_WithCommentNodeInTheMiddle_IgnoringAnnotations() {
         String code = "" + "@A\n" + "/*o*/\n" + "@B\n" + "class X {\n" + "}\n" + "";
 
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString(), "Issue with the parsing of the code, not this test.");
 
         ClassOrInterfaceDeclaration x = cu.getClassByName("X").get();
@@ -109,7 +113,7 @@ public class PositionUtilsTest {
     @Test
     public void nodeContainsAnnotations_WithAnnotationNodeInTheMiddle() {
         String code = "" + "@A\n" + "@B\n" + "@C\n" + "class X {\n" + "}\n" + "";
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parser.parse(code);
         assertEqualsStringIgnoringEol(code, cu.toString(), "Issue with the parsing of the code, not this test.");
 
         final ClassOrInterfaceDeclaration x = cu.getClassByName("X").get();
@@ -142,7 +146,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeContainsAnnotations_WithCommentAtTheEndOfAnnotations_IgnoringAnnotations() {
-        CompilationUnit cu = StaticJavaParser.parse("@A @B /*o*/ public class X {}");
+        CompilationUnit cu = parser.parse("@A @B /*o*/ public class X {}");
         ClassOrInterfaceDeclaration x = cu.getClassByName("X").get();
 
         // TODO: Should the comment be attached to the SimpleName (as opposed to the ClassOrInterfaceDeclaration?)
@@ -174,7 +178,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeContainsAnnotations_WithCommentAfterTheEnd_IgnoringAnnotations() {
-        CompilationUnit cu = StaticJavaParser.parse("@A @B public /*o*/ class X {}");
+        CompilationUnit cu = parser.parse("@A @B public /*o*/ class X {}");
         ClassOrInterfaceDeclaration x = cu.getClassByName("X").get();
 
         // TODO: Should the comment be attached to the SimpleName (as opposed to the ClassOrInterfaceDeclaration?)
@@ -206,7 +210,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeContainsAnnotations_WithCommentAfterTheEnd_IgnoringAnnotations2() {
-        CompilationUnit cu = StaticJavaParser.parse("@A @B public class /*o*/ X {}");
+        CompilationUnit cu = parser.parse("@A @B public class /*o*/ X {}");
         ClassOrInterfaceDeclaration x = cu.getClassByName("X").get();
 
         // TODO: Should the comment be attached to the SimpleName (as opposed to the ClassOrInterfaceDeclaration?)
@@ -239,7 +243,7 @@ public class PositionUtilsTest {
 
     @Test
     public void nodeContainsAnnotations_WithCommentAfterTheEnd_IgnoringAnnotations3() {
-        CompilationUnit cu = StaticJavaParser.parse("@A @B public class X /*o*/ {}");
+        CompilationUnit cu = parser.parse("@A @B public class X /*o*/ {}");
         ClassOrInterfaceDeclaration x = cu.getClassByName("X").get();
 
         //        // TODO: At what point is the declaration supposed to end and the code block begin? Should the block

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -23,11 +23,11 @@ package com.github.javaparser.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Problem;
-import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.printer.ConfigurablePrinter;

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Problem;
+import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.printer.ConfigurablePrinter;
@@ -47,6 +48,9 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 class SourceRootTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     private final Path root = CodeGenerationUtils.mavenModuleRoot(SourceRootTest.class)
             .resolve("src/test/resources/com/github/javaparser/utils/");
     private final SourceRoot sourceRoot = new SourceRoot(root);
@@ -196,7 +200,7 @@ class SourceRootTest {
         SourceRoot sr = new SourceRoot(oldRoot);
 
         // relative key -> saved under newRoot
-        CompilationUnit cuRel = StaticJavaParser.parse("package p; class R {}");
+        CompilationUnit cuRel = parser.parse("package p; class R {}");
         sr.add("p", "R.java", cuRel);
         Path expectedRelativeTarget =
                 newRoot.resolve("p/R.java").toAbsolutePath().normalize();
@@ -204,7 +208,7 @@ class SourceRootTest {
 
         // absolute key -> remains at absolute path
         Path absPath = absDir.resolve("X.java").toAbsolutePath();
-        CompilationUnit cuAbs = StaticJavaParser.parse("package abs; class X {}");
+        CompilationUnit cuAbs = parser.parse("package abs; class X {}");
         cuAbs.setStorage(absPath, StandardCharsets.UTF_8);
         sr.add(cuAbs);
 

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/TestParser.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/TestParser.java
@@ -38,6 +38,15 @@ import java.util.Map;
 
 public class TestParser {
 
+    /*
+     * Parsers are cached per language level and shared statically across all tests. This is safe only because tests
+     * run sequentially (JUnit's default lifecycle) and the cached parsers' configuration is never mutated after
+     * creation.
+     *
+     * WARNING: JavaParser is not thread-safe. If parallel test execution is ever enabled, these shared instances
+     * become a data race. The cache would then have to be made thread-local (one parser per level per thread) or
+     * dropped (create a fresh parser per call).
+     */
     private static final Map<LanguageLevel, JavaParser> parserCache = new HashMap<>();
 
     private static JavaParser parser(LanguageLevel languageLevel) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorListTest.java
@@ -38,7 +38,6 @@ class VisitorListTest {
 
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
-
     @Test
     void visitorAddAll() {
         List<CompilationUnit> list = new ArrayList<>();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorListTest.java
@@ -21,10 +21,11 @@
 
 package com.github.javaparser.utils;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.visitor.ObjectIdentityEqualsVisitor;
 import com.github.javaparser.ast.visitor.ObjectIdentityHashCodeVisitor;
@@ -35,11 +36,14 @@ import org.junit.jupiter.api.Test;
 
 class VisitorListTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
+
     @Test
     void visitorAddAll() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         VisitorList<CompilationUnit> vList =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         vList.addAll(list);
@@ -49,20 +53,20 @@ class VisitorListTest {
     @Test
     void visitorAddAllAtIndex() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class Y{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class Y{}"));
         VisitorList<CompilationUnit> vList =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        vList.add(parse("class A{}"));
-        vList.add(parse("class B{}"));
+        vList.add(parser.parse("class A{}"));
+        vList.add(parser.parse("class B{}"));
         vList.addAll(2, list);
-        vList.add(parse("class C{}"));
+        vList.add(parser.parse("class C{}"));
         for (int i = 0; i < list.size(); i++) assertEquals(list.get(i), vList.get(2 + i));
     }
 
     @Test
     void visitorListContains() {
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
         VisitorList<CompilationUnit> list =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         list.add(x1);
@@ -72,8 +76,8 @@ class VisitorListTest {
     @Test
     void visitorListContainsAll() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         VisitorList<CompilationUnit> vList =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         vList.addAll(list);
@@ -84,9 +88,9 @@ class VisitorListTest {
     void visitorListIterator() {
         VisitorList<CompilationUnit> list =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
         list.add(x1);
-        CompilationUnit x2 = parse("class X{}");
+        CompilationUnit x2 = parser.parse("class X{}");
         list.add(x2);
         Iterator<CompilationUnit> itr = list.iterator();
         assertEquals(x1, itr.next());
@@ -101,11 +105,11 @@ class VisitorListTest {
     void visitorListListIterator() {
         VisitorList<CompilationUnit> list =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
-        CompilationUnit x1 = parse("class X{}");
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        CompilationUnit x1 = parser.parse("class X{}");
         list.add(x1);
-        CompilationUnit x2 = parse("class X{}");
+        CompilationUnit x2 = parser.parse("class X{}");
         list.add(x2);
         Iterator<CompilationUnit> itr = list.listIterator(2);
         assertEquals(x1, itr.next());
@@ -118,7 +122,7 @@ class VisitorListTest {
 
     @Test
     void visitorListRemove() {
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
         VisitorList<CompilationUnit> list =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         list.add(x1);
@@ -128,8 +132,8 @@ class VisitorListTest {
     @Test
     void visitorListRemoveAll() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         VisitorList<CompilationUnit> vList =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         vList.addAll(list);
@@ -140,12 +144,12 @@ class VisitorListTest {
     @Test
     void visitorListRetainAll() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         VisitorList<CompilationUnit> vList =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         vList.addAll(list);
-        vList.add(parse("class X{}"));
+        vList.add(parser.parse("class X{}"));
         vList.retainAll(list);
         assertEquals(2, vList.size());
     }
@@ -154,14 +158,14 @@ class VisitorListTest {
     void visitorListSubList() {
         VisitorList<CompilationUnit> list =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         assertEquals(4, list.size());
         List<CompilationUnit> subLst = list.subList(1, 3);
         assertEquals(2, subLst.size());
-        subLst.add(parse("class X{}"));
+        subLst.add(parser.parse("class X{}"));
         assertEquals(3, subLst.size());
         assertEquals(5, list.size());
     }
@@ -169,8 +173,8 @@ class VisitorListTest {
     @Test
     void visitorListToArray() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         List<CompilationUnit> vList =
                 new VisitorList<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         vList.addAll(list);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorMapTest.java
@@ -21,9 +21,10 @@
 
 package com.github.javaparser.utils;
 
-import static com.github.javaparser.StaticJavaParser.parse;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.visitor.ObjectIdentityEqualsVisitor;
 import com.github.javaparser.ast.visitor.ObjectIdentityHashCodeVisitor;
@@ -32,10 +33,13 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class VisitorMapTest {
+
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
     @Test
     void normalEqualsDoesDeepCompare() {
-        CompilationUnit x1 = parse("class X{}");
-        CompilationUnit x2 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
+        CompilationUnit x2 = parser.parse("class X{}");
 
         Map<CompilationUnit, Integer> map = new HashMap<>();
         map.put(x1, 1);
@@ -45,8 +49,8 @@ class VisitorMapTest {
 
     @Test
     void objectIdentityEqualsDoesShallowCompare() {
-        CompilationUnit x1 = parse("class X{}");
-        CompilationUnit x2 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
+        CompilationUnit x2 = parser.parse("class X{}");
 
         Map<CompilationUnit, Integer> map =
                 new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
@@ -57,7 +61,7 @@ class VisitorMapTest {
 
     @Test
     void visitorMapGet() {
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
 
         Map<CompilationUnit, Integer> map =
                 new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
@@ -67,7 +71,7 @@ class VisitorMapTest {
 
     @Test
     void visitorMapContainsKey() {
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
 
         Map<CompilationUnit, Integer> map =
                 new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
@@ -77,8 +81,8 @@ class VisitorMapTest {
 
     @Test
     void visitorMapPutAll() {
-        CompilationUnit x1 = parse("class X{}");
-        CompilationUnit x2 = parse("class Y{}");
+        CompilationUnit x1 = parser.parse("class X{}");
+        CompilationUnit x2 = parser.parse("class Y{}");
         Map<CompilationUnit, Integer> map = new HashMap<>();
         map.put(x1, 1);
         map.put(x2, 2);
@@ -90,7 +94,7 @@ class VisitorMapTest {
 
     @Test
     void remove() {
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
         VisitorMap<CompilationUnit, Integer> map =
                 new VisitorMap<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         map.put(x1, 1);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
@@ -37,7 +37,6 @@ class VisitorSetTest {
 
     private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
 
-
     @Test
     void normalEqualsDoesDeepCompare() {
         Set<CompilationUnit> set = new HashSet<>();

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/VisitorSetTest.java
@@ -21,11 +21,11 @@
 
 package com.github.javaparser.utils;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseMethodDeclaration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.JavaParserAdapter;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.ObjectIdentityEqualsVisitor;
@@ -35,11 +35,14 @@ import org.junit.jupiter.api.Test;
 
 class VisitorSetTest {
 
+    private final JavaParserAdapter parser = StaticJavaParser.newParserAdapter();
+
+
     @Test
     void normalEqualsDoesDeepCompare() {
         Set<CompilationUnit> set = new HashSet<>();
-        set.add(parse("class X{}"));
-        set.add(parse("class X{}"));
+        set.add(parser.parse("class X{}"));
+        set.add(parser.parse("class X{}"));
         assertEquals(1, set.size());
     }
 
@@ -47,14 +50,14 @@ class VisitorSetTest {
     void objectIdentityEqualsDoesShallowCompare() {
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        set.add(parse("class X{}"));
-        set.add(parse("class X{}"));
+        set.add(parser.parse("class X{}"));
+        set.add(parser.parse("class X{}"));
         assertEquals(2, set.size());
     }
 
     @Test
     void visitorSetContains() {
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.add(x1);
@@ -64,8 +67,8 @@ class VisitorSetTest {
     @Test
     void visitorSetContainsAll() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.addAll(list);
@@ -76,9 +79,9 @@ class VisitorSetTest {
     void visitorSetIterator() {
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
         set.add(x1);
-        CompilationUnit x2 = parse("class X{}");
+        CompilationUnit x2 = parser.parse("class X{}");
         set.add(x2);
         Iterator<CompilationUnit> itr = set.iterator();
         assertEquals(x1, itr.next());
@@ -91,7 +94,7 @@ class VisitorSetTest {
 
     @Test
     void visitorSetRemove() {
-        CompilationUnit x1 = parse("class X{}");
+        CompilationUnit x1 = parser.parse("class X{}");
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.add(x1);
@@ -101,8 +104,8 @@ class VisitorSetTest {
     @Test
     void visitorSetRemoveAll() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.addAll(list);
@@ -113,12 +116,12 @@ class VisitorSetTest {
     @Test
     void visitorSetRetainAll() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.addAll(list);
-        set.add(parse("class X{}"));
+        set.add(parser.parse("class X{}"));
         set.retainAll(list);
         assertEquals(2, set.size());
     }
@@ -126,8 +129,8 @@ class VisitorSetTest {
     @Test
     void visitorSetToArray() {
         List<CompilationUnit> list = new ArrayList<>();
-        list.add(parse("class X{}"));
-        list.add(parse("class X{}"));
+        list.add(parser.parse("class X{}"));
+        list.add(parser.parse("class X{}"));
         Set<CompilationUnit> set =
                 new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
         set.addAll(list);
@@ -143,14 +146,14 @@ class VisitorSetTest {
     @Test
     void visitSetWithOneElement() {
         Set<Type> set = new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        set.addAll(parseMethodDeclaration("public void main() {}").findAll(Type.class));
+        set.addAll(parser.parseMethodDeclaration("public void main() {}").findAll(Type.class));
         assertEquals("[void]", set.toString());
     }
 
     @Test
     void visitSetWithMultiElements() {
         Set<Type> set = new VisitorSet<>(new ObjectIdentityHashCodeVisitor(), new ObjectIdentityEqualsVisitor());
-        set.addAll(parseMethodDeclaration("public void main(String arg1, Integer arg2) {}")
+        set.addAll(parser.parseMethodDeclaration("public void main(String arg1, Integer arg2) {}")
                 .findAll(Type.class));
         assertEquals("[void,Integer,String]", set.toString());
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -80,6 +80,36 @@ public final class StaticJavaParser {
     }
 
     /**
+     * Creates a new, independent parser with a fresh default {@link ParserConfiguration}.
+     * <p>
+     * Unlike the static {@code parse...} methods, the returned parser does <b>not</b> share the global
+     * {@link #setConfiguration(ParserConfiguration) static configuration}: configuring it never affects other callers.
+     * This makes it the preferred entry point whenever a specific configuration is needed without disturbing the shared
+     * state (for example in tests).
+     *
+     * @return a new independent parser
+     */
+    public static JavaParserAdapter newParserAdapter() {
+        return newParserAdapter(new ParserConfiguration());
+    }
+
+    /**
+     * Creates a new, independent parser using the given {@link ParserConfiguration}.
+     * <p>
+     * Unlike the static {@code parse...} methods, the returned parser does <b>not</b> share the global
+     * {@link #setConfiguration(ParserConfiguration) static configuration}: configuring it never affects other callers.
+     * This makes it the preferred entry point whenever a specific configuration is needed without disturbing the shared
+     * state (for example in tests).
+     *
+     * @param configuration the configuration the returned parser will use
+     * @return a new independent parser
+     */
+    public static JavaParserAdapter newParserAdapter(@NotNull ParserConfiguration configuration) {
+        Preconditions.checkNotNull(configuration, "Parameter configuration can't be null.");
+        return new JavaParserAdapter(new JavaParser(configuration));
+    }
+
+    /**
      * Parses the Java code contained in the {@link InputStream} and returns a
      * {@link CompilationUnit} that represents it.
      *
@@ -540,7 +570,7 @@ public final class StaticJavaParser {
     }
 
     private static JavaParserAdapter newParserAdapted() {
-        return new JavaParserAdapter(newParser());
+        return newParserAdapter(getParserConfiguration());
     }
 
     @Deprecated


### PR DESCRIPTION
Tests configured parsing by mutating the global StaticJavaParser configuration,
coupling tests through shared state and making the suite order-dependent and
impossible to parallelize.
Add StaticJavaParser.newParserAdapter() factories returning parsers backed by
their own ParserConfiguration, and migrate every test in javaparser-core-testing
to an isolated JavaParserAdapter instead of mutating the global config. Tests
needing a specific language level now carry it on their own parser, removing the
@BeforeEach/@AfterEach/@BeforeAll reset scaffolding.
Includes minor follow-ups: single-parser consolidation, assert-on-parse-failure
instead of System.err, and comments documenting language-level and thread-safety
choices.
