### PR TITLE
fix: avoid MethodAmbiguityException for inherited generic interface methods

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
@@ -108,7 +108,12 @@ class ReflectionMethodResolutionLogic {
             }
         }
         List<MethodUsage> methods = new ArrayList<>();
-        for (Method method : clazz.getMethods()) {
+        // Declared methods only. Class.getMethods() already includes inherited public methods;
+        // adding those again from the ancestor walk below duplicates the same declaration with
+        // different type-parameter substitutions (unsubstituted T vs substituted R) and used to
+        // throw MethodAmbiguityException for B<P> extends A<P> (issue #5039). Matches
+        // ReflectionClassDeclaration / JavassistUtils, which also walk ancestors separately.
+        for (Method method : clazz.getDeclaredMethods()) {
             if (method.getName().equals(name) && !method.isBridge() && !method.isSynthetic()) {
                 ResolvedMethodDeclaration methodDeclaration = new ReflectionMethodDeclaration(method, typeSolver);
                 MethodUsage methodUsage = replaceParams(typeParameterValues, scopeType, methodDeclaration);

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5039Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5039Test.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproducer for <a href="https://github.com/javaparser/javaparser/issues/5039">#5039</a>.
+ *
+ * <p>{@code B<P> extends A<P>} inherits {@code A.fn} without redeclaring it. Resolving
+ * {@code op.fn(x)} when {@code op} is {@code B<R>} used to throw {@code MethodAmbiguityException}
+ * because reflection collected the same method twice: once via {@code Class.getMethods()}
+ * (unsubstituted {@code T}) and once via the ancestor walk (substituted {@code R}).
+ */
+public class Issue5039Test extends AbstractResolutionTest {
+
+    public interface A<T> {
+        T fn(T val);
+    }
+
+    public interface B<P> extends A<P> {}
+
+    public interface DefaultA<T> {
+        default T fn(T val) {
+            return val;
+        }
+    }
+
+    public interface DefaultB<P> extends DefaultA<P> {}
+
+    public abstract static class Impl<P> implements B<P> {}
+
+    private static MethodCallExpr parseCall(String code) {
+        ParserConfiguration config = new ParserConfiguration();
+        config.setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        StaticJavaParser.setConfiguration(config);
+        return StaticJavaParser.parse(code).findFirst(MethodCallExpr.class).get();
+    }
+
+    private static void assertResolvedToTypeVariableR(MethodCallExpr call) {
+        assertEquals("R", call.calculateResolvedType().describe());
+        assertEquals("LX.R;", call.calculateResolvedType().toDescriptor());
+    }
+
+    @Test
+    void inheritedMethodOnCompiledGenericInterfaceIsNotAmbiguous() {
+        assertResolvedToTypeVariableR(
+                parseCall("class X<R> { R b(R x, " + B.class.getCanonicalName() + "<R> op) { return op.fn(x); } }"));
+    }
+
+    @Test
+    void inheritedMethodOnSourceGenericInterfaceIsNotAmbiguous() {
+        assertResolvedToTypeVariableR(parseCall("interface A<T> { T fn(T val); }\n"
+                + "interface B<P> extends A<P> {}\n"
+                + "class X<R> { R b(R x, B<R> op) { return op.fn(x); } }"));
+    }
+
+    @Test
+    void inheritedDefaultMethodOnCompiledGenericInterfaceIsNotAmbiguous() {
+        assertResolvedToTypeVariableR(parseCall(
+                "class X<R> { R b(R x, " + DefaultB.class.getCanonicalName() + "<R> op) { return op.fn(x); } }"));
+    }
+
+    @Test
+    void inheritedMethodOnCompiledClassImplementingGenericInterfaceIsNotAmbiguous() {
+        assertResolvedToTypeVariableR(
+                parseCall("class X<R> { R b(R x, " + Impl.class.getCanonicalName() + "<R> op) { return op.fn(x); } }"));
+    }
+}


### PR DESCRIPTION
Fixes #5039.

## Summary

Resolving `op.fn(x)` when `op` has type `B<R>` and `B<P> extends A<P>` (with `fn` declared only on `A`) threw `MethodAmbiguityException` on 3.28.2. The two candidates were the same method, `A.fn`, collected twice with different type-parameter substitutions:

- via `Class.getMethods()` — inherited, still parameterized by `A`'s `T`
- via the ancestor walk — parameterized by `R`

`ReflectionMethodResolutionLogic.solveMethodAsUsage` now uses `Class.getDeclaredMethods()` and leaves inherited methods to the existing ancestor walk, matching `ReflectionClassDeclaration` and `JavassistUtils`.

`#5066` is for `#5065` (primitive-array boxing) only and does not cover this case. No other open PR targets #5039 / this inheritance shape.

## Test plan

- [x] `Issue5039Test` (4 tests) on JBR 17:
  - compiled `B<P> extends A<P>` (reporter's classpath / reflection path)
  - same types in one compilation unit
  - inherited default method
  - abstract class implementing `B<P>`
- [x] Neighbor symbol-solver tests: `GenericsResolutionTest`, `MethodCallExprContextResolutionTest`, `MethodsResolutionLogicTest`, `Issue5089Test`, `Issue5080Test`, `Issue4989Test`, `Issue4710Test`, `Issue3083Test`, `Issue3037Test` (61 + 29)
- [x] `./mvnw spotless:apply`