### PR TITLE
build: guard against default-locale case conversions (fixes #3018)

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -114,3 +114,39 @@ jobs:
           verbose: false # optional (default = false):
           flags: javaparser-symbol-solver,AlsoSlowTests,${{ matrix.os }},jdk-${{ matrix.jdk }}
           env_vars: OS,JDK
+
+  ## What JavaParser reads and prints is Java source -- keywords and identifiers, not human-readable
+  ## text -- so nothing it produces may depend on the JVM's default locale. Turkish is the locale
+  ## that breaks the naive assumption: 'I' lower-cases to the dotless 'ı' and 'i' upper-cases to the
+  ## dotted 'İ', which silently corrupts keywords and reflective getter lookups alike. See issue 3018.
+  ## One run is enough: this is a property of the code, not of the OS or the JDK, both of which the
+  ## matrix above already covers.
+  turkish_locale_test:
+    name: Test in a Turkish locale
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: "0"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v6
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          java-package: jdk
+
+      - name: Cache Maven packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      ## `test.locale.args` is appended to the forked test JVMs' argLine by the root pom, so the
+      ## default locale is Turkish inside the tests themselves, not merely in the Maven process.
+      - name: Test with a Turkish default locale
+        shell: bash
+        run: ./mvnw -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B --errors clean test --activate-profiles AlsoSlowTests -Dtest.locale.args="-Duser.language=tr -Duser.country=TR"

--- a/dev-files/JavaParser-CheckStyle.xml
+++ b/dev-files/JavaParser-CheckStyle.xml
@@ -42,5 +42,17 @@
 		<!-- Imports that are not used, should be removed -->
 		<module name="UnusedImports"/>
 
+		<!--
+			Java keywords and identifiers are source tokens, not human-readable text. The no-arg
+			toLowerCase()/toUpperCase() overloads fold case with the JVM's default locale, which
+			corrupts them under tr/az/lt ("INT" becomes "ınt"). See issue 3018.
+		-->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="\.to(Lower|Upper)Case\(\)|::to(Lower|Upper)Case"/>
+			<property name="message"
+			          value="Use toLowerCase(Locale.ROOT) / toUpperCase(Locale.ROOT): the no-arg overloads depend on the JVM default locale."/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+
 	</module>
 </module>

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/NodeListTest.java
@@ -180,7 +180,7 @@ class NodeListTest extends AbstractLexicalPreservingTest {
                     propertyChanges.add(String.format(
                             "%s.%s changed from %s to %s",
                             observedNode.getClass().getSimpleName(),
-                            property.name().toLowerCase(),
+                            property.name().toLowerCase(Locale.ROOT),
                             oldValue,
                             newValue));
                 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ObservationTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/ObservationTest.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.observer.ObservableProperty;
 import com.github.javaparser.ast.type.PrimitiveType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 public class ObservationTest {
@@ -49,7 +50,10 @@ public class ObservationTest {
                     Node observedNode, ObservableProperty property, Object oldValue, Object newValue) {
                 changes.add(String.format(
                         "%s.%s changed from %s to %s",
-                        observedNode.getClass().getSimpleName(), property.name().toLowerCase(), oldValue, newValue));
+                        observedNode.getClass().getSimpleName(),
+                        property.name().toLowerCase(Locale.ROOT),
+                        oldValue,
+                        newValue));
             }
         };
         cu.registerForSubtree(observer);
@@ -97,7 +101,10 @@ public class ObservationTest {
                     Node observedNode, ObservableProperty property, Object oldValue, Object newValue) {
                 changes.add(String.format(
                         "%s.%s changed from %s to %s",
-                        observedNode.getClass().getSimpleName(), property.name().toLowerCase(), oldValue, newValue));
+                        observedNode.getClass().getSimpleName(),
+                        property.name().toLowerCase(Locale.ROOT),
+                        oldValue,
+                        newValue));
             }
         };
         cu.getClassByName("A").get().register(observer, Node.ObserverRegistrationMode.JUST_THIS_NODE);
