### PR TITLE
Close qualified method resolution through the receiver type's static imports

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/Context.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/Context.java
@@ -371,6 +371,18 @@ public interface Context {
         return solveMethodInParentContext(name, argumentsTypes, staticOnly);
     }
 
+    /**
+     * Similar to {@link #solveMethod(String, List, boolean)}, but a member lookup
+     * stops at the declared and inherited members of the type it started from:
+     * it must not escape into the enclosing lexical context (e.g. the imports of
+     * the file declaring that type, which are not visible from outside, see JLS
+     * 7.5.3/7.5.4 on the non-transitivity of static imports).
+     */
+    default SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return solveMethod(name, argumentsTypes, staticOnly);
+    }
+
     default SymbolReference<ResolvedMethodDeclaration> solveMethodInParentContext(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
         Optional<Context> optionalParentContext = getParent();
@@ -386,4 +398,14 @@ public interface Context {
      * A MethodUsage corresponds to a MethodDeclaration plus the resolved type variables.
      */
     Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes);
+
+    /**
+     * Similar to {@link #solveMethodAsUsage(String, List)}, but the lookup is a
+     * member lookup and must not escape into the enclosing lexical context of
+     * the receiver type declaration.
+     */
+    default Optional<MethodUsage> solveMethodAsUsage(
+            String name, List<ResolvedType> argumentsTypes, boolean memberOnly) {
+        return solveMethodAsUsage(name, argumentsTypes);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionCapability.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionCapability.java
@@ -29,4 +29,14 @@ public interface MethodResolutionCapability {
 
     SymbolReference<ResolvedMethodDeclaration> solveMethod(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly);
+
+    /**
+     * Similar to {@link #solveMethod(String, List, boolean)}, but a member lookup
+     * must not escape into the enclosing lexical context of this declaration
+     * (e.g. the imports of the file declaring the type).
+     */
+    default SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return solveMethod(name, argumentsTypes, staticOnly);
+    }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/resolution/logic/MethodResolutionLogic.java
@@ -1206,6 +1206,19 @@ public class MethodResolutionLogic {
         throw new UnsupportedOperationException(typeDeclaration.getClass().getCanonicalName());
     }
 
+    public static SymbolReference<ResolvedMethodDeclaration> solveMethodInType(
+            ResolvedTypeDeclaration typeDeclaration,
+            String name,
+            List<ResolvedType> argumentsTypes,
+            boolean staticOnly,
+            boolean memberOnly) {
+        if (typeDeclaration instanceof MethodResolutionCapability) {
+            return ((MethodResolutionCapability) typeDeclaration)
+                    .solveMethod(name, argumentsTypes, staticOnly, memberOnly);
+        }
+        throw new UnsupportedOperationException(typeDeclaration.getClass().getCanonicalName());
+    }
+
     public static void inferTypes(
             ResolvedType source, ResolvedType target, Map<ResolvedTypeParameterDeclaration, ResolvedType> mappings) {
         if (source.equals(target)) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/MethodUsageResolutionCapability.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/core/resolution/MethodUsageResolutionCapability.java
@@ -33,4 +33,18 @@ public interface MethodUsageResolutionCapability {
             List<ResolvedType> argumentTypes,
             Context invocationContext,
             List<ResolvedType> typeParameters);
+
+    /**
+     * Similar to {@link #solveMethodAsUsage(String, List, Context, List)}, but the
+     * lookup is a member lookup on this declaration and must not escape into the
+     * enclosing lexical context (e.g. the imports of the file declaring the type).
+     */
+    default Optional<MethodUsage> solveMethodAsUsage(
+            String name,
+            List<ResolvedType> argumentTypes,
+            Context invocationContext,
+            List<ResolvedType> typeParameters,
+            boolean memberOnly) {
+        return solveMethodAsUsage(name, argumentTypes, invocationContext, typeParameters);
+    }
 }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AbstractJavaParserContext.java
@@ -343,7 +343,13 @@ public abstract class AbstractJavaParserContext<N extends Node> implements Conte
      */
     @Override
     public Optional<MethodUsage> solveMethodAsUsage(String name, List<ResolvedType> argumentsTypes) {
-        SymbolReference<ResolvedMethodDeclaration> methodSolved = solveMethod(name, argumentsTypes, false);
+        return solveMethodAsUsage(name, argumentsTypes, false);
+    }
+
+    @Override
+    public Optional<MethodUsage> solveMethodAsUsage(
+            String name, List<ResolvedType> argumentsTypes, boolean memberOnly) {
+        SymbolReference<ResolvedMethodDeclaration> methodSolved = solveMethod(name, argumentsTypes, false, memberOnly);
         if (methodSolved.isSolved()) {
             ResolvedMethodDeclaration methodDeclaration = methodSolved.getCorrespondingDeclaration();
             if (!(methodDeclaration instanceof TypeVariableResolutionCapability)) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnonymousClassDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/AnonymousClassDeclarationContext.java
@@ -61,6 +61,12 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+        return solveMethod(name, argumentsTypes, staticOnly, false);
+    }
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
         List<ResolvedMethodDeclaration> candidateMethods = myDeclaration.getDeclaredMethods().stream()
                 .filter(m -> m.getName().equals(name) && (!staticOnly || m.isStatic()))
                 .collect(Collectors.toList());
@@ -69,7 +75,7 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
             for (ResolvedReferenceType ancestor : myDeclaration.getAncestors()) {
                 ancestor.getTypeDeclaration().ifPresent(ancestorTypeDeclaration -> {
                     SymbolReference<ResolvedMethodDeclaration> res = MethodResolutionLogic.solveMethodInType(
-                            ancestorTypeDeclaration, name, argumentsTypes, staticOnly);
+                            ancestorTypeDeclaration, name, argumentsTypes, staticOnly, memberOnly);
 
                     // consider methods from superclasses and only default methods from interfaces :
                     // not true, we should keep abstract as a valid candidate
@@ -83,7 +89,9 @@ public class AnonymousClassDeclarationContext extends AbstractJavaParserContext<
 
         // We want to avoid infinite recursion when a class is using its own method
         // see issue #75
-        if (candidateMethods.isEmpty()) {
+        // A member lookup must not escape into the enclosing lexical context
+        // (see JavaParserTypeDeclarationAdapter#solveMethod and issue #5105)
+        if (candidateMethods.isEmpty() && !memberOnly) {
             SymbolReference<ResolvedMethodDeclaration> parentSolution = getParent()
                     .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
                     .solveMethod(name, argumentsTypes, staticOnly);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ClassOrInterfaceDeclarationContext.java
@@ -108,6 +108,12 @@ public class ClassOrInterfaceDeclarationContext extends AbstractJavaParserContex
         return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
     }
 
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly, memberOnly);
+    }
+
     public SymbolReference<ResolvedConstructorDeclaration> solveConstructor(List<ResolvedType> argumentsTypes) {
         return javaParserTypeDeclarationAdapter.solveConstructor(argumentsTypes);
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ContextHelper.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/ContextHelper.java
@@ -44,10 +44,20 @@ public class ContextHelper {
             List<ResolvedType> argumentsTypes,
             Context invokationContext,
             List<ResolvedType> typeParameters) {
+        return solveMethodAsUsage(typeDeclaration, name, argumentsTypes, invokationContext, typeParameters, false);
+    }
+
+    public static Optional<MethodUsage> solveMethodAsUsage(
+            ResolvedTypeDeclaration typeDeclaration,
+            String name,
+            List<ResolvedType> argumentsTypes,
+            Context invokationContext,
+            List<ResolvedType> typeParameters,
+            boolean memberOnly) {
 
         if (typeDeclaration instanceof MethodUsageResolutionCapability) {
             return ((MethodUsageResolutionCapability) typeDeclaration)
-                    .solveMethodAsUsage(name, argumentsTypes, invokationContext, typeParameters);
+                    .solveMethodAsUsage(name, argumentsTypes, invokationContext, typeParameters, memberOnly);
         }
         throw new UnsupportedOperationException(typeDeclaration.toString());
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/EnumDeclarationContext.java
@@ -77,6 +77,12 @@ public class EnumDeclarationContext extends AbstractJavaParserContext<EnumDeclar
         return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
     }
 
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly, memberOnly);
+    }
+
     ///
     /// Private methods
     ///

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/JavaParserTypeDeclarationAdapter.java
@@ -277,6 +277,11 @@ public class JavaParserTypeDeclarationAdapter {
 
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+        return solveMethod(name, argumentsTypes, staticOnly, false);
+    }
+
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
 
         // Begin by locating methods declared "here"
         List<ResolvedMethodDeclaration> candidateMethods = typeDeclaration.getDeclaredMethods().stream()
@@ -302,7 +307,7 @@ public class JavaParserTypeDeclarationAdapter {
                     // not true, we should keep abstract as a valid candidate
                     // abstract are removed in MethodResolutionLogic.isApplicable is necessary
                     SymbolReference<ResolvedMethodDeclaration> res = MethodResolutionLogic.solveMethodInType(
-                            ancestorTypeDeclaration.get(), name, argumentsTypes, staticOnly);
+                            ancestorTypeDeclaration.get(), name, argumentsTypes, staticOnly, memberOnly);
                     if (res.isSolved()) {
                         candidateMethods.add(res.getCorrespondingDeclaration());
                     }
@@ -315,7 +320,10 @@ public class JavaParserTypeDeclarationAdapter {
         // This is relevant e.g. with nested classes.
         // Note that we want to avoid infinite recursion when a class is using its own method - see issue #75
         // We also want to avoid infinite recursion when handling static imports - see issue #4358
-        if (candidateMethods.isEmpty() && !staticOnly) {
+        // A member lookup (e.g. a call qualified by this type) must stop at the
+        // members: the imports of the file declaring the type are not visible
+        // from other files, see JLS 7.5.3/7.5.4 - see issue #5105
+        if (candidateMethods.isEmpty() && !staticOnly && !memberOnly) {
             SymbolReference<ResolvedMethodDeclaration> parentSolution = context.getParent()
                     .orElseThrow(() -> new RuntimeException("Parent context unexpectedly empty."))
                     .solveMethod(name, argumentsTypes, staticOnly);

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -91,8 +91,12 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
                 String className = ((NameExpr) scope).getName().getId();
                 SymbolReference<ResolvedTypeDeclaration> ref = solveType(className);
                 if (ref.isSolved()) {
+                    // The receiver is a type name, so only static members are
+                    // eligible (JLS 15.12) and the lookup must not escape into
+                    // the lexical context of the file declaring that type: its
+                    // static imports are not members (JLS 7.5.3/7.5.4, #5105)
                     SymbolReference<ResolvedMethodDeclaration> m = MethodResolutionLogic.solveMethodInType(
-                            ref.getCorrespondingDeclaration(), name, argumentsTypes);
+                            ref.getCorrespondingDeclaration(), name, argumentsTypes, true);
                     if (m.isSolved()) {
                         MethodUsage methodUsage = new MethodUsage(m.getCorrespondingDeclaration());
                         methodUsage = resolveMethodTypeParametersFromExplicitList(typeSolver, methodUsage);
@@ -167,9 +171,13 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
             rrtds = Collections.singleton(typeSolver.getSolvedJavaLangObject());
         }
 
+        // A call qualified by a receiver is a member lookup: it must not
+        // escape into the lexical context of the file declaring the receiver
+        // type, whose static imports are not members (JLS 7.5.3/7.5.4, #5105)
+        boolean memberOnly = wrappedNode.hasScope();
         for (ResolvedReferenceTypeDeclaration rrtd : rrtds) {
             SymbolReference<ResolvedMethodDeclaration> res =
-                    MethodResolutionLogic.solveMethodInType(rrtd, name, argumentsTypes, false);
+                    MethodResolutionLogic.solveMethodInType(rrtd, name, argumentsTypes, false, memberOnly);
             if (res.isSolved()) {
                 return res;
             }
@@ -188,12 +196,17 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
             return Optional.empty();
         }
 
+        // A call qualified by a receiver is a member lookup: it must not
+        // escape into the lexical context of the file declaring the receiver
+        // type, whose static imports are not members (JLS 7.5.3/7.5.4, #5105)
+        boolean memberOnly = wrappedNode.hasScope();
         Optional<MethodUsage> ref = ContextHelper.solveMethodAsUsage(
                 refType.getTypeDeclaration().get(),
                 name,
                 argumentsTypes,
                 invokationContext,
-                refType.typeParametersValues());
+                refType.typeParametersValues(),
+                memberOnly);
         if (ref.isPresent()) {
             MethodUsage methodUsage = ref.get();
 

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/RecordDeclarationContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/RecordDeclarationContext.java
@@ -105,8 +105,14 @@ public class RecordDeclarationContext extends AbstractJavaParserContext<RecordDe
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+        return solveMethod(name, argumentsTypes, staticOnly, false);
+    }
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
         SymbolReference<ResolvedMethodDeclaration> resolvedExplicitMethod =
-                javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly);
+                javaParserTypeDeclarationAdapter.solveMethod(name, argumentsTypes, staticOnly, memberOnly);
 
         if (!resolvedExplicitMethod.isSolved() && argumentsTypes.isEmpty()) {
             // If the method could not be resolved and has no arguments, then it could be an implicit getter for

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserAnonymousClassDeclaration.java
@@ -96,12 +96,28 @@ public class JavaParserAnonymousClassDeclaration extends AbstractClassDeclaratio
     }
 
     @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, memberOnly);
+    }
+
+    @Override
     public Optional<MethodUsage> solveMethodAsUsage(
             String name,
             List<ResolvedType> argumentTypes,
             Context invocationContext,
             List<ResolvedType> typeParameters) {
         return getContext().solveMethodAsUsage(name, argumentTypes);
+    }
+
+    @Override
+    public Optional<MethodUsage> solveMethodAsUsage(
+            String name,
+            List<ResolvedType> argumentTypes,
+            Context invocationContext,
+            List<ResolvedType> typeParameters,
+            boolean memberOnly) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, memberOnly);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -169,6 +169,16 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
         return getContext().solveMethodAsUsage(name, argumentTypes);
     }
 
