### PR TITLE
fix: match one-line Markdown comments in lexical preservation

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue5099Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue5099Test.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.printer.lexicalpreservation;
+
+import static com.github.javaparser.utils.TestUtils.assertEqualsStringIgnoringEol;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javaparser.ast.body.MethodDeclaration;
+import org.junit.jupiter.api.Test;
+
+class Issue5099Test extends AbstractLexicalPreservingTest {
+
+    @Test
+    void setJavadocCommentReplacesSingleLineMarkdownComment() {
+        considerCode("package test;\n" + "public class Error\n"
+                + "{\n"
+                + "  /// dummy.\n"
+                + "  public void x()\n"
+                + "  { }\n"
+                + "}\n");
+
+        MethodDeclaration method = cu.findFirst(MethodDeclaration.class).get();
+        method.setJavadocComment(" replacement");
+
+        assertEqualsStringIgnoringEol(
+                "package test;\n" + "public class Error\n"
+                        + "{\n"
+                        + "  /** replacement*/\n"
+                        + "  public void x()\n"
+                        + "  { }\n"
+                        + "}\n",
+                LexicalPreservingPrinter.print(cu));
+    }
+
+    @Test
+    void removeJavaDocCommentKeepsMethodWithSingleLineMarkdownComment() {
+        considerCode("package test;\n" + "public class Error\n"
+                + "{\n"
+                + "  /// dummy.\n"
+                + "  public void x()\n"
+                + "  { }\n"
+                + "}\n");
+
+        MethodDeclaration method = cu.findFirst(MethodDeclaration.class).get();
+        assertTrue(method.removeJavaDocComment());
+
+        assertEqualsStringIgnoringEol(
+                "package test;\n" + "public class Error\n"
+                        + "{\n"
+                        + "  public void x()\n"
+                        + "  { }\n"
+                        + "}\n",
+                LexicalPreservingPrinter.print(cu));
+    }
+}

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue5099Test.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/Issue5099Test.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2013-2026 The JavaParser Team.
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
  *
  * This file is part of JavaParser.
  *
@@ -63,11 +64,7 @@ class Issue5099Test extends AbstractLexicalPreservingTest {
         assertTrue(method.removeJavaDocComment());
 
         assertEqualsStringIgnoringEol(
-                "package test;\n" + "public class Error\n"
-                        + "{\n"
-                        + "  public void x()\n"
-                        + "  { }\n"
-                        + "}\n",
+                "package test;\n" + "public class Error\n" + "{\n" + "  public void x()\n" + "  { }\n" + "}\n",
                 LexicalPreservingPrinter.print(cu));
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -509,13 +509,9 @@ public class LexicalPreservingPrinter {
                         // Found a line comment that matches the first line of the markdown comment.
                         TokenTextElement startToken = (TokenTextElement) textElement;
                         maybeMatchingTokens.add(startToken);
-                        String startText = startToken.getText();
                         // A one-line Markdown comment is a single token. Completing the match only on a later
                         // SINGLE_LINE_COMMENT would leave that case unmatched and later drop the method node.
-                        if (oldContent.equals(startText)
-                                || oldContent.equals(startText + "\n")
-                                || oldContent.equals(startText + "\r\n")
-                                || oldContent.equals(startText + "\r")) {
+                        if (oldContent.equals(startToken.getText())) {
                             matchingTokens.add(startToken);
                             maybeMatchingTokens.clear();
                             inMatch = false;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalPreservingPrinter.java
@@ -506,10 +506,22 @@ public class LexicalPreservingPrinter {
                         }
                     } else if (textElement.isToken(SINGLE_LINE_COMMENT)
                             && oldContent.startsWith(((TokenTextElement) textElement).getText())) {
-                        // Found a line comment that matches the first line of the markdown comment, so start looking
-                        // for the rest of the comment.
-                        maybeMatchingTokens.add(textElement);
-                        inMatch = true;
+                        // Found a line comment that matches the first line of the markdown comment.
+                        TokenTextElement startToken = (TokenTextElement) textElement;
+                        maybeMatchingTokens.add(startToken);
+                        String startText = startToken.getText();
+                        // A one-line Markdown comment is a single token. Completing the match only on a later
+                        // SINGLE_LINE_COMMENT would leave that case unmatched and later drop the method node.
+                        if (oldContent.equals(startText)
+                                || oldContent.equals(startText + "\n")
+                                || oldContent.equals(startText + "\r\n")
+                                || oldContent.equals(startText + "\r")) {
+                            matchingTokens.add(startToken);
+                            maybeMatchingTokens.clear();
+                            inMatch = false;
+                        } else {
+                            inMatch = true;
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Fixes #5099.

A one-line Markdown comment (`/// dummy.`) is a single token. Lexical preservation only completed a Markdown match when a later `SINGLE_LINE_COMMENT` token appeared, so that case stayed unmatched.

- `setJavadocComment` threw `IllegalStateException: The matching comment to be replaced could not be found`
- `removeJavaDocComment` dropped the method node and left the `///` line behind

The matcher now treats a start token that already equals the comment content as a complete match.

Tested locally (JDK 17):
- `Issue5099Test` 2/2
- `MethodDeclarationTransformationsTest` 32/32 (3 skipped)
- `CommentTest` 16/16
- `Issue3387Test` 1/1
- `com.github.javaparser.printer.lexicalpreservation.**` 684/684 (6 skipped)