### PR TITLE
perf: Optimize ancestor deduplication in ResolvedReferenceTypeDeclaration (O(N^2) to O(N))

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
@@ -154,9 +154,9 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
             seen.addAll(queuedAncestors);
             while (!queuedAncestors.isEmpty()) {
                 ResolvedReferenceType queuedAncestor = queuedAncestors.removeFirst();
-                queuedAncestor.getTypeDeclaration().ifPresent(rtd -> new LinkedHashSet<>(
-                        queuedAncestor.getDirectAncestors())
-                        .forEach(ancestor -> {
+                queuedAncestor
+                        .getTypeDeclaration()
+                        .ifPresent(rtd -> new LinkedHashSet<>(queuedAncestor.getDirectAncestors()).forEach(ancestor -> {
                             queuedAncestors.add(ancestor);
                             if (seen.add(ancestor)) {
                                 ancestors.add(ancestor);

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
@@ -124,17 +124,21 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      * In the example above, this method returns B,C,E,D
      */
     Function<ResolvedReferenceTypeDeclaration, List<ResolvedReferenceType>> depthFirstFunc = (rrtd) -> {
-        Set<ResolvedReferenceType> ancestors = new LinkedHashSet<>();
+        List<ResolvedReferenceType> ancestors = new ArrayList<>();
         // We want to avoid infinite recursion in case of Object having Object as ancestor
         if (!rrtd.isJavaLangObject()) {
+            Set<ResolvedReferenceType> seen = new HashSet<>();
             for (ResolvedReferenceType ancestor : rrtd.getAncestors()) {
                 ancestors.add(ancestor);
+                seen.add(ancestor);
                 for (ResolvedReferenceType inheritedAncestor : ancestor.getAllAncestors()) {
-                    ancestors.add(inheritedAncestor);
+                    if (seen.add(inheritedAncestor)) {
+                        ancestors.add(inheritedAncestor);
+                    }
                 }
             }
         }
-        return new ArrayList<>(ancestors);
+        return ancestors;
     };
 
     /*
@@ -142,25 +146,25 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      * In the example above, this method returns B,C,D,E
      */
     Function<ResolvedReferenceTypeDeclaration, List<ResolvedReferenceType>> breadthFirstFunc = (rrtd) -> {
-        Set<ResolvedReferenceType> ancestors = new LinkedHashSet<>();
-        // We want to avoid infinite recursion in case of Object having Object as ancestor
+        List<ResolvedReferenceType> ancestors = new ArrayList<>();
         if (!rrtd.isJavaLangObject()) {
-            // init direct ancestors
+            Set<ResolvedReferenceType> seen = new HashSet<>();
             Deque<ResolvedReferenceType> queuedAncestors = new LinkedList<>(rrtd.getAncestors());
             ancestors.addAll(queuedAncestors);
+            seen.addAll(queuedAncestors);
             while (!queuedAncestors.isEmpty()) {
                 ResolvedReferenceType queuedAncestor = queuedAncestors.removeFirst();
                 queuedAncestor.getTypeDeclaration().ifPresent(rtd -> new LinkedHashSet<>(
-                                queuedAncestor.getDirectAncestors())
+                        queuedAncestor.getDirectAncestors())
                         .forEach(ancestor -> {
-                            // add this ancestor to the queue (for a deferred search)
                             queuedAncestors.add(ancestor);
-                            // add this ancestor to the list of ancestors
-                            ancestors.add(ancestor);
+                            if (seen.add(ancestor)) {
+                                ancestors.add(ancestor);
+                            }
                         }));
             }
         }
-        return new ArrayList<>(ancestors);
+        return ancestors;
     };
 
     // /

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/declarations/ResolvedReferenceTypeDeclaration.java
@@ -124,19 +124,17 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      * In the example above, this method returns B,C,E,D
      */
     Function<ResolvedReferenceTypeDeclaration, List<ResolvedReferenceType>> depthFirstFunc = (rrtd) -> {
-        List<ResolvedReferenceType> ancestors = new ArrayList<>();
+        Set<ResolvedReferenceType> ancestors = new LinkedHashSet<>();
         // We want to avoid infinite recursion in case of Object having Object as ancestor
         if (!rrtd.isJavaLangObject()) {
             for (ResolvedReferenceType ancestor : rrtd.getAncestors()) {
                 ancestors.add(ancestor);
                 for (ResolvedReferenceType inheritedAncestor : ancestor.getAllAncestors()) {
-                    if (!ancestors.contains(inheritedAncestor)) {
-                        ancestors.add(inheritedAncestor);
-                    }
+                    ancestors.add(inheritedAncestor);
                 }
             }
         }
-        return ancestors;
+        return new ArrayList<>(ancestors);
     };
 
     /*
@@ -144,7 +142,7 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
      * In the example above, this method returns B,C,D,E
      */
     Function<ResolvedReferenceTypeDeclaration, List<ResolvedReferenceType>> breadthFirstFunc = (rrtd) -> {
-        List<ResolvedReferenceType> ancestors = new ArrayList<>();
+        Set<ResolvedReferenceType> ancestors = new LinkedHashSet<>();
         // We want to avoid infinite recursion in case of Object having Object as ancestor
         if (!rrtd.isJavaLangObject()) {
             // init direct ancestors
@@ -154,17 +152,15 @@ public interface ResolvedReferenceTypeDeclaration extends ResolvedTypeDeclaratio
                 ResolvedReferenceType queuedAncestor = queuedAncestors.removeFirst();
                 queuedAncestor.getTypeDeclaration().ifPresent(rtd -> new LinkedHashSet<>(
                                 queuedAncestor.getDirectAncestors())
-                        .stream().forEach(ancestor -> {
+                        .forEach(ancestor -> {
                             // add this ancestor to the queue (for a deferred search)
                             queuedAncestors.add(ancestor);
                             // add this ancestor to the list of ancestors
-                            if (!ancestors.contains(ancestor)) {
-                                ancestors.add(ancestor);
-                            }
+                            ancestors.add(ancestor);
                         }));
             }
         }
-        return ancestors;
+        return new ArrayList<>(ancestors);
     };
 
     // /


### PR DESCRIPTION
I did some profiling and noticed that `depthFirstFunc` and `breadthFirstFunc` in `ResolvedReferenceTypeDeclaration` can get quite slow on large inheritance graphs.

Currently, the code uses `ancestors.contains(...)` inside the traversal loop to prevent duplicates. Since `ancestors` is an `ArrayList`, this results in an $O(N^2)$ time complexity.

To fix this, I added a local `HashSet` (`seen`) to handle the deduplication in $O(1)$ average time. We still use the `ArrayList` to collect the results, ensuring that the insertion order and the original return contracts are fully preserved.

I ran JMH benchmarks (5 warm-up iterations, 30 measurement iterations) on a graph with N = 10,000 elements, to evaluate the impact. Here are the results:

**Execution Time**

| Graph Density | Original (`ArrayList`) | Proposed (`List` + `Set`) | Speedup |
| :--- | :--- | :--- | :--- |
| **Low Duplication** | ~ 86.8 ms/op | ~ 0.42 ms/op | 204x |
| **Medium Duplication** | ~ 22.0 ms/op | ~ 0.24 ms/op | 91x |
| **High Duplication** | ~ 4.9 ms/op | ~ 0.22 ms/op | 21x |

**Memory Allocation (`gc.alloc.rate.norm`)**

| Graph Density | Original (`ArrayList`) | Proposed (`List` + `Set`) | Difference |
| :--- | :--- | :--- | :--- |
| **Low Duplication** | ~ 110.5 KB/op | ~ 436.7 KB/op | + 326.2 KB |
| **Medium Duplication** | ~ 32.9 KB/op | ~ 126.9 KB/op | + 94.0 KB |
| **High Duplication** | ~ 6.6 KB/op | ~ 30.3 KB/op | + 23.7 KB |

Full benchmark output (all densities × input sizes, both time and memory) is available here: https://gist.github.com/lucasrmendonca7/b460378dda3b0ef19ca62ae278229336

Trading ~326 KB of short-lived local memory for a 200x CPU speedup seems like a very reasonable trade-off here. The local `HashSet` is garbage collected right after the method returns.

All tests passed.

<img width="2700" height="750" alt="grafico_comparativo" src="https://github.com/user-attachments/assets/ba9270bf-abc1-496c-a592-406dd6c41891" />
