### PR TITLE
Respect ArrayType.Origin when pretty-printing array declarations

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/DefaultPrettyPrinterTest.java
@@ -30,11 +30,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.*;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.printer.configuration.DefaultConfigurationOption;
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration;
@@ -81,8 +84,9 @@ class DefaultPrettyPrinterTest {
         code = "class A { int a, b[]; }";
         assertEquals("int a, b[];", prettyPrintField(code));
 
+        // C-style array brackets (ArrayType.Origin.NAME) are kept after the variable name (issue #3444)
         code = "class A { int[] a[], b[]; }";
-        assertEquals("int[][] a, b;", prettyPrintField(code));
+        assertEquals("int[] a[], b[];", prettyPrintField(code));
 
         code = "class A { int[] a[][], b; }";
         assertEquals("int[] a[][], b;", prettyPrintField(code));
@@ -91,7 +95,7 @@ class DefaultPrettyPrinterTest {
         assertEquals("int[] a, b;", prettyPrintField(code));
 
         code = "class A { int a[], b[]; }";
-        assertEquals("int[] a, b;", prettyPrintField(code));
+        assertEquals("int a[], b[];", prettyPrintField(code));
     }
 
     @Test
@@ -100,8 +104,9 @@ class DefaultPrettyPrinterTest {
         code = "class A { void foo(){ int a, b[]; }}";
         assertEquals("int a, b[]", prettyPrintVar(code));
 
+        // C-style array brackets (ArrayType.Origin.NAME) are kept after the variable name (issue #3444)
         code = "class A { void foo(){ int[] a[], b[]; }}";
-        assertEquals("int[][] a, b", prettyPrintVar(code));
+        assertEquals("int[] a[], b[]", prettyPrintVar(code));
 
         code = "class A { void foo(){ int[] a[][], b; }}";
         assertEquals("int[] a[][], b", prettyPrintVar(code));
@@ -110,7 +115,57 @@ class DefaultPrettyPrinterTest {
         assertEquals("int[] a, b", prettyPrintVar(code));
 
         code = "class A { void foo(){ int a[], b[]; }}";
-        assertEquals("int[] a, b", prettyPrintVar(code));
+        assertEquals("int a[], b[]", prettyPrintVar(code));
+    }
+
+    @Test
+    void printingArrayFieldsPreservesOrigin_issue3444() {
+        // The pretty printer must respect ArrayType.Origin: brackets found on the name (C-style,
+        // Origin.NAME) stay after the variable name, brackets found on the type (Origin.TYPE) stay
+        // before it. See https://github.com/javaparser/javaparser/issues/3444
+
+        // Exact reproduction from the issue: the two origins must print differently.
+        assertEquals("int name[];", prettyPrintField("class A { int name[]; }"));
+        assertEquals("int[] name;", prettyPrintField("class A { int[] name; }"));
+
+        // Multi-variable declarations keep each variable's own brackets.
+        assertEquals("int a, b[];", prettyPrintField("class A { int a, b[]; }"));
+        assertEquals("int a[], b;", prettyPrintField("class A { int a[], b; }"));
+
+        // Nested arrays.
+        assertEquals("int a[][];", prettyPrintField("class A { int a[][]; }"));
+        assertEquals("int[][] a;", prettyPrintField("class A { int[][] a; }"));
+
+        // Mixed type-side and name-side brackets in a single declaration.
+        assertEquals("int[] a, b[];", prettyPrintField("class A { int[] a, b[]; }"));
+
+        // Plain declarations are unaffected.
+        assertEquals("int a;", prettyPrintField("class A { int a; }"));
+        assertEquals("int[] a;", prettyPrintField("class A { int[] a; }"));
+        assertEquals("int a, b, c;", prettyPrintField("class A { int a, b, c; }"));
+    }
+
+    @Test
+    void printingProgrammaticallyBuiltArrayTypeRespectsOrigin_issue3444() {
+        // The exact reproduction from issue #3444: an AST built from scratch (not parsed) must still
+        // honour ArrayType.Origin when pretty-printed.
+        ClassOrInterfaceDeclaration testClass = new ClassOrInterfaceDeclaration();
+        testClass.setName("TestArrayTypeOrigin");
+        testClass.addField(
+                new ArrayType(PrimitiveType.intType(), ArrayType.Origin.NAME, new NodeList<>()),
+                "originName",
+                Modifier.Keyword.PUBLIC);
+        testClass.addField(
+                new ArrayType(PrimitiveType.intType(), ArrayType.Origin.TYPE, new NodeList<>()),
+                "originType",
+                Modifier.Keyword.PUBLIC);
+
+        assertEquals(
+                "public int originName[];",
+                getDefaultPrinter().print(testClass.getFields().get(0)));
+        assertEquals(
+                "public int[] originType;",
+                getDefaultPrinter().print(testClass.getFields().get(1)));
     }
 
     @Disabled

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrintVisitorTest.java
@@ -61,11 +61,13 @@ class PrettyPrintVisitorTest extends TestParser {
 
     @Test
     void getMaximumCommonTypeWithoutAnnotations() {
+        // C-style array brackets (ArrayType.Origin.NAME) belong after the variable name and are not
+        // part of the maximum common type, so only the type-side [] levels are kept here (issue #3444).
         VariableDeclarationExpr vde1 = parseVariableDeclarationExpr("int a[], b[]");
-        assertEquals("int[]", vde1.getMaximumCommonType().get().toString());
+        assertEquals("int", vde1.getMaximumCommonType().get().toString());
 
         VariableDeclarationExpr vde2 = parseVariableDeclarationExpr("int[][] a[], b[]");
-        assertEquals("int[][][]", vde2.getMaximumCommonType().get().toString());
+        assertEquals("int[][]", vde2.getMaximumCommonType().get().toString());
 
         VariableDeclarationExpr vde3 = parseVariableDeclarationExpr("int[][] a, b[]");
         assertEquals("int[][]", vde3.getMaximumCommonType().get().toString());
@@ -76,8 +78,9 @@ class PrettyPrintVisitorTest extends TestParser {
         VariableDeclarationExpr vde1 = parseVariableDeclarationExpr("int a @Foo [], b[]");
         assertEquals("int", vde1.getMaximumCommonType().get().toString());
 
+        // The trailing name-side [] level is excluded from the maximum common type (issue #3444).
         VariableDeclarationExpr vde2 = parseVariableDeclarationExpr("int[]@Foo [] a[], b[]");
-        assertEquals("int[][] @Foo []", vde2.getMaximumCommonType().get().toString());
+        assertEquals("int[] @Foo []", vde2.getMaximumCommonType().get().toString());
     }
 
     private String print(Node node) {

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/PrettyPrinterTest.java
@@ -75,8 +75,9 @@ class PrettyPrinterTest {
         code = "class A { int a, b[]; }";
         assertEquals("int a, b[];", prettyPrintField(code));
 
+        // C-style array brackets (ArrayType.Origin.NAME) are kept after the variable name (issue #3444)
         code = "class A { int[] a[], b[]; }";
-        assertEquals("int[][] a, b;", prettyPrintField(code));
+        assertEquals("int[] a[], b[];", prettyPrintField(code));
 
         code = "class A { int[] a[][], b; }";
         assertEquals("int[] a[][], b;", prettyPrintField(code));
@@ -85,7 +86,7 @@ class PrettyPrinterTest {
         assertEquals("int[] a, b;", prettyPrintField(code));
 
         code = "class A { int a[], b[]; }";
-        assertEquals("int[] a, b;", prettyPrintField(code));
+        assertEquals("int a[], b[];", prettyPrintField(code));
     }
 
     @Test
@@ -94,8 +95,9 @@ class PrettyPrinterTest {
         code = "class A { void foo(){ int a, b[]; }}";
         assertEquals("int a, b[]", prettyPrintVar(code));
 
+        // C-style array brackets (ArrayType.Origin.NAME) are kept after the variable name (issue #3444)
         code = "class A { void foo(){ int[] a[], b[]; }}";
-        assertEquals("int[][] a, b", prettyPrintVar(code));
+        assertEquals("int[] a[], b[]", prettyPrintVar(code));
 
         code = "class A { void foo(){ int[] a[][], b; }}";
         assertEquals("int[] a[][], b", prettyPrintVar(code));
@@ -104,7 +106,7 @@ class PrettyPrinterTest {
         assertEquals("int[] a, b", prettyPrintVar(code));
 
         code = "class A { void foo(){ int a[], b[]; }}";
-        assertEquals("int[] a, b", prettyPrintVar(code));
+        assertEquals("int a[], b[]", prettyPrintVar(code));
     }
 
     private String prettyPrintConfigurable(String code) {

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/nodeTypes/NodeWithVariables.java
@@ -119,7 +119,7 @@ public interface NodeWithVariables<N extends Node> {
      * <br>For {@code int a;} this is int.
      * <br>For {@code int a,b,c,d;} this is also int.
      * <br>For {@code int a,b[],c;} this is also int.
-     * <br>For {@code int[] a[][],b[],c[][];} this is int[][].
+     * <br>For {@code int[] a[][],b[],c[][];} this is int[].
      */
     @DerivedProperty
     default Optional<Type> getMaximumCommonType() {
@@ -147,6 +147,19 @@ public interface NodeWithVariables<N extends Node> {
                 }
                 return Optional.of(type);
             }
+
+            // A pair of array brackets whose origin is on the name (like the [] in {@code int a[]})
+            // must be printed after the variable name, so it cannot be merged into the maximum common
+            // type even when every variable shares that array level. Only brackets originating on the
+            // type (like the [] in {@code int[] a}) may become part of the common type. Level 0 is the
+            // element type and carries no brackets, so it is always mergeable.
+            private boolean canMergeArrayLevel(int level) {
+                return level == 0
+                        || types.stream().allMatch(v -> toArrayLevel(v, level)
+                                .filter(ArrayType.class::isInstance)
+                                .map(t -> ((ArrayType) t).getOrigin() == ArrayType.Origin.TYPE)
+                                .orElse(false));
+            }
         }
         Helper helper = new Helper();
         int level = 0;
@@ -165,7 +178,7 @@ public interface NodeWithVariables<N extends Node> {
                     })
                     .distinct()
                     .toArray();
-            if (values.length == 1 && values[0] != null) {
+            if (values.length == 1 && values[0] != null && helper.canMergeArrayLevel(currentLevel)) {
                 level++;
             } else {
                 keepGoing = false;


### PR DESCRIPTION
## Problem

The pretty-printer ignores `ArrayType.Origin`, so a C-style array declaration `int name[]` (`Origin.NAME`) is reprinted as `int[] name` (`Origin.TYPE`), losing a distinction the AST records and breaking source round-tripping:

```java
StaticJavaParser.parse("class X { int name[]; }").toString();
// prints "int[] name;"  — should keep "int name[];"
```

## Cause

`DefaultPrettyPrinter` decides the type-side vs name-side bracket split purely from `getMaximumCommonType().getArrayLevel()`: the common type is printed before the name, and the remaining array levels are printed as trailing `[]` after the name. But `NodeWithVariables.calculateMaximumCommonType` merged every array level the variables share, comparing by string and ignoring `Origin`. Because name-side brackets are the *outer* array levels of a declarator (`int[] a[]` is `ArrayType(NAME, ArrayType(TYPE, int))`), merging a NAME level pulled it into the type prefix, so it printed before the name.

## Fix

Stop the merge climb at the first level whose brackets are `Origin.NAME`. The common type then absorbs exactly the shared *type-side* prefix, and the outer NAME levels fall through to the existing trailing-bracket printer — so the visitor needs no change:

```java
private boolean canMergeArrayLevel(int level) {
    return level == 0
            || types.stream().allMatch(v -> toArrayLevel(v, level)
                    .filter(ArrayType.class::isInstance)
                    .map(t -> ((ArrayType) t).getOrigin() == ArrayType.Origin.TYPE)
                    .orElse(false));
}
```

`Origin.TYPE` declarations and plain scalars merge exactly as before, so their output is unchanged. This also updates the `getMaximumCommonType` Javadoc example and the few existing assertions that had pinned the old origin-losing output — they now round-trip the source faithfully (e.g. `int a[], b[]` stays `int a[], b[]` instead of becoming `int[] a, b`).

## Tests

Adds round-trip tests for `Origin.NAME` / `Origin.TYPE` array declarations (both parsed and programmatically built). The full `lexicalpreservation` and printer suites pass unchanged.

Fixes #3444.
