### PR TITLE
fix: resolve a type's own type parameters before the enclosing scope

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -120,15 +120,8 @@ public class JavaParserTypeDeclarationAdapter {
             }
         }
 
-        // Before checking the ancestors of the node,
-        // it is necessary to check that the name to be resolved is not declared in the compilation unit.
-        // An example is provided in the issue https://github.com/javaparser/javaparser/issues/3214
-        SymbolReference<ResolvedTypeDeclaration> symbolRef = context.getParent()
-                .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
-                .solveType(name, typeArguments);
-        if (symbolRef.isSolved()) return symbolRef;
-
-        // Check if is a type parameter
+        // A type parameter declared here shadows any same-named type in an enclosing scope (JLS 6.4.1),
+        // so it has to be checked before delegating to the parent context.
         if (wrappedNode instanceof NodeWithTypeParameters) {
             NodeWithTypeParameters<?> nodeWithTypeParameters = (NodeWithTypeParameters<?>) wrappedNode;
             for (TypeParameter astTpRaw : nodeWithTypeParameters.getTypeParameters()) {
@@ -137,6 +130,14 @@ public class JavaParserTypeDeclarationAdapter {
                 }
             }
         }
+
+        // Before checking the ancestors of the node,
+        // it is necessary to check that the name to be resolved is not declared in the compilation unit.
+        // An example is provided in the issue https://github.com/javaparser/javaparser/issues/3214
+        SymbolReference<ResolvedTypeDeclaration> symbolRef = context.getParent()
+                .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
+                .solveType(name, typeArguments);
+        if (symbolRef.isSolved()) return symbolRef;
 
         // Check if the node implements other types
         if (wrappedNode instanceof NodeWithImplements) {

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapterTest.java
@@ -129,4 +129,61 @@ class JavaParserTypeDeclarationAdapterTest extends AbstractResolutionTest {
 
         returnTypes.forEach(type -> assertEquals("Activity.Timestamps", type));
     }
+
+    /**
+     * A type parameter shadows a same-named type declared in an enclosing scope (JLS 6.4.1), so
+     * {@code Holder<T>}'s own {@code T} must win over the top-level class {@code T}.
+     */
+    @Test
+    void typeParameterShadowsSameNamedTopLevelClass() {
+        String code = "class T {}\n"
+                + "class Holder<T> {\n"
+                + "    T get() { return null; }\n"
+                + "}\n"
+                + "class Usage {\n"
+                + "    void m(Holder<String> holder) {\n"
+                + "        holder.get();\n"
+                + "    }\n"
+                + "}";
+
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+        CompilationUnit cu = parser.parse(code);
+
+        MethodCallExpr mce = cu.findAll(MethodCallExpr.class).get(0);
+
+        assertEquals("java.lang.String", mce.calculateResolvedType().describe());
+    }
+
+    /**
+     * A nested class' type parameter shadows the enclosing class' identically named one. Resolving
+     * {@code Aggregator}'s {@code T} to {@code Runner}'s used to drop the {@code Void} argument, leaving
+     * the receiver as {@code FailFastRunner<Runner.T>}. Its ancestor {@code Runner<List<T>>} then reported
+     * the value of {@code Runner}'s {@code T} as {@code List<T>} - a value mentioning the very type
+     * parameter being replaced - so substituting it recursed until the stack overflowed.
+     */
+    @Test
+    void nestedTypeParameterShadowsEnclosingOneWithSameName() {
+        String code = "import java.util.List;\n"
+                + "class Runner<T> {\n"
+                + "    Runner<T> onFailure() { return this; }\n"
+                + "    static class Aggregator<T> {\n"
+                + "        FailFastRunner<T> failFastRunner() { return null; }\n"
+                + "    }\n"
+                + "}\n"
+                + "final class FailFastRunner<T> extends Runner<List<T>> {}\n"
+                + "class Usage {\n"
+                + "    void m(Runner.Aggregator<Void> aggregator) {\n"
+                + "        aggregator.failFastRunner().onFailure();\n"
+                + "    }\n"
+                + "}";
+
+        JavaParserAdapter parser = JavaParserAdapter.of(createParserWithResolver(defaultTypeSolver()));
+        CompilationUnit cu = parser.parse(code);
+
+        MethodCallExpr onFailure = cu.findAll(MethodCallExpr.class).get(0);
+
+        assertEquals(
+                "Runner<java.util.List<java.lang.Void>>",
+                onFailure.calculateResolvedType().describe());
+    }
 }


