### PR TITLE
fix: keep exact symbol-solver assertions under JDK 21 guards

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
@@ -46,85 +46,26 @@ public abstract class AbstractSymbolResolutionTest {
     }
 
     /**
-     * An initial attempt at allowing JDK-specific test cases. It is a work-in-progress, and subject to change.
-     * @deprecated <strong>Note that use of TestJdk should be a last-resort, preferably implementing JDK-agnostic tests.</strong>
+     * Host JDK major version parsed from {@code java.specification.version}
+     * ({@code 1.8} -&gt; 8, {@code 21} -&gt; 21). Prefer JDK-agnostic assertions; use this
+     * only when a test must branch on a known library change.
      */
-    @Deprecated
-    protected enum TestJdk {
-        JDK8(8),
-        JDK9(9),
-        JDK10(10),
-        JDK11(11),
-        JDK12(12),
-        JDK13(13),
-        JDK14(14),
-        JDK15(15),
-        JDK16(16),
-        JDK17(17),
-        JDK18(18);
-
-        private final Integer major;
-
-        /**
-         * @deprecated <strong>Note that use of TestJdk should be a last-resort, preferably implementing JDK-agnostic tests.</strong>
-         */
-        @Deprecated
-        TestJdk(Integer major) {
-            this.major = major;
+    protected static int currentHostJdkMajor() {
+        String spec = System.getProperty("java.specification.version");
+        if (spec == null || spec.isEmpty()) {
+            throw new IllegalStateException("java.specification.version is not set");
         }
-
-        /**
-         * @deprecated <strong>Note that use of TestJdk should be a last-resort, preferably implementing JDK-agnostic tests.</strong>
-         */
-        @Deprecated
-        public int getMajorVersion() {
-            return this.major;
+        if (spec.startsWith("1.")) {
+            spec = spec.substring(2);
         }
-
-        /**
-         * @deprecated <strong>Note that use of TestJdk should be a last-resort, preferably implementing JDK-agnostic tests.</strong>
-         */
-        @Deprecated
-        public static TestJdk getCurrentHostJdk() {
-            String javaVersion = System.getProperty("java.version");
-
-            // JavaParser explicitly requires a minimum of JDK8 to build.
-            if ("8".equals(javaVersion) || javaVersion.startsWith("1.8") || javaVersion.startsWith("8")) {
-                return JDK8;
-            } else if ("9".equals(javaVersion) || javaVersion.startsWith("9.")) {
-                return JDK9;
-            } else if ("10".equals(javaVersion) || javaVersion.startsWith("10.")) {
-                return JDK10;
-            } else if ("11".equals(javaVersion) || javaVersion.startsWith("11.")) {
-                return JDK11;
-            } else if ("12".equals(javaVersion) || javaVersion.startsWith("12.")) {
-                return JDK12;
-            } else if ("13".equals(javaVersion) || javaVersion.startsWith("13.")) {
-                return JDK13;
-            } else if ("14".equals(javaVersion) || javaVersion.startsWith("14.")) {
-                return JDK14;
-            } else if ("15".equals(javaVersion) || javaVersion.startsWith("15.")) {
-                return JDK15;
-            } else if ("16".equals(javaVersion) || javaVersion.startsWith("16.")) {
-                return JDK16;
-            } else if ("17".equals(javaVersion) || javaVersion.startsWith("17.")) {
-                return JDK17;
-            } else if ("18".equals(javaVersion) || javaVersion.startsWith("18.")) {
-                return JDK18;
-            }
-
-            throw new IllegalStateException("Unable to determine the current version of java running");
+        int separator = spec.indexOf('.');
+        if (separator > 0) {
+            spec = spec.substring(0, separator);
         }
-
-        /**
-         * @deprecated <strong>Note that use of TestJdk should be a last-resort, preferably implementing JDK-agnostic tests.</strong>
-         */
-        @Deprecated
-        @Override
-        public String toString() {
-            return "TestJdk{" + "System.getProperty(\"java.version\")="
-                    + System.getProperty("java.version") + ",major="
-                    + major + '}';
+        try {
+            return Integer.parseInt(spec);
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Unable to determine the current version of java running", e);
         }
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
@@ -33,8 +33,6 @@ import org.junit.jupiter.api.AfterAll;
 
 public abstract class AbstractSymbolResolutionTest {
 
-    private static final int HOST_JDK_MAJOR = parseHostJdkMajor();
-
     // StaticJavaParser is now reset before/after every test in this module by
     // StaticJavaParserConfigResetExtension (auto-detected via
     // src/test/resources/META-INF/services), so this class no longer needs its
@@ -45,34 +43,6 @@ public abstract class AbstractSymbolResolutionTest {
     public static void tearDown() {
         // clear internal caches
         JavaParserFacade.clearInstances();
-    }
-
-    /**
-     * Host JDK major version parsed from {@code java.specification.version}
-     * ({@code 1.8} -&gt; 8, {@code 21} -&gt; 21). Prefer JDK-agnostic assertions; use this
-     * only when a test must branch on a known library change.
-     */
-    protected static int currentHostJdkMajor() {
-        return HOST_JDK_MAJOR;
-    }
-
-    private static int parseHostJdkMajor() {
-        String spec = System.getProperty("java.specification.version");
-        if (spec == null || spec.isEmpty()) {
-            throw new IllegalStateException("java.specification.version is not set");
-        }
-        if (spec.startsWith("1.")) {
-            spec = spec.substring(2);
-        }
-        int separator = spec.indexOf('.');
-        if (separator > 0) {
-            spec = spec.substring(0, separator);
-        }
-        try {
-            return Integer.parseInt(spec);
-        } catch (NumberFormatException e) {
-            throw new IllegalStateException("Unable to determine the current version of java running", e);
-        }
     }
 
     /**
@@ -95,6 +65,30 @@ public abstract class AbstractSymbolResolutionTest {
             Object.class.getDeclaredMethod("wait0", long.class);
             return true;
         } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether {@code Object.registerNatives()} is present (removed in JDK 14).
+     */
+    protected static boolean hasRegisterNatives() {
+        try {
+            Object.class.getDeclaredMethod("registerNatives");
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether {@code java.lang.constant.Constable} is present (JDK 12+).
+     */
+    protected static boolean hasConstable() {
+        try {
+            Class.forName("java.lang.constant.Constable");
+            return true;
+        } catch (ClassNotFoundException e) {
             return false;
         }
     }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/AbstractSymbolResolutionTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.AfterAll;
 
 public abstract class AbstractSymbolResolutionTest {
 
+    private static final int HOST_JDK_MAJOR = parseHostJdkMajor();
+
     // StaticJavaParser is now reset before/after every test in this module by
     // StaticJavaParserConfigResetExtension (auto-detected via
     // src/test/resources/META-INF/services), so this class no longer needs its
@@ -51,6 +53,10 @@ public abstract class AbstractSymbolResolutionTest {
      * only when a test must branch on a known library change.
      */
     protected static int currentHostJdkMajor() {
+        return HOST_JDK_MAJOR;
+    }
+
+    private static int parseHostJdkMajor() {
         String spec = System.getProperty("java.specification.version");
         if (spec == null || spec.isEmpty()) {
             throw new IllegalStateException("java.specification.version is not set");
@@ -66,6 +72,30 @@ public abstract class AbstractSymbolResolutionTest {
             return Integer.parseInt(spec);
         } catch (NumberFormatException e) {
             throw new IllegalStateException("Unable to determine the current version of java running", e);
+        }
+    }
+
+    /**
+     * Whether the running JRE exposes {@code java.util.SequencedCollection} (JDK 21+).
+     */
+    protected static boolean hasSequencedCollection() {
+        try {
+            Class.forName("java.util.SequencedCollection");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether {@code Object.wait0(long)} is present (JDK 21 split of {@code wait(long)}).
+     */
+    protected static boolean hasWait0() {
+        try {
+            Object.class.getDeclaredMethod("wait0", long.class);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
         }
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -1109,8 +1109,8 @@ class JavaParserClassDeclarationTest extends AbstractResolutionTest {
         if (currentHostJdkMajor() >= 14) {
             expected.remove("java.lang.Object.registerNatives()");
         }
-        // JDK 21 split Object.wait(long) into wait0
-        if (currentHostJdkMajor() >= 21) {
+        // Object.wait0(long) is present on JREs that split wait(long)
+        if (hasWait0()) {
             expected.add("java.lang.Object.wait0(long)");
         }
         assertEquals(expected.size(), signatures.size());

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -1105,8 +1105,8 @@ class JavaParserClassDeclarationTest extends AbstractResolutionTest {
                 "java.lang.Object.wait(long)",
                 "java.lang.Object.wait(long, int)"));
 
-        // Temporary workaround to allow tests to pass on JDK14
-        if (currentHostJdkMajor() >= 14) {
+        // Object.registerNatives() is absent on JREs that dropped it
+        if (!hasRegisterNatives()) {
             expected.remove("java.lang.Object.registerNatives()");
         }
         // Object.wait0(long) is present on JREs that split wait(long)

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclarationTest.java
@@ -1106,8 +1106,12 @@ class JavaParserClassDeclarationTest extends AbstractResolutionTest {
                 "java.lang.Object.wait(long, int)"));
 
         // Temporary workaround to allow tests to pass on JDK14
-        if (TestJdk.getCurrentHostJdk().getMajorVersion() >= 14) {
+        if (currentHostJdkMajor() >= 14) {
             expected.remove("java.lang.Object.registerNatives()");
+        }
+        // JDK 21 split Object.wait(long) into wait0
+        if (currentHostJdkMajor() >= 21) {
+            expected.add("java.lang.Object.wait0(long)");
         }
         assertEquals(expected.size(), signatures.size());
         assertThat(signatures, containsInAnyOrder(expected.toArray()));

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -988,8 +988,8 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest
                 "java.lang.Object.wait(long)",
                 "java.lang.Object.wait(long, int)"));
 
-        // Temporary workaround to allow tests to pass on JDK14
-        if (currentHostJdkMajor() >= 14) {
+        // Object.registerNatives() is absent on JREs that dropped it
+        if (!hasRegisterNatives()) {
             expected.remove("java.lang.Object.registerNatives()");
         }
         // Object.wait0(long) is present on JREs that split wait(long)

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -992,8 +992,8 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest
         if (currentHostJdkMajor() >= 14) {
             expected.remove("java.lang.Object.registerNatives()");
         }
-        // JDK 21 split Object.wait(long) into wait0
-        if (currentHostJdkMajor() >= 21) {
+        // Object.wait0(long) is present on JREs that split wait(long)
+        if (hasWait0()) {
             expected.add("java.lang.Object.wait0(long)");
         }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclarationTest.java
@@ -989,8 +989,12 @@ class JavaParserEnumDeclarationTest extends AbstractTypeDeclarationTest
                 "java.lang.Object.wait(long, int)"));
 
         // Temporary workaround to allow tests to pass on JDK14
-        if (TestJdk.getCurrentHostJdk().getMajorVersion() >= 14) {
+        if (currentHostJdkMajor() >= 14) {
             expected.remove("java.lang.Object.registerNatives()");
+        }
+        // JDK 21 split Object.wait(long) into wait0
+        if (currentHostJdkMajor() >= 21) {
+            expected.add("java.lang.Object.wait0(long)");
         }
 
         assertThat(signatures, containsInAnyOrder(expected.toArray()));

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -1037,8 +1037,8 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
                 "java.lang.Object.wait(long)",
                 "java.lang.Object.wait(long, int)"));
 
-        // Temporary workaround to allow tests to pass on JDK14
-        if (currentHostJdkMajor() >= 14) {
+        // Object.registerNatives() is absent on JREs that dropped it
+        if (!hasRegisterNatives()) {
             expected.remove("java.lang.Object.registerNatives()");
         }
         // Object.wait0(long) is present on JREs that split wait(long)

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -1038,8 +1038,12 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
                 "java.lang.Object.wait(long, int)"));
 
         // Temporary workaround to allow tests to pass on JDK14
-        if (TestJdk.getCurrentHostJdk().getMajorVersion() >= 14) {
+        if (currentHostJdkMajor() >= 14) {
             expected.remove("java.lang.Object.registerNatives()");
+        }
+        // JDK 21 split Object.wait(long) into wait0
+        if (currentHostJdkMajor() >= 21) {
+            expected.add("java.lang.Object.wait0(long)");
         }
 
         assertThat(signatures, containsInAnyOrder(expected.toArray()));

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclarationTest.java
@@ -1041,8 +1041,8 @@ class JavaParserInterfaceDeclarationTest extends AbstractTypeDeclarationTest {
         if (currentHostJdkMajor() >= 14) {
             expected.remove("java.lang.Object.registerNatives()");
         }
-        // JDK 21 split Object.wait(long) into wait0
-        if (currentHostJdkMajor() >= 21) {
+        // Object.wait0(long) is present on JREs that split wait(long)
+        if (hasWait0()) {
             expected.add("java.lang.Object.wait0(long)");
         }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -648,7 +648,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         rawArrayList.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        assertEquals(9, ancestors.size());
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        assertEquals(currentHostJdkMajor() >= 21 ? 10 : 9, ancestors.size());
 
         ResolvedTypeVariable tv =
                 new ResolvedTypeVariable(arraylist.getTypeParameters().get(0));
@@ -695,7 +696,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         listOfString.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        assertEquals(2, ancestors.size());
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        assertEquals(currentHostJdkMajor() >= 21 ? 3 : 2, ancestors.size());
 
         assertEquals(
                 new ReferenceTypeImpl(
@@ -742,7 +744,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         abstractListOfString.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        assertEquals(5, ancestors.size());
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        assertEquals(currentHostJdkMajor() >= 21 ? 6 : 5, ancestors.size());
 
         assertEquals(
                 new ReferenceTypeImpl(
@@ -775,7 +778,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         arrayListOfString.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        assertEquals(9, ancestors.size());
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        assertEquals(currentHostJdkMajor() >= 21 ? 10 : 9, ancestors.size());
 
         assertEquals(
                 new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(RandomAccess.class, typeResolver)),
@@ -946,8 +950,7 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         // FIXME: Remove this temporary fix which varies the test based on the detected JDK which is running these
         // tests.
-        TestJdk currentJdk = TestJdk.getCurrentHostJdk();
-        if (currentJdk.getMajorVersion() < 12) {
+        if (currentHostJdkMajor() < 12) {
             // JDK 12 introduced "java.lang.constant.Constable"
             assertThat(
                     ancestors,

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -648,8 +648,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         rawArrayList.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        assertEquals(currentHostJdkMajor() >= 21 ? 10 : 9, ancestors.size());
+        // SequencedCollection sits between List and Collection when the JRE exposes it
+        assertEquals(hasSequencedCollection() ? 10 : 9, ancestors.size());
 
         ResolvedTypeVariable tv =
                 new ResolvedTypeVariable(arraylist.getTypeParameters().get(0));
@@ -696,8 +696,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         listOfString.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        assertEquals(currentHostJdkMajor() >= 21 ? 3 : 2, ancestors.size());
+        // SequencedCollection sits between List and Collection when the JRE exposes it
+        assertEquals(hasSequencedCollection() ? 3 : 2, ancestors.size());
 
         assertEquals(
                 new ReferenceTypeImpl(
@@ -744,8 +744,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         abstractListOfString.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        assertEquals(currentHostJdkMajor() >= 21 ? 6 : 5, ancestors.size());
+        // SequencedCollection sits between List and Collection when the JRE exposes it
+        assertEquals(hasSequencedCollection() ? 6 : 5, ancestors.size());
 
         assertEquals(
                 new ReferenceTypeImpl(
@@ -778,8 +778,8 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         arrayListOfString.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        assertEquals(currentHostJdkMajor() >= 21 ? 10 : 9, ancestors.size());
+        // SequencedCollection sits between List and Collection when the JRE exposes it
+        assertEquals(hasSequencedCollection() ? 10 : 9, ancestors.size());
 
         assertEquals(
                 new ReferenceTypeImpl(new ReflectionInterfaceDeclaration(RandomAccess.class, typeResolver)),

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/model/typesystem/ReferenceTypeTest.java
@@ -950,16 +950,7 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
 
         // FIXME: Remove this temporary fix which varies the test based on the detected JDK which is running these
         // tests.
-        if (currentHostJdkMajor() < 12) {
-            // JDK 12 introduced "java.lang.constant.Constable"
-            assertThat(
-                    ancestors,
-                    containsInAnyOrder(
-                            "java.lang.CharSequence",
-                            "java.lang.Object",
-                            "java.lang.Comparable<java.lang.String>",
-                            "java.io.Serializable"));
-        } else {
+        if (hasConstable()) {
             // JDK 12 introduced "java.lang.constant.Constable"
             assertThat(
                     ancestors,
@@ -970,6 +961,14 @@ class ReferenceTypeTest extends AbstractSymbolResolutionTest {
                             "java.io.Serializable",
                             "java.lang.constant.Constable",
                             "java.lang.constant.ConstantDesc"));
+        } else {
+            assertThat(
+                    ancestors,
+                    containsInAnyOrder(
+                            "java.lang.CharSequence",
+                            "java.lang.Object",
+                            "java.lang.Comparable<java.lang.String>",
+                            "java.io.Serializable"));
         }
     }
 

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -312,15 +312,14 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         TypeSolver typeResolver = new ReflectionTypeSolver();
         ResolvedClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
         // Serializable, Cloneable, Iterable<E>, Collection<E>, List<E>, RandomAccess
-        Set<String> expected = new HashSet<>(ImmutableSet.of(
+        Set<String> expected = new HashSet<>(Arrays.asList(
                 Serializable.class.getCanonicalName(),
                 Cloneable.class.getCanonicalName(),
                 List.class.getCanonicalName(),
                 RandomAccess.class.getCanonicalName(),
                 Collection.class.getCanonicalName(),
                 Iterable.class.getCanonicalName()));
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        if (currentHostJdkMajor() >= 21) {
+        if (hasSequencedCollection()) {
             expected.add("java.util.SequencedCollection");
         }
         assertEquals(
@@ -434,8 +433,8 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         ResolvedClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         arraylist.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        assertEquals(currentHostJdkMajor() >= 21 ? 10 : 9, ancestors.size());
+        // SequencedCollection sits between List and Collection when the JRE exposes it
+        assertEquals(hasSequencedCollection() ? 10 : 9, ancestors.size());
 
         ResolvedTypeVariable typeVariable =
                 new ResolvedTypeVariable(arraylist.getTypeParameters().get(0));

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -312,14 +312,19 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         TypeSolver typeResolver = new ReflectionTypeSolver();
         ResolvedClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
         // Serializable, Cloneable, Iterable<E>, Collection<E>, List<E>, RandomAccess
+        Set<String> expected = new HashSet<>(ImmutableSet.of(
+                Serializable.class.getCanonicalName(),
+                Cloneable.class.getCanonicalName(),
+                List.class.getCanonicalName(),
+                RandomAccess.class.getCanonicalName(),
+                Collection.class.getCanonicalName(),
+                Iterable.class.getCanonicalName()));
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        if (currentHostJdkMajor() >= 21) {
+            expected.add("java.util.SequencedCollection");
+        }
         assertEquals(
-                ImmutableSet.of(
-                        Serializable.class.getCanonicalName(),
-                        Cloneable.class.getCanonicalName(),
-                        List.class.getCanonicalName(),
-                        RandomAccess.class.getCanonicalName(),
-                        Collection.class.getCanonicalName(),
-                        Iterable.class.getCanonicalName()),
+                expected,
                 arraylist.getAllInterfaces().stream()
                         .map(i -> i.getQualifiedName())
                         .collect(Collectors.toSet()));
@@ -429,7 +434,8 @@ class ReflectionClassDeclarationTest extends AbstractSymbolResolutionTest {
         ResolvedClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         arraylist.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        assertEquals(9, ancestors.size());
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        assertEquals(currentHostJdkMajor() >= 21 ? 10 : 9, ancestors.size());
 
         ResolvedTypeVariable typeVariable =
                 new ResolvedTypeVariable(arraylist.getTypeParameters().get(0));

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclarationTest.java
@@ -82,7 +82,8 @@ class ReflectionInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
         ResolvedInterfaceDeclaration list = new ReflectionInterfaceDeclaration(List.class, typeResolver);
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         list.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        assertEquals(2, ancestors.size());
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        assertEquals(currentHostJdkMajor() >= 21 ? 3 : 2, ancestors.size());
 
         // Since List is an interface, Object cannot be an ancestor of List
         ResolvedTypeVariable typeVariable =
@@ -104,7 +105,14 @@ class ReflectionInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
         TypeSolver typeResolver = new ReflectionTypeSolver();
         ResolvedInterfaceDeclaration list = new ReflectionInterfaceDeclaration(List.class, typeResolver);
         List<ResolvedReferenceType> ancestors = list.getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc);
-        assertEquals(2, ancestors.size());
+        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
+        assertEquals(currentHostJdkMajor() >= 21 ? 3 : 2, ancestors.size());
+        List<String> names =
+                ancestors.stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toList());
+        assertTrue(names.indexOf("java.util.Collection") < names.indexOf("java.lang.Iterable"));
+
+        Map<String, ResolvedReferenceType> byName = new HashMap<>();
+        ancestors.forEach(a -> byName.put(a.getQualifiedName(), a));
 
         ResolvedTypeVariable typeVariable =
                 new ResolvedTypeVariable(list.getTypeParameters().get(0));
@@ -112,12 +120,12 @@ class ReflectionInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
                 new ReferenceTypeImpl(
                         new ReflectionInterfaceDeclaration(Collection.class, typeResolver),
                         ImmutableList.of(typeVariable)),
-                ancestors.get(0));
+                byName.get("java.util.Collection"));
         assertEquals(
                 new ReferenceTypeImpl(
                         new ReflectionInterfaceDeclaration(Iterable.class, typeResolver),
                         ImmutableList.of(typeVariable)),
-                ancestors.get(1));
+                byName.get("java.lang.Iterable"));
     }
 
     @Test

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclarationTest.java
@@ -82,8 +82,8 @@ class ReflectionInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
         ResolvedInterfaceDeclaration list = new ReflectionInterfaceDeclaration(List.class, typeResolver);
         Map<String, ResolvedReferenceType> ancestors = new HashMap<>();
         list.getAllAncestors().forEach(a -> ancestors.put(a.getQualifiedName(), a));
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        assertEquals(currentHostJdkMajor() >= 21 ? 3 : 2, ancestors.size());
+        // SequencedCollection sits between List and Collection when the JRE exposes it
+        assertEquals(hasSequencedCollection() ? 3 : 2, ancestors.size());
 
         // Since List is an interface, Object cannot be an ancestor of List
         ResolvedTypeVariable typeVariable =
@@ -105,11 +105,12 @@ class ReflectionInterfaceDeclarationTest extends AbstractSymbolResolutionTest {
         TypeSolver typeResolver = new ReflectionTypeSolver();
         ResolvedInterfaceDeclaration list = new ReflectionInterfaceDeclaration(List.class, typeResolver);
         List<ResolvedReferenceType> ancestors = list.getAllAncestors(ResolvedReferenceTypeDeclaration.breadthFirstFunc);
-        // JDK 21 inserts java.util.SequencedCollection into the List/Collection hierarchy
-        assertEquals(currentHostJdkMajor() >= 21 ? 3 : 2, ancestors.size());
         List<String> names =
                 ancestors.stream().map(ResolvedReferenceType::getQualifiedName).collect(Collectors.toList());
-        assertTrue(names.indexOf("java.util.Collection") < names.indexOf("java.lang.Iterable"));
+        List<String> expectedNames = hasSequencedCollection()
+                ? ImmutableList.of("java.util.SequencedCollection", "java.util.Collection", "java.lang.Iterable")
+                : ImmutableList.of("java.util.Collection", "java.lang.Iterable");
+        assertEquals(expectedNames, names);
 
         Map<String, ResolvedReferenceType> byName = new HashMap<>();
         ancestors.forEach(a -> byName.put(a.getQualifiedName(), a));


### PR DESCRIPTION
Refs #5109.

`javaparser-symbol-solver-testing` fails on JDK 21+ for two independent reasons:

- Reflection against `List`/`ArrayList` now includes `java.util.SequencedCollection`, so exact ancestor counts and exact interface sets no longer match.
- JDK 21 split `Object.wait(long)` and `java.lang.Object.wait0(long)` shows up in method lists.
- `TestJdk` only enumerates through 18, so `getCurrentHostJdk()` throws on newer hosts.

This keeps the JDK 8-era exact counts / `containsInAnyOrder` / set equality, branching only where the library changed (same pattern as Constable on JDK 12). Host major version is parsed from `java.specification.version` (`1.8` -> 8, `21` -> 21). `Runtime.version()` is not used because the tests still compile at Java 8.

I did not add JDK 21 to the CI matrix: `javaparser-core` currently fails to compile on JDK 21+ (`NodeList.getLast()` vs `java.util.List.getLast()`). That is tracked in #5111.

Tested locally:

- JDK 17: `ReferenceTypeTest`, `ReflectionClassDeclarationTest`, `ReflectionInterfaceDeclarationTest`, `JavaParserClassDeclarationTest`, `JavaParserEnumDeclarationTest`, `JavaParserInterfaceDeclarationTest` — 247/247 (6 skipped)
- JDK 21 (classes compiled with JDK 17): same 6 classes, 247/247 (6 skipped)
- `spotless:apply`
