### PR TITLE
Make identifier and keyword case conversions locale-independent

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/LocaleIndependenceTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/LocaleIndependenceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.utils;
+
+import static com.github.javaparser.StaticJavaParser.parse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JavaParser transforms Java identifiers and keywords with {@code toLowerCase()} /
+ * {@code toUpperCase()} in a number of places. Those overloads use the default locale, and in a
+ * Turkish locale {@code 'I'} lower-cases to {@code 'ı'} (dotless) and {@code 'i'} upper-cases to
+ * {@code 'İ'} (dotted). Since these strings are Java source, not human-readable text, the
+ * conversions must be locale-independent.
+ *
+ * <p>See issue 3018.
+ */
+class LocaleIndependenceTest {
+
+    private static final Locale TURKISH = Locale.forLanguageTag("tr-TR");
+
+    private Locale previousDefault;
+
+    @BeforeEach
+    void setTurkishLocale() {
+        previousDefault = Locale.getDefault();
+        Locale.setDefault(TURKISH);
+    }
+
+    @AfterEach
+    void restoreLocale() {
+        Locale.setDefault(previousDefault);
+    }
+
+    @Test
+    void utilsCaseConversionsAreLocaleIndependent() {
+        assertEquals("Int", Utils.capitalize("int"));
+        assertEquals("int", Utils.decapitalize("Int"));
+        assertEquals("isInterface", Utils.screamingToCamelCase("IS_INTERFACE"));
+        assertEquals("IS_INTERFACE", Utils.camelCaseToScreaming("isInterface"));
+    }
+
+    @Test
+    void observablePropertyNamesAreLocaleIndependent() {
+        // camelCaseName() feeds the reflective getter lookup in ObservableProperty#getRawValue,
+        // so a mangled name makes the property unreadable. 43 of the 104 constants contain an 'I'.
+        assertEquals("annotations", ObservableProperty.ANNOTATIONS.camelCaseName());
+        assertEquals("interface", ObservableProperty.INTERFACE.camelCaseName());
+        assertEquals(ObservableProperty.ANNOTATIONS, ObservableProperty.fromCamelCaseName("annotations"));
+    }
+
+    @Test
+    void observablePropertyValuesAreReadable() {
+        CompilationUnit cu = parse("class A { }");
+        assertEquals("[]", String.valueOf(ObservableProperty.ANNOTATIONS.getRawValue(cu.getType(0))));
+    }
+
+    @Test
+    void lexicalPreservingPrinterWorksInAnyLocale() {
+        CompilationUnit cu = parse("class A { void f(){} }");
+        LexicalPreservingPrinter.setup(cu);
+        cu.getType(0)
+                .asClassOrInterfaceDeclaration()
+                .getMethods()
+                .get(0)
+                .setModifiers(Modifier.Keyword.PUBLIC, Modifier.Keyword.STATIC);
+        assertEquals("class A { public static void f(){} }", LexicalPreservingPrinter.print(cu));
+    }
+
+    @Test
+    void generatedAccessorNamesAreLocaleIndependent() {
+        CompilationUnit cu = parse("class A { int id; }");
+        FieldDeclaration field =
+                cu.getType(0).asClassOrInterfaceDeclaration().getFields().get(0);
+        assertEquals("getId", field.createGetter().getNameAsString());
+        assertEquals("setId", field.createSetter().getNameAsString());
+    }
+
+    @Test
+    void resolvedPrimitiveTypeLookupIsLocaleIndependent() {
+        assertEquals(ResolvedPrimitiveType.INT, ResolvedPrimitiveType.byName("INT"));
+        assertEquals(ResolvedPrimitiveType.INT, ResolvedPrimitiveType.byName("int"));
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/body/FieldDeclaration.java
@@ -49,6 +49,7 @@ import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.NonEmptyProperty;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -192,7 +193,8 @@ public class FieldDeclaration extends BodyDeclaration<FieldDeclaration>
             throw new IllegalStateException("You can use this only when the field is attached to a class or an enum");
         VariableDeclarator variable = getVariable(0);
         String fieldName = variable.getNameAsString();
-        String fieldNameUpper = fieldName.toUpperCase().substring(0, 1) + fieldName.substring(1, fieldName.length());
+        String fieldNameUpper =
+                fieldName.toUpperCase(Locale.ROOT).substring(0, 1) + fieldName.substring(1, fieldName.length());
         final MethodDeclaration getter;
         getter = parentClass
                 .map(clazz -> clazz.addMethod("get" + fieldNameUpper, Modifier.Keyword.PUBLIC))
@@ -222,7 +224,8 @@ public class FieldDeclaration extends BodyDeclaration<FieldDeclaration>
             throw new IllegalStateException("You can use this only when the field is attached to a class or an enum");
         VariableDeclarator variable = getVariable(0);
         String fieldName = variable.getNameAsString();
-        String fieldNameUpper = fieldName.toUpperCase().substring(0, 1) + fieldName.substring(1, fieldName.length());
+        String fieldNameUpper =
+                fieldName.toUpperCase(Locale.ROOT).substring(0, 1) + fieldName.substring(1, fieldName.length());
         final MethodDeclaration setter;
         setter = parentClass
                 .map(clazz -> clazz.addMethod("set" + fieldNameUpper, Modifier.Keyword.PUBLIC))

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/NoBinaryIntegerLiteralsValidator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/validator/language_level_validations/chunks/NoBinaryIntegerLiteralsValidator.java
@@ -25,6 +25,7 @@ import com.github.javaparser.ast.expr.LiteralStringValueExpr;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
 import com.github.javaparser.ast.validator.ProblemReporter;
 import com.github.javaparser.ast.validator.VisitorValidator;
+import java.util.Locale;
 
 public class NoBinaryIntegerLiteralsValidator extends VisitorValidator {
 
@@ -41,7 +42,7 @@ public class NoBinaryIntegerLiteralsValidator extends VisitorValidator {
     }
 
     private static void validate(LiteralStringValueExpr n, ProblemReporter arg) {
-        if (n.getValue().toUpperCase().startsWith("0B")) {
+        if (n.getValue().toUpperCase(Locale.ROOT).startsWith("0B")) {
             arg.report(n, "Binary literal values are not supported.");
         }
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/CsmAttribute.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.printer.SourcePrinter;
+import java.util.Locale;
 
 public class CsmAttribute implements CsmElement {
 
@@ -57,7 +58,7 @@ public class CsmAttribute implements CsmElement {
             case IDENTIFIER:
                 return GeneratedJavaParserConstants.IDENTIFIER;
             case TYPE: {
-                String expectedImage = "\"" + text.toLowerCase() + "\"";
+                String expectedImage = "\"" + text.toLowerCase(Locale.ROOT) + "\"";
                 for (int i = 0; i < GeneratedJavaParserConstants.tokenImage.length; i++) {
                     if (GeneratedJavaParserConstants.tokenImage[i].equals(expectedImage)) {
                         return i;
@@ -69,7 +70,7 @@ public class CsmAttribute implements CsmElement {
             }
             case KEYWORD:
             case OPERATOR: {
-                String expectedImage = "\"" + tokenText.toLowerCase() + "\"";
+                String expectedImage = "\"" + tokenText.toLowerCase(Locale.ROOT) + "\"";
                 for (int i = 0; i < GeneratedJavaParserConstants.tokenImage.length; i++) {
                     if (GeneratedJavaParserConstants.tokenImage[i].equals(expectedImage)) {
                         return i;

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/PrintingHelper.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/concretesyntaxmodel/PrintingHelper.java
@@ -21,6 +21,7 @@
 package com.github.javaparser.printer.concretesyntaxmodel;
 
 import com.github.javaparser.printer.Stringable;
+import java.util.Locale;
 
 class PrintingHelper {
 
@@ -29,7 +30,7 @@ class PrintingHelper {
             return ((Stringable) value).asString();
         }
         if (value instanceof Enum) {
-            return ((Enum) value).name().toLowerCase();
+            return ((Enum) value).name().toLowerCase(Locale.ROOT);
         } else {
             if (value != null) {
                 return value.toString();

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedPrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/types/ResolvedPrimitiveType.java
@@ -24,6 +24,7 @@ import com.github.javaparser.utils.TypeUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -55,7 +56,7 @@ public enum ResolvedPrimitiveType implements ResolvedType {
     }
 
     public static ResolvedType byName(String name) {
-        name = name.toLowerCase();
+        name = name.toLowerCase(Locale.ROOT);
         for (ResolvedPrimitiveType ptu : values()) {
             if (ptu.describe().equals(name)) {
                 return ptu;

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/Utils.java
@@ -113,7 +113,7 @@ public class Utils {
      */
     public static String screamingToCamelCase(String original) {
         StringBuilder sb = new StringBuilder();
-        String[] parts = original.toLowerCase().split("_");
+        String[] parts = original.toLowerCase(Locale.ROOT).split("_");
         for (int i = 0; i < parts.length; i++) {
             sb.append(i == 0 ? parts[i] : capitalize(parts[i]));
         }
@@ -128,7 +128,7 @@ public class Utils {
         if (input.isEmpty()) {
             return "";
         }
-        StringBuilder scream = new StringBuilder(input.substring(0, 1).toUpperCase());
+        StringBuilder scream = new StringBuilder(input.substring(0, 1).toUpperCase(Locale.ROOT));
         for (char c : input.substring(1).toCharArray()) {
             if (Character.isUpperCase(c)) {
                 scream.append("_");
@@ -163,14 +163,14 @@ public class Utils {
      * Capitalizes the first character in the string.
      */
     public static String capitalize(String s) {
-        return stringTransformer(s, "capitalize", String::toUpperCase);
+        return stringTransformer(s, "capitalize", str -> str.toUpperCase(Locale.ROOT));
     }
 
     /**
      * Lower-cases the first character in the string.
      */
     public static String decapitalize(String s) {
-        return stringTransformer(s, "decapitalize", String::toLowerCase);
+        return stringTransformer(s, "decapitalize", str -> str.toLowerCase(Locale.ROOT));
     }
 
     private static String stringTransformer(

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -63,6 +63,7 @@ import com.github.javaparser.utils.Log;
 import com.github.javaparser.utils.Pair;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -317,7 +318,7 @@ public class TypeExtractor extends DefaultVisitorAdapter {
 
     @Override
     public ResolvedType visit(DoubleLiteralExpr node, Boolean solveLambdas) {
-        if (node.getValue().toLowerCase().endsWith("f")) {
+        if (node.getValue().toLowerCase(Locale.ROOT).endsWith("f")) {
             return ResolvedPrimitiveType.FLOAT;
         }
         return ResolvedPrimitiveType.DOUBLE;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typesolvers/JavaParserTypeSolver.java
@@ -256,7 +256,10 @@ public class JavaParserTypeSolver implements TypeSolver {
             if (Files.exists(srcDirectory)) {
                 try (DirectoryStream<Path> srcDirectoryStream = Files.newDirectoryStream(srcDirectory)) {
                     srcDirectoryStream.forEach(file -> {
-                        if (file.getFileName().toString().toLowerCase().endsWith(".java")) {
+                        if (file.getFileName()
+                                .toString()
+                                .toLowerCase(Locale.ROOT)
+                                .endsWith(".java")) {
                             parse(file).ifPresent(units::add);
                         } else if (recursively && file.toFile().isDirectory()) {
                             units.addAll(parseDirectoryRecursively(file));


### PR DESCRIPTION
Java keywords and identifiers are normalised with the default-locale `String.toLowerCase()`/`toUpperCase()` overloads. In a Turkish locale `I` folds to dotless `ı` and `i` to dotted `İ`, so these conversions corrupt the strings they exist to normalise.

The worst site is `Utils.screamingToCamelCase`, which `ObservableProperty.camelCaseName()` uses to build a reflective getter name. **43 of the 104 `ObservableProperty` constants contain an `I`**, so their getters are not found and everything routed through the concrete syntax model throws, `LexicalPreservingPrinter` included:

```
RuntimeException: Unable to get value for ANNOTATIONS from class A { } (ClassOrInterfaceDeclaration)
```

**Measurement.** 23 probes over the public API, run in two separate JVMs (`-Duser.language=en` vs `tr`) rather than `Locale.setDefault`, because some values are captured in static initialisers and a single JVM cannot see those:

| build | divergences |
|---|---|
| master | **20 / 23** |
| this PR | 5 / 23 |
| this PR + #5086 | **0 / 23** |

**Relationship to #5086.** @tarann26's open PR fixes `PrimitiveType`, which is exactly the 5 that remain here. This PR deliberately does not touch that file. The two share no file, and cherry-picking this commit onto `pull/5086/head` applies with zero conflicts. Happy to fold them together or rebase if you would rather have one PR.

**Tests.** No test in the suite touches `Locale`, which is why 13 sites survived since 2016-17. The new `LocaleIndependenceTest` asserts values under a Turkish default; all 6 fail on master. Reverting only `Utils.java` still fails 2, so the other sites are independently load-bearing.

Three of the sites I pinned (`NoBinaryIntegerLiteralsValidator`, `TypeExtractor`, `JavaParserTypeSolver`) are latent. I could not make them misbehave in a Turkish locale since their inputs have no `i`/`I`. They are changed for consistency, not because I measured a failure.

Full suite green: 2092 run, 0 failures, 34 skipped. Part of #3018.

---
Drafted with the assistance of Claude Opus 5 (`claude-opus-5`); I have reviewed and verified every change and the measurements above.
