### PR TITLE
fix(deps): update guava to 33.7.1-jre to fix JDK 9 compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.checkerframework</groupId>


### PR DESCRIPTION
Fixes #5095.

One-line update of guava to 33.7.1-jre, which replaces the broken 33.7.0-jre artifact that entered master with #5094.

Verified on zulu 9.0.7 (the JDK the failing `maven_test (ubuntu-latest, 9)` and `maven_test (windows-latest, 9)` matrix entries resolve to), `./mvnw -pl javaparser-symbol-solver-core -am clean compile`:
- 33.7.0-jre -> compilation failure (compiler NPE, root cause and reproducer in #5095)
- 33.7.1-jre -> BUILD SUCCESS

Regression check on JDK 17: full `javaparser-symbol-solver-testing` suite passes with the update (2090 tests, 0 failures).

guava 33.7.1 is the patch release confirmed in google/guava#8614; it removes the stray `Multi-Release` manifest header from the published jre and android jars, so future renovate bumps are safe again.
