### PR TITLE
fix: substitute type arguments into declared method usages (#5080)

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/model/typesystem/ReferenceTypeImpl.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/model/typesystem/ReferenceTypeImpl.java
@@ -158,15 +158,33 @@ public class ReferenceTypeImpl extends ResolvedReferenceType {
 
     @Override
     public Set<MethodUsage> getDeclaredMethods() {
-        // TODO replace variables
         Set<MethodUsage> methods = new HashSet<>();
         getTypeDeclaration().ifPresent(referenceTypeDeclaration -> {
             for (ResolvedMethodDeclaration methodDeclaration : referenceTypeDeclaration.getDeclaredMethods()) {
-                MethodUsage methodUsage = new MethodUsage(methodDeclaration);
-                methods.add(methodUsage);
+                methods.add(substituteTypeParameters(new MethodUsage(methodDeclaration)));
             }
         });
         return methods;
+    }
+
+    /**
+     * Applies this type's type arguments to the given method usage's parameter, return and exception
+     * types, mirroring what {@link #getFieldType(String)} does for fields. For a parameterized type such
+     * as {@code List<String>}, the usage of {@code get(int)} thus reports {@code String} rather than the
+     * raw type variable {@code E}. Only type variables declared on the type are replaced (not those
+     * declared on the method), and they are resolved against ancestors (see issue #5080).
+     */
+    private MethodUsage substituteTypeParameters(MethodUsage methodUsage) {
+        MethodUsage result = methodUsage;
+        List<ResolvedType> paramTypes = result.getParamTypes();
+        for (int i = 0; i < paramTypes.size(); i++) {
+            result = result.replaceParamType(i, useThisTypeParametersOnTheGivenType(paramTypes.get(i)));
+        }
+        List<ResolvedType> exceptionTypes = result.exceptionTypes();
+        for (int i = 0; i < exceptionTypes.size(); i++) {
+            result = result.replaceExceptionType(i, useThisTypeParametersOnTheGivenType(exceptionTypes.get(i)));
+        }
+        return result.replaceReturnType(useThisTypeParametersOnTheGivenType(result.returnType()));
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5080Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5080Test.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Root-cause coverage for <a href="https://github.com/javaparser/javaparser/issues/5080">#5080</a>.
+ *
+ * <p>A parameterized {@link com.github.javaparser.resolution.types.ResolvedReferenceType} must substitute
+ * its type arguments into method usages, symmetrically with what it already does for fields via
+ * {@code getFieldType}. These tests exercise {@code getDeclaredMethods()} directly, independently of any
+ * consumer-side compensation.
+ */
+class Issue5080Test extends AbstractResolutionTest {
+
+    private final TypeSolver typeSolver = new ReflectionTypeSolver();
+
+    private ResolvedType type(String qualifiedName) {
+        return new ReferenceTypeImpl(typeSolver.solveType(qualifiedName));
+    }
+
+    private ReferenceTypeImpl genericType(String qualifiedName, ResolvedType... args) {
+        return new ReferenceTypeImpl(typeSolver.solveType(qualifiedName), Arrays.asList(args));
+    }
+
+    private MethodUsage method(ReferenceTypeImpl type, String name, int arity) {
+        return type.getDeclaredMethods().stream()
+                .filter(m -> m.getName().equals(name) && m.getNoParams() == arity)
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+    }
+
+    /**
+     * {@code List<String>.get(int)} must report {@code String} as its return type, not the raw type
+     * variable {@code E} — the method-level counterpart of the field substitution done by getFieldType.
+     */
+    @Test
+    void declaredMethodReturnTypeIsSubstituted() {
+        ReferenceTypeImpl listOfString = genericType("java.util.List", type("java.lang.String"));
+        assertEquals(
+                "java.lang.String", method(listOfString, "get", 1).returnType().describe());
+    }
+
+    /**
+     * {@code List<String>.add(E)} must report {@code String} as its parameter type.
+     */
+    @Test
+    void declaredMethodParameterTypeIsSubstituted() {
+        ReferenceTypeImpl listOfString = genericType("java.util.List", type("java.lang.String"));
+        assertEquals(
+                "java.lang.String",
+                method(listOfString, "add", 1).getParamType(0).describe());
+    }
+
+    /**
+     * {@code List<String>.<T>toArray(T[])} is generic on the method's own type variable {@code T};
+     * substituting the type's argument must NOT touch it.
+     */
+    @Test
+    void methodLevelTypeParameterIsNotSubstituted() {
+        ReferenceTypeImpl listOfString = genericType("java.util.List", type("java.lang.String"));
+        String returnType = method(listOfString, "toArray", 1).returnType().describe();
+        assertTrue(returnType.contains("T"), "method-level type parameter must not be substituted, was: " + returnType);
+    }
+}


### PR DESCRIPTION
Fixes: #5080 

A parameterized ResolvedReferenceType substitutes its type arguments into fields (getFieldType → useThisTypeParametersOnTheGivenType) but not into methods: ReferenceTypeImpl.getDeclaredMethods() returned usages typed against the raw declaration, with a standing // TODO replace variables. As a result, the usage of List<String>.get(int) reported the type variable E instead of String — the method-level counterpart of the field was missing.

This asymmetry is the root cause behind #4989 (fixed there with a consumer-side workaround) and forced other call sites (LambdaExprContext) to re-substitute by hand.

Fix

Fill the TODO: getDeclaredMethods() now applies the type's arguments to each method usage's parameter, return and exception types, using the same primitive already used for fields (useThisTypeParametersOnTheGivenType). Substitution only replaces type variables declared on the type (not on the method) and resolves them against ancestors.

As a side effect this also fixes a latent defect in AbstractTypeDeclaration.getAllMethods(): its ancestor loop computed the substituted usage but then stored the raw one (methods.add(mu)). Since getDeclaredMethods() now returns substituted usages, inherited generic methods come out correctly substituted with no change needed to that loop.

Tests

New Issue5080Test exercises getDeclaredMethods() directly (independently of any consumer):

List<String>.get(int) returns String (was E).
List<String>.add(E) accepts String (was E).
List<String>.<T>toArray(T[]) keeps its method-level T — guard against over-substitution.
Verified as a genuine reproducer: the two substitution tests fail on master (expected <java.lang.String> but was <E>) and pass with this change.

Validation

Full javaparser-symbol-solver-testing suite green: 2085 run, 0 failures, 0 errors — including functional-interface (SAM) detection in FunctionalInterfaceLogic, the main behavioral surface that consumes getAllMethods().

Scope

This PR restores the field/method symmetry at the type level only. Removing the now-redundant inline compensations in JavaParserFacade.toMethodUsage and LambdaExprContext requires a new type-level "all methods as substituted usages" accessor and a wider migration; it is tracked separately in [#5081](https://github.com/jlerbsc/javaparser/issues/5081).

Notes

ReferenceTypeImpl is the only subclass of ResolvedReferenceType, and the type-level getDeclaredMethods() has a single production caller (AbstractTypeDeclaration.getAllMethods()), so the blast radius is contained.
Behavioral note for downstream users: getDeclaredMethods() on a parameterized type now returns substituted usages (a bug fix aligned with the removed TODO).
