### PR TITLE
fix: spell keywords from their literal, not the enum constant name

### DIFF
--- a/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/PrimitiveTypeTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/ast/type/PrimitiveTypeTest.java
@@ -66,4 +66,16 @@ class PrimitiveTypeTest {
             Locale.setDefault(originalLocale);
         }
     }
+
+    /**
+     * The printed keyword and the lookup key are now the same literal, rather than two independent
+     * derivations of the constant's name that could drift apart -- which is exactly how issue 3018
+     * ended up with two faces.
+     */
+    @Test
+    void everyPrimitiveResolvesByItsCodeRepresentation() {
+        for (PrimitiveType.Primitive primitive : PrimitiveType.Primitive.values()) {
+            assertEquals(Optional.of(primitive), PrimitiveType.Primitive.byTypeName(primitive.asString()));
+        }
+    }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/ConcreteSyntaxModelTest.java
@@ -25,7 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.utils.LineSeparator;
 import org.junit.jupiter.api.Test;
@@ -95,5 +97,18 @@ class ConcreteSyntaxModelTest {
     void printAnEmptyInterfaceWithModifier() {
         Node node = parser.parse("public interface A {}");
         assertEquals("public interface A {" + LineSeparator.SYSTEM + "}" + LineSeparator.SYSTEM, print(node));
+    }
+
+    /**
+     * The keyword text must come from {@link Modifier.Keyword#asString()}, not from the constant's
+     * name: {@code NON_SEALED} spells out as {@code non-sealed}, and lower-casing the name produced
+     * the illegal {@code non_sealed}.
+     */
+    @Test
+    void printAClassWithATwoWordModifier() {
+        ClassOrInterfaceDeclaration node = new ClassOrInterfaceDeclaration();
+        node.setName("A");
+        node.setModifiers(Modifier.Keyword.NON_SEALED);
+        assertEquals("non-sealed class A {" + LineSeparator.SYSTEM + "}", print(node));
     }
 }

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/printer/lexicalpreservation/transformations/ast/body/ClassOrInterfaceDeclarationTransformationsTest.java
@@ -21,8 +21,10 @@
 
 package com.github.javaparser.printer.lexicalpreservation.transformations.ast.body;
 
+import static com.github.javaparser.ast.Modifier.Keyword.NON_SEALED;
 import static com.github.javaparser.ast.Modifier.Keyword.PROTECTED;
 import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
+import static com.github.javaparser.ast.Modifier.Keyword.SEALED;
 import static com.github.javaparser.ast.Modifier.createModifierList;
 
 import com.github.javaparser.ParserConfiguration;
@@ -161,6 +163,25 @@ class ClassOrInterfaceDeclarationTransformationsTest extends AbstractLexicalPres
         ClassOrInterfaceDeclaration cid = consider("public class A {}");
         cid.setModifiers(createModifierList(PROTECTED));
         assertTransformedToString("protected class A {}", cid);
+    }
+
+    /**
+     * Modifiers used to be mapped to their token by a hand-written switch that predated the sealed
+     * classes: {@code sealed}, {@code non-sealed} and {@code default} all threw
+     * {@link UnsupportedOperationException} instead of being printed.
+     */
+    @Test
+    void addingSealedModifier() {
+        ClassOrInterfaceDeclaration cid = consider("class A {}");
+        cid.setModifiers(createModifierList(SEALED));
+        assertTransformedToString("sealed class A {}", cid);
+    }
+
+    @Test
+    void addingNonSealedModifier() {
+        ClassOrInterfaceDeclaration cid = consider("class A {}");
+        cid.setModifiers(createModifierList(NON_SEALED));
+        assertTransformedToString("non-sealed class A {}", cid);
     }
 
     // members

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/Modifier.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/Modifier.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.visitor.GenericVisitor;
 import com.github.javaparser.ast.visitor.VoidVisitor;
 import com.github.javaparser.metamodel.JavaParserMetaModel;
 import com.github.javaparser.metamodel.ModifierMetaModel;
+import com.github.javaparser.printer.Stringable;
 import java.util.Arrays;
 
 /**
@@ -96,7 +97,7 @@ public class Modifier extends Node {
     /**
      * The Java modifier keywords.
      */
