### PR TITLE
fix: resolve ::new to its constructor declaration (fixes #4933)

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/MethodReferenceExpr.java
@@ -40,6 +40,8 @@ import com.github.javaparser.metamodel.MethodReferenceExprMetaModel;
 import com.github.javaparser.metamodel.NonEmptyProperty;
 import com.github.javaparser.metamodel.OptionalProperty;
 import com.github.javaparser.resolution.Resolvable;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -59,6 +61,12 @@ public class MethodReferenceExpr extends Expression
         implements NodeWithTypeArguments<MethodReferenceExpr>,
                 NodeWithIdentifier<MethodReferenceExpr>,
                 Resolvable<ResolvedMethodDeclaration> {
+
+    /**
+     * The identifier of a constructor reference, as opposed to the method name of an ordinary method
+     * reference (JLS §15.13).
+     */
+    public static final String CONSTRUCTOR_REFERENCE_IDENTIFIER = "new";
 
     private Expression scope;
 
@@ -235,10 +243,46 @@ public class MethodReferenceExpr extends Expression
 
     /**
      * @return the method declaration this method reference is referencing.
+     * @throws UnsolvedSymbolException if the method declaration cannot be found, or if this is a
+     *         constructor reference. A constructor reference denotes a
+     *         {@link ResolvedConstructorDeclaration}, which is not a
+     *         {@link ResolvedMethodDeclaration}; use {@link #resolveInvokedConstructor()} instead.
+     * @see #isConstructorReference()
+     * @see #resolveInvokedConstructor()
      */
     @Override
     public ResolvedMethodDeclaration resolve() {
         return getSymbolResolver().resolveDeclaration(this, ResolvedMethodDeclaration.class);
+    }
+
+    /**
+     * Resolves the constructor this constructor reference is referencing.
+     * <p>
+     * The constructor is selected from the constructors of the scope type using the parameter types
+     * of the functional interface method the reference is assigned to, so that
+     * {@code Supplier<Foo> s = Foo::new} and {@code Function<String, Foo> f = Foo::new} resolve to
+     * {@code Foo()} and {@code Foo(String)} respectively.
+     * <p>
+     * Array constructor references such as {@code String[]::new} cannot be resolved: JLS §15.13.1
+     * defines them as array creation, for which there is no constructor declaration.
+     *
+     * @return the constructor declaration this constructor reference is referencing.
+     * @throws UnsolvedSymbolException if the constructor declaration cannot be found, or if this is
+     *         an ordinary method reference rather than a constructor reference.
+     * @see #isConstructorReference()
+     */
+    public ResolvedConstructorDeclaration resolveInvokedConstructor() {
+        return getSymbolResolver().resolveDeclaration(this, ResolvedConstructorDeclaration.class);
+    }
+
+    /**
+     * A constructor reference is a method reference whose identifier is the keyword {@code new},
+     * such as {@code Foo::new} or {@code String[]::new} (JLS §15.13).
+     *
+     * @return whether this method reference references a constructor rather than a method.
+     */
+    public boolean isConstructorReference() {
+        return CONSTRUCTOR_REFERENCE_IDENTIFIER.equals(getIdentifier());
     }
 
     /*

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/JavaSymbolSolver.java
@@ -255,8 +255,32 @@ public class JavaSymbolSolver implements SymbolResolver {
             }
         }
         if (node instanceof MethodReferenceExpr) {
+            MethodReferenceExpr methodReferenceExpr = (MethodReferenceExpr) node;
+            if (methodReferenceExpr.isConstructorReference()) {
+                // A constructor reference denotes a ResolvedConstructorDeclaration, which is not a
+                // ResolvedMethodDeclaration. Callers asking for the latter -- MethodReferenceExpr#resolve()
+                // among them -- cannot be served, so point them at the constructor-specific entry point.
+                if (!resultClass.isAssignableFrom(ResolvedConstructorDeclaration.class)) {
+                    throw new UnsolvedSymbolException("\"" + node + "\" is a constructor reference, not a method "
+                            + "reference. Use MethodReferenceExpr#resolveInvokedConstructor() or "
+                            + "resolveDeclaration(node, ResolvedConstructorDeclaration.class).");
+                }
+                SymbolReference<ResolvedConstructorDeclaration> result =
+                        JavaParserFacade.get(typeSolver).solveConstructorReference(methodReferenceExpr);
+                if (result.isSolved()) {
+                    return resultClass.cast(result.getCorrespondingDeclaration());
+                }
+                throw new UnsolvedSymbolException(
+                        "We are unable to find the constructor declaration corresponding to " + node);
+            }
+            // Conversely, an ordinary method reference cannot produce a ResolvedConstructorDeclaration.
+            if (!resultClass.isAssignableFrom(ResolvedMethodDeclaration.class)) {
+                throw new UnsolvedSymbolException("\"" + node + "\" is a method reference, not a constructor "
+                        + "reference. Use MethodReferenceExpr#resolve() or "
+                        + "resolveDeclaration(node, ResolvedMethodDeclaration.class).");
+            }
             SymbolReference<ResolvedMethodDeclaration> result =
-                    JavaParserFacade.get(typeSolver).solve((MethodReferenceExpr) node);
+                    JavaParserFacade.get(typeSolver).solve(methodReferenceExpr);
             if (result.isSolved()) {
                 if (resultClass.isInstance(result.getCorrespondingDeclaration())) {
                     return resultClass.cast(result.getCorrespondingDeclaration());

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -46,6 +46,7 @@ import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.javaparsermodel.contexts.FieldAccessContext;
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.MethodReferenceExprContext;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserAnonymousClassDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserEnumDeclaration;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
@@ -339,6 +340,18 @@ public class JavaParserFacade {
         List<ResolvedType> argumentTypes = new LinkedList<>();
         return JavaParserFactory.getContext(methodReferenceExpr, typeSolver)
                 .solveMethod(methodReferenceExpr.getIdentifier(), argumentTypes, false);
+    }
+
+    /**
+     * Given a constructor reference (e.g. {@code Foo::new}) find out to which constructor declaration it
+     * corresponds.
+     */
+    public SymbolReference<ResolvedConstructorDeclaration> solveConstructorReference(
+            MethodReferenceExpr methodReferenceExpr) {
+        // pass empty argument list to be populated
+        List<ResolvedType> argumentTypes = new LinkedList<>();
+        return ((MethodReferenceExprContext) JavaParserFactory.getContext(methodReferenceExpr, typeSolver))
+                .solveConstructor(argumentTypes);
     }
 
     public SymbolReference<ResolvedAnnotationDeclaration> solve(AnnotationExpr annotationExpr) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/TypeExtractor.java
@@ -861,7 +861,7 @@ public class TypeExtractor extends DefaultVisitorAdapter {
                     // constructors are not returned by getAllMethods(). Skipping is safe: a constructor
                     // always returns the constructed type, which equals the functional interface's
                     // return type — the inference pair (formal, actual) would carry no new information.
-                    if (!"new".equals(node.getIdentifier())) {
+                    if (!node.isConstructorReference()) {
                         ResolvedType actualType = facade.toMethodUsage(node, functionalMethod.getParamTypes())
                                 .returnType();
                         ResolvedType formalType = functionalMethod.returnType();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -355,7 +355,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
             MethodReferenceExpr ref = rawArg.asMethodReferenceExpr();
             ResolvedType actualReturnType = null;
 
-            if ("new".equals(ref.getIdentifier())) {
+            if (ref.isConstructorReference()) {
                 // Constructor reference X::new always returns the constructed type X
                 try {
                     actualReturnType = ref.getScope().calculateResolvedType();

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodReferenceExprContext.java
@@ -25,6 +25,7 @@ import static com.github.javaparser.resolution.Navigator.demandParentNode;
 
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
@@ -35,6 +36,7 @@ import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclarat
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.logic.ConstructorResolutionLogic;
 import com.github.javaparser.resolution.logic.FunctionalInterfaceLogic;
 import com.github.javaparser.resolution.logic.InferenceContext;
 import com.github.javaparser.resolution.logic.MethodResolutionLogic;
@@ -62,8 +64,9 @@ public class MethodReferenceExprContext extends ExpressionContext<MethodReferenc
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
-        if ("new".equals(name)) {
-            throw new UnsupportedOperationException("Constructor calls not yet resolvable");
+        // A constructor reference does not denote a method; it is resolved by solveConstructor().
+        if (MethodReferenceExpr.CONSTRUCTOR_REFERENCE_IDENTIFIER.equals(name)) {
+            return SymbolReference.unsolved();
         }
 
         argumentsTypes.addAll(inferArgumentTypes());
@@ -94,9 +97,60 @@ public class MethodReferenceExprContext extends ExpressionContext<MethodReferenc
         return SymbolReference.unsolved();
     }
 
+    /**
+     * Given a constructor reference (e.g. {@code Foo::new}) find out to which constructor declaration it
+     * corresponds. The candidate constructors are those of the scope type, and they are matched against the
+     * parameter types of the functional interface method the reference is assigned to, so that
+     * {@code Supplier<Foo>} selects {@code Foo()} while {@code Function<String, Foo>} selects
+     * {@code Foo(String)}.
+     *
+     * @param argumentsTypes an empty, mutable list which is populated with the inferred argument types.
+     * @return the referenced constructor, or an unsolved reference when this is not a constructor reference,
+     *         when it is an array constructor reference, or when no constructor is applicable.
+     */
+    public SymbolReference<ResolvedConstructorDeclaration> solveConstructor(List<ResolvedType> argumentsTypes) {
+        if (!wrappedNode.isConstructorReference()) {
+            return SymbolReference.unsolved();
+        }
+        // JLS 15.13.1: an array constructor reference such as String[]::new denotes array creation, for
+        // which no constructor declaration exists. It has to be rejected here because
+        // findTypeDeclarations() maps an array scope to java.lang.Object, which would otherwise make
+        // String[]::new resolve to a constructor of Object.
+        if (isArrayConstructorReference()) {
+            return SymbolReference.unsolved();
+        }
+
+        argumentsTypes.addAll(inferArgumentTypes());
+
+        // Unlike MethodResolutionLogic, ConstructorResolutionLogic does not know about the lambda
+        // constraint types that inferArgumentTypes() produces, so they are replaced by their bound.
+        List<ResolvedType> boundArgumentsTypes = new ArrayList<>(argumentsTypes.size());
+        for (ResolvedType argumentType : argumentsTypes) {
+            boundArgumentsTypes.add(
+                    argumentType.isConstraint()
+                            ? argumentType.asConstraintType().getBound()
+                            : argumentType);
+        }
+
+        for (ResolvedReferenceTypeDeclaration rrtd : findTypeDeclarations(Optional.of(wrappedNode.getScope()))) {
+            SymbolReference<ResolvedConstructorDeclaration> resAttempt = ConstructorResolutionLogic.findMostApplicable(
+                    rrtd.getConstructors(), boundArgumentsTypes, typeSolver);
+            if (resAttempt.isSolved()) {
+                return resAttempt;
+            }
+        }
+
+        return SymbolReference.unsolved();
+    }
+
     ///
     /// Private methods
     ///
+
+    private boolean isArrayConstructorReference() {
+        Expression scope = wrappedNode.getScope();
+        return scope.isTypeExpr() && scope.asTypeExpr().getType().isArrayType();
+    }
 
     private List<ResolvedType> inferArgumentTypes() {
         if (demandParentNode(wrappedNode) instanceof MethodCallExpr) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/MethodReferenceResolutionTest.java
@@ -22,6 +22,9 @@
 package com.github.javaparser.symbolsolver.resolution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -33,13 +36,13 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.resolution.Navigator;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class MethodReferenceResolutionTest extends AbstractResolutionTest {
@@ -608,7 +611,6 @@ class MethodReferenceResolutionTest extends AbstractResolutionTest {
     }
 
     @Test
-    @Disabled(value = "Waiting for constructor calls to be resolvable")
     void zeroArgumentConstructor_resolveToDeclaration() {
         // configure symbol solver before parsing
         StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
@@ -622,11 +624,142 @@ class MethodReferenceResolutionTest extends AbstractResolutionTest {
         MethodReferenceExpr methodReferenceExpr =
                 (MethodReferenceExpr) returnStmt.getExpression().get();
 
-        // resolve method reference expression
-        ResolvedMethodDeclaration resolvedMethodDeclaration = methodReferenceExpr.resolve();
+        // resolve constructor reference expression
+        ResolvedConstructorDeclaration resolvedConstructorDeclaration = methodReferenceExpr.resolveInvokedConstructor();
 
-        // check that the expected method declaration equals the resolved method declaration
-        assertEquals("Supplier<SuperClass>", resolvedMethodDeclaration.getQualifiedSignature());
+        // the target type Supplier<SuperClass> takes no argument, so the no-arg constructor is selected
+        assertEquals("SuperClass.SuperClass()", resolvedConstructorDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void singleArgumentConstructor_resolveToDeclaration() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        // parse compilation unit and get method reference expression
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz =
+                Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "singleArgumentConstructor");
+        ReturnStmt returnStmt = Navigator.demandReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr =
+                (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        // resolve constructor reference expression
+        ResolvedConstructorDeclaration resolvedConstructorDeclaration = methodReferenceExpr.resolveInvokedConstructor();
+
+        // the same SuperClass::new text selects a different constructor, driven by the target type
+        // Function<String, SuperClass>
+        assertEquals("SuperClass.SuperClass(java.lang.String)", resolvedConstructorDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void constructorReference_resolveReportsTheConstructorSpecificEntryPoint() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz =
+                Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "zeroArgumentConstructor");
+        ReturnStmt returnStmt = Navigator.demandReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr =
+                (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        assertTrue(methodReferenceExpr.isConstructorReference());
+
+        // a constructor declaration is not a method declaration, so resolve() cannot serve it
+        UnsolvedSymbolException exception = assertThrows(UnsolvedSymbolException.class, methodReferenceExpr::resolve);
+        assertTrue(exception.getMessage().contains("resolveInvokedConstructor()"));
+    }
+
+    @Test
+    void methodReference_resolveInvokedConstructorReportsTheMethodSpecificEntryPoint() {
+        // configure symbol solver before parsing
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+
+        CompilationUnit cu = parseSample("MethodReferences");
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz =
+                Navigator.demandClass(cu, "MethodReferences");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "classMethod");
+        ReturnStmt returnStmt = Navigator.demandReturnStmt(method);
+        MethodReferenceExpr methodReferenceExpr =
+                (MethodReferenceExpr) returnStmt.getExpression().get();
+
+        assertFalse(methodReferenceExpr.isConstructorReference());
+
+        UnsolvedSymbolException exception =
+                assertThrows(UnsolvedSymbolException.class, methodReferenceExpr::resolveInvokedConstructor);
+        assertTrue(exception.getMessage().contains("resolve()"));
+    }
+
+    @Test
+    void genericConstructorReference_resolveToDeclaration() {
+        String s = "import java.util.ArrayList;\n" + "import java.util.Collection;\n"
+                + "import java.util.List;\n"
+                + "import java.util.function.Function;\n"
+                + "\n"
+                + "public class GenericConstructorReference {\n"
+                + "    Function<Collection<String>, List<String>> copy() {\n"
+                + "        return ArrayList::new;\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        CompilationUnit cu = StaticJavaParser.parse(s);
+
+        MethodReferenceExpr methodReferenceExpr =
+                cu.findFirst(MethodReferenceExpr.class).get();
+
+        ResolvedConstructorDeclaration resolvedConstructorDeclaration = methodReferenceExpr.resolveInvokedConstructor();
+
+        assertEquals(
+                "java.util.ArrayList.ArrayList(java.util.Collection<? extends E>)",
+                resolvedConstructorDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void constructorReferenceAsMethodArgument_resolveToDeclaration() {
+        String s = "import java.util.stream.Stream;\n" + "\n"
+                + "public class ConstructorReferenceArgument {\n"
+                + "    static class Box {\n"
+                + "        Box() { }\n"
+                + "        Box(String s) { }\n"
+                + "    }\n"
+                + "    long count(Stream<String> stream) {\n"
+                + "        return stream.map(Box::new).count();\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        CompilationUnit cu = StaticJavaParser.parse(s);
+
+        MethodReferenceExpr methodReferenceExpr =
+                cu.findFirst(MethodReferenceExpr.class).get();
+
+        ResolvedConstructorDeclaration resolvedConstructorDeclaration = methodReferenceExpr.resolveInvokedConstructor();
+
+        // the argument type comes from the parameter of Stream.map, i.e. Function<? super String, ? extends R>
+        assertEquals(
+                "ConstructorReferenceArgument.Box.Box(java.lang.String)",
+                resolvedConstructorDeclaration.getQualifiedSignature());
+    }
+
+    @Test
+    void arrayConstructorReference_isNotResolvable() {
+        String s = "import java.util.function.IntFunction;\n" + "\n"
+                + "public class ArrayConstructorReference {\n"
+                + "    IntFunction<String[]> create() {\n"
+                + "        return String[]::new;\n"
+                + "    }\n"
+                + "}";
+        StaticJavaParser.getParserConfiguration().setSymbolResolver(new JavaSymbolSolver(new ReflectionTypeSolver()));
+        CompilationUnit cu = StaticJavaParser.parse(s);
+
+        MethodReferenceExpr methodReferenceExpr =
+                cu.findFirst(MethodReferenceExpr.class).get();
+
+        // JLS 15.13.1: an array constructor reference denotes array creation, there is no constructor
+        // declaration to resolve to. It must not silently fall back to a constructor of java.lang.Object.
+        assertThrows(UnsolvedSymbolException.class, methodReferenceExpr::resolveInvokedConstructor);
     }
 
     @Test


### PR DESCRIPTION
MethodReferenceExprContext preventively threw UnsupportedOperationException for any constructor reference, so MethodReferenceExpr#resolve() could not be called on X::new -- and the exception escaped the UnsolvedSymbolException that callers catch when walking an AST.

Constructor references are now resolved by matching the constructors of the scope type against the parameter types of the target functional interface, which is what discriminates the overloads: Supplier<Foo> selects Foo() while Function<String, Foo> selects Foo(String).

A ResolvedConstructorDeclaration is not a ResolvedMethodDeclaration, so the result cannot be returned by resolve() without a source and binary breaking change. It is exposed through the new MethodReferenceExpr#resolveInvokedConstructor() instead; resolve() now reports an UnsolvedSymbolException naming that entry point, as NameExpr#resolve() does for type names. The reverse case is handled symmetrically.

Two traps are dealt with explicitly:
- ConstructorResolutionLogic, unlike MethodResolutionLogic, does not know the lambda constraint types produced by inferArgumentTypes(); they are replaced by their bound before constructor lookup.
- findTypeDeclarations() maps an array scope to java.lang.Object, so String[]::new would otherwise resolve to a constructor of Object. Per JLS 15.13.1 an array constructor reference denotes array creation and has no constructor declaration, so it is rejected up front.

The test that was waiting on this expected the target functional interface type as the qualified signature of the resolved declaration; it now expects the constructor, SuperClass.SuperClass().

Note that a constructor reference in an assignment, cast, conditional or array initializer still fails in inferArgumentTypes(). That gap is not specific to constructor references -- ordinary method references fail the same way in those positions -- and is left for a separate change.

Fixes #4933 .