+    @Override
+    public Optional<MethodUsage> solveMethodAsUsage(
+            String name,
+            List<ResolvedType> argumentTypes,
+            Context invocationContext,
+            List<ResolvedType> typeParameters,
+            boolean memberOnly) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, memberOnly);
+    }
+
     /**
      * This method is deprecated because the context is an implementation detail that should not be exposed.
      * Ideally this method should become private. For this reason all further usages of this method are discouraged.
@@ -332,6 +342,12 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
         return getContext().solveMethod(name, argumentsTypes, staticOnly);
+    }
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, memberOnly);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -191,6 +191,16 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
             List<ResolvedType> argumentTypes,
             Context invokationContext,
             List<ResolvedType> typeParameters) {
+        return solveMethodAsUsage(name, argumentTypes, invokationContext, typeParameters, false);
+    }
+
+    @Override
+    public Optional<MethodUsage> solveMethodAsUsage(
+            String name,
+            List<ResolvedType> argumentTypes,
+            Context invocationContext,
+            List<ResolvedType> typeParameters,
+            boolean memberOnly) {
         if (VALUES.equals(name) && argumentTypes.isEmpty()) {
             return Optional.of(new MethodUsage(new JavaParserEnumDeclaration.ValuesMethod(this, typeSolver)));
         }
@@ -201,12 +211,18 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
                 return Optional.of(new MethodUsage(new JavaParserEnumDeclaration.ValueOfMethod(this, typeSolver)));
             }
         }
-        return getContext().solveMethodAsUsage(name, argumentTypes);
+        return getContext().solveMethodAsUsage(name, argumentTypes, memberOnly);
     }
 
     @Override
     public SymbolReference<ResolvedMethodDeclaration> solveMethod(
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+        return solveMethod(name, argumentsTypes, staticOnly, false);
+    }
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
         if (VALUES.equals(name) && argumentsTypes.isEmpty()) {
             return SymbolReference.solved(new JavaParserEnumDeclaration.ValuesMethod(this, typeSolver));
         }
@@ -217,7 +233,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
                 return SymbolReference.solved(new JavaParserEnumDeclaration.ValueOfMethod(this, typeSolver));
             }
         }
-        return getContext().solveMethod(name, argumentsTypes, staticOnly);
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, memberOnly);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -286,12 +286,28 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
     }
 
     @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, memberOnly);
+    }
+
+    @Override
     public Optional<MethodUsage> solveMethodAsUsage(
             String name,
             List<ResolvedType> argumentTypes,
             Context invocationContext,
             List<ResolvedType> typeParameters) {
         return getContext().solveMethodAsUsage(name, argumentTypes);
+    }
+
+    @Override
+    public Optional<MethodUsage> solveMethodAsUsage(
+            String name,
+            List<ResolvedType> argumentTypes,
+            Context invocationContext,
+            List<ResolvedType> typeParameters,
+            boolean memberOnly) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, memberOnly);
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserRecordDeclaration.java
@@ -217,6 +217,16 @@ public class JavaParserRecordDeclaration extends AbstractTypeDeclaration
         return getContext().solveMethodAsUsage(name, argumentTypes);
     }
 
+    @Override
+    public Optional<MethodUsage> solveMethodAsUsage(
+            String name,
+            List<ResolvedType> argumentTypes,
+            Context invocationContext,
+            List<ResolvedType> typeParameters,
+            boolean memberOnly) {
+        return getContext().solveMethodAsUsage(name, argumentTypes, memberOnly);
+    }
+
     /**
      * This method is deprecated because the context is an implementation detail that should not be exposed.
      * Ideally this method should become private. For this reason all further usages of this method are discouraged.
@@ -396,6 +406,12 @@ public class JavaParserRecordDeclaration extends AbstractTypeDeclaration
             String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
 
         return getContext().solveMethod(name, argumentsTypes, staticOnly);
+    }
+
+    @Override
+    public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+            String name, List<ResolvedType> argumentsTypes, boolean staticOnly, boolean memberOnly) {
+        return getContext().solveMethod(name, argumentsTypes, staticOnly, memberOnly);
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5105Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue5105Test.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2013-2026 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * This file is part of JavaParser is provided in both LICENCE.LGPL and
+ * LICENCE.APACHE files. JavaParser is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ * General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class Issue5105Test extends AbstractSymbolResolutionTest {
+
+    private List<MethodCallExpr> calls() throws IOException {
+        Path issueResourcesPath = adaptPath("src/test/resources/issue5105");
+        ReflectionTypeSolver rts = new ReflectionTypeSolver();
+        JavaParserTypeSolver jpts = new JavaParserTypeSolver(issueResourcesPath);
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(rts);
+        cts.add(jpts);
+        ParserConfiguration pc = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(pc);
+        CompilationUnit cu = StaticJavaParser.parse(issueResourcesPath.resolve("qq/Outer.java"));
+        return cu.findAll(MethodCallExpr.class);
+    }
+
+    @Test
+    public void qualifiedCallDoesNotUseReceiverTypeStaticImports() throws IOException {
+        // Mid declares nothing; the static import lives in Mid.java, not in Outer.java,
+        // so Mid.ping() has no member to resolve to (JLS 7.5.3/7.5.4: static imports
+        // are not transitive)
+        MethodCallExpr call = calls().stream()
+                .filter(c -> c.getNameAsString().equals("ping")
+                        && c.getScope().isPresent()
+                        && c.getScope().get().isNameExpr())
+                .findAny()
+                .get();
+        assertThrows(UnsolvedSymbolException.class, call::resolve);
+    }
+
+    @Test
+    public void instanceQualifiedCallDoesNotUseReceiverTypeStaticImports() throws IOException {
+        // same rule for a call qualified by an instance of the receiver type
+        MethodCallExpr call = calls().stream()
+                .filter(c -> c.getNameAsString().equals("ping")
+                        && c.getScope().isPresent()
+                        && c.getScope().get().isObjectCreationExpr())
+                .findAny()
+                .get();
+        assertThrows(UnsolvedSymbolException.class, call::resolve);
+    }
+
+    @Test
+    public void subclassQualifiedCallDoesNotUseSuperclassTypeStaticImports() throws IOException {
+        // MidSub extends Mid and Mid only statically imports Sink.ping();
+        // the inherited-member lookup must not escape into Mid.java's imports
+        // either (JLS 7.5.3/7.5.4)
+        MethodCallExpr call = calls().stream()
+                .filter(c -> c.getNameAsString().equals("ping")
+                        && c.getScope().isPresent()
+                        && c.getScope().get().isNameExpr()
+                        && c.getScope().get().asNameExpr().getNameAsString().equals("MidSub"))
+                .findAny()
+                .get();
+        assertThrows(UnsolvedSymbolException.class, call::resolve);
+    }
+
+    @Test
+    public void inheritedStaticMemberViaSubclassStillResolves() throws IOException {
+        // Deep extends Sink and inherits its static ping(); a member lookup
+        // must still find inherited members
+        MethodCallExpr call = calls().stream()
+                .filter(c -> c.getNameAsString().equals("ping")
+                        && c.getScope().isPresent()
+                        && c.getScope().get().isNameExpr()
+                        && c.getScope().get().asNameExpr().getNameAsString().equals("Deep"))
+                .findAny()
+                .get();
+        assertEquals("qq.Sink.ping()", call.resolve().getQualifiedSignature());
+    }
+
+    @Test
+    public void instanceCallOnRealMemberStillResolves() throws IOException {
+        // control: an instance method that is genuinely declared on the receiver
+        MethodCallExpr call = calls().stream()
+                .filter(c -> c.getNameAsString().equals("inst"))
+                .findAny()
+                .get();
+        assertEquals("qq.Sink.inst()", call.resolve().getQualifiedSignature());
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Deep.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Deep.java
@@ -1,0 +1,4 @@
+package qq;
+
+public class Deep extends Sink {
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Mid.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Mid.java
@@ -1,0 +1,6 @@
+package qq;
+
+import static qq.Sink.*;
+
+public class Mid {
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/MidSub.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/MidSub.java
@@ -1,0 +1,4 @@
+package qq;
+
+public class MidSub extends Mid {
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Outer.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Outer.java
@@ -1,0 +1,23 @@
+package qq;
+
+public class Outer {
+    public String a() {
+        return Mid.ping();
+    }
+
+    public String b() {
+        return new Mid().ping();
+    }
+
+    public String c() {
+        return new Sink().inst();
+    }
+
+    public String d() {
+        return MidSub.ping();
+    }
+
+    public String e() {
+        return Deep.ping();
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Sink.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue5105/qq/Sink.java
@@ -1,0 +1,11 @@
+package qq;
+
+public class Sink {
+    public static String ping() {
+        return "p";
+    }
+
+    public String inst() {
+        return "i";
+    }
+}


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

Fixes #5105.

`Mid.ping()` and `new Mid().ping()` no longer resolve to a method that `Mid` only statically imports. They are unsolved when `Mid` has no such member, matching javac. `new Sink().inst()` is unchanged.

Root cause: `JavaParserTypeDeclarationAdapter` falls through to the enclosing lexical context, which holds the imports of the file declaring the type. Correct for an unqualified name written inside that class. Wrong for a member lookup from outside, because static imports are not transitive (JLS 7.5.3/7.5.4). `staticOnly` closes that fall-through but also filters out instance methods, so it cannot carry both jobs.

Fix: a new `memberOnly` flag runs through `Context`, `MethodResolutionCapability`, `MethodUsageResolutionCapability` and their JavaParser implementations, including the ancestor recursion of `JavaParserTypeDeclarationAdapter` and `AnonymousClassDeclarationContext`. It is set when a method call has a receiver.

What stays as before: the fall-through stays open for unqualified names. A lookup on a subclass no longer escapes into the file of its superclass. Inherited static members still resolve. A receiver that is a type name also passes `staticOnly`, matching JLS 15.12 for `TypeName` receivers.

What changes: enum synthetic methods (`values`, `valueOf`) keep their dispatch on the new paths. A `this`-qualified call to a method that only the file's own static imports provide is now unsolved, matching javac.

Not covered: fields and method references keep their existing mechanisms (#4982 thread local, `FieldAccessContext`). Unifying them is left as follow-up.

Verification: `Issue5105Test` covers `qq/Sink`, `qq/Mid` (imports only), `qq/MidSub` (extends Mid), `qq/Deep` (extends Sink) and `qq/Outer`.

1. Both qualified `ping` calls fail on main and are unsolved with the fix.
2. The subclass-qualified call is unsolved as well.
3. The inherited-static call and the control call resolve.
4. `javaparser-symbol-solver-testing` 2105 and `javaparser-core-testing` 2853 tests pass.