### PR DESCRIPTION
## The problem

```java
import java.util.List;

class Runner<T> {
    Runner<T> onFailure() { return this; }

    static class Aggregator<T> {                     // its own T
        FailFastRunner<T> failFastRunner() { return null; }
    }
}

final class FailFastRunner<T> extends Runner<List<T>> {}

class Usage {
    void m(Runner.Aggregator<Void> aggregator) {
        aggregator.failFastRunner().onFailure();      // StackOverflowError
    }
}
```

Resolving the last line throws `StackOverflowError`, alternating between
`ResolvedTypeParameterValueProvider.useThisTypeParametersOnTheGivenType` and
`ReferenceTypeImpl.transformTypeParameters` for ~500 frames each.

How it gets there:

1. `failFastRunner()`'s declared return type is `FailFastRunner<T>`. Resolving that `T`
   yields **`Runner`'s `T`**, not `Aggregator`'s.
2. `typeParamValue` matches a type parameter to its declaring type by container id. The
   receiver `Aggregator<Void>` knows `Aggregator.T = Void`, but it is asked for `Runner.T`
   — no match, so `Void` is dropped and the call resolves to `FailFastRunner<Runner.T>`.
3. Since `FailFastRunner<T> extends Runner<List<T>>`, that receiver's ancestor becomes
   `Runner<List<Runner.T>>`. Asked for the value of `Runner.T`, it answers `List<Runner.T>`.
4. That value mentions the parameter being replaced, so `T → List<T>` has no fixed point:
   it expands to `List<List<T>>`, `List<List<List<T>>>`, … until the stack is exhausted.

Step 1 is the defect; 2–4 are consequences.

## The fix

`JavaParserTypeDeclarationAdapter.solveType` asked the parent context *before* checking the
type parameters declared on the node itself:

```java
// before
SymbolReference<ResolvedTypeDeclaration> symbolRef = context.getParent()
        .solveType(name, typeArguments);
if (symbolRef.isSolved()) return symbolRef;                 // returns here

// Check if is a type parameter
if (wrappedNode instanceof NodeWithTypeParameters) { ... }  // never reached
```

The parent context runs the same lookup recursively, so resolving `"T"` inside `Aggregator`
walked out to `Runner`, hit *its* type-parameter check, and returned `Runner.T` — one line
before `Aggregator`'s own parameters would have been consulted.

This moves the type-parameter check above the parent lookup. No logic change, only order.

## Why this is correct

JLS 6.4.1: a type parameter declaration shadows any other declaration of the same name in an
enclosing scope. `solveType` returns on the first match, so the order of its checks *is* the
shadowing precedence — the local declaration has to come first.

The reorder can only change an outcome when a name matches both a local type parameter and
something in an enclosing scope, and there the local one is always the correct answer.

Verified against `javac` on 10 scenarios:

| Scenario | Before | After | `javac` |
|---|---|---|---|
| Type parameter vs same-named top-level class | `T` (the class) | `String` | `String` |
| Nested parameter vs enclosing parameter (above) | `StackOverflowError` | `Runner<List<Void>>` | same |
| Parameter named `List` vs `import java.util.List` | `java.util.List` | `String` | `String` |
| Parameter vs enclosing class' nested class name | `Outer.Inner` | `String` | `String` |
| `Outer<T>` / `static C<T> extends Outer<String>` | `String` | `Integer` | `Integer` |
| No collision (plain generics, method `<T>`, inherited member type) | unchanged | unchanged | — |

Note the fifth row: the old behaviour returned a wrong *concrete* type rather than a crash.

Also:

- Full test suite green (2100 tests).
- `issue3214` still passes. That parent lookup guards against **ancestors**, and it stays
  above the `extends`/`implements`/`checkAncestorsForType` checks, so its intent is preserved.
- One behaviour change on code `javac` rejects: for `Box<String>` where `Box` is a type
  parameter, the name now resolves to the parameter and the type argument is ignored.

Not addressed here: a `static` nested class can still see the outer class' type parameters,
which `javac` rejects outright. It needs no local parameter to shadow it, so it is a separate
issue from this one.
