### PR TITLE
refactor: resolve method usages via type-level getAllMethodsAsUsages (#5081)

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedReferenceType.java
@@ -432,6 +432,41 @@ public abstract class ResolvedReferenceType
     }
 
     /**
+     * All methods available on this type — declared here and inherited — as {@link MethodUsage}s whose
+     * parameter, return and exception types carry this type's (and each ancestor's) type arguments. This is
+     * the {@link MethodUsage} counterpart of {@link #getAllMethods()} (which returns raw declarations) and
+     * the whole-hierarchy extension of {@link #getFieldType(String)}. Methods overridden further down the
+     * hierarchy shadow the inherited ones and are not duplicated.
+     */
+    public Set<MethodUsage> getAllMethodsAsUsages() {
+        Set<MethodUsage> methods = new HashSet<>();
+        Set<String> visitedSignatures = new HashSet<>();
+        // Methods declared on this type, already substituted with this type's own arguments.
+        for (MethodUsage methodUsage : getDeclaredMethods()) {
+            if (visitedSignatures.add(enhancedSignature(methodUsage))) {
+                methods.add(methodUsage);
+            }
+        }
+        // Inherited methods: getAllAncestors() expresses each ancestor's arguments in terms of this type,
+        // so ancestor.getDeclaredMethods() yields usages already substituted relative to this type.
+        for (ResolvedReferenceType ancestor : getAllAncestors()) {
+            for (MethodUsage methodUsage : ancestor.getDeclaredMethods()) {
+                if (visitedSignatures.add(enhancedSignature(methodUsage))) {
+                    methods.add(methodUsage);
+                }
+            }
+        }
+        return methods;
+    }
+
+    // Deduplication key used to drop overridden methods: the declared return type plus the (substituted)
+    // signature. Mirrors the key historically used by AbstractTypeDeclaration#getAllMethods.
+    private static String enhancedSignature(MethodUsage methodUsage) {
+        return String.format(
+                "%s %s", methodUsage.getDeclaration().getReturnType().describe(), methodUsage.getSignature());
+    }
+
+    /**
      * Fields which are visible to inheritors. They include all inherited fields which are visible to this
      * type plus all declared fields which are not private.
      */

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -460,31 +460,20 @@ public class JavaParserFacade {
                     + typeOfScope.getClass().getCanonicalName());
         }
 
-        // Extract the type declaration from the reference type
-        ResolvedReferenceTypeDeclaration resolvedTypeDecl = typeOfScope
-                .asReferenceType()
-                .getTypeDeclaration()
-                .orElseThrow(() ->
-                        new UnsolvedSymbolException("TypeDeclaration unexpectedly empty for type: " + typeOfScope));
-
-        Set<MethodUsage> allMethods = resolvedTypeDecl.getAllMethods();
-        String methodName = methodReferenceExpr.getIdentifier();
-
         // JLS §15.12.2.1: "Identify Potentially Applicable Methods"
         // "The class or interface determined by compile-time step 1 (§15.12.1) is searched
         // for all member methods that are potentially applicable to this method invocation."
-        // Filter methods by name first.
         //
