### PR TITLE
fix: refine method reference return type on parameterized scope (#4989)

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -474,8 +474,17 @@ public class JavaParserFacade {
         // "The class or interface determined by compile-time step 1 (§15.12.1) is searched
         // for all member methods that are potentially applicable to this method invocation."
         // Filter methods by name first.
-        List<MethodUsage> candidateMethods =
-                allMethods.stream().filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
+        //
+        // getAllMethods() returns usages typed against the raw type declaration, so a method such as
+        // Class<T>::cast still returns the type variable T. We substitute the scope type's arguments
+        // (e.g. T -> Sub for Class<Sub>) using the same primitive as LambdaExprContext, so that poly
+        // inference for pipelines like list.stream().map(Sub.class::cast) can refine Stream<Base> to
+        // Stream<Sub> and the following method reference resolves (see issue #4989).
+        ResolvedReferenceType scopeType = typeOfScope.asReferenceType();
+        List<MethodUsage> candidateMethods = allMethods.stream()
+                .filter(m -> m.getName().equals(methodName))
+                .map(m -> substituteScopeTypeParameters(m, scopeType))
+                .collect(Collectors.toList());
 
         if (candidateMethods.isEmpty()) {
             throw new UnsolvedSymbolException("Cannot find method '" + methodName + "' in type " + typeOfScope);
@@ -615,6 +624,30 @@ public class JavaParserFacade {
                         + paramTypes + ". Candidates found: "
                         + candidateMethods.size() + " method(s) named '"
                         + methodName + "' in type " + typeOfScope);
+    }
+
+    /**
+     * Applies {@code scopeType}'s type arguments to {@code methodUsage}'s parameter, return and exception
+     * types, mirroring what {@link ResolvedReferenceType#getFieldType(String)} does for fields.
+     *
+     * <p>Methods obtained via {@link ResolvedReferenceTypeDeclaration#getAllMethods()} are typed against the
+     * raw type declaration; for a parameterized scope such as {@code Class<Sub>} the return type of
+     * {@code cast} is still the type variable {@code T}. Substitution relies on
+     * {@link ResolvedReferenceType#useThisTypeParametersOnTheGivenType(ResolvedType)}, which only replaces
+     * type variables declared on the type (not on the method) and resolves them against ancestors.
+     */
+    private static MethodUsage substituteScopeTypeParameters(MethodUsage methodUsage, ResolvedReferenceType scopeType) {
+        MethodUsage result = methodUsage;
+        List<ResolvedType> paramTypes = result.getParamTypes();
+        for (int i = 0; i < paramTypes.size(); i++) {
+            result = result.replaceParamType(i, scopeType.useThisTypeParametersOnTheGivenType(paramTypes.get(i)));
+        }
+        List<ResolvedType> exceptionTypes = result.exceptionTypes();
+        for (int i = 0; i < exceptionTypes.size(); i++) {
+            result =
+                    result.replaceExceptionType(i, scopeType.useThisTypeParametersOnTheGivenType(exceptionTypes.get(i)));
+        }
+        return result.replaceReturnType(scopeType.useThisTypeParametersOnTheGivenType(result.returnType()));
     }
 
     protected ResolvedType getBinaryTypeConcrete(

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -644,8 +644,8 @@ public class JavaParserFacade {
         }
         List<ResolvedType> exceptionTypes = result.exceptionTypes();
         for (int i = 0; i < exceptionTypes.size(); i++) {
-            result =
-                    result.replaceExceptionType(i, scopeType.useThisTypeParametersOnTheGivenType(exceptionTypes.get(i)));
+            result = result.replaceExceptionType(
+                    i, scopeType.useThisTypeParametersOnTheGivenType(exceptionTypes.get(i)));
         }
         return result.replaceReturnType(scopeType.useThisTypeParametersOnTheGivenType(result.returnType()));
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
@@ -85,8 +85,8 @@ public class Issue4989Test extends AbstractResolutionTest {
 
     @BeforeEach
     void setup() {
-        ParserConfiguration config = new ParserConfiguration()
-                .setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        ParserConfiguration config =
+                new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
         StaticJavaParser.setConfiguration(config);
     }
 
@@ -150,10 +150,8 @@ public class Issue4989Test extends AbstractResolutionTest {
         CompilationUnit cu = StaticJavaParser.parse(CODE);
 
         for (MethodCallExpr mce : cu.findAll(MethodCallExpr.class)) {
-            ResolvedMethodDeclaration resolved = assertDoesNotThrow(
-                    mce::resolve, () -> "Failed to resolve: " + mce);
-            assertDoesNotThrow(
-                    resolved::getQualifiedSignature, () -> "Failed getQualifiedSignature for: " + mce);
+            ResolvedMethodDeclaration resolved = assertDoesNotThrow(mce::resolve, () -> "Failed to resolve: " + mce);
+            assertDoesNotThrow(resolved::getQualifiedSignature, () -> "Failed getQualifiedSignature for: " + mce);
         }
     }
 
@@ -242,7 +240,8 @@ public class Issue4989Test extends AbstractResolutionTest {
                 .findFirst()
                 .orElseThrow(AssertionError::new);
 
-        String resolved = assertDoesNotThrow(() -> mapCall.calculateResolvedType().describe());
+        String resolved =
+                assertDoesNotThrow(() -> mapCall.calculateResolvedType().describe());
         org.junit.jupiter.api.Assertions.assertTrue(
                 resolved.contains("Base"), "Expected the mapped stream element type to mention Base, was: " + resolved);
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4989Test.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproducer for <a href="https://github.com/javaparser/javaparser/issues/4989">#4989</a>.
+ *
+ * <p>Resolving {@code methodCallExpr.resolve().getQualifiedSignature()} on a stream pipeline that
+ * uses {@code X.class::isInstance} / {@code X.class::cast} followed by an instance method reference
+ * ({@code this::convert}) fails, because {@code Class::cast} does not refine the stream element
+ * type from the source type to the cast target type.
+ *
+ * <pre>{@code
+ * contentBlocks.stream()
+ *     .filter(ToolUseBlock.class::isInstance)
+ *     .map(ToolUseBlock.class::cast)
+ *     .map(this::convertToolUseBlockToToolCall)
+ *     .collect(Collectors.toList());
+ * }</pre>
+ */
+public class Issue4989Test extends AbstractResolutionTest {
+
+    private static final String CODE = ""
+            + "import java.util.List;\n"
+            + "import java.util.stream.Collectors;\n"
+            + "\n"
+            + "public class ChatCompletionsResponseBuilder {\n"
+            + "\n"
+            + "    interface ContentBlock {}\n"
+            + "\n"
+            + "    static class ToolUseBlock implements ContentBlock {\n"
+            + "        String id;\n"
+            + "        String name;\n"
+            + "        String input;\n"
+            + "    }\n"
+            + "\n"
+            + "    static class ToolCall {\n"
+            + "        ToolCall(String id, String name, String input) {}\n"
+            + "    }\n"
+            + "\n"
+            + "    public List<ToolCall> extractToolCalls(List<ContentBlock> contentBlocks) {\n"
+            + "        return contentBlocks.stream()\n"
+            + "                .filter(ToolUseBlock.class::isInstance)\n"
+            + "                .map(ToolUseBlock.class::cast)\n"
+            + "                .map(this::convertToolUseBlockToToolCall)\n"
+            + "                .collect(Collectors.toList());\n"
+            + "    }\n"
+            + "\n"
+            + "    private ToolCall convertToolUseBlockToToolCall(ToolUseBlock toolUse) {\n"
+            + "        return new ToolCall(toolUse.id, toolUse.name, toolUse.input);\n"
+            + "    }\n"
+            + "}\n";
+
+    @BeforeEach
+    void setup() {
+        ParserConfiguration config = new ParserConfiguration()
+                .setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+    }
+
+    /**
+     * {@code X.class::cast} used as a stream mapper should yield {@code Stream<X>}, not the
+     * pre-cast element type.
+     */
+    @Test
+    void mapClassCastShouldRefineStreamElementType() {
+        String code = ""
+                + "import java.util.List;\n"
+                + "import java.util.stream.Stream;\n"
+                + "public class A {\n"
+                + "  interface Base {}\n"
+                + "  static class Sub implements Base {}\n"
+                + "  public Stream<Sub> f(List<Base> list) {\n"
+                + "    return list.stream().map(Sub.class::cast);\n"
+                + "  }\n"
+                + "}\n";
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        MethodCallExpr mapCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("map"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        assertEquals(
+                "java.util.stream.Stream<A.Sub>",
+                mapCall.calculateResolvedType().describe());
+    }
+
+    /**
+     * Direct resolution of the instance method reference after {@code class::cast}.
+     * This is the failure reported in the issue:
+     * {@code Unable to resolve method reference this::convertToolUseBlockToToolCall ...}
+     */
+    @Test
+    void resolveInstanceMethodReferenceAfterClassCast() {
+        CompilationUnit cu = StaticJavaParser.parse(CODE);
+
+        MethodReferenceExpr thisConvert = cu.findAll(MethodReferenceExpr.class).stream()
+                .filter(m -> m.toString().equals("this::convertToolUseBlockToToolCall"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        ResolvedMethodDeclaration resolved =
+                assertDoesNotThrow(thisConvert::resolve, "Failed to resolve this::convertToolUseBlockToToolCall");
+        assertEquals(
+                "ChatCompletionsResponseBuilder.convertToolUseBlockToToolCall("
+                        + "ChatCompletionsResponseBuilder.ToolUseBlock)",
+                resolved.getQualifiedSignature());
+    }
+
+    /**
+     * Exactly the API used by the reporter:
+     * {@code methodCallExpr.resolve().getQualifiedSignature()} on every call in the pipeline,
+     * including {@code collect(...)} whose scope contains the failing method reference.
+     */
+    @Test
+    void resolveAllMethodCallsInStreamPipeline() {
+        CompilationUnit cu = StaticJavaParser.parse(CODE);
+
+        for (MethodCallExpr mce : cu.findAll(MethodCallExpr.class)) {
+            ResolvedMethodDeclaration resolved = assertDoesNotThrow(
+                    mce::resolve, () -> "Failed to resolve: " + mce);
+            assertDoesNotThrow(
+                    resolved::getQualifiedSignature, () -> "Failed getQualifiedSignature for: " + mce);
+        }
+    }
+
+    /**
+     * Control case: the same instance method reference works when the stream element type is
+     * already the expected parameter type (no {@code class::cast} involved).
+     */
+    @Test
+    void baselineInstanceMethodReferenceWithoutCastWorks() {
+        String code = ""
+                + "import java.util.List;\n"
+                + "import java.util.stream.Collectors;\n"
+                + "public class A {\n"
+                + "  static class Sub { String v; }\n"
+                + "  static class Out { Out(String v) {} }\n"
+                + "  public List<Out> f(List<Sub> list) {\n"
+                + "    return list.stream().map(this::convert).collect(Collectors.toList());\n"
+                + "  }\n"
+                + "  private Out convert(Sub s) { return new Out(s.v); }\n"
+                + "}\n";
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodReferenceExpr mre = cu.findFirst(MethodReferenceExpr.class).orElseThrow(AssertionError::new);
+        assertEquals("A.convert(A.Sub)", mre.resolve().getQualifiedSignature());
+
+        MethodCallExpr collect = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("collect"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+        assertEquals(
+                "java.util.stream.Stream.collect(java.util.stream.Collector<? super T, A, R>)",
+                collect.resolve().getQualifiedSignature());
+        assertEquals("java.util.List<A.Out>", collect.calculateResolvedType().describe());
+    }
+
+    /**
+     * Edge case: the referenced method is inherited from a generic ancestor parameterized differently
+     * from the scope type. Substitution must resolve the type variable through the ancestor
+     * ({@code Box<String>} → {@code T = String}), which a direct-type-parameters-only approach cannot do.
+     */
+    @Test
+    void unboundInstanceMethodReferenceToInheritedGenericMethodIsRefined() {
+        String code = ""
+                + "import java.util.List;\n"
+                + "import java.util.stream.Stream;\n"
+                + "public class A {\n"
+                + "  static class Box<T> { T get() { return null; } }\n"
+                + "  static class StringBox extends Box<String> {}\n"
+                + "  public Stream<String> f(List<StringBox> list) {\n"
+                + "    return list.stream().map(StringBox::get);\n"
+                + "  }\n"
+                + "}\n";
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        MethodCallExpr mapCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("map"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        assertEquals(
+                "java.util.stream.Stream<java.lang.String>",
+                mapCall.calculateResolvedType().describe());
+    }
+
+    /**
+     * Edge case: a wildcard-typed scope ({@code Class<? extends Base>}) must not break substitution.
+     * The primitive used has a dedicated guard for bounded wildcards.
+     */
+    @Test
+    void classCastWithWildcardScopeResolves() {
+        String code = ""
+                + "import java.util.List;\n"
+                + "import java.util.stream.Stream;\n"
+                + "public class A {\n"
+                + "  interface Base {}\n"
+                + "  static class Sub implements Base {}\n"
+                + "  public Stream<? extends Base> f(List<Object> list, Class<? extends Base> c) {\n"
+                + "    return list.stream().map(c::cast);\n"
+                + "  }\n"
+                + "}\n";
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+        MethodCallExpr mapCall = cu.findAll(MethodCallExpr.class).stream()
+                .filter(m -> m.getNameAsString().equals("map"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        String resolved = assertDoesNotThrow(() -> mapCall.calculateResolvedType().describe());
+        org.junit.jupiter.api.Assertions.assertTrue(
+                resolved.contains("Base"), "Expected the mapped stream element type to mention Base, was: " + resolved);
+    }
+}


### PR DESCRIPTION
Fixes #4989 .

Methods obtained from a parameterized type via getAllMethods() are typed
against the raw declaration, so Class<Sub>::cast still returned the type
variable T. This left stream pipelines like list.stream().map(Sub.class::cast)
as Stream<Base>, breaking resolution of a following instance method reference
(this::convert).
toMethodUsage now substitutes the scope type's arguments into each candidate
via useThisTypeParametersOnTheGivenType — the same primitive already used by
LambdaExprContext — so return, parameter and exception types are refined
(T -> Sub) before overload resolution and poly inference.
Add Issue4989Test covering the reported pipeline plus edge cases: an inherited
generic method (ancestor-resolved substitution) and a bounded-wildcard scope.