-    public enum Keyword {
+    public enum Keyword implements Stringable {
         DEFAULT("default"),
         PUBLIC("public"),
         PROTECTED("protected"),
@@ -122,6 +123,7 @@ public class Modifier extends Node {
         /**
          * @return the Java keyword represented by this enum constant.
          */
+        @Override
         public String asString() {
             return codeRepresentation;
         }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/type/PrimitiveType.java
@@ -40,7 +40,6 @@ import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -87,20 +86,20 @@ public class PrimitiveType extends Type implements NodeWithAnnotations<Primitive
     }
 
     public enum Primitive implements Stringable {
-        BOOLEAN("Boolean", "Z"),
-        CHAR("Character", "C"),
-        BYTE("Byte", "B"),
-        SHORT("Short", "S"),
-        INT("Integer", "I"),
-        LONG("Long", "J"),
-        FLOAT("Float", "F"),
-        DOUBLE("Double", "D");
+        BOOLEAN("boolean", "Boolean", "Z"),
+        CHAR("char", "Character", "C"),
+        BYTE("byte", "Byte", "B"),
+        SHORT("short", "Short", "S"),
+        INT("int", "Integer", "I"),
+        LONG("long", "Long", "J"),
+        FLOAT("float", "Float", "F"),
+        DOUBLE("double", "Double", "D");
 
         final String nameOfBoxedType;
 
         final String descriptor;
 
-        private String codeRepresentation;
+        private final String codeRepresentation;
 
         /*
          * Returns the Primitive constant corresponding to the specified type name (e.g. "boolean", "int",
@@ -108,7 +107,7 @@ public class PrimitiveType extends Type implements NodeWithAnnotations<Primitive
          */
         public static Optional<Primitive> byTypeName(String name) {
             for (Primitive primitive : values()) {
-                if (primitive.name().toLowerCase(Locale.ROOT).equals(name)) {
+                if (primitive.asString().equals(name)) {
                     return Optional.of(primitive);
                 }
             }
@@ -135,9 +134,9 @@ public class PrimitiveType extends Type implements NodeWithAnnotations<Primitive
             return descriptor;
         }
 
-        Primitive(String nameOfBoxedType, String descriptor) {
+        Primitive(String codeRepresentation, String nameOfBoxedType, String descriptor) {
             this.nameOfBoxedType = nameOfBoxedType;
-            this.codeRepresentation = name().toLowerCase(Locale.ROOT);
+            this.codeRepresentation = codeRepresentation;
             this.descriptor = descriptor;
         }
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/lexicalpreservation/LexicalDifferenceCalculator.java
@@ -360,36 +360,22 @@ class LexicalDifferenceCalculator {
         }
     }
 
+    /**
+     * The token that spells out the given modifier.
+     * <p>
+     * The mapping is derived from {@link Modifier.Keyword#asString()} rather than hand-written, so a
+     * keyword added to the language cannot be forgotten here. It was: {@code default}, {@code sealed}
+     * and {@code non-sealed} all threw {@link UnsupportedOperationException}.
+     */
     public static int toToken(Modifier modifier) {
-        switch (modifier.getKeyword()) {
-            case PUBLIC:
-                return GeneratedJavaParserConstants.PUBLIC;
-            case PRIVATE:
-                return GeneratedJavaParserConstants.PRIVATE;
-            case PROTECTED:
-                return GeneratedJavaParserConstants.PROTECTED;
-            case STATIC:
-                return GeneratedJavaParserConstants.STATIC;
-            case FINAL:
-                return GeneratedJavaParserConstants.FINAL;
-            case ABSTRACT:
-                return GeneratedJavaParserConstants.ABSTRACT;
-            case TRANSIENT:
-                return GeneratedJavaParserConstants.TRANSIENT;
-            case SYNCHRONIZED:
-                return GeneratedJavaParserConstants.SYNCHRONIZED;
-            case VOLATILE:
-                return GeneratedJavaParserConstants.VOLATILE;
-            case NATIVE:
-                return GeneratedJavaParserConstants.NATIVE;
-            case STRICTFP:
-                return GeneratedJavaParserConstants.STRICTFP;
-            case TRANSITIVE:
-                return GeneratedJavaParserConstants.TRANSITIVE;
-            default:
-                throw new UnsupportedOperationException(
-                        "Not supported keyword" + modifier.getKeyword().name());
+        String expectedImage = "\"" + modifier.getKeyword().asString() + "\"";
+        for (int i = 0; i < GeneratedJavaParserConstants.tokenImage.length; i++) {
+            if (GeneratedJavaParserConstants.tokenImage[i].equals(expectedImage)) {
+                return i;
+            }
         }
+        throw new UnsupportedOperationException(
+                "Not supported keyword " + modifier.getKeyword().name());
     }
 
     // /


### PR DESCRIPTION
Two printing paths derived Java keyword text from the name of an enum constant. That works only while every keyword is a single lowercase word, and it stopped being true when sealed classes arrived.

PrintingHelper falls back to `((Enum) value).name().toLowerCase(...)` for enum-valued properties that do not implement Stringable, and Modifier is printed through exactly that path (ConcreteSyntaxModel, attribute(KEYWORD)). Modifier.Keyword already has an asString() returning the correct literal -- it simply did not declare the interface -- so NON_SEALED printed as the illegal `non_sealed`, in every locale:

    input:  non-sealed class C extends P {}
    toString()          : non-sealed class C extends P { }
    ConcreteSyntaxModel : non_sealed class C extends P { }

Declaring `Keyword implements Stringable` routes it through asString(). For the other fourteen keywords the two spellings are identical, so nothing else changes.

LexicalDifferenceCalculator.toToken mapped keywords to tokens with a hand-written switch that predated `sealed`: adding SEALED, NON_SEALED or DEFAULT to a node threw UnsupportedOperationException instead of printing. The mapping is now derived from asString() by looking up the token image, the way CsmAttribute already resolves keyword and operator tokens, so a keyword added to the language cannot be forgotten. Verified constant by constant: the derived lookup returns exactly what the switch returned for the twelve it handled, and resolves the three it did not.

PrimitiveType.Primitive gets the same treatment for the same reason: the code representation is now a literal passed to the constructor rather than derived from name(), byTypeName compares against asString() instead of recomputing that derivation, and codeRepresentation becomes final. Two independent derivations of one string is how 3018 ended up with two faces.

The three new tests fail on the current code with `expected non-sealed`, `Not supported keywordSEALED` and `Not supported keywordNON_SEALED`.