@@ -144,7 +151,10 @@ public class ObservationTest {
                     Node observedNode, ObservableProperty property, Object oldValue, Object newValue) {
                 changes.add(String.format(
                         "%s.%s changed from %s to %s",
-                        observedNode.getClass().getSimpleName(), property.name().toLowerCase(), oldValue, newValue));
+                        observedNode.getClass().getSimpleName(),
+                        property.name().toLowerCase(Locale.ROOT),
+                        oldValue,
+                        newValue));
             }
         };
         cu.getClassByName("A")
@@ -207,7 +217,10 @@ public class ObservationTest {
                     Node observedNode, ObservableProperty property, Object oldValue, Object newValue) {
                 changes.add(String.format(
                         "%s.%s changed from %s to %s",
-                        observedNode.getClass().getSimpleName(), property.name().toLowerCase(), oldValue, newValue));
+                        observedNode.getClass().getSimpleName(),
+                        property.name().toLowerCase(Locale.ROOT),
+                        oldValue,
+                        newValue));
             }
         };
         cu.getClassByName("A").get().register(observer, Node.ObserverRegistrationMode.SELF_PROPAGATING);

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/observer/PropagatingAstObserverTest.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 class PropagatingAstObserverTest {
@@ -49,7 +50,10 @@ class PropagatingAstObserverTest {
                     Node observedNode, ObservableProperty property, Object oldValue, Object newValue) {
                 changes.add(String.format(
                         "%s.%s changed from %s to %s",
-                        observedNode.getClass().getSimpleName(), property.name().toLowerCase(), oldValue, newValue));
+                        observedNode.getClass().getSimpleName(),
+                        property.name().toLowerCase(Locale.ROOT),
+                        oldValue,
+                        newValue));
             }
         };
         cu.registerForSubtree(observer);

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,13 @@
         -->
         <java.release>8</java.release>
         <byte-buddy.version>1.18.13-jdk5</byte-buddy.version>
-        <argLine>-javaagent:'${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar'</argLine>
+        <!--
+            Extra JVM arguments appended to every forked test JVM. Empty by default; the CI job that
+            runs the suite in a Turkish locale sets it to `-Duser.language=tr -Duser.country=TR`, so
+            that a default-locale case conversion cannot creep back in unnoticed. See issue 3018.
+        -->
+        <test.locale.args/>
+        <argLine>-javaagent:'${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar' ${test.locale.args}</argLine>
         <build.timestamp>2026-05-31T00:00:00Z</build.timestamp>
         <jacoco.javaagent/>
 


### PR DESCRIPTION
Issue 3018 was addressed by pinning Locale.ROOT at fifteen call sites, but nothing stops a sixteenth. The same bug had already been fixed once in Modifier (3.6.8) before it came back elsewhere. Two mechanical guards close it for good.

Checkstyle gains a RegexpSinglelineJava rule banning the no-arg toLowerCase()/toUpperCase() overloads and the matching method references. It runs at error severity, so `mvn checkstyle:check` -- already part of the formatting workflow -- fails the build. Only main sources are scanned, so tests that deliberately fold case are unaffected. 

A new CI job runs the whole suite with a Turkish default locale, where 'I' lower-cases to the dotless 'ı' and 'i' upper-cases to the dotted 'İ'. That catches what a hand-written list of call sites cannot. It is one job rather than a matrix axis: locale independence is a property of the code, not of the OS or the JDK, which the matrix already covers.

The locale has to reach the forked test JVMs, not merely the Maven process, so the root pom gains an empty `test.locale.args` property appended to `argLine`; the job sets it to `-Duser.language=tr -Duser.country=TR`.

Running that job for the first time found three real failures in ObservationTest, whose observer builds its expected change strings with `property.name().toLowerCase()`: the ObservableProperty constants containing an 'I' produced "annotatıons" and friends. NodeListTest and PropagatingAstObserverTest carry the same pattern and pass only by accident. All six call sites now pin Locale.ROOT.


Fixes #3018 .
