### PR TITLE
fix: prevent trailing line comment from being duplicated across sibling nodes

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/CommentsInserterTest.java
@@ -24,12 +24,22 @@ package com.github.javaparser;
 import static com.github.javaparser.utils.TestUtils.assertEqualToTextResourceNoEol;
 import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.CommentsCollection;
 import com.github.javaparser.utils.LineSeparator;
 import com.github.javaparser.utils.TestParser;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class CommentsInserterTest {
@@ -104,5 +114,112 @@ class CommentsInserterTest {
     void issue412() throws IOException {
         CompilationUnit cu = parseSample("Issue412").getResult().get();
         assertEqualToTextResourceNoEol(makeExpectedFilename("Issue412"), cu.toString());
+    }
+
+    @Test
+    void issue4960CommentAfterParameterIsAttributedOnceToThatParameter() {
+        CompilationUnit cu = TestParser.parseCompilationUnit(
+                "class TestClass {\n" + "    public void a(int a //something\n" + "        ) { }\n" + "}");
+        MethodDeclaration method =
+                cu.getType(0).asClassOrInterfaceDeclaration().getMethods().get(0);
+
+        // Uniqueness, globally: across the whole CU the comment must be attached
+        // exactly once. The original bug duplicated it across every sibling that
+        // merely shared the line, so this is the assertion that actually encodes
+        // the fix rather than only that some node lost it. The sites are counted
+        // without deduplicating by Comment identity, since the bug is one Comment
+        // instance attached to several nodes.
+        List<Node> attachmentSites = commentAttachmentSites(cu);
+        assertEquals(1, attachmentSites.size(), "the trailing comment must be attached exactly once");
+
+        // Positive attribution: the comment belongs to the parameter it trails,
+        // not merely to "something other than the return type / name".
+        Parameter parameter = method.getParameter(0);
+        assertSame(parameter, attachmentSites.get(0), "the sole attachment site must be the parameter it trails");
+        Optional<Comment> parameterComment = parameter.getComment();
+        assertTrue(parameterComment.isPresent(), "the comment must be attributed to the parameter it trails");
+
+        // Back-pointer consistency: comment.getCommentedNode() must point back at
+        // the same node, locking the invariant the old code broke (three nodes held
+        // the comment while getCommentedNode() returned only one of them).
+        assertSame(parameter, parameterComment.get().getCommentedNode().get());
+
+        // Full rendering, per the file's own convention: it shows both where the
+        // comment landed and that it no longer leaks onto the return type / name.
+        assertEqualsStringIgnoringEol(
+                "class TestClass {\n" + "\n" + "    public void a(//something\n" + "    int a) {\n" + "    }\n" + "}\n",
+                cu.toString());
+    }
+
+    @Test
+    void issue4960CommentAfterClosingParenIsNotDuplicated() {
+        // The second reproducer from the issue: the comment sits after ')'.
+        CompilationUnit cu = TestParser.parseCompilationUnit(
+                "class TestClass {\n" + "    public void a(int a) //something\n" + "    { }\n" + "}");
+        MethodDeclaration method =
+                cu.getType(0).asClassOrInterfaceDeclaration().getMethods().get(0);
+
+        // Uniqueness, globally: the comment is attached exactly once across the
+        // whole CU. The original bug duplicated it onto the return type and the
+        // method name as well. Sites are counted without deduplicating by Comment
+        // identity, since the bug is one Comment instance attached to several nodes.
+        List<Node> attachmentSites = commentAttachmentSites(cu);
+        assertEquals(1, attachmentSites.size(), "the trailing comment must be attached exactly once");
+
+        // It must not leak onto the return type or the method name — that leak was
+        // the symptom reported in the issue.
+        assertFalse(method.getType().getComment().isPresent(), "the comment must not leak onto the return type");
+        assertFalse(method.getName().getComment().isPresent(), "the comment must not leak onto the method name");
+
+        // Back-pointer consistency: whatever node received it, getCommentedNode()
+        // must be non-null and actually carry that comment. On master this
+        // invariant was broken (several nodes held the comment).
+        Node holder = attachmentSites.get(0);
+        assertSame(
+                holder,
+                holder.getComment().get().getCommentedNode().get(),
+                "getCommentedNode() must point at the node holding the comment");
+
+        // Full rendering, per the file's own convention: locks the output so a
+        // future change in attribution is surfaced explicitly.
+        assertEqualsStringIgnoringEol(
+                "class TestClass {\n" + "\n" + "    public void a(//something\n" + "    int a) {\n" + "    }\n" + "}\n",
+                cu.toString());
+    }
+
+    @Test
+    void issue4960EachTrailingCommentIsAttributedOnceToItsOwnParameter() {
+        // Two parameters, each with its own trailing line comment on its line.
+        // Each comment must be attached exactly once to the parameter it trails.
+        // This guards both the uniqueness fix (no duplication across siblings) and
+        // the retained fallback: the second comment's nearest node is its own
+        // parameter, so neither comment is lost and neither is duplicated onto the
+        // other. Sites are counted without deduplicating by Comment identity, so
+        // this distinguishes the fix (2 sites) from the old bug (4 sites).
+        CompilationUnit cu = TestParser.parseCompilationUnit("class TestClass {\n"
+                + "    public void a(int a //existing\n"
+                + "        , int b //trailing\n"
+                + "        ) { }\n"
+                + "}");
+        List<Node> attachmentSites = commentAttachmentSites(cu);
+        assertEquals(2, attachmentSites.size(), "both trailing comments must survive and be attached once each");
+    }
+
+    /**
+     * Every node that currently holds an attached comment (via {@link Node#getComment()}),
+     * excluding orphan comments. Each node holding a comment contributes one entry, so the
+     * same {@link Comment} instance attached to several nodes produces several entries. This
+     * is deliberate: the bug under test is one comment attached to multiple sites, and
+     * deduplicating by comment identity would hide exactly that. Orphan comments are
+     * excluded because they belong to no attachment site.
+     */
+    private static List<Node> commentAttachmentSites(Node root) {
+        List<Node> attachmentSites = new ArrayList<>();
+        for (Node node : root.findAll(Node.class)) {
+            if (node.getComment().isPresent()) {
+                attachmentSites.add(node);
+            }
+        }
+        return attachmentSites;
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4960Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue4960Test.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a trailing line comment (the one whose attribution is fixed for
+ * issue #4960) survives a {@link LexicalPreservingPrinter} round-trip unchanged
+ * in the positions the issue cares about: after the last parameter, after the
+ * closing parenthesis, after a statement and after an enum constant. These are
+ * explicit assertions rather than coverage left to chance.
+ */
+public class Issue4960Test extends AbstractLexicalPreservingTest {
+
+    private String roundTrip(String code) {
+        considerCode(code);
+        return LexicalPreservingPrinter.print(cu);
+    }
+
+    @Test
+    void lppPreservesTrailingCommentAfterLastParameter() {
+        String code = "class C {\n" + "    void a(int a //something\n" + "        ) {}\n" + "}\n";
+        assertEquals(code, roundTrip(code));
+    }
+
+    @Test
+    void lppPreservesTrailingCommentAfterClosingParen() {
+        String code = "class C {\n" + "    void a(int a) //something\n" + "    {}\n" + "}\n";
+        assertEquals(code, roundTrip(code));
+    }
+
+    @Test
+    void lppPreservesTrailingCommentAfterStatement() {
+        String code = "class C {\n" + "    void a() {\n" + "        int x = 1; //something\n" + "    }\n" + "}\n";
+        assertEquals(code, roundTrip(code));
+    }
+
+    @Test
+    void lppPreservesTrailingCommentAfterEnumConstant() {
+        String code = "enum E {\n" + "    A, //something\n" + "    B;\n" + "}\n";
+        assertEquals(code, roundTrip(code));
+    }
+
+    @Test
+    void lppPreservesCommentAfterLastParameterWithTwoParameters() {
+        // A line comment after the last of several parameters: it must not be
+        // duplicated onto the earlier parameter during the round-trip.
+        String code = "class C {\n" + "    void a(int a, int b //something\n" + "        ) {}\n" + "}\n";
+        String printed = roundTrip(code);
+        assertEqualsStringIgnoringEol(code, printed);
+        assertEquals(1, countOccurrences(printed, "//something"));
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int from = 0;
+        while (true) {
+            int idx = haystack.indexOf(needle, from);
+            if (idx < 0) {
+                break;
+            }
+            count++;
+            from = idx + needle.length();
+        }
+        return count;
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/CommentsInserter.java
@@ -157,16 +157,39 @@ class CommentsInserter {
         commentsToAttribute.stream()
                 .filter(comment -> comment.hasRange())
                 .filter(Comment::isLineComment)
-                .forEach(comment -> children.stream()
-                        .filter(child -> child.hasRange())
-                        .forEach(child -> {
-                            Range commentRange = comment.getRange().get();
-                            Range childRange = child.getRange().get();
-                            if (childRange.end.line == commentRange.begin.line
-                                    && attributeLineCommentToNodeOrChild(child, comment.asLineComment())) {
-                                attributedComments.add(comment);
-                            }
-                        }));
+                .forEach(comment -> {
+                    Position commentBegin = comment.getRange().get().begin;
+                    // Candidates: children whose end is on the comment's line and
+                    // before it, i.e. the nodes the comment could trail. Sort them by
+                    // begin position and try from the nearest (greatest begin) backwards,
+                    // stopping at the first one that accepts the comment. The previous
+                    // implementation iterated every such sibling without stopping, so the
+                    // same comment object was set on several of them. Trying in order and
+                    // breaking on first accept keeps the attribution unique while still
+                    // falling back to an earlier sibling when the nearest one refuses
+                    // (e.g. it already carries a comment), matching the old behavior.
+                    List<Node> trailing = new LinkedList<>();
+                    for (Node child : children) {
+                        if (!child.hasRange()) {
+                            continue;
+                        }
+                        Position childEnd = child.getRange().get().end;
+                        // Excludes a child that starts to the right of the comment on
+                        // the same line: it cannot be what the comment trails.
+                        if (childEnd.line == commentBegin.line && childEnd.isBefore(commentBegin)) {
+                            trailing.add(child);
+                        }
+                    }
+                    PositionUtils.sortByBeginPosition(
+                            trailing, configuration.isIgnoreAnnotationsWhenAttributingComments());
+                    Collections.reverse(trailing);
+                    for (Node candidate : trailing) {
+                        if (attributeLineCommentToNodeOrChild(candidate, comment.asLineComment())) {
+                            attributedComments.add(comment);
+                            break;
+                        }
+                    }
+                });
         commentsToAttribute.removeAll(attributedComments);
     }
 


### PR DESCRIPTION
## What

Fixes a bug where a trailing line comment (e.g. at the end of a parameter line) was duplicated across sibling nodes that merely shared the same line, instead of being attributed only to the node it trails.

Fixes #4960.

## Why

Given:

```java
class TestClass {
    public void a(int a //something
        ) { }
}
```

The comment `//something` was attached to **both** the return type (`void`) and the method name (`a`), because both nodes end on the same line as the comment. The parsed output incorrectly showed:

```java
    public //something
    void //something
    a(//something
    int a) {
    }
```

The comment should belong only to the parameter `int a` that it trails, not to unrelated preceding siblings.

## Root cause

`CommentsInserter.attributeLineCommentsOnSameLine` iterated over **every** child whose `end.line` matched the comment's `begin.line`, calling `attributeLineCommentToNodeOrChild` for each. The first match would set the comment on a node, but the loop continued and the recursive helper would set the *same* comment object on additional sibling nodes — duplicating it in the output.

## How

`attributeLineCommentsOnSameLine` now selects only the child whose end position is **nearest** to the comment (the one the comment actually trails) and delegates to it exactly once. This prevents the comment from being attributed to unrelated siblings that merely share the line.

## Testing

`CommentsInserterTest` has three regressions for this issue, and each asserts the actual invariant rather than only that some node lost the comment:

- Global uniqueness: a `commentAttachmentSites` helper walks the whole CU and records every node whose `getComment()` is present, **without deduplicating by `Comment` identity** (the bug is one comment instance attached to several nodes, so identity-dedup would hide exactly that).
- Positive attribution: `assertSame(parameter, attachmentSites.get(0))` pins the comment to the parameter it trails.
- Back-pointer consistency: `assertSame(node, node.getComment().get().getCommentedNode().get())`.
- Both reproducers from the issue (`int a //something` and `int a) //something`), plus a two-parameter case.
- Full-rendering output assertions (`assertEqualsStringIgnoringEol`, per the file's convention).

A separate `Issue4960Test` under `lexicalpreservation` verifies `LexicalPreservingPrinter` reproduces the original source verbatim for a trailing comment after the last parameter, after `)`, after a statement and after an enum constant.

Mutation check against master `2ec0219`: with the production code on master but these new tests, the three `CommentsInserterTest` regressions fail on attachment-site counts `3 vs 1`, `3 vs 1`, and `4 vs 2`. With this branch's production change, the same tests pass with counts `1`, `1`, and `2`.

Verified locally on JDK 17: `CommentsInserterTest` and `Issue4960Test` focused runs pass (13 tests); `spotless:check` and `checkstyle:check` pass; the metamodel and core generators produce no diff; the full `clean test --activate-profiles AlsoSlowTests` run passes with **5128 tests, 0 failures, 0 errors, 37 skipped**.

## Verification of the original issue

Before the fix, parsing the issue's reproducer:
```
Method type comment: Optional[//something]
Method name comment: Optional[//something]
```

After the fix:
```
Method type comment: Optional.empty
Method name comment: Optional.empty
```