-        // getAllMethods() returns usages typed against the raw type declaration, so a method such as
-        // Class<T>::cast still returns the type variable T. We substitute the scope type's arguments
-        // (e.g. T -> Sub for Class<Sub>) using the same primitive as LambdaExprContext, so that poly
-        // inference for pipelines like list.stream().map(Sub.class::cast) can refine Stream<Base> to
-        // Stream<Sub> and the following method reference resolves (see issue #4989).
-        ResolvedReferenceType scopeType = typeOfScope.asReferenceType();
-        List<MethodUsage> candidateMethods = allMethods.stream()
-                .filter(m -> m.getName().equals(methodName))
-                .map(m -> substituteScopeTypeParameters(m, scopeType))
-                .collect(Collectors.toList());
+        // getAllMethodsAsUsages() returns member methods (declared and inherited) with the scope type's
+        // arguments already substituted, so e.g. Class<Sub>::cast reports Sub rather than the type
+        // variable T. This lets poly inference for pipelines like list.stream().map(Sub.class::cast)
+        // refine Stream<Base> to Stream<Sub> without any consumer-side compensation (see #4989, #5080).
+        Set<MethodUsage> allMethods = typeOfScope.asReferenceType().getAllMethodsAsUsages();
+        String methodName = methodReferenceExpr.getIdentifier();
+
+        // Filter methods by name.
+        List<MethodUsage> candidateMethods =
+                allMethods.stream().filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
 
         if (candidateMethods.isEmpty()) {
             throw new UnsolvedSymbolException("Cannot find method '" + methodName + "' in type " + typeOfScope);
@@ -624,30 +613,6 @@ public class JavaParserFacade {
                         + paramTypes + ". Candidates found: "
                         + candidateMethods.size() + " method(s) named '"
                         + methodName + "' in type " + typeOfScope);
-    }
-
-    /**
-     * Applies {@code scopeType}'s type arguments to {@code methodUsage}'s parameter, return and exception
-     * types, mirroring what {@link ResolvedReferenceType#getFieldType(String)} does for fields.
-     *
-     * <p>Methods obtained via {@link ResolvedReferenceTypeDeclaration#getAllMethods()} are typed against the
-     * raw type declaration; for a parameterized scope such as {@code Class<Sub>} the return type of
-     * {@code cast} is still the type variable {@code T}. Substitution relies on
-     * {@link ResolvedReferenceType#useThisTypeParametersOnTheGivenType(ResolvedType)}, which only replaces
-     * type variables declared on the type (not on the method) and resolves them against ancestors.
-     */
-    private static MethodUsage substituteScopeTypeParameters(MethodUsage methodUsage, ResolvedReferenceType scopeType) {
-        MethodUsage result = methodUsage;
-        List<ResolvedType> paramTypes = result.getParamTypes();
-        for (int i = 0; i < paramTypes.size(); i++) {
-            result = result.replaceParamType(i, scopeType.useThisTypeParametersOnTheGivenType(paramTypes.get(i)));
-        }
-        List<ResolvedType> exceptionTypes = result.exceptionTypes();
-        for (int i = 0; i < exceptionTypes.size(); i++) {
-            result = result.replaceExceptionType(
-                    i, scopeType.useThisTypeParametersOnTheGivenType(exceptionTypes.get(i)));
-        }
-        return result.replaceReturnType(scopeType.useThisTypeParametersOnTheGivenType(result.returnType()));
     }
 
     protected ResolvedType getBinaryTypeConcrete(

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/LambdaExprContext.java
@@ -156,44 +156,28 @@ public class LambdaExprContext extends ExpressionContext<LambdaExpr> {
                                             String outerMethodName = outerCall.getNameAsString();
                                             int outerArgCount =
                                                     outerCall.getArguments().size();
-                                            final int fOuterArgPos = outerArgPos;
-                                            final ResolvedType fOuterScopeType = outerScopeType;
-                                            // getTypeDeclaration().getAllMethods() returns MethodUsage objects
-                                            // whose parameter types still carry the type declaration's own
-                                            // type parameters (e.g. Stream<T_stream>), not yet substituted
-                                            // with the concrete arguments (e.g. Stream<A>). We apply
-                                            // useThisTypeParametersOnTheGivenType() below to perform that
-                                            // substitution using the outer scope's concrete type arguments.
-                                            outerScopeType
+                                            // getAllMethodsAsUsages() already substitutes the outer scope's type
+                                            // arguments into each usage (e.g. Stream<A>.sorted expects
+                                            // Comparator<? super A>, not Comparator<? super T_stream>), so no
+                                            // consumer-side substitution is needed here (see #5081).
+                                            for (MethodUsage mu : outerScopeType
                                                     .asReferenceType()
-                                                    .getTypeDeclaration()
-                                                    .ifPresent(outerDecl -> {
-                                                        for (MethodUsage mu : outerDecl.getAllMethods()) {
-                                                            if (mu.getName().equals(outerMethodName)
-                                                                    && mu.getNoParams() == outerArgCount) {
-                                                                // Raw parameter type from the type declaration,
-                                                                // e.g. `Comparator<? super T_stream>` for sorted.
-                                                                ResolvedType rawType =
-                                                                        MethodResolutionLogic
-                                                                                .getMethodUsageExplicitAndVariadicParameterType(
-                                                                                        mu, fOuterArgPos);
-                                                                // Substitute the outer scope's concrete type
-                                                                // arguments (e.g. T_stream → A for Stream<A>),
-                                                                // yielding the expected type `Comparator<? super A>`.
-                                                                ResolvedType expectedType = fOuterScopeType
-                                                                        .asReferenceType()
-                                                                        .useThisTypeParametersOnTheGivenType(rawType);
-                                                                // Register the pair in the inference context:
-                                                                //   comparing's return type `Comparator<T>`
-                                                                //   ↔ expected type `Comparator<? super A>`
-                                                                // This lets the engine resolve T → `? super A`,
-                                                                // whose bound (A) is the concrete element type.
-                                                                inferenceContext.addPair(
-                                                                        methodUsage.returnType(), expectedType);
-                                                                break;
-                                                            }
-                                                        }
-                                                    });
+                                                    .getAllMethodsAsUsages()) {
+                                                if (mu.getName().equals(outerMethodName)
+                                                        && mu.getNoParams() == outerArgCount) {
+                                                    ResolvedType expectedType =
+                                                            MethodResolutionLogic
+                                                                    .getMethodUsageExplicitAndVariadicParameterType(
+                                                                            mu, outerArgPos);
+                                                    // Register the pair in the inference context:
+                                                    //   comparing's return type `Comparator<T>`
+                                                    //   ↔ expected type `Comparator<? super A>`
+                                                    // This lets the engine resolve T → `? super A`,
+                                                    // whose bound (A) is the concrete element type.
+                                                    inferenceContext.addPair(methodUsage.returnType(), expectedType);
+                                                    break;
+                                                }
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION

Fixes #5082   .

Both JavaParserFacade.toMethodUsage and LambdaExprContext compensated by hand
for the fact that methods enumerated from a parameterized type were not
substituted: they dropped to the raw type declaration and re-applied the scope's
type arguments through useThisTypeParametersOnTheGivenType. Now that #5080 makes
ReferenceTypeImpl.getDeclaredMethods() substitute, this duplication can be
retired.
Add ResolvedReferenceType.getAllMethodsAsUsages(): all member methods (declared
and inherited) as MethodUsages with the type's (and each ancestor's) arguments
already applied, overridden methods de-duplicated. It is the MethodUsage
counterpart of getAllMethods() (which returns raw declarations) and the
whole-hierarchy extension of getFieldType.
- toMethodUsage now sources candidates from getAllMethodsAsUsages() and drops the
  private substituteScopeTypeParameters helper. This also covers methods declared
  directly on a parameterized scope (e.g. Class<Sub>::cast), which the previous
  declaration-level getAllMethods() left raw.
- LambdaExprContext iterates the same accessor and drops its inline
  re-substitution.
