### PR TITLE
fix(deps): use OkHttp JVM artifact

### DIFF
--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
             <version>5.5.0</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Summary

Completes the OkHttp 5 upgrade in #5092 by selecting the JVM artifact.

OkHttp 5's `okhttp` coordinate is multiplatform metadata and no longer provides the JVM classes used by `TestUtils`. This changes only the artifact ID to `okhttp-jvm`; the Renovate-selected 5.5.0 version and test scope remain unchanged.

## Verification

- Reproduced the exact bot failure in GitHub Actions: `javaparser-core-testing` could not resolve `okhttp3.OkHttpClient`, `Request`, or `Response` on every tested JDK/OS lane.
- Java 8: `./mvnw -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B --errors -pl javaparser-core-testing -am clean test` — 2,842 tests passed, 8 skipped.
- JAIPilot Remote, JDK 17: `./mvnw -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B --errors clean test --activate-profiles AlsoSlowTests` — all 9 modules passed; 5,044 tests passed, 42 skipped, 0 failures/errors.
- `git diff --check` passed; final diff is one dependency-coordinate line.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
