### PR TITLE
build: keep the byte-buddy agent in the test modules' argLine

### DIFF
--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -64,7 +64,8 @@
                 <configuration>
                     <reportFormat>plain</reportFormat>
                     <failIfNoTests>true</failIfNoTests>
-                    <argLine>@{jacoco.javaagent}</argLine>
+                    <!-- Note that <argLine> overwrites, not appends, hence need for `${argLine}` -->
+                    <argLine>${argLine} @{jacoco.javaagent}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -69,7 +69,8 @@
                 <configuration>
                     <reportFormat>plain</reportFormat>
                     <failIfNoTests>true</failIfNoTests>
-                    <argLine>@{jacoco.javaagent}</argLine>
+                    <!-- Note that <argLine> overwrites, not appends, hence need for `${argLine}` -->
+                    <argLine>${argLine} @{jacoco.javaagent}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -74,7 +74,7 @@
                             <parallel>methods</parallel>
                             <threadCount>4</threadCount>
                             <!-- Note that <argLine> overwrites, not appends, hence need for `${argLine}` -->
-                            <argLine>-Xms256m -Xmx2g -verbose:gc @{jacoco.javaagent}</argLine>
+                            <argLine>${argLine} -Xms256m -Xmx2g -verbose:gc @{jacoco.javaagent}</argLine>
                             <reportFormat>plain</reportFormat>
                             <failIfNoTests>true</failIfNoTests>
                         </configuration>
@@ -92,7 +92,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <!-- Note that <argLine> overwrites, not appends, hence need for `${argLine}` -->
-                            <argLine>-Xms256m -Xmx2g -verbose:gc @{jacoco.javaagent}</argLine>
+                            <argLine>${argLine} -Xms256m -Xmx2g -verbose:gc @{jacoco.javaagent}</argLine>
                             <reportFormat>plain</reportFormat>
                             <failIfNoTests>true</failIfNoTests>
                         </configuration>


### PR DESCRIPTION
The root pom preloads byte-buddy-agent through the `argLine` property so that Mockito's inline mock maker never has to attach to the running JVM. The four test modules override surefire's <argLine> without re-injecting ${argLine}, so that preload was silently dropped -- even in the two files whose comment says exactly that it must not be.

`mvn -X` on javaparser-symbol-solver-testing showed the forked JVM receiving only JaCoCo's agent:

    java -Xms256m -Xmx2g -verbose:gc
         -javaagent:...org.jacoco.agent-0.8.15-runtime.jar=destfile=...
         -jar ...surefirebooter....jar

Mockito therefore fell back to dynamic self-attachment, which fails on JDK 21:

    *** java.lang.instrument ASSERTION FAILED ***: "success" with message
        createInstrumentationImpl failed at InvocationAdapter.c line: 425
    Agent failed to start!
    java.lang.IllegalStateException: Could not initialize plugin:
        interface org.mockito.plugins.MockMaker (alternate: null)

The messages appear after "Running <test>", i.e. at attach time rather than at JVM startup. The defect is older than the symptom: it only became visible when JDK 19-21 joined the CI matrix in 154d89b. It is unrelated to the byte-buddy bump in b2d5d6b -- JDK 21 fails identically with 1.18.13-jdk5, 1.18.12-jdk5 and 1.18.4.

Upgrading Mockito is not an option: mockito-inline stops at 4.x and mockito-core 5.x requires Java 11, while the matrix still covers JDK 8. The preloaded agent has to keep working.

Verified with the previously failing CommentTest and ConstraintFormulaTest: green on JDK 21 and on JDK 8, with no agent errors. The full javaparser-core-testing module runs 2842 tests, 0 failures on JDK 21.

javaparser-core-testing-bdd gets the same fix for consistency; it has no Mockito dependency, so it was not affected.

Fixes #9999.
