### PR TITLE
fix: overloads on primitive array parameters are no longer ambiguous (fixes #5065)

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -224,8 +224,15 @@ public class MethodResolutionLogic {
                     expectedDeclaredType = replaceTypeParam(expectedDeclaredType, tp, typeSolver);
                 }
                 if (!expectedDeclaredType.isAssignableBy(actualArgumentType)) {
-                    // Check boxing/unboxing compatibility using TypeSolver
-                    if (isBoxingCompatibleWithTypeSolver(expectedDeclaredType, actualArgumentType, typeSolver)) {
+                    // Check boxing/unboxing compatibility using TypeSolver.
+                    // Boxing or widening of the component types of two array types is only
+                    // meaningful for a variadic parameter, where the conversion applies to each
+                    // individual argument instead of to the array as a whole.
+                    if (isBoxingCompatibleWithTypeSolver(
+                            expectedDeclaredType,
+                            actualArgumentType,
+                            typeSolver,
+                            methodDeclaration.getParam(i).isVariadic())) {
                         // This parameter is compatible via boxing/unboxing
                         continue;
                     }
@@ -595,6 +602,23 @@ public class MethodResolutionLogic {
      */
     private static boolean isBoxingCompatibleWithTypeSolver(
             ResolvedType expectedType, ResolvedType actualType, TypeSolver typeSolver) {
+        return isBoxingCompatibleWithTypeSolver(expectedType, actualType, typeSolver, true);
+    }
+
+    /**
+     * Same as {@link #isBoxingCompatibleWithTypeSolver(ResolvedType, ResolvedType, TypeSolver)} but
+     * allows to forbid boxing and widening between the component types of two array types.
+     *
+     * @param arrayComponentConversionAllowed {@code true} when the compared array types stand for a
+     *      variadic parameter, in which case the conversion applies to each individual argument.
+     *      {@code false} for a genuine array parameter: no boxing or widening conversion exists
+     *      between distinct primitive array types (JLS 5.2), so the component types must be equal.
+     */
+    private static boolean isBoxingCompatibleWithTypeSolver(
+            ResolvedType expectedType,
+            ResolvedType actualType,
+            TypeSolver typeSolver,
+            boolean arrayComponentConversionAllowed) {
         // Handle null types
         if (expectedType == null || actualType == null) {
             return false;
@@ -604,7 +628,8 @@ public class MethodResolutionLogic {
             ResolvedWildcard wildcard = expectedType.asWildcard();
             if (wildcard.isBounded()) {
                 // Check compatibility with the wildcard bound
-                return isBoxingCompatibleWithTypeSolver(wildcard.getBoundedType(), actualType, typeSolver);
+                return isBoxingCompatibleWithTypeSolver(
+                        wildcard.getBoundedType(), actualType, typeSolver, arrayComponentConversionAllowed);
             }
             // Unbounded wildcard (?) - can accept anything via boxing
             return actualType.isPrimitive();
@@ -613,8 +638,13 @@ public class MethodResolutionLogic {
         if (expectedType.isArray() && actualType.isArray()) {
             ResolvedType expectedComponent = expectedType.asArrayType().getComponentType();
             ResolvedType actualComponent = actualType.asArrayType().getComponentType();
+            if (!arrayComponentConversionAllowed
+                    && (expectedComponent.isPrimitive() || actualComponent.isPrimitive())) {
+                return expectedComponent.equals(actualComponent);
+            }
             // Check if component types are boxing compatible
-            return isBoxingCompatibleWithTypeSolver(expectedComponent, actualComponent, typeSolver);
+            return isBoxingCompatibleWithTypeSolver(
+                    expectedComponent, actualComponent, typeSolver, arrayComponentConversionAllowed);
         }
         // Boxing (reference type expected, primitive provided)
         if (expectedType.isReferenceType() && actualType.isPrimitive()) {
@@ -674,7 +704,10 @@ public class MethodResolutionLogic {
         if (actualType.isConstraint()) {
             // Check compatibility with the constraint bound
             return isBoxingCompatibleWithTypeSolver(
-                    expectedType, actualType.asConstraintType().getBound(), typeSolver);
+                    expectedType,
+                    actualType.asConstraintType().getBound(),
+                    typeSolver,
+                    arrayComponentConversionAllowed);
         }
         return false;
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5065Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5065Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Overloads that only differ in their primitive array parameter type were reported as ambiguous.
+ *
+ * <p>{@code isBoxingCompatibleWithTypeSolver} recursed into the component types of two array types
+ * and then accepted them through {@code isAssignableBy}, so {@code float[]} (and {@code double[]})
+ * were considered applicable for an {@code int[]} argument because {@code float} is assignable by
+ * {@code int}. Widening does not apply to array types, so all three overloads looked applicable and
+ * resolution failed with {@code MethodAmbiguityException}.
+ */
+class Issue5065Test extends AbstractResolutionTest {
+
+    @Test
+    void overloadsDifferingOnlyInPrimitiveArrayParameterAreNotAmbiguous() {
+        String code = "class Arrays {\n"
+                + "    static int[] copyOf(int[] original, int newLength) { return original; }\n"
+                + "    static float[] copyOf(float[] original, int newLength) { return original; }\n"
+                + "    static double[] copyOf(double[] original, int newLength) { return original; }\n"
+                + "}\n"
+                + "class A {\n"
+                + "    void test() {\n"
+                + "        int[] ints = {1};\n"
+                + "        float[] floats = {1f};\n"
+                + "        Arrays.copyOf(ints, 1);\n"
+                + "        Arrays.copyOf(floats, 1);\n"
+                + "    }\n"
+                + "}\n";
+
+        ParserConfiguration configuration =
+                new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver(false)));
+        CompilationUnit cu =
+                new JavaParser(configuration).parse(code).getResult().get();
+
+        List<MethodCallExpr> calls = cu.findAll(MethodCallExpr.class);
+
+        assertEquals("Arrays.copyOf(int[], int)", calls.get(0).resolve().getQualifiedSignature());
+        assertEquals("Arrays.copyOf(float[], int)", calls.get(1).resolve().getQualifiedSignature());
+    }
+}


### PR DESCRIPTION
Fixes #5065

## Problem

Resolving a call to an overloaded method whose overloads differ only in the primitive component type of an array parameter fails with `MethodAmbiguityException`:

```java
int[] a = new int[1];
Arrays.copyOf(a, 2); // MethodAmbiguityException: copyOf(int[],int) / copyOf(float[],int) / copyOf(double[],int)
```

## Root cause

`MethodResolutionLogic.isBoxingCompatibleWithTypeSolver` recursed into the component types when both the expected and the actual type were arrays, and then accepted the pair through `isAssignableBy`. Because `int` is assignable to `float` and `double` by widening primitive conversion, `float[]` and `double[]` were reported as applicable for an `int[]` argument, so several overloads survived applicability filtering and the resolution ended up ambiguous.

Per JLS 5.2 there is neither a boxing nor a widening conversion between two distinct primitive array types, so this component-wise recursion is wrong for a real array parameter.

## Fix

`isBoxingCompatibleWithTypeSolver` now takes a flag that distinguishes a genuine array parameter from an array type that was synthesized for a variadic parameter:

- For a real array parameter, if either component type is primitive, the component types must be equal. This mirrors `ResolvedArrayType#isAssignableBy`.
- For a variadic parameter the previous component-wise behaviour is kept, because there the conversion applies to each individual argument rather than to the array as a whole (`groupTrailingArgumentsIntoArray` turns the trailing arguments into an array type, and boxing/widening per argument is legal there).

The flag is threaded through the wildcard, component and constraint recursions, and the call site passes `methodDeclaration.getParam(i).isVariadic()`.

## Tests

- New regression test `Issue5065Test#overloadsDifferingOnlyInPrimitiveArrayParameterAreNotAmbiguous` asserts that `Arrays.copyOf(intArray, n)` resolves to `Arrays.copyOf(int[], int)` and `Arrays.copyOf(floatArray, n)` to `Arrays.copyOf(float[], int)`. It fails with `MethodAmbiguityException` without the core change.
- `javaparser-symbol-solver-testing`: 2093 tests, 0 failures, 0 errors, 34 skipped.
- `javaparser-core-testing`: 2842 tests, 0 failures, 0 errors, 8 skipped.
- `javaparser-core-testing-bdd`: 625 tests, 0 failures, 0 errors.
- `spotless:check` passes for the touched sources.

Note: the varargs tests in `MethodsResolutionLogicTest` are exactly what motivated the flag; an unconditional strict-equality check in the array branch regressed five of them.
