### PR TITLE
Fix malformed Javadocs

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/XmlPrinter.java
@@ -124,7 +124,7 @@ public class XmlPrinter {
      * Output the XML Document representing an AST node to given XMLStreamWriter.
      * <p>
      * This method outputs the starting of XML document, then delegates to
-     * {@link #outputNode(Node, String, XMLStreamWriter) for writing the root element of XML document, and finally
+     * {@link #outputNode(Node, String, XMLStreamWriter)} for writing the root element of XML document, and finally
      * outputs the ending of XML document.
      * </p>
      * <p>

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -112,7 +112,7 @@ public class MethodResolutionLogic {
      *
      * @return true, if the given ResolvedMethodDeclaration matches the given name/types (normally obtained from a MethodUsage)
      *
-     * @see {@link MethodResolutionLogic#isApplicable(MethodUsage, String, List, TypeSolver)}
+     * @see MethodResolutionLogic#isApplicable(MethodUsage, String, List, TypeSolver)
      */
     private static boolean isApplicable(
             ResolvedMethodDeclaration methodDeclaration,
@@ -577,9 +577,8 @@ public class MethodResolutionLogic {
      * @return true, if the given MethodUsage matches the given name/types (normally
      *         obtained from a ResolvedMethodDeclaration)
      *
-     * @see {@link MethodResolutionLogic#isApplicable(ResolvedMethodDeclaration, String, List, TypeSolver)}
-     *      }
-     * @see {@link MethodResolutionLogic#isApplicable(ResolvedMethodDeclaration, String, List, TypeSolver, boolean)}
+     * @see MethodResolutionLogic#isApplicable(ResolvedMethodDeclaration, String, List, TypeSolver)
+     * @see MethodResolutionLogic#isApplicable(ResolvedMethodDeclaration, String, List, TypeSolver, boolean)
      */
     public static boolean isApplicable(
             MethodUsage methodUsage,
@@ -752,21 +751,21 @@ public class MethodResolutionLogic {
      *
      * This method performs deep substitution of type variables, handling various
      * type structures including:
-     * - Simple type variables (T, E, K, V, etc.)
-     * - Wildcards with type variable bounds (? super T, ? extends E)
-     * - Parameterized types with type variables (List<T>, Map<K, V>)
-     * - Nested combinations of the above (Consumer<? super T>, List<List<E>>)
+     * - Simple type variables ({@code T}, {@code E}, {@code K}, {@code V}, etc.)
+     * - Wildcards with type variable bounds ({@code ? super T}, {@code ? extends E})
+     * - Parameterized types with type variables ({@code List<T>}, {@code Map<K, V>})
+     * - Nested combinations of the above ({@code Consumer<? super T>}, {@code List<List<E>>})
      *
      * The substitution is based on a mapping between type parameter declarations
-     * (the formal parameters as declared, e.g., <T> in class Foo<T>) and their
-     * actual type arguments (the concrete types used, e.g., String in Foo<String>).
+     * (the formal parameters as declared, e.g., {@code <T>} in class {@code Foo<T>}) and their
+     * actual type arguments (the concrete types used, e.g., {@code String} in {@code Foo<String>}).
      *
      * Example transformations:
-     * - T -> String (when typeParams contains T and typeArgs contains String)
-     * - ? super T -> ? super String
-     * - Consumer<? super T> -> Consumer<? super String>
-     * - List<T> -> List<String>
-     * - Map<K, V> -> Map<String, Integer> (with appropriate mappings)
+     * - {@code T -> String} (when typeParams contains T and typeArgs contains String)
+     * - {@code ? super T -> ? super String}
+     * - {@code Consumer<? super T> -> Consumer<? super String>}
+     * - {@code List<T> -> List<String>}
+     * - {@code Map<K, V> -> Map<String, Integer>} (with appropriate mappings)
      *
      * @param type the type in which to substitute type variables
      * @param typeParams the list of type parameter declarations (formal parameters)

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedType.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * <ul>
  *     <li>
  *         It could be a primitive type or a reference type (enum, class, interface).
- *         In the latter case, it could take type typeParametersValues (other {@code TypeUsages}).</p>
+ *         In the latter case, it could take type typeParametersValues (other {@code TypeUsages}).
  *     </li>
  *     <li>
  *         It could also be a {@code TypeVariable}, like in: {@code class A<B> {} } where {@code B} is a {@code TypeVariable}.

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javassistmodel/JavassistTypeDeclarationAdapter.java
@@ -276,7 +276,7 @@ public class JavassistTypeDeclarationAdapter {
     /**
      * Get the nested classes.
      * <br>
-     * {@code class Foo { class Bar {} }
+     * {@code class Foo { class Bar {} }}
      * In the example above we expect the nested types for {@code Foo} to be {@code Bar}.
      *
      * @return The nested classes.


### PR DESCRIPTION
## Summary

- fix six malformed Javadoc constructs in four Java source files
- keep the cleanup independent of the Checkstyle upgrade
- leave the existing Java and Checkstyle configuration unchanged

## Context

This applies the source cleanup requested in [the maintainer review](https://github.com/javaparser/javaparser/pull/5112#issuecomment-5476599130) directly to `master`. It does not include the Checkstyle 14 upgrade or a workflow JDK change.

## Verification

- Java 11: `./mvnw -B -ntp checkstyle:check` — passed all nine modules with zero violations
- Java 11: `./run_core_metamodel_generator.sh && ./run_core_generators.sh` — passed with no generated or formatting diff
- Java 11: `./mvnw -B -ntp test` — passed all nine modules; 2,092 tests run, 0 failures, 0 errors, 80 skipped
- `git diff --check` — passed

## AI assistance

Prepared using [JAIPilot](https://github.com/JAIPilot/jaipilot):

- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Host model: `gpt-5.6-sol`
- Reasoning effort: `xhigh`
- Service mode: `fast`
- Execution mode: local
