### PR TITLE
Fix/5089 inference variable name collision

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/InferenceContext.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/InferenceContext.java
@@ -47,14 +47,19 @@ public class InferenceContext {
     }
 
     private InferenceVariableType inferenceVariableTypeForTp(ResolvedTypeParameterDeclaration tp) {
-        if (!inferenceVariableTypeMap.containsKey(tp.getName())) {
+        // The key must identify the type parameter *declaration*, not just its name: two distinct
+        // type variables that happen to share a name (e.g. the U of Stream.reduce(U, BiFunction<U,
+        // ? super T, U>, BinaryOperator<U>) and the U of BiFunction<T, U, R>) would otherwise be
+        // unified into a single inference variable and accumulate contradictory bounds.
+        String key = tp.getQualifiedName();
+        if (!inferenceVariableTypeMap.containsKey(key)) {
             InferenceVariableType inferenceVariableType =
                     new InferenceVariableType(nextInferenceVariableId++, typeSolver);
             inferenceVariableTypes.add(inferenceVariableType);
             inferenceVariableType.setCorrespondingTp(tp);
-            inferenceVariableTypeMap.put(tp.getName(), inferenceVariableType);
+            inferenceVariableTypeMap.put(key, inferenceVariableType);
         }
-        return inferenceVariableTypeMap.get(tp.getName());
+        return inferenceVariableTypeMap.get(key);
     }
 
     /**

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2065Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue2065Test.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
@@ -32,6 +33,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class Issue2065Test extends AbstractResolutionTest {
+
+    private CompilationUnit parse(String code) {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+        return StaticJavaParser.parse(code);
+    }
 
     @Test
     void test() {
@@ -42,16 +50,30 @@ public class Issue2065Test extends AbstractResolutionTest {
                 + "    }\n"
                 + "}";
 
-        ParserConfiguration config = new ParserConfiguration();
-        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
-        StaticJavaParser.setConfiguration(config);
-
-        CompilationUnit cu = StaticJavaParser.parse(code);
+        CompilationUnit cu = parse(code);
         List<MethodCallExpr> exprs = cu.findAll(MethodCallExpr.class);
         for (MethodCallExpr expr : exprs) {
             if (expr.getNameAsString().contentEquals("max")) {
                 assertEquals("java.lang.Math.max(int, int)", expr.resolve().getQualifiedSignature());
             }
         }
+    }
+
+    /**
+     * The lambda passed to {@code reduce} must be typed as {@code BinaryOperator<Integer>}, not left
+     * with an unresolved type variable.
+     */
+    @Test
+    void theTypeOfTheLambdaIsInferred() {
+        CompilationUnit cu = parse("import java.util.stream.Stream;\n" + "public class A {\n"
+                + "    public void test(){\n"
+                + "        Stream.of(1,2).reduce((a, b) -> Math.max(a, b));\n"
+                + "    }\n"
+                + "}");
+
+        LambdaExpr lambda = cu.findFirst(LambdaExpr.class).get();
+        assertEquals(
+                "java.util.function.BinaryOperator<java.lang.Integer>",
+                lambda.calculateResolvedType().describe());
     }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5089Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5089Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code InferenceContext} used to key its inference variables by the bare name of a type
+ * parameter, so two type parameters that merely share a name were unified into a single inference
+ * variable and accumulated contradictory bounds.
+ *
+ * <p>{@code Stream.reduce(U, BiFunction<U, ? super T, U>, BinaryOperator<U>)} is the case that
+ * surfaced it: the {@code U} of {@code reduce} (bound to {@code Integer} by the identity argument)
+ * and the {@code U} of {@code BiFunction<T, U, R>} (bound to {@code String} through
+ * {@code ? super T}) collapsed into one variable, and resolution failed with
+ * {@code IllegalStateException: Equivalent types are: [String, ..., Integer]}.
+ *
+ * <p>Nothing about {@code Stream} or {@code reduce} is special here — any generic method whose type
+ * parameter shares a name with a type parameter of a functional interface in its own signature is
+ * affected.
+ */
+public class Issue5089Test extends AbstractResolutionTest {
+
+    @Test
+    void inferenceVariablesOfDistinctDeclarationsAreNotUnifiedByName() {
+        String code = "import java.util.stream.Stream;\n" + "\n"
+                + "public class A {\n"
+                + "    public void test(){\n"
+                + "        Stream.of(\"a\",\"bb\").reduce(0, (acc, s) -> acc + s.length(), (x, y) -> x + y);\n"
+                + "    }\n"
+                + "}";
+
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+
+        CompilationUnit cu = StaticJavaParser.parse(code);
+
+        MethodCallExpr reduce = cu.findAll(MethodCallExpr.class).stream()
+                .filter(expr -> expr.getNameAsString().contentEquals("reduce"))
+                .findFirst()
+                .get();
+        assertEquals("java.lang.Integer", reduce.calculateResolvedType().describe());
+
+        LambdaExpr accumulator = cu.findFirst(LambdaExpr.class).get();
+        assertEquals(
+                "java.util.function.BiFunction<java.lang.Integer, ? super java.lang.String, java.lang.Integer>",
+                accumulator.calculateResolvedType().describe());
+    }
+}


### PR DESCRIPTION
Fixes #5089 .

`InferenceContext` keyed its inference variable map on the bare name of a type parameter, so two type parameters that merely shared a name were unified into a single inference variable and accumulated contradictory bounds. 

### Contents

- Tthe fix `InferenceContext` plus `Issue5089Test`.
- **test only, unrelated to this fix.** #2065 was about the type inferred for a lambda, but its test only asserted that the call *inside* the lambda body resolved. This adds the missing assertion on the lambda's own type.

#2065 is being closed separately as not reproducible.

### What this fix does not do

It is **not JLS-conformant**, only strictly better than the status quo. JLS §18.1.3 requires *fresh* inference variables per invocation; a qualified key still shares one variable across two invocations of the same generic method within a single `InferenceContext`. This only stops *unrelated declarations* from colliding. `InferenceContext` is the pre-JLS-18 engine — routing lambda inference through `resolution/typeinference/TypeInference.java` is the real fix and a far larger change.


### Worth a reviewer's attention

For a method type parameter, `getQualifiedName()` embeds the method's full signature string in `containerId`. If the JavaParser / Reflection / Javassist models render that signature differently for the same declaration, two variables that *should* unify would stop doing so.

### Still broken, not addressed here

In the same snippet, the combiner lambda `(x, y) -> x + y` resolves to `BinaryOperator<U>` with `U` unsubstituted — the third argument's formal type is not refined by the enclosing call's inference. Separate defect, can be filed on request.
