### PR TITLE
build: use <release> so the CI matrix can cover JDK 19+ (fixes #5111)

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -34,7 +34,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         ## Different JDK versions have different implementations etc. -- test on all combinations (ideally 8 to latest).
         ### exclude pre-8 (min development version jdk8)
-        jdk: [ 8,9,10,11,12,13,14,15,16,17,18 ]
+        jdk: [ 8,9,10,11,12,13,14,15,16,17,18,19,20,21 ]
         # The below configurations are no longer available on github runners and is not supported by the 
         # setup-java action, nor are they available from the supported distributions.
         # See https://github.com/actions/setup-java for details

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <!--
+            Java release the artifacts are compiled against. Using `<release>` rather than
+            `<source>/<target>` makes javac resolve the JDK 8 API signatures from ct.sym instead
+            of the host JDK's, so the Java 8 baseline is actually verified and the build is not
+            affected by APIs added to JDK classes later on (e.g. SequencedCollection in JDK 21).
+        -->
+        <java.release>8</java.release>
         <byte-buddy.version>1.18.12-jdk5</byte-buddy.version>
         <argLine>-javaagent:'${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar'</argLine>
         <build.timestamp>2026-05-31T00:00:00Z</build.timestamp>
@@ -399,7 +406,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.12.0</version>
                     <configuration>
-                        <source>${java.version}</source>
+                        <release>${java.release}</release>
                         <additionalOptions>
                             <!-- doclint requires perfect JavaDoc, and fails the generation of javadoc on even minor problems -->
                             <!-- Ideally we will have perfectly formatted javadoc, but for now just disable it. -->
@@ -490,8 +497,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.release}</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The root pom compiled with `<source>`/`<target>` set to 1.8. With those flags javac still resolves the *host* JDK's API signatures, so building javaparser-core on JDK 21 failed on the SequencedCollection methods that JEP 431 added to java.util.List:

    NodeList.java:[189,24] addFirst(N) in NodeList cannot implement
                           addFirst(E) in java.util.List

It also emitted "bootstrap class path not set in conjunction with -source 8", i.e. the Java 8 baseline was never actually verified: code using a post-8 JDK API compiled fine as long as the language level was 8.

Compile with `<release>` instead, driven by a new `java.release` property. javac then reads the JDK 8 signatures from ct.sym, which both removes the clash and makes the Java 8 baseline real. The javadoc plugin follows the same property.

The test expectations that assumed a pre-21 JDK were fixed by #5110, so with this change the whole reactor now builds *and* passes on JDK 21 — add 19, 20 and 21 to the CI matrix so that stays true.

Verified locally with `mvn clean test -P AlsoSlowTests` on the full reactor: green on JDK 8, 18 and 21, and javaparser-core still emits class-file major version 52.

`java.version` is kept as-is: javaparser-core still passes it to ph-javacc-maven-plugin, which wants the 1.8 form.

Fixes #5111 .
